### PR TITLE
ci: Remove build command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,12 +39,6 @@ jobs:
           git_committer_name: github-actions[bot]
           git_committer_email: "github-actions[bot]@users.noreply.github.com"
 
-      - name: Build package
-        if: steps.release.outputs.released == 'true'
-        run: |
-          pip install build
-          python -m build
-
       - name: Publish to GitHub Releases
         if: steps.release.outputs.released == 'true'
         uses: python-semantic-release/publish-action@v9


### PR DESCRIPTION
## Summary
Remove build command as semantic release already builds

## Motivation
Running build twice causes an issue

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->