### PR TITLE
docs: add CONTRIBUTING.md and rename Local Agent Studio to ADK

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to ADK
+
+Contributions are welcome! Please ensure all tests pass before submitting a pull request.
+
+## Development Setup
+
+### Prerequisites
+
+- Python 3.14 or higher
+- [uv](https://github.com/astral-sh/uv) (`brew install uv`)
+
+### Getting Started
+
+```bash
+git clone https://github.com/PolyAI-LDN/adk.git
+cd adk
+uv venv
+source .venv/bin/activate
+uv pip install -e ".[dev]"
+pre-commit install
+```
+
+## Running Tests
+
+```bash
+pytest
+```
+
+Test files are located in `src/poly/tests/`.
+
+## Project Structure
+
+- `src/poly/cli.py` - CLI interface
+- `src/poly/project.py` - Core project management
+- `src/poly/resources/` - Resource type implementations
+- `src/poly/handlers/` - API handler implementations
+- `src/poly/tests/` - Test suite
+- `src/poly/types/` - Python type definitions for the Agent Studio runtime
+
+## Code Style
+
+The project uses [ruff](https://github.com/astral-sh/ruff) for linting and formatting, enforced via pre-commit hooks.
+
+- **Line length**: 100 characters
+- **Formatting**: `ruff format .`
+- **Linting**: `ruff check .` (auto-fix with `ruff check . --fix`)
+
+## Commit Conventions
+
+We use [conventional commits](https://www.conventionalcommits.org/):
+
+| Commit prefix | Version bump | Example |
+|---|---|---|
+| `fix:` | Patch (2.0.4 → 2.0.5) | `fix: handle missing config file` |
+| `feat:` | Minor (2.0.4 → 2.1.0) | `feat: add poly export command` |
+| `feat!:` / `BREAKING CHANGE:` | Major (2.0.4 → 3.0.0) | `feat!: redesign resource schema` |
+| `chore:`, `docs:`, `ci:` | No release | `docs: update README` |
+
+## Tooling
+
+We recommend using [Claude Code](https://claude.ai/download) for development. The repo includes a `.claude/` directory with project-specific instructions and permissions pre-configured.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Agent Development Kit (ADK)
 
 [![PyPI version](https://img.shields.io/pypi/v/polyai-adk)](https://pypi.org/project/polyai-adk/)
-[![Python version](https://img.shields.io/pypi/pyversions/polyai-adk)](https://pypi.org/project/polyai-adk/)
+[![Python 3.14](https://img.shields.io/badge/python-3.14-blue)](https://www.python.org/downloads/)
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Develop with Claude Code](https://img.shields.io/badge/Develop%20with-Claude%20Code-DC9E63?logo=claude)](https://claude.ai/download)
@@ -159,50 +159,13 @@ poly chat --channel webchat
 poly chat --metadata   # show functions, flows, and state each turn
 ```
 
-## Development Setup
-
-### Prerequisites
-
-- Python 3.14 or higher
-- [uv](https://github.com/astral-sh/uv) (`brew install uv`)
-
-### Getting Started
-
-```bash
-git clone https://github.com/PolyAI-LDN/local_agent_studio.git
-cd local_agent_studio
-uv venv
-source .venv/bin/activate
-uv pip install -e ".[dev]"
-pre-commit install
-```
-
-### Running Tests
-
-```bash
-pytest
-```
-
-Test files are located in `src/poly/tests/`.
-
-### Project Structure
-
-- `src/poly/cli.py` - CLI interface
-- `src/poly/project.py` - Core project management
-- `src/poly/resources/` - Resource type implementations
-- `src/poly/handlers/` - API handler implementations
-- `src/poly/tests/` - Test suite
-- `src/poly/types/` - Python type definitions for the Agent Studio runtime
-
 ## Bugs & Feature Requests
 
-Please report bugs or request features via the [GitHub Issues](https://github.com/PolyAI-LDN/local_agent_studio/issues) page.
+Please report bugs or request features via the [GitHub Issues](https://github.com/PolyAI-LDN/adk/issues) page.
 
 ## Contributing
 
-Contributions are welcome! The project uses **ruff** for linting/formatting (enforced via pre-commit hooks) and **pytest** for testing. Please ensure all tests pass before submitting a pull request.
-
-We recommend using [Claude Code](https://claude.ai/download) for development. The repo includes a `.claude/` directory with project-specific instructions and permissions pre-configured.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, code style, and contribution guidelines.
 
 ## Releases
 

--- a/src/poly/docs/docs/legal/licensing.md
+++ b/src/poly/docs/docs/legal/licensing.md
@@ -1,9 +1,9 @@
 ---
 title: 'License acknowledgements'
-description: 'Third-party software licenses used in PolyAI Local Agent Studio.'
+description: 'Third-party software licenses used in PolyAI ADK.'
 ---
 
-PolyAI Local Agent Studio uses the following third-party open source software packages. We gratefully acknowledge the contributions of the open source community.
+PolyAI ADK uses the following third-party open source software packages. We gratefully acknowledge the contributions of the open source community.
 
 ## Package licenses
 

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -495,7 +495,7 @@ class Function(Resource):
                 or line.startswith("@func_latency_control")
             ):
                 raise ValueError(
-                    "Local Agent Studio decorators found in raw code. This might be because of a parameter mismatch."
+                    "ADK decorators found in raw code. This might be because of a parameter mismatch."
                 )
 
         resource_mappings = kwargs.get("resource_mappings") or []

--- a/src/poly/resources/handoff.py
+++ b/src/poly/resources/handoff.py
@@ -64,7 +64,7 @@ class HandoffSipConfig:
 
 @dataclass
 class Handoff(MultiResourceYamlResource):
-    """Handoff resource for Local Agent Studio."""
+    """Handoff resource for ADK."""
 
     description: str
     is_default: bool

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -1,4 +1,4 @@
-"""Util functions for resources in Local Agent Studio
+"""Util functions for resources in ADK
 
 Copyright PolyAI Limited
 """

--- a/src/poly/resources/sms.py
+++ b/src/poly/resources/sms.py
@@ -35,7 +35,7 @@ class EnvPhoneNumbers:
 
 @dataclass
 class SMSTemplate(MultiResourceYamlResource):
-    """SMS resource for Local Agent Studio."""
+    """SMS resource for ADK."""
 
     text: str
     env_phone_numbers: Optional[EnvPhoneNumbers]

--- a/src/poly/resources/variable.py
+++ b/src/poly/resources/variable.py
@@ -1,4 +1,4 @@
-"""Variable resource for Local Agent Studio
+"""Variable resource for ADK
 
 Variables are a special resource type that does not exist as files on the
 filesystem. Instead they are stored in-memory and are used for referencing in

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for Local Agent Studio Resources
+"""Unit tests for ADK Resources
 
 Copyright PolyAI Limited
 """
@@ -244,13 +244,13 @@ def test_code(conv: Conversation, flow: Flow, test_param: int):
             str(cm.exception),
         )
 
-        # Test with local agent studio decorators in raw code
+        # Test with ADK decorators in raw code
         test_function.function_type = FunctionType.GLOBAL
         test_function.code = "@func_description('A test function')\n@func_parameter('test_param', 'test parameter')\n@utils.test_decorator\ndef test_code(conv: Conversation, test_param: str):\n    print(random.randint(1, test_param))"
         with self.assertRaises(ValueError) as cm:
             test_function.validate()
         self.assertIn(
-            "Local Agent Studio decorators found in raw code. This might be because of a parameter mismatch.",
+            "ADK decorators found in raw code. This might be because of a parameter mismatch.",
             str(cm.exception),
         )
 

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -1,4 +1,4 @@
-"""Unit tests for Local Agent Studio Utils
+"""Unit tests for ADK Utils
 
 Copyright PolyAI Limited
 """


### PR DESCRIPTION
## Summary

Add a dedicated CONTRIBUTING.md with dev setup and contribution guidelines extracted from the README. Rename all references from "Local Agent Studio" / "local_agent_studio" to "ADK" across the codebase.

## Motivation

The README was getting long with dev setup details mixed in, and the old project name was still referenced in many places.

## Changes

- Created `CONTRIBUTING.md` with dev setup, project structure, code style, commit conventions, and tooling sections
- Replaced README dev setup and contributing sections with a link to `CONTRIBUTING.md`
- Replaced broken dynamic Python version badge with a static `Python 3.14` badge
- Updated all `local_agent_studio` GitHub URLs to `adk`
- Renamed "Local Agent Studio" to "ADK" in docstrings, comments, error messages, and docs across 9 files

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)