### PR TITLE
ci: add PR title validation for conventional commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,31 @@ on:
     - main
 
 jobs:
+  pr-title:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Validate PR title follows conventional commits
+      env:
+        PR_TITLE: ${{ github.event.pull_request.title }}
+      run: |
+        # Conventional commit types from CONTRIBUTING.md
+        pattern='^(feat|fix|chore|docs|ci|build|perf|refactor|style|test)(\(.+\))?!?: .+'
+        if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+          echo "::error::PR title does not follow conventional commits format."
+          echo ""
+          echo "Expected: <type>[optional scope][!]: <description>"
+          echo "  Types: feat, fix, chore, docs, ci, build, perf, refactor, style, test"
+          echo "  Examples:"
+          echo "    feat: add poly export command"
+          echo "    fix(cli): handle missing config file"
+          echo "    feat!: redesign resource schema"
+          echo ""
+          echo "See CONTRIBUTING.md for details."
+          exit 1
+        fi
+        echo "PR title is valid: $PR_TITLE"
+
   lint-and-test:
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
## Summary

Adds a CI job that validates PR titles follow the conventional commits format defined in CONTRIBUTING.md.

## Motivation

PR titles that don't follow conventional commits break semantic-release versioning since it parses commit messages (squash-merged from PR titles) to determine version bumps.

## Changes

- Added `pr-title` job to `.github/workflows/ci.yml` that runs only on `pull_request` events
- Validates titles match `<type>[optional scope][!]: <description>` where type is one of: `feat`, `fix`, `chore`, `docs`, `ci`, `build`, `perf`, `refactor`, `style`, `test`
- Uses environment variable for the PR title (not direct interpolation) to prevent script injection

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Example failure output:
```
::error::PR title does not follow conventional commits format.

Expected: <type>[optional scope][!]: <description>
  Types: feat, fix, chore, docs, ci, build, perf, refactor, style, test
  Examples:
    feat: add poly export command
    fix(cli): handle missing config file
    feat!: redesign resource schema

See CONTRIBUTING.md for details.
```