### PR TITLE
docs: fix prerequisites around API key generation

### DIFF
--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -12,26 +12,11 @@ To use the ADK, you must have:
 - access to a **workspace in PolyAI Agent Studio**
 - a valid **API key**
 
-Access is provided by your PolyAI contact:
+Access and API credentials are provided by your PolyAI contact.
+
+If you need access to the PolyAI platform, contact:
 
 - `developers@poly-ai.com`
-
-
-## Generate API key
-
-Log in to Agent Studio and open your workspace. In the **Data Access** tab (next to the **Users** tab), click **+ API Key** in the top right to generate a key.
-
-![Generating an API key in Agent Studio — Data Access tab with the + API Key button highlighted](../assets/api-key-data-access.png)
-
-Then set it as an environment variable:
-
-~~~bash
-export POLY_ADK_KEY=<your-api-key>
-~~~
-
-The `POLY_ADK_KEY` environment variable must be set before running any `poly` commands. To make it permanent, add the export line to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
-
-Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
 
 ## Local requirements
 
@@ -63,7 +48,7 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 Before continuing, confirm:
 
 - [ ] You have access to an **Agent Studio workspace**
-- [ ] You have obtained an **API key** 
+- [ ] You have obtained an **API key** from your PolyAI contact
 - [ ] `uv` is installed
 - [ ] `git` is available locally
 

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -12,11 +12,26 @@ To use the ADK, you must have:
 - access to a **workspace in PolyAI Agent Studio**
 - a valid **API key**
 
-Access and API credentials are provided by your PolyAI contact.
-
-If you need access to the PolyAI platform, contact:
+Access is provided by your PolyAI contact:
 
 - `developers@poly-ai.com`
+
+
+## Generate API key
+
+Log in to Agent Studio and open your workspace. In the **Data Access** tab (next to the **Users** tab), click **+ API Key** in the top right to generate a key.
+
+![Generating an API key in Agent Studio — Data Access tab with the + API Key button highlighted](../assets/api-key-data-access.png)
+
+Then set it as an environment variable:
+
+~~~bash
+export POLY_ADK_KEY=<your-api-key>
+~~~
+
+The `POLY_ADK_KEY` environment variable must be set before running any `poly` commands. To make it permanent, add the export line to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
+
+Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
 
 ## Local requirements
 
@@ -48,7 +63,7 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 Before continuing, confirm:
 
 - [ ] You have access to an **Agent Studio workspace**
-- [ ] You have obtained an **API key** from your PolyAI contact
+- [ ] You have obtained an **API key** 
 - [ ] `uv` is installed
 - [ ] `git` is available locally
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -5,7 +5,7 @@ description: Reference for the core commands provided by the PolyAI ADK CLI.
 
 <p class="lead">
 The PolyAI ADK is accessed through the <code>poly</code> command.
-When in doubt about a flag or option, run the command with <code>--help</code> - that output reflects your installed version exactly.
+Use the CLI help output as the first source of truth.
 </p>
 
 ## Start with help
@@ -22,9 +22,9 @@ Each command also supports its own help output. For example:
 poly push --help
 ~~~
 
-!!! tip "Help output reflects your installed version"
+!!! tip "Use help output as the source of truth"
 
-    This reference page covers the standard commands. Run `poly <command> --help` to confirm the exact flags available in your environment.
+    The installed CLI is the fastest way to confirm the commands and flags available in your local environment.
 
 ## Core commands
 
@@ -53,6 +53,10 @@ poly pull --force
 poly pull --format
 ~~~
 
+If the branch you are currently on no longer exists in Agent Studio, `poly pull` automatically switches to the `main` branch and displays a warning message with the new branch name.
+
+When using JSON output (`--json`), the response includes `new_branch_name` and `new_branch_id` fields if a branch switch occurred.
+
 ### `poly push`
 
 Push local changes to Agent Studio.
@@ -65,16 +69,11 @@ poly push --dry-run
 poly push --skip-validation
 poly push --force
 poly push --format
-poly push --email user@example.com
 ~~~
 
-| Flag | Description |
-|---|---|
-| `--force` | Force overwrite — load the latest remote version and push on top of it. |
-| `--dry-run` | Validate and stage changes without actually sending them. |
-| `--skip-validation` | Skip local validation before pushing. |
-| `--format` | Format resources before pushing. |
-| `--email EMAIL` | Email address to use for metadata when creating commands. |
+When pushing creates a new branch (for example, when pushing to Agent Studio for the first time on a branch), the CLI displays a message with the new branch name.
+
+When using JSON output (`--json`), the response includes `new_branch_name` and `new_branch_id` fields if a new branch was created.
 
 ### `poly status`
 
@@ -155,10 +154,6 @@ poly review --delete
 
 Start an interactive chat session with your agent.
 
-!!! warning "Merge before chatting"
-
-    `poly chat` connects to the **main branch** of your Sandbox environment in Agent Studio — not your local files, and not your current branch. To test changes made on a feature branch, you must first push the branch with `poly push`, merge it in Agent Studio, and then run `poly chat`.
-
 Examples:
 
 ~~~bash
@@ -180,82 +175,8 @@ poly docs --all
 poly docs --all --output rules.md
 ~~~
 
-Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools - pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
+Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools — pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
 
-## Machine-readable JSON output
-
-All core subcommands accept a `--json` flag that switches stdout to a single JSON object. This is designed for scripting, CI pipelines, and any integration that needs stable, parseable output rather than human-readable console text.
-
-~~~bash
-poly status --json
-poly push --json
-poly pull --json
-poly validate --json
-poly diff --json
-poly revert --json --all
-poly branch list --json
-poly branch create my-feature --json
-poly branch current --json
-poly format --json
-poly init --region us-1 --account_id 123 --project_id my_project --json
-~~~
-
-When `--json` is used:
-
-- stdout contains exactly one JSON object
-- the process exits with code `0` on success and non-zero on failure
-- human-readable console messages are suppressed
-
-### JSON output shapes
-
-The exact fields vary by command. Common fields include:
-
-| Command | Key fields |
-|---|---|
-| `poly status --json` | `files_with_conflicts`, `modified_files`, `new_files`, `deleted_files` |
-| `poly push --json` | `success`, `message`, `dry_run` |
-| `poly pull --json` | `success`, `files_with_conflicts` |
-| `poly validate --json` | `valid`, `errors` |
-| `poly diff --json` | `diffs` |
-| `poly revert --json` | `success`, `files_reverted` |
-| `poly branch list --json` | `current_branch`, `branches` |
-| `poly branch create --json` | `success`, `new_branch_id`, `branch_name` |
-| `poly branch current --json` | `current_branch` |
-| `poly format --json` | `success`, `check_only`, `format_errors`, `affected`, `ty_ran`, `ty_returncode`, `ty_timed_out` |
-| `poly init --json` | `success`, `root_path` |
-
-Error responses always include `{ "success": false, "error": "..." }`.
-
-!!! info "`init` with `--json` requires explicit flags"
-
-    When using `poly init --json`, you must supply `--region`, `--account_id`, and `--project_id` explicitly. Interactive prompts are not supported in JSON mode.
-
-### `poly push --output-json-commands`
-
-Adds a `commands` array to the JSON output of `poly push`, containing the serialized Agent Studio commands that were staged. Useful for dry-run review and integration testing.
-
-~~~bash
-poly push --json --dry-run --output-json-commands
-~~~
-
-The output will include a `commands` key with each command serialized from its protobuf representation.
-
-### Driving pull/push from a captured projection
-
-The `--from-projection` flag on `pull`, `push`, `init`, and `branch switch` lets you supply a projection JSON directly (as a string or via stdin with `-`) instead of fetching it from the API. This is useful for offline workflows and integration testing.
-
-~~~bash
-poly pull --from-projection - < projection.json
-poly push --from-projection '{"topics": [...], ...}'
-cat projection.json | poly pull --from-projection -
-~~~
-
-The `--output-json-projection` flag on `pull`, `init`, and `branch switch` includes the projection in the JSON output when `--json` is also set. This lets you capture a projection from one command and feed it into another.
-
-~~~bash
-poly pull --json --output-json-projection | jq .projection > proj.json
-poly push --from-projection - < proj.json
-~~~
 
 ## Working pattern
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -177,6 +177,83 @@ poly docs --all --output rules.md
 
 Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools — pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
 
+Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools - pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
+
+## Machine-readable JSON output
+
+All core subcommands accept a `--json` flag that switches stdout to a single JSON object. This is designed for scripting, CI pipelines, and any integration that needs stable, parseable output rather than human-readable console text.
+
+~~~bash
+poly status --json
+poly push --json
+poly pull --json
+poly validate --json
+poly diff --json
+poly revert --json --all
+poly branch list --json
+poly branch create my-feature --json
+poly branch current --json
+poly format --json
+poly init --region us-1 --account_id 123 --project_id my_project --json
+~~~
+
+When `--json` is used:
+
+- stdout contains exactly one JSON object
+- the process exits with code `0` on success and non-zero on failure
+- human-readable console messages are suppressed
+
+### JSON output shapes
+
+The exact fields vary by command. Common fields include:
+
+| Command | Key fields |
+|---|---|
+| `poly status --json` | `files_with_conflicts`, `modified_files`, `new_files`, `deleted_files` |
+| `poly push --json` | `success`, `message`, `dry_run` |
+| `poly pull --json` | `success`, `files_with_conflicts` |
+| `poly validate --json` | `valid`, `errors` |
+| `poly diff --json` | `diffs` |
+| `poly revert --json` | `success`, `files_reverted` |
+| `poly branch list --json` | `current_branch`, `branches` |
+| `poly branch create --json` | `success`, `new_branch_id`, `branch_name` |
+| `poly branch current --json` | `current_branch` |
+| `poly format --json` | `success`, `check_only`, `format_errors`, `affected`, `ty_ran`, `ty_returncode`, `ty_timed_out` |
+| `poly init --json` | `success`, `root_path` |
+
+Error responses always include `{ "success": false, "error": "..." }`.
+
+!!! info "`init` with `--json` requires explicit flags"
+
+    When using `poly init --json`, you must supply `--region`, `--account_id`, and `--project_id` explicitly. Interactive prompts are not supported in JSON mode.
+
+### `poly push --output-json-commands`
+
+Adds a `commands` array to the JSON output of `poly push`, containing the serialized Agent Studio commands that were staged. Useful for dry-run review and integration testing.
+
+~~~bash
+poly push --json --dry-run --output-json-commands
+~~~
+
+The output will include a `commands` key with each command serialized from its protobuf representation.
+
+### Driving pull/push from a captured projection
+
+The `--from-projection` flag on `pull`, `push`, `init`, and `branch switch` lets you supply a projection JSON directly (as a string or via stdin with `-`) instead of fetching it from the API. This is useful for offline workflows and integration testing.
+
+~~~bash
+poly pull --from-projection - < projection.json
+poly push --from-projection '{"topics": [...], ...}'
+cat projection.json | poly pull --from-projection -
+~~~
+
+The `--output-json-projection` flag on `pull`, `init`, and `branch switch` includes the projection in the JSON output when `--json` is also set. This lets you capture a projection from one command and feed it into another.
+
+~~~bash
+poly pull --json --output-json-projection | jq .projection > proj.json
+poly push --from-projection - < proj.json
+~~~
+
 
 ## Working pattern
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -154,14 +154,34 @@ poly validate
 
 ### `poly review`
 
-Create a GitHub gist for reviewing changes.
+Create a GitHub Gist of Agent Studio project changes to share with others.
+
+Running `poly review` without a subcommand creates a new gist comparing local changes against the remote project. Use `--before` and `--after` to compare two remote branches or versions.
 
 Examples:
 
 ~~~bash
 poly review
 poly review --before main --after feature-branch
-poly review --delete
+~~~
+
+#### `poly review list`
+
+Interactively select a review gist and open it in the browser.
+
+~~~bash
+poly review list
+poly review list --json
+~~~
+
+#### `poly review delete`
+
+Interactively select and delete review gists. Use `--id` to delete a specific gist directly without an interactive prompt.
+
+~~~bash
+poly review delete
+poly review delete --id GIST_ID
+poly review delete --json
 ~~~
 
 ### `poly chat`

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -191,8 +191,6 @@ poly docs --all --output rules.md
 
 Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools — pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
 
-Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools - pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
-
 ## Machine-readable JSON output
 
 All core subcommands accept a `--json` flag that switches stdout to a single JSON object. This is designed for scripting, CI pipelines, and any integration that needs stable, parseable output rather than human-readable console text.


### PR DESCRIPTION
## Summary

This PR relates to https://github.com/polyai/adk/pull/45 and updates API key generation info 

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->