### PR TITLE
fix: Add directory walking to account for topics with '/' in name

### DIFF
--- a/src/poly/resources/topic.py
+++ b/src/poly/resources/topic.py
@@ -160,9 +160,10 @@ class Topic(YamlResource):
         if not os.path.exists(topics_path):
             return discovered_topics
 
-        for file_name in os.listdir(topics_path):
-            if file_name.endswith(".yaml") or file_name.endswith(".yml"):
-                file_path = os.path.join(topics_path, file_name)
-                discovered_topics.append(file_path)
+        for dirpath, _, filenames in os.walk(topics_path):
+            for file_name in filenames:
+                if file_name.endswith(".yaml") or file_name.endswith(".yml"):
+                    file_path = os.path.join(dirpath, file_name)
+                    discovered_topics.append(file_path)
 
         return discovered_topics

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1335,6 +1335,40 @@ example_queries: []
             self.assertEqual(result.content, "")
             self.assertEqual(result.example_queries, [])
 
+    def test_discover_resources(self):
+        """Test discovering topic YAML files from the topics directory."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            topics_dir = os.path.join(tmpdir, "topics")
+            os.makedirs(topics_dir)
+            open(os.path.join(topics_dir, "billing.yaml"), "w").close()
+            open(os.path.join(topics_dir, "support.yaml"), "w").close()
+            open(os.path.join(topics_dir, "not_a_topic.txt"), "w").close()
+
+            discovered = Topic.discover_resources(tmpdir)
+            self.assertEqual(len(discovered), 2)
+            self.assertIn(os.path.join(topics_dir, "billing.yaml"), discovered)
+            self.assertIn(os.path.join(topics_dir, "support.yaml"), discovered)
+
+    def test_discover_resources_nonexistent_path(self):
+        """discover_resources returns empty list when topics directory doesn't exist."""
+        self.assertEqual(Topic.discover_resources("/nonexistent"), [])
+
+    def test_discover_resources_finds_topics_in_subdirectories(self):
+        """Topics with '/' in the name create subdirectories; discover_resources should find them."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmpdir:
+            topics_dir = os.path.join(tmpdir, "topics")
+            nested_dir = os.path.join(topics_dir, "billing")
+            os.makedirs(nested_dir)
+            open(os.path.join(topics_dir, "support.yaml"), "w").close()
+            open(os.path.join(nested_dir, "payments.yaml"), "w").close()
+
+            discovered = Topic.discover_resources(tmpdir)
+            self.assertEqual(len(discovered), 2)
+            self.assertIn(os.path.join(topics_dir, "support.yaml"), discovered)
+            self.assertIn(os.path.join(nested_dir, "payments.yaml"), discovered)
+
 
 TEST_DISCLAIMER = VoiceDisclaimerMessage(
     resource_id="disclaimer_123",


### PR DESCRIPTION
## Summary

Fix topic discovery to find YAML files in nested subdirectories by replacing `os.listdir` with `os.walk` in `Topic.discover_resources`.

## Motivation

Topics whose names contain `/` (e.g. `billing/payments`) are stored in subdirectories under `topics/`. The previous implementation used `os.listdir`, which only scanned the top-level directory and silently missed these nested topic files.

## Changes

- `Topic.discover_resources` now recursively walks the `topics/` directory tree to find all `.yaml`/`.yml` files
- Added unit tests for `discover_resources`: basic discovery, nonexistent path, and nested subdirectory cases

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)