### PR TITLE
fix: Raise proper error message for invalid format functions

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -21,6 +21,7 @@ from typing import Any, Optional
 import argcomplete
 import requests
 import questionary
+import traceback
 
 from poly.output.console import (
     console,
@@ -695,129 +696,137 @@ class AgentStudioCLI:
         else:
             logging.basicConfig(level=logging.WARNING)
 
-        if args.command == "init":
-            cls.init_project(
-                args.base_path,
-                args.region,
-                args.account_id,
-                args.project_id,
-                args.format,
-                args.from_projection,
-                output_json=args.json,
-                output_json_projection=args.output_json_projection,
-            )
-
-        elif args.command == "pull":
-            cls.pull(
-                args.path,
-                args.force,
-                args.format,
-                args.from_projection,
-                output_json=args.json,
-                output_json_projection=args.output_json_projection,
-            )
-
-        elif args.command == "push":
-            cls.push(
-                args.path,
-                args.force,
-                args.skip_validation,
-                args.dry_run,
-                args.format,
-                args.email,
-                args.from_projection,
-                output_json=args.json,
-                output_commands=args.output_json_commands,
-            )
-
-        elif args.command == "status":
-            cls.status(args.path, args.json)
-
-        elif args.command == "revert":
-            cls.revert(args.path, args.all, args.files, output_json=args.json)
-
-        elif args.command == "diff":
-            cls.diff(args.path, args.files, args.json)
-
-        elif args.command == "review":
-            if args.review_subcommand == "delete":
-                cls.delete_gists(gist_id=args.id, output_json=args.json)
-            elif args.review_subcommand == "list":
-                cls.list_gists(output_json=args.json)
-            else:
-                if args.before and args.after:
-                    cls.review(
-                        base_path=args.path,
-                        before_name=args.before,
-                        after_name=args.after,
-                        output_json=args.json,
-                    )
-                else:
-                    cls.review(args.path, output_json=args.json)
-
-        elif args.command == "branch":
-            if args.branch_subcommand == "list":
-                cls.branch_list(args.path, args.json)
-
-            elif args.branch_subcommand == "create":
-                cls.branch_create(
-                    args.path,
-                    args.branch_name,
-                    args.json,
-                    getattr(args, "environment", None),
-                    getattr(args, "force", False),
-                )
-
-            elif args.branch_subcommand == "switch":
-                cls.branch_switch(
-                    args.path,
-                    args.branch_name,
-                    getattr(args, "force", False),
-                    getattr(args, "format", False),
-                    args.json,
+        try:
+            if args.command == "init":
+                cls.init_project(
+                    args.base_path,
+                    args.region,
+                    args.account_id,
+                    args.project_id,
+                    args.format,
+                    args.from_projection,
+                    output_json=args.json,
                     output_json_projection=args.output_json_projection,
-                    from_projection=args.from_projection,
                 )
 
-            elif args.branch_subcommand == "current":
-                cls.get_current_branch(args.path, args.json)
+            elif args.command == "pull":
+                cls.pull(
+                    args.path,
+                    args.force,
+                    args.format,
+                    args.from_projection,
+                    output_json=args.json,
+                    output_json_projection=args.output_json_projection,
+                )
 
-            elif args.branch_subcommand == "delete":
-                cls.branch_delete(args.path, args.branch_name, args.json)
+            elif args.command == "push":
+                cls.push(
+                    args.path,
+                    args.force,
+                    args.skip_validation,
+                    args.dry_run,
+                    args.format,
+                    args.email,
+                    args.from_projection,
+                    output_json=args.json,
+                    output_commands=args.output_json_commands,
+                )
 
-        elif args.command == "format":
-            cls.format(
-                args.path,
-                args.files,
-                getattr(args, "check", False),
-                getattr(args, "ty", False),
-                output_json=args.json,
-            )
+            elif args.command == "status":
+                cls.status(args.path, args.json)
 
-        elif args.command == "validate":
-            cls.validate_project(args.path, args.json)
+            elif args.command == "revert":
+                cls.revert(args.path, args.all, args.files, output_json=args.json)
 
-        elif args.command == "docs":
-            cls.docs(
-                documents=args.documents,
-                all_documents=getattr(args, "all", False),
-                output=getattr(args, "output", None),
-            )
+            elif args.command == "diff":
+                cls.diff(args.path, args.files, args.json)
 
-        elif args.command == "chat":
-            show_all = args.metadata
-            cls.chat(
-                args.path,
-                args.environment,
-                args.variant,
-                args.channel,
-                show_functions=show_all or args.functions,
-                show_flow=show_all or args.flows,
-                show_state=show_all or args.state,
-            )
+            elif args.command == "review":
+                if args.review_subcommand == "delete":
+                    cls.delete_gists(gist_id=args.id, output_json=args.json)
+                elif args.review_subcommand == "list":
+                    cls.list_gists(output_json=args.json)
+                else:
+                    if args.before and args.after:
+                        cls.review(
+                            base_path=args.path,
+                            before_name=args.before,
+                            after_name=args.after,
+                            output_json=args.json,
+                        )
+                    else:
+                        cls.review(args.path, output_json=args.json)
 
-        elif args.command == "completion":
-            cls.print_completion(args.shell)
+            elif args.command == "branch":
+                if args.branch_subcommand == "list":
+                    cls.branch_list(args.path, args.json)
+
+                elif args.branch_subcommand == "create":
+                    cls.branch_create(
+                        args.path,
+                        args.branch_name,
+                        args.json,
+                        getattr(args, "environment", None),
+                        getattr(args, "force", False),
+                    )
+
+                elif args.branch_subcommand == "switch":
+                    cls.branch_switch(
+                        args.path,
+                        args.branch_name,
+                        getattr(args, "force", False),
+                        getattr(args, "format", False),
+                        args.json,
+                        output_json_projection=args.output_json_projection,
+                        from_projection=args.from_projection,
+                    )
+
+                elif args.branch_subcommand == "current":
+                    cls.get_current_branch(args.path, args.json)
+
+                elif args.branch_subcommand == "delete":
+                    cls.branch_delete(args.path, args.branch_name, args.json)
+
+            elif args.command == "format":
+                cls.format(
+                    args.path,
+                    args.files,
+                    getattr(args, "check", False),
+                    getattr(args, "ty", False),
+                    output_json=args.json,
+                )
+
+            elif args.command == "validate":
+                cls.validate_project(args.path, args.json)
+
+            elif args.command == "docs":
+                cls.docs(
+                    documents=args.documents,
+                    all_documents=getattr(args, "all", False),
+                    output=getattr(args, "output", None),
+                )
+
+            elif args.command == "chat":
+                show_all = args.metadata
+                cls.chat(
+                    args.path,
+                    args.environment,
+                    args.variant,
+                    args.channel,
+                    show_functions=show_all or args.functions,
+                    show_flow=show_all or args.flows,
+                    show_state=show_all or args.state,
+                )
+
+            elif args.command == "completion":
+                cls.print_completion(args.shell)
+
+        except Exception as e:
+            if hasattr(args, "json") and args.json:
+                json_print({"success": False, "error": str(e), "traceback": traceback.format_exc()})
+                sys.exit(1)
+            else:
+                raise
 
     @classmethod
     def print_completion(cls, shell: str) -> None:

--- a/src/poly/docs/functions.md
+++ b/src/poly/docs/functions.md
@@ -38,7 +38,7 @@ flows/{flow_name}/
 ## Decorators
 
 - **`@func_description('...')`** (required for global and transition functions): Description shown to the LLM to decide when to call the function.
-- **`@func_parameter('param_name', '...')`** (required for each parameter except `conv` and `flow`): Description of the parameter shown to the LLM.
+- **`@func_parameter('param_name', '...')`** (required for each parameter except `conv` and `flow`): Description of the parameter shown to the LLM. All parameters must also have a typed Python annotation (e.g. `booking_ref: str`)
 - **`@func_latency_control(...)`** (optional): Configure delay messages while the function runs.
 
 Function steps do not support `@func_parameter` or `@func_description`.

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1106,7 +1106,7 @@ class AgentStudioProject:
                     "hash"
                 )
 
-                has_changed, _ = resource.get_status(original_resource_hash)
+                has_changed = resource.is_modified(original_resource_hash)
 
                 if has_changed:
                     updated_resources.setdefault(resource_type, {})[resource_id] = resource
@@ -1595,15 +1595,21 @@ class AgentStudioProject:
                 os.path.relpath(kept_local_resource_mapping.file_path, self.root_path),
                 {},
             ).get("hash")
+
+            local_content = kept_local_resource_mapping.resource_type.read_from_file(
+                kept_local_resource_mapping.file_path
+            )
+            if resource_utils.contains_merge_conflict(local_content):
+                files_with_conflicts.append(kept_local_resource_mapping.file_path)
+                continue
+
             local_resource = self.read_local_resource(
                 resource=kept_local_resource_mapping, resource_mappings=local_resources_mappings
             )
 
-            modified, has_conflict = local_resource.get_status(original_hash)
+            modified = local_resource.is_modified(original_hash)
             if modified:
                 modified_files.append(kept_local_resource_mapping.file_path)
-            if has_conflict:
-                files_with_conflicts.append(kept_local_resource_mapping.file_path)
 
         return files_with_conflicts, modified_files, new_files, deleted_files
 
@@ -1649,11 +1655,24 @@ class AgentStudioProject:
                 os.path.relpath(local_resource_mapping.file_path, self.root_path), {}
             ).get("hash")
 
+            local_content = local_resource_mapping.resource_type.read_from_file(
+                local_resource_mapping.file_path
+            )
+            if resource_utils.contains_merge_conflict(local_content):
+                original_resource = self.resources.get(
+                    local_resource_mapping.resource_type, {}
+                ).get(local_resource_mapping.resource_id)
+                original_content = original_resource.raw if original_resource else ""
+                diffs[local_resource_mapping.file_path] = resource_utils.get_diff(
+                    original_content, local_content
+                )
+                continue
+
             local_resource = self.read_local_resource(
                 resource=local_resource_mapping, resource_mappings=local_resources_mappings
             )
 
-            modified, _ = local_resource.get_status(original_hash)
+            modified = local_resource.is_modified(original_hash)
             if not modified:
                 continue
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1912,7 +1912,7 @@ class AgentStudioProject:
             )
         except Exception as e:
             raise ValueError(
-                f"Error reading resource {resource.resource_name} at {resource.file_path}"
+                f"Error reading resource {resource.resource_name} at {resource.file_path}: {str(e)}"
             ) from e
 
         return resource

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -572,59 +572,58 @@ class Function(Resource):
         parameters: list[FunctionParameters] = []
         description: str = None
         latency_control = FunctionLatencyControl()
-        try:
-            target = Function._get_target_function(code, function_name)
-            if target:
-                removable_lines: set[int] = set()
-                for decorator in target.decorator_list:
-                    if not (hasattr(decorator, "func") and hasattr(decorator.func, "id")):
-                        continue
+        target = Function._get_target_function(code, function_name)
+        if target:
+            removable_lines: set[int] = set()
+            for decorator in target.decorator_list:
+                if not (hasattr(decorator, "func") and hasattr(decorator.func, "id")):
+                    continue
 
-                    decorator_name = decorator.func.id
+                decorator_name = decorator.func.id
 
-                    if decorator_name == "func_parameter" and len(decorator.args) == 2:
-                        name, desc = (arg.value for arg in decorator.args)
-                        _type = next(
-                            (arg.annotation.id for arg in target.args.args if arg.arg == name),
-                            None,
+                if decorator_name == "func_parameter" and len(decorator.args) == 2:
+                    name, desc = (arg.value for arg in decorator.args)
+                    matched_arg = next((arg for arg in target.args.args if arg.arg == name), None)
+                    if matched_arg is None or matched_arg.annotation is None:
+                        raise ValueError(
+                            f"Parameter {name!r} has no type annotation. "
+                            f"Supported types: str, int, float, bool."
                         )
-                        if not _type:
-                            raise SyntaxError(f"Parameter {name!r} is missing a type.")
-
-                        _id = next(
-                            (param.id for param in known_parameters if param.name == name),
-                            f"PARAMETER-{uuid.uuid4().hex[:8]}",
+                    if not hasattr(matched_arg.annotation, "id"):
+                        raise ValueError(
+                            f"Parameter {name!r} has an unsupported type annotation. "
+                            f"Supported types: str, int, float, bool."
                         )
+                    _type = matched_arg.annotation.id
 
-                        if _type in PY_TO_SCHEMA:
-                            parameters.append(
-                                FunctionParameters(
-                                    id=_id,
-                                    name=name,
-                                    description=desc,
-                                    type=PY_TO_SCHEMA[_type],
-                                )
-                            )
-                            removable_lines.update(
-                                range(decorator.lineno - 1, decorator.end_lineno)
-                            )
-                    elif decorator_name == "func_description" and len(decorator.args) == 1:
-                        description = (decorator.args[0].value).strip()
-                        removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
-
-                    elif decorator_name == "func_latency_control":
-                        latency_control = Function._parse_latency_control_decorator(
-                            decorator, known_latency_control
-                        )
-                        removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
-
-                if removable_lines:
-                    lines = code.splitlines(True)
-                    code = "".join(
-                        line for idx, line in enumerate(lines) if idx not in removable_lines
+                    _id = next(
+                        (param.id for param in known_parameters if param.name == name),
+                        f"PARAMETER-{uuid.uuid4().hex[:8]}",
                     )
-        except SyntaxError as e:
-            logger.error(f"error while extracting decorators from function e={e!r}")
+
+                    if _type in PY_TO_SCHEMA:
+                        parameters.append(
+                            FunctionParameters(
+                                id=_id,
+                                name=name,
+                                description=desc,
+                                type=PY_TO_SCHEMA[_type],
+                            )
+                        )
+                        removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
+                elif decorator_name == "func_description" and len(decorator.args) == 1:
+                    description = (decorator.args[0].value).strip()
+                    removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
+
+                elif decorator_name == "func_latency_control":
+                    latency_control = Function._parse_latency_control_decorator(
+                        decorator, known_latency_control
+                    )
+                    removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
+
+            if removable_lines:
+                lines = code.splitlines(True)
+                code = "".join(line for idx, line in enumerate(lines) if idx not in removable_lines)
         return code, parameters, description, latency_control
 
     @staticmethod

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -155,22 +155,18 @@ class Resource(BaseResource, ABC):
         """
         pass
 
-    def get_status(self, other_hash: str) -> tuple[bool, bool]:
-        """Check if the status of the resource
-        Has it changed locally and if it has a merge conflict
+    def is_modified(self, other_hash: str) -> bool:
+        """
 
         Args:
             other_hash (str): The other resource hash to compare to.
 
         Returns:
-            tuple[bool, bool]: A tuple containing two booleans:
-                - True if the resource has changed locally
-                - True if the resource has a merge conflict
+            bool: True if the resource has changed locally, False otherwise.
         """
         current_hash = self.compute_hash()
         modified = other_hash != current_hash
-        has_conflict = utils.contains_merge_conflict(self.raw)
-        return modified, has_conflict
+        return modified
 
     def get_diff(self, other_resource: "Resource") -> str:
         """Get the diff of the resource compared to the local version.

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -558,7 +558,7 @@ class ProjectStatusTest(unittest.TestCase):
         self.assertEqual(
             files_with_conflicts, [os.path.join(TEST_DIR, "functions", "test_function.py")]
         )
-        self.assertEqual(modified_files, [os.path.join(TEST_DIR, "functions", "test_function.py")])
+        self.assertEqual(modified_files, [])
         self.assertEqual(new_files, [])
         self.assertEqual(deleted_files, [])
 

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -837,6 +837,30 @@ def test_code(conv: Conversation, test_param: int):
         func.code = 'def trans_func(conv: Conversation, flow: Flow):\n    # conv.goto_flow("Missing Flow")\n    conv.goto_flow("Other Flow")\n'
         self.assertIsNone(func.validate(resource_mappings=resource_mappings))
 
+    def test_extract_decorators_untyped_parameter_raises_value_error(self):
+        """A parameter without a type annotation raises ValueError."""
+        code = """@func_description('Book a table')
+@func_parameter('booking_ref', 'The booking reference')
+def my_func(conv: Conversation, booking_ref):
+    pass
+"""
+        with self.assertRaises(ValueError) as ctx:
+            Function._extract_decorators(code, "my_func", [])
+        self.assertIn("booking_ref", str(ctx.exception))
+        self.assertIn("has no type annotation", str(ctx.exception))
+
+    def test_extract_decorators_complex_type_annotation_raises_value_error(self):
+        """A parameter with a complex annotation (e.g. Optional[str]) raises ValueError."""
+        code = """@func_description('Book a table')
+@func_parameter('booking_ref', 'The booking reference')
+def my_func(conv: Conversation, booking_ref: Optional[str]):
+    pass
+"""
+        with self.assertRaises(ValueError) as ctx:
+            Function._extract_decorators(code, "my_func", [])
+        self.assertIn("booking_ref", str(ctx.exception))
+        self.assertIn("unsupported type annotation", str(ctx.exception))
+
 
 TEST_TOPIC = Topic(
     resource_id="123",


### PR DESCRIPTION
## Summary

Fixes two related issues: untyped or unsupported function parameters now raise a clear `ValueError` instead of crashing with `AttributeError`, and merge-conflicted files are correctly excluded from `modified_files` in `project_status` and handled without crashing in `get_diffs`. Also surfaces all CLI errors as structured JSON when `--json` is set.

## Motivation

In v0.6.x, functions with untyped parameters (e.g. `def f(conv, booking_ref)`) caused `_extract_decorators` to crash with `AttributeError: 'NoneType' has no attribute 'id'`. Separately, files with merge conflicts were being passed to `read_local_resource`, which would now raise rather than silently fail. Both issues needed to be fixed together for `poly status` and `poly diff` to be reliable after a branch pull with conflicts.

Closes #<!-- issue number -->

## Changes

- `_extract_decorators`: guard `arg.annotation` access before reading `.id`; raise `ValueError` with a distinct message for missing vs unsupported type annotations; remove the `try/except SyntaxError` wrapper so errors propagate to the user
- `resource.py`: rename `get_status` → `is_modified`, removing merge conflict detection from the resource itself
- `project_status`: check for merge conflicts on raw file content before calling `read_local_resource`; conflicted files now appear only in `files_with_conflicts`, not also in `modified_files`
- `get_diffs`: same conflict-before-parse pattern; shows diff of conflict markers vs original; fix `type(resource_type)` key bug and missing second arg to `get_diff`
- `cli.py`: wrap the command dispatch in `try/except`; when `--json` is set, errors are returned as `{"success": false, "error": "...", "traceback": "..."}` instead of raising
- `src/poly/docs/functions.md`: note that all parameters must have a supported type annotation

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->