### PR TITLE
fix: allow ?query ending for API operations

### DIFF
--- a/src/poly/resources/api_integration.py
+++ b/src/poly/resources/api_integration.py
@@ -30,9 +30,10 @@ from poly.resources.resource import (
 
 logger = logging.getLogger(__name__)
 
-# RFC 3986 path chars + {param} placeholders (e.g. /users/{id}/orders)
+# RFC 3986 path + {param} placeholders; optional ?query (query allows pchar, /, ?)
 OPERATION_RESOURCE_PATTERN = re.compile(
-    r"^(/([a-zA-Z0-9._~!$&'()*+,;=:@%-]|%[0-9A-Fa-f]{2}|\{[a-zA-Z_][a-zA-Z0-9_]*\})*)+$"
+    r"^(/([a-zA-Z0-9._~!$&'()*+,;=:@%-]|%[0-9A-Fa-f]{2}|\{[a-zA-Z_][a-zA-Z0-9_]*\})*)+"
+    r"(?:\?([a-zA-Z0-9._~!$&'()*+,;=:@%/?-]|%[0-9A-Fa-f]{2}|\{[a-zA-Z_][a-zA-Z0-9_]*\})*)?$"
 )
 
 AVAILABLE_OPERATIONS = {"GET", "POST", "PATCH", "PUT", "DELETE"}

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -5928,6 +5928,20 @@ class TestApiIntegrationValidate(unittest.TestCase):
         )
         integration.validate()  # should not raise
 
+    def test_operation_resource_with_query_string_is_valid(self):
+        """Validation accepts resources with an optional ?query (e.g. fixed query params)."""
+        integration = self._make_integration(
+            operations=[
+                ApiIntegrationOperation(
+                    resource_id="op-1",
+                    name="create_patient",
+                    method="POST",
+                    resource="/Patient/Create?locationId={location_id}",
+                ),
+            ]
+        )
+        integration.validate()  # should not raise
+
     def test_duplicate_operation_name_and_method_raises_value_error(self):
         """Validation rejects two operations that share the same name and method."""
         integration = self._make_integration(


### PR DESCRIPTION
## Summary
Update validation regex to allow API operation with ?query ending
<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->