### PR TITLE
fix: don't delete or fail to update conditions when their parent step…

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -872,6 +872,8 @@ class SyncClientHandler:
         # the variable will be deleted as well. So we need to delete variables
         # first or its delete command will fail.
         Variable,
+        # Conditions should be deleted before steps, as steps auto delete their conditions
+        Condition,
     ]
 
     PRIORITY_UPDATE_TYPES = [

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1585,10 +1585,13 @@ class AgentStudioProject:
                     continue
 
                 deleted_original_step = next(
-                    step
-                    for step in deleted_steps
-                    if step.flow_id == condition.flow_id
-                    and step.step_id == original_condition.child_step
+                    (
+                        step
+                        for step in deleted_steps
+                        if step.flow_id == condition.flow_id
+                        and step.step_id == original_condition.child_step
+                    ),
+                    None,
                 )
                 if deleted_original_step:
                     new_resources.setdefault(Condition, {})[condition_id] = condition

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -26,6 +26,7 @@ from poly.resources import (
     BaseFlowStep,
     ChatGreeting,
     ChatStylePrompt,
+    Condition,
     Entity,
     ExperimentalConfig,
     FlowConfig,
@@ -1545,6 +1546,53 @@ class AgentStudioProject:
         for variant in updated_variants:
             if not variant.is_default:
                 updated_resources[Variant].pop(variant.resource_id, None)
+
+        # Don't delete condition if parent step is being deleted
+        for flow_step in list(deleted_resources.get(FlowStep, {}).values()):
+            for condition in flow_step.conditions:
+                deleted_resources.get(Condition, {}).pop(condition.resource_id, None)
+
+        # If we are deleting a step and pointing a condition to a different step, the delete will auto delete the condition so the update will fail. We should instead make it a create
+        deleted_steps = list(deleted_resources.get(FlowStep, {}).values()) + list(
+            deleted_resources.get(FunctionStep, {}).values()
+        )
+        updated_conditions = list(updated_resources.get(Condition, {}).items())
+        if deleted_steps:
+            flows_with_deleted_steps = {deleted_step.flow_id for deleted_step in deleted_steps}
+            for condition_id, condition in updated_conditions:
+                if condition.flow_id not in flows_with_deleted_steps:
+                    continue
+                original_flow_step: FlowStep = next(
+                    (
+                        flow_step
+                        for flow_step in self.resources.get(FlowStep, {}).values()
+                        if flow_step.flow_id == condition.flow_id
+                        and flow_step.step_id == condition.step_id
+                    ),
+                    None,
+                )
+                if not original_flow_step:
+                    continue
+                original_condition: Condition = next(
+                    (
+                        cond
+                        for cond in original_flow_step.conditions
+                        if cond.resource_id == condition_id
+                    ),
+                    None,
+                )
+                if not original_condition:
+                    continue
+
+                deleted_original_step = next(
+                    step
+                    for step in deleted_steps
+                    if step.flow_id == condition.flow_id
+                    and step.step_id == original_condition.child_step
+                )
+                if deleted_original_step:
+                    new_resources.setdefault(Condition, {})[condition_id] = condition
+                    updated_resources.get(Condition, {}).pop(condition_id, None)
 
         return PushPhaseChangeSet(
             main=ResourceChangeSet(

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -1539,6 +1539,101 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertNotIn(var_id, cleaned_deleted.get(Variable, {}))
         self.assertNotIn(var_id, cleaned_new.get(Variable, {}))
 
+    def test_clean_resources_before_push_does_not_delete_condition_when_parent_step_deleted(self):
+        """When a FlowStep is deleted, its conditions should not be in deleted_resources."""
+        condition = Condition(
+            resource_id="CONDITION-cond-1",
+            name="cond-1",
+            condition_type="step_condition",
+            step_id="step-1",
+            flow_id="flow-123",
+            child_step="step-2",
+        )
+        flow_step = FlowStep(
+            resource_id="flow-123_step-1",
+            step_id="step-1",
+            name="Step 1",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            step_type=StepType.ADVANCED_STEP,
+            prompt="Hello",
+            conditions=[condition],
+        )
+
+        deleted_resources = {
+            FlowStep: {"flow-123_step-1": flow_step},
+            Condition: {"CONDITION-cond-1": condition},
+        }
+
+        push_changes = self.project._clean_resources_before_push(
+            {},
+            {},
+            {},
+            deleted_resources,
+        )
+        cleaned_deleted = push_changes.main.deleted
+
+        # The step should still be deleted
+        self.assertIn("flow-123_step-1", cleaned_deleted.get(FlowStep, {}))
+        # But the condition belonging to that step should NOT be deleted
+        self.assertNotIn("CONDITION-cond-1", cleaned_deleted.get(Condition, {}))
+
+    def test_clean_resources_before_push_condition_update_becomes_create_when_original_target_step_deleted(self):
+        """When a condition is updated but its original child_step is being deleted,
+        move it from updated to new (the platform auto-deletes the condition on step delete,
+        so an update would fail)."""
+        original_condition = Condition(
+            resource_id="CONDITION-cond-1",
+            name="cond-1",
+            condition_type="step_condition",
+            step_id="step-1",
+            flow_id="flow-123",
+            child_step="step-to-delete",
+        )
+        original_flow_step = FlowStep(
+            resource_id="flow-123_step-1",
+            step_id="step-1",
+            name="Step 1",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            step_type=StepType.ADVANCED_STEP,
+            prompt="Hello",
+            conditions=[original_condition],
+        )
+        step_to_delete = FlowStep(
+            resource_id="flow-123_step-to-delete",
+            step_id="step-to-delete",
+            name="Step To Delete",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            step_type=StepType.ADVANCED_STEP,
+            prompt="Goodbye",
+        )
+        updated_condition = Condition(
+            resource_id="CONDITION-cond-1",
+            name="cond-1",
+            condition_type="step_condition",
+            step_id="step-1",
+            flow_id="flow-123",
+            child_step="step-new-target",
+        )
+
+        self.project.resources.setdefault(FlowStep, {})["flow-123_step-1"] = original_flow_step
+
+        push_changes = self.project._clean_resources_before_push(
+            {},
+            {},
+            {Condition: {"CONDITION-cond-1": updated_condition}},
+            {FlowStep: {"flow-123_step-to-delete": step_to_delete}},
+        )
+        cleaned_new = push_changes.main.new
+        cleaned_updated = push_changes.main.updated
+
+        # Condition should be promoted to a create
+        self.assertIn("CONDITION-cond-1", cleaned_new.get(Condition, {}))
+        # And removed from updated
+        self.assertNotIn("CONDITION-cond-1", cleaned_updated.get(Condition, {}))
+
 
 class PushProjectTest(unittest.TestCase):
     """Tests for the push_project method"""


### PR DESCRIPTION
## Summary

Fixes two bugs in `_clean_resources_before_push` that caused push failures when a flow step with conditions was deleted.

## Motivation

When a FlowStep is deleted, Agent Studio automatically deletes its child Conditions server-side. This caused two issues:
1. Explicitly including the condition in `deleted_resources` would result in a double-delete error.
2. If a condition was also being *updated* (e.g. re-pointed to a new step), the update request would fail because the platform had already deleted the condition when the step was removed.

## Changes

- Strip conditions from `deleted_resources` when their parent `FlowStep` is being deleted (platform handles the cascade)
- Promote affected conditions from `updated_resources` to `new_resources` when their original `child_step` is being deleted in the same push

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
