### PR TITLE
docs: fix: Raise proper error message for invalid format functions

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -260,7 +260,7 @@ The exact fields vary by command. Common fields include:
 
 For `poly branch delete --json`, when a branch that was the current branch is deleted, the response also includes `"switched_to": "main"`.
 
-Error responses always include `{ "success": false, "error": "..." }`.
+Error responses always include `{ "success": false, "error": "...", "traceback": "..." }`.
 
 !!! info "`init` with `--json` requires explicit flags"
 

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -105,6 +105,10 @@ Global and transition functions use decorators to describe themselves to the mod
 
 Function steps do not support `@func_description` or `@func_parameter`.
 
+!!! warning "All parameters must have a type annotation"
+
+    Every parameter decorated with `@func_parameter` must have a Python type annotation (for example, `booking_ref: str`). Parameters without an annotation, or with an unsupported annotation such as `Optional[str]`, will raise a `ValueError` when the function is processed. Only the types listed in the table below are supported.
+
 ## Parameter types
 
 Supported parameter types map to schema types as follows:


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->