### PR TITLE
fix: Allow specifying lang code in chat requests

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -633,6 +633,21 @@ class AgentStudioCLI:
             help="Name of variant to use for the chat session.",
         )
         chat_parser.add_argument(
+            "--lang",
+            type=str,
+            help="Language tag for both input and output messages (e.g. en-US, fr-FR). If not specified use default for project",
+        )
+        chat_parser.add_argument(
+            "--input-lang",
+            type=str,
+            help="Language tag for input messages (e.g. en-US, fr-FR). If not specified use default for project",
+        )
+        chat_parser.add_argument(
+            "--output-lang",
+            type=str,
+            help="Language tag for output messages (e.g. en-US, fr-FR). If not specified use default for project",
+        )
+        chat_parser.add_argument(
             "--channel",
             type=str,
             default="voice",
@@ -809,11 +824,15 @@ class AgentStudioCLI:
 
             elif args.command == "chat":
                 show_all = args.metadata
+                input_lang = args.input_lang or args.lang
+                output_lang = args.output_lang or args.lang
                 cls.chat(
                     args.path,
                     args.environment,
                     args.variant,
                     args.channel,
+                    input_lang=input_lang,
+                    output_lang=output_lang,
                     show_functions=show_all or args.functions,
                     show_flow=show_all or args.flows,
                     show_state=show_all or args.state,
@@ -1983,6 +2002,8 @@ class AgentStudioCLI:
         environment: str = None,
         variant: str = None,
         channel: str = None,
+        input_lang: str = None,
+        output_lang: str = None,
         show_functions: bool = False,
         show_flow: bool = False,
         show_state: bool = False,
@@ -2021,6 +2042,8 @@ class AgentStudioCLI:
                     environment,
                     channel,
                     variant,
+                    input_lang,
+                    output_lang,
                 )
             except (requests.HTTPError, ValueError) as e:
                 error(f"Failed to create chat session: {e}")
@@ -2052,6 +2075,8 @@ class AgentStudioCLI:
                 project,
                 conversation_id,
                 environment,
+                input_lang=input_lang,
+                output_lang=output_lang,
                 show_functions=show_functions,
                 show_flow=show_flow,
                 show_state=show_state,
@@ -2068,6 +2093,8 @@ class AgentStudioCLI:
         project: AgentStudioProject,
         conversation_id: str,
         environment: str,
+        input_lang: str = None,
+        output_lang: str = None,
         show_functions: bool = False,
         show_flow: bool = False,
         show_state: bool = False,
@@ -2097,9 +2124,7 @@ class AgentStudioCLI:
 
                 try:
                     reply = project.send_message(
-                        conversation_id,
-                        user_input,
-                        environment,
+                        conversation_id, user_input, environment, input_lang, output_lang
                     )
                 except requests.HTTPError as e:
                     error(f"Failed to send message: {e}")

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -287,6 +287,8 @@ class AgentStudioInterface:
         environment: str = "sandbox",
         variant_id: Optional[str] = None,
         channel: str = "chat.polyai",
+        input_lang: Optional[str] = None,
+        output_lang: Optional[str] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -302,7 +304,14 @@ class AgentStudioInterface:
             dict: The API response containing the conversation ID and initial greeting
         """
         return PlatformAPIHandler.create_chat(
-            region, account_id, project_id, environment, variant_id, channel
+            region,
+            account_id,
+            project_id,
+            environment,
+            variant_id,
+            channel,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     @staticmethod
@@ -313,6 +322,8 @@ class AgentStudioInterface:
         conversation_id: str,
         text: str,
         environment: str = "sandbox",
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Send a message to an existing chat conversation.
 
@@ -328,7 +339,14 @@ class AgentStudioInterface:
             dict: The API response containing the assistant's reply
         """
         return PlatformAPIHandler.send_chat_message(
-            region, account_id, project_id, conversation_id, text, environment
+            region,
+            account_id,
+            project_id,
+            conversation_id,
+            text,
+            environment,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     def get_branch_chat_info(self, branch_id: str) -> dict:
@@ -355,6 +373,8 @@ class AgentStudioInterface:
         lambda_deployment_version: str,
         channel: str = "chat.polyai",
         variant_id: Optional[str] = None,
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -378,6 +398,8 @@ class AgentStudioInterface:
             lambda_deployment_version,
             channel,
             variant_id,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     @staticmethod
@@ -387,6 +409,8 @@ class AgentStudioInterface:
         project_id: str,
         conversation_id: str,
         text: str,
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Send a message to an existing draft chat conversation.
 
@@ -406,6 +430,8 @@ class AgentStudioInterface:
             project_id,
             conversation_id,
             text,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     @staticmethod

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -221,6 +221,8 @@ class PlatformAPIHandler:
         environment: str = "sandbox",
         variant_id: ty.Optional[str] = None,
         channel: str = "chat.polyai",
+        input_lang: ty.Optional[str] = None,
+        output_lang: ty.Optional[str] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -230,6 +232,9 @@ class PlatformAPIHandler:
             project_id: The project ID
             environment: The environment to chat against (sandbox, pre-release, live)
             variant_id: Optional variant ID (e.g. 'Voice')
+            channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
+            input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
+            output_lang: Optional language code for the agent's response,
 
         Returns:
             dict: The API response containing the conversation ID
@@ -241,6 +246,10 @@ class PlatformAPIHandler:
         }
         if variant_id:
             data["variant_id"] = variant_id
+        if input_lang:
+            data["asr_lang_code"] = input_lang
+        if output_lang:
+            data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -251,6 +260,8 @@ class PlatformAPIHandler:
         conversation_id: str,
         text: str,
         environment: str = "sandbox",
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Send a message to an existing chat conversation.
 
@@ -261,6 +272,8 @@ class PlatformAPIHandler:
             conversation_id: The conversation ID
             text: The user message text
             environment: The environment (sandbox, pre-release, live)
+            input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
+            output_lang: Optional language code for the agent's response, e.g. "en-
 
         Returns:
             dict: The API response containing the assistant's reply
@@ -271,6 +284,10 @@ class PlatformAPIHandler:
             conversation_id=conversation_id,
         )
         data = {"message": text, "client_env": environment}
+        if input_lang:
+            data["asr_lang_code"] = input_lang
+        if output_lang:
+            data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -311,6 +328,8 @@ class PlatformAPIHandler:
         lambda_deployment_version: str,
         channel: str = "chat.polyai",
         variant_id: ty.Optional[str] = None,
+        input_lang: ty.Optional[str] = None,
+        output_lang: ty.Optional[str] = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -322,6 +341,8 @@ class PlatformAPIHandler:
             lambda_deployment_version: Branch lambda version from sourcerer
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             variant_id: Optional variant ID (e.g. 'Voice')
+            input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
+            output_lang: Optional language code for the agent's response, e.g. "en-
 
         Returns:
             dict: The API response containing the conversation ID
@@ -334,6 +355,10 @@ class PlatformAPIHandler:
         }
         if variant_id:
             data["variant_id"] = variant_id
+        if input_lang:
+            data["asr_lang_code"] = input_lang
+        if output_lang:
+            data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -343,6 +368,8 @@ class PlatformAPIHandler:
         project_id: str,
         conversation_id: str,
         text: str,
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Send a message to an existing draft chat conversation.
 
@@ -352,6 +379,8 @@ class PlatformAPIHandler:
             project_id: The project ID
             conversation_id: The conversation ID
             text: The user message text
+            input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
+            output_lang: Optional language code for the agent's response, e.g. "en-
 
         Returns:
             dict: The API response containing the assistant's reply
@@ -362,4 +391,8 @@ class PlatformAPIHandler:
             conversation_id=conversation_id,
         )
         data = {"message": text}
+        if input_lang:
+            data["asr_lang_code"] = input_lang
+        if output_lang:
+            data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2257,6 +2257,8 @@ class AgentStudioProject:
         environment: str,
         channel: str,
         variant: Optional[str],
+        input_lang: Optional[str] = None,
+        output_lang: Optional[str] = None,
     ) -> dict:
         """Create a chat session (standard or draft).
 
@@ -2267,6 +2269,8 @@ class AgentStudioProject:
             environment (str): The environment to create the chat session in: draft, sandbox, pre-release or live.
             channel (str): The channel to create the chat session in: chat.polyai or webchat.polyai.
             variant (ty.Optional[str]): The variant ID to create the chat session in.
+            input_lang (str): Optional. The language code for the input messages, e.g. "en-GB" or "fr-FR".
+            output_lang (str): Optional. The language code for the agent's responses, e.g. "en-GB" or "fr-FR".
 
         Returns:
             dict: API response with conversation_id and initial greeting.
@@ -2291,6 +2295,8 @@ class AgentStudioProject:
                 lambda_deployment_version=lambda_deployment_version,
                 channel=channel,
                 variant_id=variant,
+                input_lang=input_lang,
+                output_lang=output_lang,
             )
 
         return AgentStudioInterface.create_chat(
@@ -2300,6 +2306,8 @@ class AgentStudioProject:
             environment=environment,
             variant_id=variant,
             channel=channel,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     def send_message(
@@ -2307,6 +2315,8 @@ class AgentStudioProject:
         conversation_id: str,
         text: str,
         environment: str,
+        input_lang: str = None,
+        output_lang: str = None,
     ) -> dict:
         """Send a message to an active chat conversation.
 
@@ -2314,6 +2324,8 @@ class AgentStudioProject:
             conversation_id (str): The ID of the conversation to send the message to.
             text (str): The user message text to send.
             environment (str): The environment of the conversation: draft, sandbox, pre-release or live.
+            input_lang (str): Optional. The language code of the input message, e.g. "en-GB" or "fr-FR".
+            output_lang (str): Optional. The language code for the agent's response, e.g. "en-GB" or "fr-FR".
 
         Returns:
             dict: API response with the agent's reply.
@@ -2328,6 +2340,8 @@ class AgentStudioProject:
                 project_id=self.project_id,
                 conversation_id=conversation_id,
                 text=text,
+                input_lang=input_lang,
+                output_lang=output_lang,
             )
         return AgentStudioInterface.send_chat_message(
             region=self.region,
@@ -2336,6 +2350,8 @@ class AgentStudioProject:
             conversation_id=conversation_id,
             text=text,
             environment=environment,
+            input_lang=input_lang,
+            output_lang=output_lang,
         )
 
     def end_chat(


### PR DESCRIPTION
## Summary

Adds `--lang`, `--input-lang`, and `--output-lang` flags to `poly chat`, allowing users to specify language codes for ASR (input) and TTS (output) when starting or continuing a chat session.

## Motivation

Users chatting against multilingual agents need a way to specify the expected input/output language without relying on the project default. This exposes the existing `asr_lang_code` / `tts_lang_code` API fields via the CLI.

## Changes

- Added `--lang`, `--input-lang`, `--output-lang` arguments to the `chat` subcommand in `cli.py`
- `--lang` sets both input and output lang; `--input-lang`/`--output-lang` override individually
- Threaded `input_lang` / `output_lang` through `AgentStudioProject.create_chat_session`, `send_message`, `AgentStudioInterface`, and `PlatformAPIHandler` for both standard and draft/branch chat flows
- Maps `input_lang` → `asr_lang_code` and `output_lang` → `tts_lang_code` in API request payloads

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
<img width="1596" height="214" alt="Screenshot 2026-04-15 at 12 05 11" src="https://github.com/user-attachments/assets/721b5ee0-5cec-4b4e-b5ca-194df29a732a" />

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->