### PR TITLE
docs: fix API key provisioning — self-generated, not provided by contact

### DIFF
--- a/docs/docs/get-started/access-and-waitlist.md
+++ b/docs/docs/get-started/access-and-waitlist.md
@@ -16,7 +16,7 @@ To use the ADK, you must have:
 - access to a **PolyAI Agent Studio workspace**
 - an **API key**
 
-Both are provided by your PolyAI contact. Without them, the ADK cannot connect to Agent Studio.
+Workspace access is provided by your PolyAI contact. Once you have access, you generate your own API key directly inside Agent Studio — see [Prerequisites](./prerequisites.md) for the steps. Without both, the ADK cannot connect to Agent Studio.
 
 ## Requesting access
 

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -51,7 +51,19 @@ https://studio.poly.ai/<account_id>/<project_id>/...
 
 Copy both values — you will need them in the next step.
 
-### Step 5 — Pull the agent into the ADK
+### Step 5 — Generate an API key
+
+The ADK uses an API key to authenticate with Agent Studio. In your workspace, open the **API Keys** tab (next to the **Users** tab) and click **+ API key** to generate one.
+
+Then set it as an environment variable:
+
+```bash
+export POLY_ADK_KEY=<your-api-key>
+```
+
+To make it permanent, add the export line to your shell profile (`~/.zshrc` or `~/.bashrc`).
+
+### Step 6 — Pull the agent into the ADK
 
 Once the [ADK is installed](./installation.md), link your local folder to the project and pull its configuration down:
 
@@ -64,7 +76,7 @@ poly pull
 
 You now have a fully editable local copy of your agent.
 
-### Step 6 — Continue with the ADK
+### Step 7 — Continue with the ADK
 
 From here, the standard ADK workflow applies. You can:
 
@@ -106,16 +118,16 @@ Your local folder will mirror the project in Agent Studio and you can begin edit
 
 ## Next step
 
-Now that you have an agent in Agent Studio, the next thing you need is an **API key** — this is what allows the ADK to authenticate with Agent Studio and pull your project locally. Head to the prerequisites page to generate one and install the required local tools.
+Install the ADK and confirm your local tools are in place before running your first commands.
 
 <div class="grid cards" markdown>
 
--   **Prerequisites**
+-   **Installation**
 
     ---
 
-    Generate your API key and confirm the local tools needed before installation.
-    [Open prerequisites](./prerequisites.md)
+    Install the ADK and set up your local environment.
+    [Open installation](./installation.md)
 
 -   **What is the ADK?**
 

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -64,10 +64,10 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 
 Before continuing, confirm:
 
-- [ ] You have access to an **Agent Studio workspace**
-- [ ] You have generated an **API key** in Agent Studio
-- [ ] `uv` is installed
-- [ ] `git` is available locally
+- You have access to an **Agent Studio workspace**
+- You have generated an **API key** in Agent Studio
+- `uv` is installed
+- `git` is available locally
 
 ## Next step
 

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -65,7 +65,7 @@ See the [uv installation guide](https://docs.astral.sh/uv/getting-started/instal
 Before continuing, confirm:
 
 - [ ] You have access to an **Agent Studio workspace**
-- [ ] You have obtained an **API key** from your PolyAI contact
+- [ ] You have generated an **API key** in Agent Studio
 - [ ] `uv` is installed
 - [ ] `git` is available locally
 


### PR DESCRIPTION
## Summary

Corrects the inaccurate claim that both workspace access and the API key are provided by a PolyAI contact. The API key is self-generated by the user inside Agent Studio.

## Motivation

The docs stated "Both are provided by your PolyAI contact" — this is wrong for the API key. It also meant the Getting Started flow sent users to Prerequisites for an API key *after* they'd already been told to run `poly pull`, which requires the key.

## Changes

- `access-and-waitlist.md`: distinguish workspace access (from contact) vs API key (self-generated in Agent Studio)
- `prerequisites.md`: update checklist item from "obtained from your PolyAI contact" to "generated in Agent Studio"
- `get-started.md`: add **Step 5 — Generate an API key** (with `POLY_ADK_KEY` env var export) between finding account/project IDs and pulling; renumber Steps 5–6 → 6–7; replace the misplaced "Next step → Prerequisites" CTA with "Next step → Installation"

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)