### PR TITLE
fix: Don't show diff for reordered entities

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -371,7 +371,7 @@ class FlowStep(BaseFlowStep, YamlResource):
 
         if self.step_type == StepType.DEFAULT_STEP:
             output["conditions"] = [condition.to_yaml_dict() for condition in self.conditions]
-            output["extracted_entities"] = self.extracted_entities
+            output["extracted_entities"] = sorted(self.extracted_entities)
 
         output["prompt"] = self.prompt
         return output

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -722,6 +722,22 @@ class GetDiffsTest(unittest.TestCase):
         func_path = os.path.join(TEST_DIR, "functions", "extra_function.py")
         self.assertNotIn(func_path, diffs)
 
+    def test_get_diffs_no_diff_for_reordered_extracted_entities(self):
+        """Reordering extracted_entities should not produce a diff."""
+        project_data = deepcopy(PROJECT_DATA)
+        # Reverse the extracted_entities order so it differs from local YAML
+        step = project_data["resources"]["flow_steps"][
+            "test_flow_with_punctuation!_welcome_step"
+        ]
+        step["extracted_entities"] = list(reversed(step["extracted_entities"]))
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+        diffs = project.get_diffs(all_files=True)
+
+        step_path = os.path.join(
+            "flows", "test_flow_with_punctuation!", "steps", "welcome_step.yaml"
+        )
+        self.assertNotIn(step_path, diffs)
+
 
 class CleanResourcesBeforePushTest(unittest.TestCase):
     """Tests for the _clean_resources_before_push method"""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -3479,6 +3479,27 @@ prompt: This is a default step
             self.assertEqual(exit_cond.exit_flow_position, {"x": 10.0, "y": 10.0})
             self.assertEqual(exit_cond.description, "Exit the flow")
 
+    def test_to_yaml_dict_sorts_extracted_entities(self):
+        """Extracted entities should be sorted alphabetically in YAML output."""
+        step = FlowStep(
+            resource_id="flow-123_step-1",
+            step_id="step-1",
+            name="Test Step",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            step_type=StepType.DEFAULT_STEP,
+            asr_biasing=None,
+            dtmf_config=None,
+            conditions=[],
+            extracted_entities=["zebra", "apple", "mango"],
+            prompt="Extract some entities.",
+            position={"x": 0.0, "y": 0.0},
+        )
+
+        result = step.to_yaml_dict()
+
+        self.assertEqual(result["extracted_entities"], ["apple", "mango", "zebra"])
+
 
 class EntityTests(unittest.TestCase):
     def test_validate_entity(self):


### PR DESCRIPTION
## Summary

Fix spurious diffs after push caused by `extracted_entities` list ordering differences between local YAML and the platform.

## Motivation

After pushing, `poly diff` shows reordering-only changes to `extracted_entities` in flow steps. The platform returns entity IDs in a different order than local YAML, producing false diffs with no meaningful content change.

## Changes

- Sort `extracted_entities` in `FlowStep.to_yaml_dict()` so both local and remote representations use a consistent alphabetical order

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->