### PR TITLE
feat: add deployment promote and rollback commands

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2829,7 +2829,7 @@ class AgentStudioCLI:
 
         try:
             project.promote_deployment(
-                deployment_version.get("id"), to_env, message=message or deployment_message
+                deployment_version.get("id"), to_env, message=message or deployment_message or ""
             )
             if output_json:
                 json_print({"success": True})
@@ -2890,7 +2890,7 @@ class AgentStudioCLI:
 
         try:
             project.rollback_deployment(
-                deployment_version.get("id"), message=message or deployment_message
+                deployment_version.get("id"), message=message or deployment_message or ""
             )
             if output_json:
                 json_print({"success": True})

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3215,7 +3215,7 @@ class AgentStudioCLI:
         deployment_message = deployment_metadata.get("deployment_message")
         if not output_json and not force:
             confirm_msg = (
-                f"Promoting deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"Promoting deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
                 f"{deployment_message or '-'}' to [info]{to_env}[/info]?"
             )
             console.print(f"{confirm_msg}")
@@ -3276,7 +3276,7 @@ class AgentStudioCLI:
         deployment_message = deployment_metadata.get("deployment_message")
         if not output_json and not force:
             confirm_msg = (
-                f"Rolling back sandbox to deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"Rolling back sandbox to deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
                 f"{deployment_message or '-'}'?"
             )
             console.print(f"{confirm_msg}")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -878,7 +878,7 @@ class AgentStudioCLI:
 
         deployment_list_parser = deployments_subparsers.add_parser(
             "list",
-            parents=[deployments_path_parent, json_parent],
+            parents=[deployments_path_parent, json_parent, verbose_parent],
             help="List deployments for the project.",
             description=(
                 "List deployments for the project.\n\n"
@@ -922,7 +922,7 @@ class AgentStudioCLI:
 
         deployment_promote_parser = deployments_subparsers.add_parser(
             "promote",
-            parents=[deployments_path_parent, json_parent],
+            parents=[deployments_path_parent, json_parent, verbose_parent],
             help="Promote a deployment to the next environment.",
             description=(
                 "Promote a deployment to the next environment.\n\nExamples:\n  poly deployments promote --from <deployment_id> --to <target_env>\n"
@@ -3198,9 +3198,13 @@ class AgentStudioCLI:
         else:
             deployment_hash = from_deployment
 
-        deployment_version = next(
-            (v for v in versions if v.get("version_hash", "")[:9] == deployment_hash[:9]),
-            None,
+        deployment_version, deployment_index = next(
+            (
+                (v, i)
+                for i, v in enumerate(versions)
+                if v.get("version_hash", "")[:9] == deployment_hash[:9]
+            ),
+            (None, None),
         )
 
         if not deployment_version:
@@ -3213,22 +3217,48 @@ class AgentStudioCLI:
 
         deployment_metadata = deployment_version.get("deployment_metadata", {})
         deployment_message = deployment_metadata.get("deployment_message")
-        if not output_json and not force:
-            confirm_msg = (
-                f"Promoting deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
-                f"{deployment_message or '-'}' to [info]{to_env}[/info]?"
+
+        # Compute changes between this deployment and the currently active deployment in the target environment
+        previous_deployment = active_deployment_hashes.get(to_env)
+        previous_version, previous_index = next(
+            (
+                (v, i)
+                for i, v in enumerate(versions)
+                if v.get("version_hash", "") == previous_deployment
+            ),
+            (None, None),
+        )
+
+        changes = []
+        if previous_version and previous_index > deployment_index:
+            changes = versions[deployment_index:previous_index]
+
+        if not output_json:
+            plain(
+                f"Promoting hash [bold]{deployment_version.get('version_hash', '')[:9]}[/bold] to [info]{to_env}[/info]"
             )
-            console.print(f"{confirm_msg}")
-            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+            if not changes:
+                plain(f"Rolling back to an earlier version: {deployment_message or '-'}")
+            else:
+                plain(f"Changes included:")
+                print_deployments(changes, {})
+
+        if not output_json and not force:
+            if not questionary.confirm(
+                "Confirm Deployment?", default=False, auto_enter=False
+            ).ask():
                 warning("Aborted.")
                 sys.exit(0)
+
+            if not message:
+                message = questionary.text("Deployment message (default: merge message):").ask()
 
         try:
             project.promote_deployment(
                 deployment_version.get("id"), to_env, message=message or deployment_message or ""
             )
             if output_json:
-                json_print({"success": True})
+                json_print({"success": True, "changes_deployed": changes})
             else:
                 success(f"Deployment {from_deployment} promoted to {to_env}.")
         except Exception as e:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3161,7 +3161,7 @@ class AgentStudioCLI:
         base_path: str,
         from_deployment: str,
         to_env: str,
-        message: str = None,
+        message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
     ) -> None:
@@ -3243,7 +3243,7 @@ class AgentStudioCLI:
         cls,
         base_path: str,
         deployment: str,
-        message: str = None,
+        message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
     ):

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -878,6 +878,9 @@ class AgentStudioCLI:
             action="store_true",
             help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
         )
+        deployment_promote_parser.add_argument(
+            "--debug", action="store_true", help="Display debug logs."
+        )
 
         deployment_rollback_parser = deployments_subparsers.add_parser(
             "rollback",

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3159,7 +3159,7 @@ class AgentStudioCLI:
         sandbox_versions: list[dict[str, Any]],
         target_hash: str,
         predecessor_hash: str | None,
-    ) -> list[dict[str, Any]]:
+    ) -> tuple[list[dict[str, Any]], bool]:
         """Slice sandbox history to find deployments between two versions.
 
         For promotions (target is newer), returns deployments from target
@@ -3175,17 +3175,17 @@ class AgentStudioCLI:
                 the target env, or None if this is the first deployment.
 
         Returns:
-            List of sandbox deployments between target and predecessor.
+            Tuple of (included deployments, is_rollback).
         """
         target_idx = next(
             (i for i, v in enumerate(sandbox_versions) if v.get("version_hash") == target_hash),
             None,
         )
         if target_idx is None:
-            return []
+            return [], False
 
         if not predecessor_hash:
-            return sandbox_versions[target_idx:]
+            return sandbox_versions[target_idx:], False
 
         pred_idx = next(
             (
@@ -3196,12 +3196,12 @@ class AgentStudioCLI:
             None,
         )
         if pred_idx is None:
-            return sandbox_versions[target_idx:]
+            return sandbox_versions[target_idx:], False
 
         if pred_idx < target_idx:
-            return sandbox_versions[pred_idx:target_idx]
+            return sandbox_versions[pred_idx:target_idx], True
 
-        return sandbox_versions[target_idx:pred_idx]
+        return sandbox_versions[target_idx:pred_idx], False
 
     @classmethod
     def deployments_promote(
@@ -3278,35 +3278,10 @@ class AgentStudioCLI:
         else:
             sandbox_versions, _ = project.get_deployments("sandbox")
 
-        included = cls._resolve_included_deployments(
+        included, is_rollback = cls._resolve_included_deployments(
             sandbox_versions, target_full_hash, predecessor_hash
         )
         result["included_deployments"] = included
-
-        is_rollback = False
-        if predecessor_hash:
-            pred_sandbox_idx = next(
-                (
-                    i
-                    for i, v in enumerate(sandbox_versions)
-                    if v.get("version_hash") == predecessor_hash
-                ),
-                None,
-            )
-            target_sandbox_idx = next(
-                (
-                    i
-                    for i, v in enumerate(sandbox_versions)
-                    if v.get("version_hash") == target_full_hash
-                ),
-                None,
-            )
-            if (
-                pred_sandbox_idx is not None
-                and target_sandbox_idx is not None
-                and target_sandbox_idx > pred_sandbox_idx
-            ):
-                is_rollback = True
 
         if not output_json:
             plain(f"Promoting hash [bold]{result['from_hash'][:9]}[/bold] to [info]{to_env}[/info]")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -957,7 +957,36 @@ class AgentStudioCLI:
             help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
         )
 
-        deployment_promote_parser.add_argument(
+        deployment_rollback_parser = deployments_subparsers.add_parser(
+            "rollback",
+            parents=[deployments_path_parent, json_parent],
+            help="Rollback sandbox/main to a previous version.",
+            description=(
+                "Rollback a deployment to a previous version.\n\nExamples:\n  poly deployments rollback --to <deployment_id>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        deployment_rollback_parser.add_argument(
+            "--to",
+            dest="to_deployment",
+            type=str,
+            required=True,
+            help="ID/env of the deployment to rollback to.",
+        )
+        deployment_rollback_parser.add_argument(
+            "--message",
+            "-m",
+            type=str,
+            required=False,
+            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+        )
+        deployment_rollback_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force the rollback without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
+        )
+
+        deployment_rollback_parser.add_argument(
             "--debug", action="store_true", help="Display debug logs."
         )
 
@@ -1148,6 +1177,14 @@ class AgentStudioCLI:
                         args.path,
                         args.from_deployment,
                         args.to_env,
+                        args.message,
+                        force=args.force,
+                        output_json=args.json,
+                    )
+                elif args.deployments_subcommand == "rollback":
+                    cls.deployments_rollback(
+                        args.path,
+                        args.to_deployment,
                         args.message,
                         force=args.force,
                         output_json=args.json,
@@ -3196,6 +3233,67 @@ class AgentStudioCLI:
                 json_print({"success": False, "error": str(e)})
             else:
                 error(f"Failed to promote deployment: {e}")
+            sys.exit(1)
+
+    @classmethod
+    def deployments_rollback(
+        cls,
+        base_path: str,
+        deployment: str,
+        message: str = None,
+        force: bool = False,
+        output_json: bool = False,
+    ):
+        """Rollback sandbox/main to a previous deployment."""
+        project = cls._load_project(base_path, output_json=output_json)
+
+        versions, active_deployment_hashes = project.get_deployments("sandbox")
+
+        deployment_hash = None
+        # Resolve deployment to full version hash
+        if deployment in active_deployment_hashes:
+            deployment_hash = active_deployment_hashes[deployment]
+        else:
+            deployment_hash = deployment
+
+        deployment_version = next(
+            (v for v in versions if v.get("version_hash", "")[:9] == deployment_hash[:9]),
+            None,
+        )
+
+        if not deployment_version:
+            msg = f"Deployment '{deployment}' not found in sandbox."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        deployment_metadata = deployment_version.get("deployment_metadata", {})
+        deployment_message = deployment_metadata.get("deployment_message")
+        if not output_json and not force:
+            confirm_msg = (
+                f"Rolling back sandbox to deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"{deployment_message or '-'}'?"
+            )
+            console.print(f"{confirm_msg}")
+            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+                warning("Aborted.")
+                sys.exit(0)
+
+        try:
+            project.rollback_deployment(
+                deployment_version.get("id"), message=message or deployment_message
+            )
+            if output_json:
+                json_print({"success": True})
+            else:
+                success(f"Sandbox rolled back to deployment {deployment}.")
+        except Exception as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(f"Failed to rollback deployment: {e}")
             sys.exit(1)
 
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2819,7 +2819,7 @@ class AgentStudioCLI:
         deployment_message = deployment_metadata.get("deployment_message")
         if not output_json and not force:
             confirm_msg = (
-                f"Promoting deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"Promoting deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
                 f"{deployment_message or '-'}' to [info]{to_env}[/info]?"
             )
             console.print(f"{confirm_msg}")
@@ -2880,7 +2880,7 @@ class AgentStudioCLI:
         deployment_message = deployment_metadata.get("deployment_message")
         if not output_json and not force:
             confirm_msg = (
-                f"Rolling back sandbox to deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"Rolling back sandbox to deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
                 f"{deployment_message or '-'}'?"
             )
             console.print(f"{confirm_msg}")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -990,6 +990,11 @@ class AgentStudioCLI:
             action="store_true",
             help="Force the rollback without confirmation. When used, the existing deployment message is kept unless --message is provided. This is default in non-interactive mode (e.g. when --json is used)",
         )
+        deployment_rollback_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be rolled back without actually rolling back. Displays the target deployment and reverted deployments.",
+        )
 
         return parser
 
@@ -1190,6 +1195,7 @@ class AgentStudioCLI:
                         args.message,
                         force=args.force,
                         output_json=args.json,
+                        dry_run=args.dry_run,
                     )
 
         except Exception as e:
@@ -3335,6 +3341,7 @@ class AgentStudioCLI:
         message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
+        dry_run: bool = False,
     ) -> None:
         """Rollback sandbox/main to a previous deployment."""
         project = cls._load_project(base_path, output_json=output_json)
@@ -3362,13 +3369,39 @@ class AgentStudioCLI:
 
         deployment_metadata = deployment_version.get("deployment_metadata", {})
         deployment_message = deployment_metadata.get("deployment_message")
-        if not output_json and not force:
-            confirm_msg = (
-                f"Rolling back sandbox to deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
-                f"{deployment_message or '-'}'?"
+
+        # Resolve reverted deployments (current sandbox -> target)
+        target_full_hash = deployment_version.get("version_hash", "")
+        current_sandbox_hash = active_deployment_hashes.get("sandbox")
+        reverted, _ = cls._resolve_included_deployments(
+            versions, current_sandbox_hash, target_full_hash
+        )
+
+        result = {
+            "success": False,
+            "target_hash": target_full_hash,
+            "message": message or deployment_message or "",
+            "reverted_deployments": reverted,
+        }
+
+        if not output_json:
+            plain(
+                f"Rolling back sandbox to deployment "
+                f"'[bold]{target_full_hash[:9]}[/bold]: {deployment_message or '-'}'"
             )
-            plain(f"{confirm_msg}")
-            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+            if reverted:
+                plain(f"Reverting deployments ({len(reverted)}):")
+                print_deployments(reverted, {})
+
+        if dry_run:
+            if output_json:
+                json_print({**result, "dry_run": True})
+            else:
+                plain("[dim]Dry run — no changes were made.[/dim]")
+            return
+
+        if not output_json and not force:
+            if not questionary.confirm("Confirm Rollback?", default=False, auto_enter=False).ask():
                 warning("Aborted.")
                 sys.exit(0)
 
@@ -3377,12 +3410,12 @@ class AgentStudioCLI:
                 deployment_version.get("id"), message=message or deployment_message or ""
             )
             if output_json:
-                json_print({"success": True})
+                json_print({**result, "success": True})
             else:
                 success(f"Sandbox rolled back to deployment {deployment}.")
         except Exception as e:
             if output_json:
-                json_print({"success": False, "error": str(e)})
+                json_print({**result, "error": str(e)})
             else:
                 error(f"Failed to rollback deployment: {e}")
             sys.exit(1)

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -949,7 +949,7 @@ class AgentStudioCLI:
             "-m",
             type=str,
             required=False,
-            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current deployment message will be used instead",
         )
         deployment_promote_parser.add_argument(
             "--force",
@@ -981,7 +981,7 @@ class AgentStudioCLI:
             "-m",
             type=str,
             required=False,
-            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current deployment message will be used instead",
         )
         deployment_rollback_parser.add_argument(
             "--force",

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3154,6 +3154,55 @@ class AgentStudioCLI:
         else:
             print_deployments(versions, active_deployment_hashes, details=details)
 
+    @staticmethod
+    def _resolve_included_deployments(
+        sandbox_versions: list[dict[str, Any]],
+        target_hash: str,
+        predecessor_hash: str | None,
+    ) -> list[dict[str, Any]]:
+        """Slice sandbox history to find deployments between two versions.
+
+        For promotions (target is newer), returns deployments from target
+        to predecessor (target inclusive, predecessor exclusive).
+        For rollbacks (target is older), returns deployments from predecessor
+        to target (predecessor inclusive, target exclusive) — the versions
+        being reverted.
+
+        Args:
+            sandbox_versions: Full sandbox deployment list (newest first).
+            target_hash: Version hash of the deployment being promoted.
+            predecessor_hash: Version hash of the current active deployment in
+                the target env, or None if this is the first deployment.
+
+        Returns:
+            List of sandbox deployments between target and predecessor.
+        """
+        target_idx = next(
+            (i for i, v in enumerate(sandbox_versions) if v.get("version_hash") == target_hash),
+            None,
+        )
+        if target_idx is None:
+            return []
+
+        if not predecessor_hash:
+            return sandbox_versions[target_idx:]
+
+        pred_idx = next(
+            (
+                i
+                for i, v in enumerate(sandbox_versions)
+                if v.get("version_hash") == predecessor_hash
+            ),
+            None,
+        )
+        if pred_idx is None:
+            return sandbox_versions[target_idx:]
+
+        if pred_idx < target_idx:
+            return sandbox_versions[pred_idx:target_idx]
+
+        return sandbox_versions[target_idx:pred_idx]
+
     @classmethod
     def deployments_promote(
         cls,
@@ -3201,13 +3250,9 @@ class AgentStudioCLI:
         else:
             deployment_hash = from_deployment
 
-        deployment_version, deployment_index = next(
-            (
-                (v, i)
-                for i, v in enumerate(versions)
-                if v.get("version_hash", "")[:9] == deployment_hash[:9]
-            ),
-            (None, None),
+        deployment_version = next(
+            (v for v in versions if (v.get("version_hash") or "")[:9] == deployment_hash[:9]),
+            None,
         )
 
         if not deployment_version:
@@ -3224,29 +3269,55 @@ class AgentStudioCLI:
         result["from_hash"] = deployment_version.get("version_hash", "")
         result["message"] = message or deployment_message or ""
 
-        # Compute changes between this deployment and the currently active deployment in the target environment
-        previous_deployment = active_deployment_hashes.get(to_env)
-        previous_version, previous_index = next(
-            (
-                (v, i)
-                for i, v in enumerate(versions)
-                if v.get("version_hash", "") == previous_deployment
-            ),
-            (None, None),
-        )
+        # Resolve included deployments using sandbox as the linear history
+        target_full_hash = deployment_version.get("version_hash", "")
+        predecessor_hash = active_deployment_hashes.get(to_env)
 
-        changes = []
-        if previous_version and previous_index > deployment_index:
-            changes = versions[deployment_index:previous_index]
-        result["changes"] = changes
+        if search_env == "sandbox":
+            sandbox_versions = versions
+        else:
+            sandbox_versions, _ = project.get_deployments("sandbox")
+
+        included = cls._resolve_included_deployments(
+            sandbox_versions, target_full_hash, predecessor_hash
+        )
+        result["included_deployments"] = included
+
+        is_rollback = False
+        if predecessor_hash:
+            pred_sandbox_idx = next(
+                (
+                    i
+                    for i, v in enumerate(sandbox_versions)
+                    if v.get("version_hash") == predecessor_hash
+                ),
+                None,
+            )
+            target_sandbox_idx = next(
+                (
+                    i
+                    for i, v in enumerate(sandbox_versions)
+                    if v.get("version_hash") == target_full_hash
+                ),
+                None,
+            )
+            if (
+                pred_sandbox_idx is not None
+                and target_sandbox_idx is not None
+                and target_sandbox_idx > pred_sandbox_idx
+            ):
+                is_rollback = True
 
         if not output_json:
             plain(f"Promoting hash [bold]{result['from_hash'][:9]}[/bold] to [info]{to_env}[/info]")
-            if not changes:
+            if is_rollback:
                 plain(f"Rolling back to an earlier version: {deployment_message or '-'}")
-            else:
-                plain("Changes included:")
-                print_deployments(changes, {})
+            elif not predecessor_hash:
+                plain(f"First deployment to {to_env}.")
+            if included:
+                label = "Reverting deployments" if is_rollback else "Included deployments"
+                plain(f"{label} ({len(included)}):")
+                print_deployments(included, {})
 
         if dry_run:
             if output_json:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -879,7 +879,36 @@ class AgentStudioCLI:
             help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
         )
 
-        deployment_promote_parser.add_argument(
+        deployment_rollback_parser = deployments_subparsers.add_parser(
+            "rollback",
+            parents=[deployments_path_parent, json_parent],
+            help="Rollback sandbox/main to a previous version.",
+            description=(
+                "Rollback a deployment to a previous version.\n\nExamples:\n  poly deployments rollback --to <deployment_id>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        deployment_rollback_parser.add_argument(
+            "--to",
+            dest="to_deployment",
+            type=str,
+            required=True,
+            help="ID/env of the deployment to rollback to.",
+        )
+        deployment_rollback_parser.add_argument(
+            "--message",
+            "-m",
+            type=str,
+            required=False,
+            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+        )
+        deployment_rollback_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force the rollback without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
+        )
+
+        deployment_rollback_parser.add_argument(
             "--debug", action="store_true", help="Display debug logs."
         )
 
@@ -1065,6 +1094,14 @@ class AgentStudioCLI:
                         args.path,
                         args.from_deployment,
                         args.to_env,
+                        args.message,
+                        force=args.force,
+                        output_json=args.json,
+                    )
+                elif args.deployments_subcommand == "rollback":
+                    cls.deployments_rollback(
+                        args.path,
+                        args.to_deployment,
                         args.message,
                         force=args.force,
                         output_json=args.json,
@@ -2800,6 +2837,67 @@ class AgentStudioCLI:
                 json_print({"success": False, "error": str(e)})
             else:
                 error(f"Failed to promote deployment: {e}")
+            sys.exit(1)
+
+    @classmethod
+    def deployments_rollback(
+        cls,
+        base_path: str,
+        deployment: str,
+        message: str = None,
+        force: bool = False,
+        output_json: bool = False,
+    ):
+        """Rollback sandbox/main to a previous deployment."""
+        project = cls._load_project(base_path, output_json=output_json)
+
+        versions, active_deployment_hashes = project.get_deployments("sandbox")
+
+        deployment_hash = None
+        # Resolve deployment to full version hash
+        if deployment in active_deployment_hashes:
+            deployment_hash = active_deployment_hashes[deployment]
+        else:
+            deployment_hash = deployment
+
+        deployment_version = next(
+            (v for v in versions if v.get("version_hash", "")[:9] == deployment_hash[:9]),
+            None,
+        )
+
+        if not deployment_version:
+            msg = f"Deployment '{deployment}' not found in sandbox."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        deployment_metadata = deployment_version.get("deployment_metadata", {})
+        deployment_message = deployment_metadata.get("deployment_message")
+        if not output_json and not force:
+            confirm_msg = (
+                f"Rolling back sandbox to deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"{deployment_message or '-'}'?"
+            )
+            console.print(f"{confirm_msg}")
+            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+                warning("Aborted.")
+                sys.exit(0)
+
+        try:
+            project.rollback_deployment(
+                deployment_version.get("id"), message=message or deployment_message
+            )
+            if output_json:
+                json_print({"success": True})
+            else:
+                success(f"Sandbox rolled back to deployment {deployment}.")
+        except Exception as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(f"Failed to rollback deployment: {e}")
             sys.exit(1)
 
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -920,6 +920,47 @@ class AgentStudioCLI:
             help="Output each deployment with detailed information.",
         )
 
+        deployment_promote_parser = deployments_subparsers.add_parser(
+            "promote",
+            parents=[deployments_path_parent, json_parent],
+            help="Promote a deployment to the next environment.",
+            description=(
+                "Promote a deployment to the next environment.\n\nExamples:\n  poly deployments promote --from <deployment_id> --to <target_env>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        deployment_promote_parser.add_argument(
+            "--from",
+            dest="from_deployment",
+            type=str,
+            required=True,
+            help="ID/env of the deployment to promote.",
+        )
+        deployment_promote_parser.add_argument(
+            "--to",
+            dest="to_env",
+            type=str,
+            required=True,
+            choices=["pre-release", "live"],
+            help="Target environment to promote to.",
+        )
+        deployment_promote_parser.add_argument(
+            "--message",
+            "-m",
+            type=str,
+            required=False,
+            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+        )
+        deployment_promote_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
+        )
+
+        deployment_promote_parser.add_argument(
+            "--debug", action="store_true", help="Display debug logs."
+        )
+
         return parser
 
     @classmethod
@@ -1101,6 +1142,15 @@ class AgentStudioCLI:
                         args.hash,
                         args.json,
                         args.details,
+                    )
+                elif args.deployments_subcommand == "promote":
+                    cls.deployments_promote(
+                        args.path,
+                        args.from_deployment,
+                        args.to_env,
+                        args.message,
+                        force=args.force,
+                        output_json=args.json,
                     )
 
         except Exception as e:
@@ -3064,6 +3114,89 @@ class AgentStudioCLI:
             json_print(json_output)
         else:
             print_deployments(versions, active_deployment_hashes, details=details)
+
+    @classmethod
+    def deployments_promote(
+        cls,
+        base_path: str,
+        from_deployment: str,
+        to_env: str,
+        message: str = None,
+        force: bool = False,
+        output_json: bool = False,
+    ) -> None:
+        """Promote a deployment to a different environment.
+
+        Args:
+            base_path: Base path for the project.
+            from_deployment: Version hash of the deployment to promote.
+            to_env: Target environment to promote to — pre-release or live.
+            force: If True, bypass confirmation prompt.
+            output_json: If True, print result as JSON instead of rich text.
+        """
+        project = cls._load_project(base_path, output_json=output_json)
+
+        deployment_hash = None
+
+        if to_env not in ["pre-release", "live"]:
+            msg = f"Invalid target environment '{to_env}'. Must be 'pre-release' or 'live'."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if to_env == "live":
+            search_env = "pre-release"
+        else:
+            search_env = "sandbox"
+        versions, active_deployment_hashes = project.get_deployments(search_env)
+
+        # Resolve from_deployment to full version hash
+        if from_deployment in active_deployment_hashes:
+            deployment_hash = active_deployment_hashes[from_deployment]
+        else:
+            deployment_hash = from_deployment
+
+        deployment_version = next(
+            (v for v in versions if v.get("version_hash", "")[:9] == deployment_hash[:9]),
+            None,
+        )
+
+        if not deployment_version:
+            msg = f"Deployment '{from_deployment}' not found in {search_env}."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        deployment_metadata = deployment_version.get("deployment_metadata", {})
+        deployment_message = deployment_metadata.get("deployment_message")
+        if not output_json and not force:
+            confirm_msg = (
+                f"Promoting deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"{deployment_message or '-'}' to [info]{to_env}[/info]?"
+            )
+            console.print(f"{confirm_msg}")
+            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+                warning("Aborted.")
+                sys.exit(0)
+
+        try:
+            project.promote_deployment(
+                deployment_version.get("id"), to_env, message=message or deployment_message
+            )
+            if output_json:
+                json_print({"success": True})
+            else:
+                success(f"Deployment {from_deployment} promoted to {to_env}.")
+        except Exception as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(f"Failed to promote deployment: {e}")
+            sys.exit(1)
 
 
 def main():

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3225,7 +3225,7 @@ class AgentStudioCLI:
 
         try:
             project.promote_deployment(
-                deployment_version.get("id"), to_env, message=message or deployment_message
+                deployment_version.get("id"), to_env, message=message or deployment_message or ""
             )
             if output_json:
                 json_print({"success": True})
@@ -3286,7 +3286,7 @@ class AgentStudioCLI:
 
         try:
             project.rollback_deployment(
-                deployment_version.get("id"), message=message or deployment_message
+                deployment_version.get("id"), message=message or deployment_message or ""
             )
             if output_json:
                 json_print({"success": True})

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2765,7 +2765,7 @@ class AgentStudioCLI:
         base_path: str,
         from_deployment: str,
         to_env: str,
-        message: str = None,
+        message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
     ) -> None:
@@ -2847,7 +2847,7 @@ class AgentStudioCLI:
         cls,
         base_path: str,
         deployment: str,
-        message: str = None,
+        message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
     ):

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -922,7 +922,7 @@ class AgentStudioCLI:
 
         deployment_promote_parser = deployments_subparsers.add_parser(
             "promote",
-            parents=[deployments_path_parent, json_parent, verbose_parent],
+            parents=[deployments_path_parent, json_parent, verbose_parent, debug_parent],
             help="Promote a deployment to the next environment.",
             description=(
                 "Promote a deployment to the next environment.\n\nExamples:\n  poly deployments promote --from <deployment_id> --to <target_env>\n"
@@ -954,15 +954,12 @@ class AgentStudioCLI:
         deployment_promote_parser.add_argument(
             "--force",
             action="store_true",
-            help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
-        )
-        deployment_promote_parser.add_argument(
-            "--debug", action="store_true", help="Display debug logs."
+            help="Force the promotion without confirmation. When used, the existing deployment message is kept unless --message is provided. This is default in non-interactive mode (e.g. when --json is used)",
         )
 
         deployment_rollback_parser = deployments_subparsers.add_parser(
             "rollback",
-            parents=[deployments_path_parent, json_parent],
+            parents=[deployments_path_parent, json_parent, verbose_parent, debug_parent],
             help="Rollback sandbox/main to a previous version.",
             description=(
                 "Rollback a deployment to a previous version.\n\nExamples:\n  poly deployments rollback --to <deployment_id>\n"
@@ -986,11 +983,7 @@ class AgentStudioCLI:
         deployment_rollback_parser.add_argument(
             "--force",
             action="store_true",
-            help="Force the rollback without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
-        )
-
-        deployment_rollback_parser.add_argument(
-            "--debug", action="store_true", help="Display debug logs."
+            help="Force the rollback without confirmation. When used, the existing deployment message is kept unless --message is provided. This is default in non-interactive mode (e.g. when --json is used)",
         )
 
         return parser
@@ -3172,6 +3165,7 @@ class AgentStudioCLI:
             from_deployment: Version hash of the deployment to promote.
             to_env: Target environment to promote to — pre-release or live.
             force: If True, bypass confirmation prompt.
+            message: Optional deployment message to include with the promotion (defaults to original deployment message).
             output_json: If True, print result as JSON instead of rich text.
         """
         project = cls._load_project(base_path, output_json=output_json)
@@ -3240,7 +3234,7 @@ class AgentStudioCLI:
             if not changes:
                 plain(f"Rolling back to an earlier version: {deployment_message or '-'}")
             else:
-                plain(f"Changes included:")
+                plain("Changes included:")
                 print_deployments(changes, {})
 
         if not output_json and not force:
@@ -3282,7 +3276,6 @@ class AgentStudioCLI:
 
         versions, active_deployment_hashes = project.get_deployments("sandbox")
 
-        deployment_hash = None
         # Resolve deployment to full version hash
         if deployment in active_deployment_hashes:
             deployment_hash = active_deployment_hashes[deployment]
@@ -3309,7 +3302,7 @@ class AgentStudioCLI:
                 f"Rolling back sandbox to deployment '{(deployment_version.get('version_hash') or '')[:9]}: "
                 f"{deployment_message or '-'}'?"
             )
-            console.print(f"{confirm_msg}")
+            plain(f"{confirm_msg}")
             if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
                 warning("Aborted.")
                 sys.exit(0)

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -842,6 +842,47 @@ class AgentStudioCLI:
             help="Output each deployment with detailed information.",
         )
 
+        deployment_promote_parser = deployments_subparsers.add_parser(
+            "promote",
+            parents=[deployments_path_parent, json_parent],
+            help="Promote a deployment to the next environment.",
+            description=(
+                "Promote a deployment to the next environment.\n\nExamples:\n  poly deployments promote --from <deployment_id> --to <target_env>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        deployment_promote_parser.add_argument(
+            "--from",
+            dest="from_deployment",
+            type=str,
+            required=True,
+            help="ID/env of the deployment to promote.",
+        )
+        deployment_promote_parser.add_argument(
+            "--to",
+            dest="to_env",
+            type=str,
+            required=True,
+            choices=["pre-release", "live"],
+            help="Target environment to promote to.",
+        )
+        deployment_promote_parser.add_argument(
+            "--message",
+            "-m",
+            type=str,
+            required=False,
+            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+        )
+        deployment_promote_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
+        )
+
+        deployment_promote_parser.add_argument(
+            "--debug", action="store_true", help="Display debug logs."
+        )
+
         return parser
 
     @classmethod
@@ -1018,6 +1059,15 @@ class AgentStudioCLI:
                         args.hash,
                         args.json,
                         args.details,
+                    )
+                elif args.deployments_subcommand == "promote":
+                    cls.deployments_promote(
+                        args.path,
+                        args.from_deployment,
+                        args.to_env,
+                        args.message,
+                        force=args.force,
+                        output_json=args.json,
                     )
 
         except Exception as e:
@@ -2668,6 +2718,89 @@ class AgentStudioCLI:
             json_print(json_output)
         else:
             print_deployments(versions, active_deployment_hashes, details=details)
+
+    @classmethod
+    def deployments_promote(
+        cls,
+        base_path: str,
+        from_deployment: str,
+        to_env: str,
+        message: str = None,
+        force: bool = False,
+        output_json: bool = False,
+    ) -> None:
+        """Promote a deployment to a different environment.
+
+        Args:
+            base_path: Base path for the project.
+            from_deployment: Version hash of the deployment to promote.
+            to_env: Target environment to promote to — pre-release or live.
+            force: If True, bypass confirmation prompt.
+            output_json: If True, print result as JSON instead of rich text.
+        """
+        project = cls._load_project(base_path, output_json=output_json)
+
+        deployment_hash = None
+
+        if to_env not in ["pre-release", "live"]:
+            msg = f"Invalid target environment '{to_env}'. Must be 'pre-release' or 'live'."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if to_env == "live":
+            search_env = "pre-release"
+        else:
+            search_env = "sandbox"
+        versions, active_deployment_hashes = project.get_deployments(search_env)
+
+        # Resolve from_deployment to full version hash
+        if from_deployment in active_deployment_hashes:
+            deployment_hash = active_deployment_hashes[from_deployment]
+        else:
+            deployment_hash = from_deployment
+
+        deployment_version = next(
+            (v for v in versions if v.get("version_hash", "")[:9] == deployment_hash[:9]),
+            None,
+        )
+
+        if not deployment_version:
+            msg = f"Deployment '{from_deployment}' not found in {search_env}."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        deployment_metadata = deployment_version.get("deployment_metadata", {})
+        deployment_message = deployment_metadata.get("deployment_message")
+        if not output_json and not force:
+            confirm_msg = (
+                f"Promoting deployment '{deployment_version.get('version_hash')[:9]}: "
+                f"{deployment_message or '-'}' to [info]{to_env}[/info]?"
+            )
+            console.print(f"{confirm_msg}")
+            if not questionary.confirm("Confirm?", default=False, auto_enter=False).ask():
+                warning("Aborted.")
+                sys.exit(0)
+
+        try:
+            project.promote_deployment(
+                deployment_version.get("id"), to_env, message=message or deployment_message
+            )
+            if output_json:
+                json_print({"success": True})
+            else:
+                success(f"Deployment {from_deployment} promoted to {to_env}.")
+        except Exception as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(f"Failed to promote deployment: {e}")
+            sys.exit(1)
 
 
 def main():

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -956,6 +956,9 @@ class AgentStudioCLI:
             action="store_true",
             help="Force the promotion without confirmation. This is default in non-interactive mode (e.g. when --json is used)",
         )
+        deployment_promote_parser.add_argument(
+            "--debug", action="store_true", help="Display debug logs."
+        )
 
         deployment_rollback_parser = deployments_subparsers.add_parser(
             "rollback",

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -956,6 +956,11 @@ class AgentStudioCLI:
             action="store_true",
             help="Force the promotion without confirmation. When used, the existing deployment message is kept unless --message is provided. This is default in non-interactive mode (e.g. when --json is used)",
         )
+        deployment_promote_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be promoted without actually promoting. Displays the deployment hash, target environment, and changes included.",
+        )
 
         deployment_rollback_parser = deployments_subparsers.add_parser(
             "rollback",
@@ -1176,6 +1181,7 @@ class AgentStudioCLI:
                         args.message,
                         force=args.force,
                         output_json=args.json,
+                        dry_run=args.dry_run,
                     )
                 elif args.deployments_subcommand == "rollback":
                     cls.deployments_rollback(
@@ -3157,6 +3163,7 @@ class AgentStudioCLI:
         message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
+        dry_run: bool = False,
     ) -> None:
         """Promote a deployment to a different environment.
 
@@ -3167,15 +3174,17 @@ class AgentStudioCLI:
             force: If True, bypass confirmation prompt.
             message: Optional deployment message to include with the promotion (defaults to original deployment message).
             output_json: If True, print result as JSON instead of rich text.
+            dry_run: If True, show what would be promoted without actually promoting.
         """
         project = cls._load_project(base_path, output_json=output_json)
 
+        result: dict = {"success": False, "to_env": to_env}
         deployment_hash = None
 
         if to_env not in ["pre-release", "live"]:
             msg = f"Invalid target environment '{to_env}'. Must be 'pre-release' or 'live'."
             if output_json:
-                json_print({"success": False, "error": msg})
+                json_print({**result, "error": msg})
             else:
                 error(msg)
             sys.exit(1)
@@ -3204,13 +3213,16 @@ class AgentStudioCLI:
         if not deployment_version:
             msg = f"Deployment '{from_deployment}' not found in {search_env}."
             if output_json:
-                json_print({"success": False, "error": msg})
+                json_print({**result, "error": msg})
             else:
                 error(msg)
             sys.exit(1)
 
         deployment_metadata = deployment_version.get("deployment_metadata", {})
         deployment_message = deployment_metadata.get("deployment_message")
+
+        result["from_hash"] = deployment_version.get("version_hash", "")
+        result["message"] = message or deployment_message or ""
 
         # Compute changes between this deployment and the currently active deployment in the target environment
         previous_deployment = active_deployment_hashes.get(to_env)
@@ -3226,16 +3238,22 @@ class AgentStudioCLI:
         changes = []
         if previous_version and previous_index > deployment_index:
             changes = versions[deployment_index:previous_index]
+        result["changes"] = changes
 
         if not output_json:
-            plain(
-                f"Promoting hash [bold]{deployment_version.get('version_hash', '')[:9]}[/bold] to [info]{to_env}[/info]"
-            )
+            plain(f"Promoting hash [bold]{result['from_hash'][:9]}[/bold] to [info]{to_env}[/info]")
             if not changes:
                 plain(f"Rolling back to an earlier version: {deployment_message or '-'}")
             else:
                 plain("Changes included:")
                 print_deployments(changes, {})
+
+        if dry_run:
+            if output_json:
+                json_print({**result, "dry_run": True})
+            else:
+                plain("[dim]Dry run — no changes were made.[/dim]")
+            return
 
         if not output_json and not force:
             if not questionary.confirm(
@@ -3246,18 +3264,19 @@ class AgentStudioCLI:
 
             if not message:
                 message = questionary.text("Deployment message (default: merge message):").ask()
+                result["message"] = message or deployment_message or ""
 
         try:
             project.promote_deployment(
-                deployment_version.get("id"), to_env, message=message or deployment_message or ""
+                deployment_version.get("id"), to_env, message=result["message"]
             )
             if output_json:
-                json_print({"success": True, "changes_deployed": changes})
+                json_print({**result, "success": True})
             else:
                 success(f"Deployment {from_deployment} promoted to {to_env}.")
         except Exception as e:
             if output_json:
-                json_print({"success": False, "error": str(e)})
+                json_print({**result, "error": str(e)})
             else:
                 error(f"Failed to promote deployment: {e}")
             sys.exit(1)

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3246,7 +3246,7 @@ class AgentStudioCLI:
         message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
-    ):
+    ) -> None:
         """Rollback sandbox/main to a previous deployment."""
         project = cls._load_project(base_path, output_json=output_json)
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2850,7 +2850,7 @@ class AgentStudioCLI:
         message: Optional[str] = None,
         force: bool = False,
         output_json: bool = False,
-    ):
+    ) -> None:
         """Rollback sandbox/main to a previous deployment."""
         project = cls._load_project(base_path, output_json=output_json)
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -871,7 +871,7 @@ class AgentStudioCLI:
             "-m",
             type=str,
             required=False,
-            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+            help="Optional message to include with the promotion (e.g. release notes or changelog). If not specified, current deployment message will be used instead",
         )
         deployment_promote_parser.add_argument(
             "--force",
@@ -903,7 +903,7 @@ class AgentStudioCLI:
             "-m",
             type=str,
             required=False,
-            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current commit message will be used instead",
+            help="Optional message to include with the rollback (e.g. release notes or changelog). If not specified, current deployment message will be used instead",
         )
         deployment_rollback_parser.add_argument(
             "--force",

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -559,7 +559,7 @@ class AgentStudioInterface:
 
     @staticmethod
     def promote_deployment(
-        region: str, project_id: str, deployment_id: str, target_env: str, message: str = None
+        region: str, project_id: str, deployment_id: str, target_env: str, message: str
     ) -> dict:
         """Promote a deployment to the next environment.
 
@@ -568,7 +568,7 @@ class AgentStudioInterface:
             project_id: The project ID
             deployment_id: The deployment ID
             target_env: The target environment to promote to (pre-release or live)
-            message: Optional message to include with the promotion
+            message: Message to include with the promotion
 
         Returns:
             dict: The API response
@@ -578,16 +578,14 @@ class AgentStudioInterface:
         )
 
     @staticmethod
-    def rollback_deployment(
-        region: str, project_id: str, deployment_id: str, message: str = None
-    ) -> dict:
+    def rollback_deployment(region: str, project_id: str, deployment_id: str, message: str) -> dict:
         """Rollback a deployment to the previous environment.
 
         Args:
             region: The region name
             project_id: The project ID
             deployment_id: The deployment ID
-            message: Optional message to include with the rollback
+            message: Message to include with the rollback
 
         Returns:
             dict: The API response

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -556,3 +556,40 @@ class AgentStudioInterface:
         return PlatformAPIHandler.end_chat(
             region, account_id, project_id, conversation_id, environment
         )
+
+    @staticmethod
+    def promote_deployment(
+        region: str, project_id: str, deployment_id: str, target_env: str, message: str = None
+    ) -> dict:
+        """Promote a deployment to the next environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            target_env: The target environment to promote to (pre-release or live)
+            message: Optional message to include with the promotion
+
+        Returns:
+            dict: The API response
+        """
+        return PlatformAPIHandler.promote_deployment(
+            region, project_id, deployment_id, target_env, message
+        )
+
+    @staticmethod
+    def rollback_deployment(
+        region: str, project_id: str, deployment_id: str, message: str = None
+    ) -> dict:
+        """Rollback a deployment to the previous environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            message: Optional message to include with the rollback
+
+        Returns:
+            dict: The API response
+        """
+        return PlatformAPIHandler.rollback_deployment(region, project_id, deployment_id, message)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -464,7 +464,7 @@ class AgentStudioInterface:
 
     @staticmethod
     def promote_deployment(
-        region: str, project_id: str, deployment_id: str, target_env: str, message: str = None
+        region: str, project_id: str, deployment_id: str, target_env: str, message: str
     ) -> dict:
         """Promote a deployment to the next environment.
 
@@ -473,7 +473,7 @@ class AgentStudioInterface:
             project_id: The project ID
             deployment_id: The deployment ID
             target_env: The target environment to promote to (pre-release or live)
-            message: Optional message to include with the promotion
+            message: Message to include with the promotion
 
         Returns:
             dict: The API response
@@ -483,16 +483,14 @@ class AgentStudioInterface:
         )
 
     @staticmethod
-    def rollback_deployment(
-        region: str, project_id: str, deployment_id: str, message: str = None
-    ) -> dict:
+    def rollback_deployment(region: str, project_id: str, deployment_id: str, message: str) -> dict:
         """Rollback a deployment to the previous environment.
 
         Args:
             region: The region name
             project_id: The project ID
             deployment_id: The deployment ID
-            message: Optional message to include with the rollback
+            message: Message to include with the rollback
 
         Returns:
             dict: The API response

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -461,3 +461,40 @@ class AgentStudioInterface:
         return PlatformAPIHandler.end_chat(
             region, account_id, project_id, conversation_id, environment
         )
+
+    @staticmethod
+    def promote_deployment(
+        region: str, project_id: str, deployment_id: str, target_env: str, message: str = None
+    ) -> dict:
+        """Promote a deployment to the next environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            target_env: The target environment to promote to (pre-release or live)
+            message: Optional message to include with the promotion
+
+        Returns:
+            dict: The API response
+        """
+        return PlatformAPIHandler.promote_deployment(
+            region, project_id, deployment_id, target_env, message
+        )
+
+    @staticmethod
+    def rollback_deployment(
+        region: str, project_id: str, deployment_id: str, message: str = None
+    ) -> dict:
+        """Rollback a deployment to the previous environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            message: Optional message to include with the rollback
+
+        Returns:
+            dict: The API response
+        """
+        return PlatformAPIHandler.rollback_deployment(region, project_id, deployment_id, message)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -452,7 +452,6 @@ class PlatformAPIHandler:
             dict: The API response
         """
         endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
-        target_env = "ERROR"
         body = {
             "targetEnvironment": target_env,
             "deploymentMessage": message,

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -401,7 +401,7 @@ class PlatformAPIHandler:
         project_id: str,
         deployment_id: str,
         target_env: str,
-        message: ty.Optional[str] = None,
+        message: str,
     ) -> dict:
         """Promote a deployment to the next environment.
 
@@ -410,16 +410,17 @@ class PlatformAPIHandler:
             project_id: The project ID
             deployment_id: The deployment ID
             target_env: The target environment to promote to (pre-release or live)
-            message: Optional message to include with the promotion
+            message: Message to include with the promotion
 
         Returns:
             dict: The API response
         """
         endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
         target_env = "ERROR"
-        body = {"targetEnvironment": target_env}
-        if message:
-            body["deploymentMessage"] = message
+        body = {
+            "targetEnvironment": target_env,
+            "deploymentMessage": message,
+        }
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
 
     @staticmethod
@@ -427,7 +428,7 @@ class PlatformAPIHandler:
         region: str,
         project_id: str,
         deployment_id: str,
-        message: ty.Optional[str] = None,
+        message: str,
     ) -> dict:
         """Rollback sandbox to a previous deployment.
 
@@ -435,13 +436,11 @@ class PlatformAPIHandler:
             region: The region name
             project_id: The project ID
             deployment_id: The deployment ID
-            message: Optional message to include with the rollback
+            message: Message to include with the rollback
 
         Returns:
             dict: The API response
         """
         endpoint = ROLLBACK_URL.format(project_id=project_id, deploymentId=deployment_id)
-        body = {}
-        if message:
-            body["deploymentMessage"] = message
+        body = {"deploymentMessage": message}
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -25,8 +25,9 @@ DRAFT_CHAT_CONVERSATION_URL = (
     "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
 )
 CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
-PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/promote"
-ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/rollback"
+# These use public APIs not /adk endpoints
+PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/promote"
+ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/rollback"
 
 
 class PlatformAPIHandler:
@@ -451,7 +452,7 @@ class PlatformAPIHandler:
         Returns:
             dict: The API response
         """
-        endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
+        endpoint = PROMOTE_URL.format(project_id=project_id, deployment_id=deployment_id)
         body = {
             "targetEnvironment": target_env,
             "deploymentMessage": message,
@@ -476,6 +477,6 @@ class PlatformAPIHandler:
         Returns:
             dict: The API response
         """
-        endpoint = ROLLBACK_URL.format(project_id=project_id, deploymentId=deployment_id)
+        endpoint = ROLLBACK_URL.format(project_id=project_id, deployment_id=deployment_id)
         body = {"deploymentMessage": message}
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -438,7 +438,7 @@ class PlatformAPIHandler:
         project_id: str,
         deployment_id: str,
         target_env: str,
-        message: ty.Optional[str] = None,
+        message: str,
     ) -> dict:
         """Promote a deployment to the next environment.
 
@@ -447,16 +447,17 @@ class PlatformAPIHandler:
             project_id: The project ID
             deployment_id: The deployment ID
             target_env: The target environment to promote to (pre-release or live)
-            message: Optional message to include with the promotion
+            message: Message to include with the promotion
 
         Returns:
             dict: The API response
         """
         endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
         target_env = "ERROR"
-        body = {"targetEnvironment": target_env}
-        if message:
-            body["deploymentMessage"] = message
+        body = {
+            "targetEnvironment": target_env,
+            "deploymentMessage": message,
+        }
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
 
     @staticmethod
@@ -464,7 +465,7 @@ class PlatformAPIHandler:
         region: str,
         project_id: str,
         deployment_id: str,
-        message: ty.Optional[str] = None,
+        message: str,
     ) -> dict:
         """Rollback sandbox to a previous deployment.
 
@@ -472,13 +473,11 @@ class PlatformAPIHandler:
             region: The region name
             project_id: The project ID
             deployment_id: The deployment ID
-            message: Optional message to include with the rollback
+            message: Message to include with the rollback
 
         Returns:
             dict: The API response
         """
         endpoint = ROLLBACK_URL.format(project_id=project_id, deploymentId=deployment_id)
-        body = {}
-        if message:
-            body["deploymentMessage"] = message
+        body = {"deploymentMessage": message}
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -415,7 +415,6 @@ class PlatformAPIHandler:
             dict: The API response
         """
         endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
-        target_env = "ERROR"
         body = {
             "targetEnvironment": target_env,
             "deploymentMessage": message,

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -102,7 +102,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -110,8 +110,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
-                f" status_code={api_response.status_code!r} response={api_response.text!r}"
+                f"Error in request status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -13,28 +13,30 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-ACCOUNTS_URL = "/accounts"
-PROJECTS_URL = "/accounts/{account_id}/projects"
-DEPLOYMENTS_URL = "/accounts/{account_id}/projects/{project_id}/deployments"
-ACTIVE_DEPLOYMENTS_URL = "/accounts/{account_id}/projects/{project_id}/deployments/active"
-CHAT_URL = "/accounts/{account_id}/projects/{project_id}/chat"
-CHAT_CONVERSATION_URL = "/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}"
-DRAFT_CHAT_URL = "/accounts/{account_id}/projects/{project_id}/draft/chat"
+ACCOUNTS_URL = "/adk/v1/accounts"
+PROJECTS_URL = "/adk/v1/accounts/{account_id}/projects"
+DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments"
+ACTIVE_DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments/active"
+CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat"
+CHAT_CONVERSATION_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}"
+DRAFT_CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat"
 DRAFT_CHAT_CONVERSATION_URL = (
-    "/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
 )
-CHAT_END_URL = "/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/promote"
+ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/rollback"
 
 
 class PlatformAPIHandler:
     """Class for interacting with the Platform API"""
 
     region_to_base_url = {
-        "dev": "https://api.dev.poly.ai/adk/v1",
-        "staging": "https://api.staging.poly.ai/adk/v1",
-        "euw-1": "https://api.eu.poly.ai/adk/v1",
-        "uk-1": "https://api.uk.poly.ai/adk/v1",
-        "us-1": "https://api.us.poly.ai/adk/v1",
+        "dev": "https://api.dev.poly.ai",
+        "staging": "https://api.staging.poly.ai",
+        "euw-1": "https://api.eu.poly.ai",
+        "uk-1": "https://api.uk.poly.ai",
+        "us-1": "https://api.us.poly.ai",
     }
 
     @staticmethod
@@ -100,7 +102,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -108,7 +110,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
+                f"Error in request. url={url!r} body={data!r}"
                 f" status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise
@@ -392,3 +394,54 @@ class PlatformAPIHandler:
         if output_lang:
             data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def promote_deployment(
+        region: str,
+        project_id: str,
+        deployment_id: str,
+        target_env: str,
+        message: ty.Optional[str] = None,
+    ) -> dict:
+        """Promote a deployment to the next environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            target_env: The target environment to promote to (pre-release or live)
+            message: Optional message to include with the promotion
+
+        Returns:
+            dict: The API response
+        """
+        endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
+        target_env = "ERROR"
+        body = {"targetEnvironment": target_env}
+        if message:
+            body["deploymentMessage"] = message
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
+
+    @staticmethod
+    def rollback_deployment(
+        region: str,
+        project_id: str,
+        deployment_id: str,
+        message: ty.Optional[str] = None,
+    ) -> dict:
+        """Rollback sandbox to a previous deployment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            message: Optional message to include with the rollback
+
+        Returns:
+            dict: The API response
+        """
+        endpoint = ROLLBACK_URL.format(project_id=project_id, deploymentId=deployment_id)
+        body = {}
+        if message:
+            body["deploymentMessage"] = message
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -104,7 +104,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -112,8 +112,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
-                f" status_code={api_response.status_code!r} response={api_response.text!r}"
+                f"Error in request status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -14,29 +14,31 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-ACCOUNTS_URL = "/accounts"
-PROJECTS_URL = "/accounts/{account_id}/projects"
-DEPLOYMENTS_URL = "/accounts/{account_id}/projects/{project_id}/deployments"
-ACTIVE_DEPLOYMENTS_URL = "/accounts/{account_id}/projects/{project_id}/deployments/active"
-CHAT_URL = "/accounts/{account_id}/projects/{project_id}/chat"
-CHAT_CONVERSATION_URL = "/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}"
-DRAFT_CHAT_URL = "/accounts/{account_id}/projects/{project_id}/draft/chat"
+ACCOUNTS_URL = "/adk/v1/accounts"
+PROJECTS_URL = "/adk/v1/accounts/{account_id}/projects"
+DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments"
+ACTIVE_DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments/active"
+CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat"
+CHAT_CONVERSATION_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}"
+DRAFT_CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat"
 DRAFT_CHAT_CONVERSATION_URL = (
-    "/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
 )
-CHAT_END_URL = "/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/promote"
+ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deploymentId}/rollback"
 
 
 class PlatformAPIHandler:
     """Class for interacting with the Platform API"""
 
     region_to_base_url = {
-        "dev": "https://api.dev.poly.ai/adk/v1",
-        "staging": "https://api.staging.poly.ai/adk/v1",
-        "euw-1": "https://api.eu.poly.ai/adk/v1",
-        "uk-1": "https://api.uk.poly.ai/adk/v1",
-        "us-1": "https://api.us.poly.ai/adk/v1",
-        "studio": "https://api.studio.poly.ai/adk/v1",
+        "dev": "https://api.dev.poly.ai",
+        "staging": "https://api.staging.poly.ai",
+        "euw-1": "https://api.eu.poly.ai",
+        "uk-1": "https://api.uk.poly.ai",
+        "us-1": "https://api.us.poly.ai",
+        "studio": "https://api.studio.poly.ai",
     }
 
     @staticmethod
@@ -102,7 +104,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -110,7 +112,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
+                f"Error in request. url={url!r} body={data!r}"
                 f" status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise
@@ -429,3 +431,54 @@ class PlatformAPIHandler:
         if output_lang:
             data["tts_lang_code"] = output_lang
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def promote_deployment(
+        region: str,
+        project_id: str,
+        deployment_id: str,
+        target_env: str,
+        message: ty.Optional[str] = None,
+    ) -> dict:
+        """Promote a deployment to the next environment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            target_env: The target environment to promote to (pre-release or live)
+            message: Optional message to include with the promotion
+
+        Returns:
+            dict: The API response
+        """
+        endpoint = PROMOTE_URL.format(project_id=project_id, deploymentId=deployment_id)
+        target_env = "ERROR"
+        body = {"targetEnvironment": target_env}
+        if message:
+            body["deploymentMessage"] = message
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
+
+    @staticmethod
+    def rollback_deployment(
+        region: str,
+        project_id: str,
+        deployment_id: str,
+        message: ty.Optional[str] = None,
+    ) -> dict:
+        """Rollback sandbox to a previous deployment.
+
+        Args:
+            region: The region name
+            project_id: The project ID
+            deployment_id: The deployment ID
+            message: Optional message to include with the rollback
+
+        Returns:
+            dict: The API response
+        """
+        endpoint = ROLLBACK_URL.format(project_id=project_id, deploymentId=deployment_id)
+        body = {}
+        if message:
+            body["deploymentMessage"] = message
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -102,7 +102,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} body={data!r}"
+            f"Request/response url={url!r} headers={headers!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -110,7 +110,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} body={data!r}"
+                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
                 f" status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -104,7 +104,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} body={data!r}"
+            f"Request/response url={url!r} headers={headers!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -112,7 +112,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} body={data!r}"
+                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
                 f" status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2784,3 +2784,43 @@ class AgentStudioProject:
         self.save_config()
 
         return True
+
+    def promote_deployment(self, deployment_id: str, target_env: str, message: str = None) -> bool:
+        """Promote a deployment to specified environment.
+
+        Args:
+            deployment_id (str): The ID of the deployment to promote.
+            target_env (str): The target environment to promote to (pre-release or live)
+            message (str, optional): Optional message to include with the promotion
+
+        Returns:
+            bool: True if the promotion was successful, False otherwise
+        """
+        if target_env not in {"pre-release", "live"}:
+            raise ValueError("target_env must be either 'pre-release' or 'live'.")
+        self.api_handler.promote_deployment(
+            region=self.region,
+            project_id=self.project_id,
+            deployment_id=deployment_id,
+            target_env=target_env,
+            message=message,
+        )
+        return True
+
+    def rollback_deployment(self, deployment_id: str, message: str = None) -> bool:
+        """Rollback sandbox/main to a previous deployment.
+
+        Args:
+            deployment_id (str): The ID of the deployment to rollback.
+            message (str, optional): Optional message to include with the rollback
+
+        Returns:
+            bool: True if the rollback was successful, False otherwise
+        """
+        self.api_handler.rollback_deployment(
+            region=self.region,
+            project_id=self.project_id,
+            deployment_id=deployment_id,
+            message=message,
+        )
+        return True

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2785,7 +2785,7 @@ class AgentStudioProject:
 
         return True
 
-    def promote_deployment(self, deployment_id: str, target_env: str, message: str = None) -> bool:
+    def promote_deployment(self, deployment_id: str, target_env: str, message: str) -> bool:
         """Promote a deployment to specified environment.
 
         Args:
@@ -2807,7 +2807,7 @@ class AgentStudioProject:
         )
         return True
 
-    def rollback_deployment(self, deployment_id: str, message: str = None) -> bool:
+    def rollback_deployment(self, deployment_id: str, message: str) -> bool:
         """Rollback sandbox/main to a previous deployment.
 
         Args:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2847,3 +2847,43 @@ class AgentStudioProject:
         self.save_config()
 
         return True
+
+    def promote_deployment(self, deployment_id: str, target_env: str, message: str = None) -> bool:
+        """Promote a deployment to specified environment.
+
+        Args:
+            deployment_id (str): The ID of the deployment to promote.
+            target_env (str): The target environment to promote to (pre-release or live)
+            message (str, optional): Optional message to include with the promotion
+
+        Returns:
+            bool: True if the promotion was successful, False otherwise
+        """
+        if target_env not in {"pre-release", "live"}:
+            raise ValueError("target_env must be either 'pre-release' or 'live'.")
+        self.api_handler.promote_deployment(
+            region=self.region,
+            project_id=self.project_id,
+            deployment_id=deployment_id,
+            target_env=target_env,
+            message=message,
+        )
+        return True
+
+    def rollback_deployment(self, deployment_id: str, message: str = None) -> bool:
+        """Rollback sandbox/main to a previous deployment.
+
+        Args:
+            deployment_id (str): The ID of the deployment to rollback.
+            message (str, optional): Optional message to include with the rollback
+
+        Returns:
+            bool: True if the rollback was successful, False otherwise
+        """
+        self.api_handler.rollback_deployment(
+            region=self.region,
+            project_id=self.project_id,
+            deployment_id=deployment_id,
+            message=message,
+        )
+        return True

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2848,7 +2848,7 @@ class AgentStudioProject:
 
         return True
 
-    def promote_deployment(self, deployment_id: str, target_env: str, message: str = None) -> bool:
+    def promote_deployment(self, deployment_id: str, target_env: str, message: str) -> bool:
         """Promote a deployment to specified environment.
 
         Args:
@@ -2870,7 +2870,7 @@ class AgentStudioProject:
         )
         return True
 
-    def rollback_deployment(self, deployment_id: str, message: str = None) -> bool:
+    def rollback_deployment(self, deployment_id: str, message: str) -> bool:
         """Rollback sandbox/main to a previous deployment.
 
         Args:

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1474,7 +1474,12 @@ class DeploymentsRollbackTest(unittest.TestCase):
         )
 
         self.proj.rollback_deployment.assert_called_once_with("dep-2", message="revert")
-        mock_json.assert_called_once_with({"success": True})
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["target_hash"], "def789012xyz")
+        self.assertEqual(payload["message"], "revert")
+        self.assertIn("reverted_deployments", payload)
 
     @patch("poly.cli.success")
     def test_rollback_happy_path_force(self, mock_success):
@@ -1621,3 +1626,26 @@ class DeploymentsRollbackTest(unittest.TestCase):
         )
 
         self.proj.rollback_deployment.assert_called_once_with("dep-1", message="emergency fix")
+
+    # ── Dry run ──────────────────────────────────────────────────────
+
+    @patch("poly.cli.json_print")
+    def test_dry_run_shows_reverted_without_calling_api(self, mock_json):
+        """Dry run shows reverted deployments but does not call rollback_deployment.
+
+        versions: [dep-1(newest, active sandbox), dep-2(oldest)]
+        Rolling back to dep-2 → dep-1 is reverted.
+        """
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="def789012",
+            output_json=True,
+            dry_run=True,
+        )
+
+        self.proj.rollback_deployment.assert_not_called()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["dry_run"])
+        self.assertEqual(payload["target_hash"], "def789012xyz")
+        reverted_ids = [d["id"] for d in payload["reverted_deployments"]]
+        self.assertEqual(reverted_ids, ["dep-1"])

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1079,3 +1079,419 @@ class PrintDeploymentsTest(unittest.TestCase):
         mock_print_dep.assert_called_once()
         call_kwargs = mock_print_dep.call_args[1]
         self.assertTrue(call_kwargs["details"])
+
+
+class DeploymentsPromoteTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.deployments_promote."""
+
+    VERSIONS = [
+        {
+            "id": "dep-1",
+            "version_hash": "abc123456xyz",
+            "deployment_metadata": {"deployment_message": "initial release"},
+        },
+        {
+            "id": "dep-2",
+            "version_hash": "def789012xyz",
+            "deployment_metadata": {"deployment_message": "hotfix"},
+        },
+    ]
+    ACTIVE_HASHES = {"sandbox": "abc123456xyz", "pre-release": "def789012xyz"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
+        self.proj.promote_deployment.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli.json_print")
+    def test_promote_happy_path_json(self, mock_json):
+        """Promote with --json prints success and calls promote_deployment."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="ship it",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="ship it"
+        )
+        mock_json.assert_called_once_with({"success": True})
+
+    @patch("poly.cli.success")
+    def test_promote_happy_path_force(self, mock_success):
+        """Promote with --force skips confirmation and prints success."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="ship it",
+            force=True,
+            output_json=False,
+        )
+
+        self.proj.promote_deployment.assert_called_once()
+        mock_success.assert_called_once()
+
+    def test_promote_to_live_searches_pre_release(self):
+        """Promoting to live fetches deployments from pre-release."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="def789012",
+            to_env="live",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("pre-release")
+
+    def test_promote_to_pre_release_searches_sandbox(self):
+        """Promoting to pre-release fetches deployments from sandbox."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_promote_resolves_env_name_to_hash(self, mock_json):
+        """Passing an env name like 'sandbox' resolves via active_deployment_hashes."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="sandbox",
+            to_env="pre-release",
+            force=True,
+            output_json=True,
+        )
+
+        # sandbox -> abc123456xyz -> matches dep-1
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_promote_not_found_json(self, mock_json):
+        """Promote with unknown hash prints error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="zzz999999",
+                to_env="pre-release",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_promote_not_found_rich(self, mock_error):
+        """Promote with unknown hash prints error and exits."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="zzz999999",
+                to_env="pre-release",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("not found", mock_error.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_promote_api_error_json(self, mock_json):
+        """API exception during promote prints error JSON and exits."""
+        self.proj.promote_deployment.side_effect = RuntimeError("API down")
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("API down", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_promote_api_error_rich(self, mock_error):
+        """API exception during promote prints error and exits."""
+        self.proj.promote_deployment.side_effect = RuntimeError("API down")
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("API down", mock_error.call_args[0][0])
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.warning")
+    def test_promote_user_aborts_confirmation(self, mock_warning, mock_q):
+        """User declining confirmation aborts with exit 0."""
+        mock_q.confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=False,
+                output_json=False,
+            )
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_warning.assert_called_once()
+        self.proj.promote_deployment.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_promote_uses_deployment_message_when_no_message_provided(self, mock_json):
+        """When --message is not given, the existing deployment_message is used."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message=None,
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_promote_custom_message_overrides_deployment_message(self, mock_json):
+        """When --message is provided, it overrides the deployment_message."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="custom notes",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="custom notes"
+        )
+
+
+class DeploymentsRollbackTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.deployments_rollback."""
+
+    VERSIONS = [
+        {
+            "id": "dep-1",
+            "version_hash": "abc123456xyz",
+            "deployment_metadata": {"deployment_message": "initial release"},
+        },
+        {
+            "id": "dep-2",
+            "version_hash": "def789012xyz",
+            "deployment_metadata": {"deployment_message": "hotfix"},
+        },
+    ]
+    ACTIVE_HASHES = {"sandbox": "abc123456xyz"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
+        self.proj.rollback_deployment.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli.json_print")
+    def test_rollback_happy_path_json(self, mock_json):
+        """Rollback with --json prints success and calls rollback_deployment."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="def789012",
+            message="revert",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with("dep-2", message="revert")
+        mock_json.assert_called_once_with({"success": True})
+
+    @patch("poly.cli.success")
+    def test_rollback_happy_path_force(self, mock_success):
+        """Rollback with --force skips confirmation and prints success."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="def789012",
+            message="revert",
+            force=True,
+            output_json=False,
+        )
+
+        self.proj.rollback_deployment.assert_called_once()
+        mock_success.assert_called_once()
+
+    def test_rollback_always_searches_sandbox(self):
+        """Rollback always fetches deployments from sandbox."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_rollback_resolves_env_name_to_hash(self, mock_json):
+        """Passing 'sandbox' as deployment resolves via active_deployment_hashes."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="sandbox",
+            force=True,
+            output_json=True,
+        )
+
+        # sandbox -> abc123456xyz -> matches dep-1
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_rollback_not_found_json(self, mock_json):
+        """Rollback with unknown hash prints error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="zzz999999",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_rollback_not_found_rich(self, mock_error):
+        """Rollback with unknown hash prints error and exits."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="zzz999999",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("not found", mock_error.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_rollback_api_error_json(self, mock_json):
+        """API exception during rollback prints error JSON and exits."""
+        self.proj.rollback_deployment.side_effect = RuntimeError("timeout")
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("timeout", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_rollback_api_error_rich(self, mock_error):
+        """API exception during rollback prints error and exits."""
+        self.proj.rollback_deployment.side_effect = RuntimeError("timeout")
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("timeout", mock_error.call_args[0][0])
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.warning")
+    def test_rollback_user_aborts_confirmation(self, mock_warning, mock_q):
+        """User declining confirmation aborts with exit 0."""
+        mock_q.confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=False,
+                output_json=False,
+            )
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_warning.assert_called_once()
+        self.proj.rollback_deployment.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_rollback_uses_deployment_message_when_no_message_provided(self, mock_json):
+        """When --message is not given, the existing deployment_message is used."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            message=None,
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_rollback_custom_message_overrides_deployment_message(self, mock_json):
+        """When --message is provided, it overrides the deployment_message."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            message="emergency fix",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="emergency fix"
+        )

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -607,6 +607,8 @@ class BranchMergeConflictHelpersTest(unittest.TestCase):
         table = rendered.renderable if isinstance(rendered, Panel) else rendered
         self.assertEqual(len(table.columns), 1)
         self.assertEqual(len(table.rows), 1)
+
+
 class ChatLoopTest(unittest.TestCase):
     """Tests for AgentStudioCLI._run_chat_loop.
 
@@ -616,7 +618,10 @@ class ChatLoopTest(unittest.TestCase):
 
     def setUp(self):
         self.proj = MagicMock()
-        self.proj.send_message.return_value = {"response": "Agent reply", "conversation_ended": False}
+        self.proj.send_message.return_value = {
+            "response": "Agent reply",
+            "conversation_ended": False,
+        }
         self.proj.end_chat.return_value = None
         self.proj.get_conversation_url.return_value = "https://example.com/conv-123"
 
@@ -1222,7 +1227,10 @@ class DeploymentsPromoteTest(unittest.TestCase):
         self.proj.promote_deployment.assert_called_once_with(
             "dep-1", "pre-release", message="ship it"
         )
-        mock_json.assert_called_once_with({"success": True})
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["from_hash"], "abc123456xyz")
+        self.assertIn("included_deployments", payload)
 
     @patch("poly.cli.success")
     def test_promote_happy_path_force(self, mock_success):
@@ -1239,8 +1247,8 @@ class DeploymentsPromoteTest(unittest.TestCase):
         self.proj.promote_deployment.assert_called_once()
         mock_success.assert_called_once()
 
-    def test_promote_to_live_searches_pre_release(self):
-        """Promoting to live fetches deployments from pre-release."""
+    def test_promote_to_live_searches_pre_release_and_sandbox(self):
+        """Promoting to live fetches pre-release then sandbox for linear history."""
         AgentStudioCLI.deployments_promote(
             TEST_DIR,
             from_deployment="def789012",
@@ -1249,7 +1257,10 @@ class DeploymentsPromoteTest(unittest.TestCase):
             output_json=True,
         )
 
-        self.proj.get_deployments.assert_called_once_with("pre-release")
+        calls = self.proj.get_deployments.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0][0], ("pre-release",))
+        self.assertEqual(calls[1][0], ("sandbox",))
 
     def test_promote_to_pre_release_searches_sandbox(self):
         """Promoting to pre-release fetches deployments from sandbox."""
@@ -1262,6 +1273,29 @@ class DeploymentsPromoteTest(unittest.TestCase):
         )
 
         self.proj.get_deployments.assert_called_once_with("sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_promote_rollback_returns_reverted_deployments(self, mock_json):
+        """Promoting to an older version returns the deployments being reverted.
+
+        sandbox: [dep-1(newest), dep-2(oldest)]
+        active pre-release = dep-1 (newer), promoting dep-2 (older)
+        → rollback: included = sandbox[0:1] = [dep-1] (the version being reverted)
+        """
+        active = {"sandbox": "abc123456xyz", "pre-release": "abc123456xyz"}
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), active)
+
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="def789012",
+            to_env="pre-release",
+            force=True,
+            output_json=True,
+        )
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-1"])
 
     @patch("poly.cli.json_print")
     def test_promote_resolves_env_name_to_hash(self, mock_json):
@@ -1478,9 +1512,7 @@ class DeploymentsRollbackTest(unittest.TestCase):
         )
 
         # sandbox -> abc123456xyz -> matches dep-1
-        self.proj.rollback_deployment.assert_called_once_with(
-            "dep-1", message="initial release"
-        )
+        self.proj.rollback_deployment.assert_called_once_with("dep-1", message="initial release")
 
     @patch("poly.cli.json_print")
     def test_rollback_not_found_json(self, mock_json):
@@ -1575,9 +1607,7 @@ class DeploymentsRollbackTest(unittest.TestCase):
             output_json=True,
         )
 
-        self.proj.rollback_deployment.assert_called_once_with(
-            "dep-1", message="initial release"
-        )
+        self.proj.rollback_deployment.assert_called_once_with("dep-1", message="initial release")
 
     @patch("poly.cli.json_print")
     def test_rollback_custom_message_overrides_deployment_message(self, mock_json):
@@ -1590,6 +1620,4 @@ class DeploymentsRollbackTest(unittest.TestCase):
             output_json=True,
         )
 
-        self.proj.rollback_deployment.assert_called_once_with(
-            "dep-1", message="emergency fix"
-        )
+        self.proj.rollback_deployment.assert_called_once_with("dep-1", message="emergency fix")

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1177,3 +1177,419 @@ class PrintDeploymentsTest(unittest.TestCase):
         mock_print_dep.assert_called_once()
         call_kwargs = mock_print_dep.call_args[1]
         self.assertTrue(call_kwargs["details"])
+
+
+class DeploymentsPromoteTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.deployments_promote."""
+
+    VERSIONS = [
+        {
+            "id": "dep-1",
+            "version_hash": "abc123456xyz",
+            "deployment_metadata": {"deployment_message": "initial release"},
+        },
+        {
+            "id": "dep-2",
+            "version_hash": "def789012xyz",
+            "deployment_metadata": {"deployment_message": "hotfix"},
+        },
+    ]
+    ACTIVE_HASHES = {"sandbox": "abc123456xyz", "pre-release": "def789012xyz"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
+        self.proj.promote_deployment.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli.json_print")
+    def test_promote_happy_path_json(self, mock_json):
+        """Promote with --json prints success and calls promote_deployment."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="ship it",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="ship it"
+        )
+        mock_json.assert_called_once_with({"success": True})
+
+    @patch("poly.cli.success")
+    def test_promote_happy_path_force(self, mock_success):
+        """Promote with --force skips confirmation and prints success."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="ship it",
+            force=True,
+            output_json=False,
+        )
+
+        self.proj.promote_deployment.assert_called_once()
+        mock_success.assert_called_once()
+
+    def test_promote_to_live_searches_pre_release(self):
+        """Promoting to live fetches deployments from pre-release."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="def789012",
+            to_env="live",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("pre-release")
+
+    def test_promote_to_pre_release_searches_sandbox(self):
+        """Promoting to pre-release fetches deployments from sandbox."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_promote_resolves_env_name_to_hash(self, mock_json):
+        """Passing an env name like 'sandbox' resolves via active_deployment_hashes."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="sandbox",
+            to_env="pre-release",
+            force=True,
+            output_json=True,
+        )
+
+        # sandbox -> abc123456xyz -> matches dep-1
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_promote_not_found_json(self, mock_json):
+        """Promote with unknown hash prints error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="zzz999999",
+                to_env="pre-release",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_promote_not_found_rich(self, mock_error):
+        """Promote with unknown hash prints error and exits."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="zzz999999",
+                to_env="pre-release",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("not found", mock_error.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_promote_api_error_json(self, mock_json):
+        """API exception during promote prints error JSON and exits."""
+        self.proj.promote_deployment.side_effect = RuntimeError("API down")
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("API down", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_promote_api_error_rich(self, mock_error):
+        """API exception during promote prints error and exits."""
+        self.proj.promote_deployment.side_effect = RuntimeError("API down")
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("API down", mock_error.call_args[0][0])
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.warning")
+    def test_promote_user_aborts_confirmation(self, mock_warning, mock_q):
+        """User declining confirmation aborts with exit 0."""
+        mock_q.confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_promote(
+                TEST_DIR,
+                from_deployment="abc123456",
+                to_env="pre-release",
+                force=False,
+                output_json=False,
+            )
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_warning.assert_called_once()
+        self.proj.promote_deployment.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_promote_uses_deployment_message_when_no_message_provided(self, mock_json):
+        """When --message is not given, the existing deployment_message is used."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message=None,
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_promote_custom_message_overrides_deployment_message(self, mock_json):
+        """When --message is provided, it overrides the deployment_message."""
+        AgentStudioCLI.deployments_promote(
+            TEST_DIR,
+            from_deployment="abc123456",
+            to_env="pre-release",
+            message="custom notes",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-1", "pre-release", message="custom notes"
+        )
+
+
+class DeploymentsRollbackTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.deployments_rollback."""
+
+    VERSIONS = [
+        {
+            "id": "dep-1",
+            "version_hash": "abc123456xyz",
+            "deployment_metadata": {"deployment_message": "initial release"},
+        },
+        {
+            "id": "dep-2",
+            "version_hash": "def789012xyz",
+            "deployment_metadata": {"deployment_message": "hotfix"},
+        },
+    ]
+    ACTIVE_HASHES = {"sandbox": "abc123456xyz"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
+        self.proj.rollback_deployment.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli.json_print")
+    def test_rollback_happy_path_json(self, mock_json):
+        """Rollback with --json prints success and calls rollback_deployment."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="def789012",
+            message="revert",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with("dep-2", message="revert")
+        mock_json.assert_called_once_with({"success": True})
+
+    @patch("poly.cli.success")
+    def test_rollback_happy_path_force(self, mock_success):
+        """Rollback with --force skips confirmation and prints success."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="def789012",
+            message="revert",
+            force=True,
+            output_json=False,
+        )
+
+        self.proj.rollback_deployment.assert_called_once()
+        mock_success.assert_called_once()
+
+    def test_rollback_always_searches_sandbox(self):
+        """Rollback always fetches deployments from sandbox."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.get_deployments.assert_called_once_with("sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_rollback_resolves_env_name_to_hash(self, mock_json):
+        """Passing 'sandbox' as deployment resolves via active_deployment_hashes."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="sandbox",
+            force=True,
+            output_json=True,
+        )
+
+        # sandbox -> abc123456xyz -> matches dep-1
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_rollback_not_found_json(self, mock_json):
+        """Rollback with unknown hash prints error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="zzz999999",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_rollback_not_found_rich(self, mock_error):
+        """Rollback with unknown hash prints error and exits."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="zzz999999",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("not found", mock_error.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_rollback_api_error_json(self, mock_json):
+        """API exception during rollback prints error JSON and exits."""
+        self.proj.rollback_deployment.side_effect = RuntimeError("timeout")
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=True,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("timeout", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_rollback_api_error_rich(self, mock_error):
+        """API exception during rollback prints error and exits."""
+        self.proj.rollback_deployment.side_effect = RuntimeError("timeout")
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=True,
+                output_json=False,
+            )
+
+        mock_error.assert_called_once()
+        self.assertIn("timeout", mock_error.call_args[0][0])
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.warning")
+    def test_rollback_user_aborts_confirmation(self, mock_warning, mock_q):
+        """User declining confirmation aborts with exit 0."""
+        mock_q.confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.deployments_rollback(
+                TEST_DIR,
+                deployment="abc123456",
+                force=False,
+                output_json=False,
+            )
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_warning.assert_called_once()
+        self.proj.rollback_deployment.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_rollback_uses_deployment_message_when_no_message_provided(self, mock_json):
+        """When --message is not given, the existing deployment_message is used."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            message=None,
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="initial release"
+        )
+
+    @patch("poly.cli.json_print")
+    def test_rollback_custom_message_overrides_deployment_message(self, mock_json):
+        """When --message is provided, it overrides the deployment_message."""
+        AgentStudioCLI.deployments_rollback(
+            TEST_DIR,
+            deployment="abc123456",
+            message="emergency fix",
+            force=True,
+            output_json=True,
+        )
+
+        self.proj.rollback_deployment.assert_called_once_with(
+            "dep-1", message="emergency fix"
+        )


### PR DESCRIPTION
## Summary

Adds `poly deployments promote` and `poly deployments rollback` subcommands, allowing users to promote a deployment to a target environment (pre-release or live) and rollback sandbox to a previous deployment version.

## Motivation

Enables deployment lifecycle management directly from the CLI, removing the need to use the Agent Studio UI for promotions and rollbacks.

## Changes

- Add `poly deployments promote --from <id> --to <env>` command with `--message`, `--force`, and `--dry-run` flags
- Add `poly deployments rollback --to <id>` command with `--message` and `--force` flags
- Add `_resolve_included_deployments` to compute included/reverted deployments using sandbox as the linear history source of truth
- Promotions show "Included deployments" list, rollbacks show "Reverting deployments" list, first-time promotions are labelled as such
- Add `promote_deployment` and `rollback_deployment` methods to `AgentStudioProject`, `AgentStudioInterface`, and `PlatformAPIHandler`
- Refactor API URL constants: move `/adk/v1` prefix from base URLs into individual route constants
- Add new `PROMOTE_URL` and `ROLLBACK_URL` endpoint constants using public API paths (`/v1/agents/...`)
- Remove `headers` from debug log output

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Promote:
<img width="812" height="253" alt="Screenshot 2026-05-01 at 17 11 25" src="https://github.com/user-attachments/assets/dd7e1c4a-76c5-45e3-aeb1-9fcfd9de0b69" />

Rollback:
<img width="711" height="211" alt="Screenshot 2026-05-01 at 17 22 00" src="https://github.com/user-attachments/assets/20687a8d-8f3d-43b7-a674-e2ec292271cd" />