### PR TITLE
feat: Clean KB topic names

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,9 @@ A CLI and Python package for managing [Agent Studio](https://studio.us.poly.ai) 
 
 **[Documentation](https://polyai.github.io/adk/)**
 
-## Early Access
+⚠️ **The PolyAI ADK is being continually updated.**
 
-⚠️ **The PolyAI ADK is currently in Early Access.**
-
-Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them.
-
-[Request access to the PolyAI ADK](https://fehky.share-eu1.hsforms.com/2oSGLpUctRvyqXcb6K44DAQ)
-
-Once approved, the PolyAI team will provide the credentials required to use the ADK.
+Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them. Updating may require you to re-initialse or force pulling your project to ensure it is in a compatible format
 
 ## Prerequisites
 
@@ -28,8 +22,6 @@ Before using the ADK you must:
 
 - have access to a **PolyAI Agent Studio workspace**
 - obtain an **ADK API key** from the PolyAI team
-
-Access to both is granted through the Early Access Program.
 
 Store your API key as an environment variable named: `POLY_ADK_KEY`
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A CLI and Python package for managing [Agent Studio](https://studio.us.poly.ai) 
 
 ⚠️ **The PolyAI ADK is being continually updated.**
 
-Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them. Updating may require you to re-initialse or force pulling your project to ensure it is in a compatible format
+Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them. Updating may require you to re-initialse or run `poly pull --force` on your project to ensure it is in a compatible format.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@ A CLI and Python package for managing [Agent Studio](https://studio.us.poly.ai) 
 
 **[Documentation](https://polyai.github.io/adk/)**
 
-⚠️ **The PolyAI ADK is being continually updated.**
+## Early Access
 
-Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them. Updating may require you to re-initialse or run `poly pull --force` on your project to ensure it is in a compatible format.
+⚠️ **The PolyAI ADK is currently in Early Access.**
+
+Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them.
+
+[Request access to the PolyAI ADK](https://fehky.share-eu1.hsforms.com/2oSGLpUctRvyqXcb6K44DAQ)
+
+Once approved, the PolyAI team will provide the credentials required to use the ADK.
 
 ## Prerequisites
 
@@ -22,6 +28,8 @@ Before using the ADK you must:
 
 - have access to a **PolyAI Agent Studio workspace**
 - obtain an **ADK API key** from the PolyAI team
+
+Access to both is granted through the Early Access Program.
 
 Store your API key as an environment variable named: `POLY_ADK_KEY`
 

--- a/src/poly/docs/topics.md
+++ b/src/poly/docs/topics.md
@@ -12,12 +12,12 @@ File names are cleaned to lowercase snake_case. For example, a topic named `"Ope
 
 ## Structure
 
-Each topic has six fields:
+Each topic has five fields:
 
 - **name** (string): The display name of the topic. This is the canonical name — the filename is derived from it (cleaned to lowercase snake_case).
 - **enabled** (bool): Whether the topic is active. Default: `true`.
 - **example_queries**: List of example user inputs that should trigger this topic.
-- **content**: Factual information retrieved via RAG. No function calls or `$variables` allowed here.
+- **content**: Factual information retrieved via RAG. No function calls or variable references allowed here.
 - **actions**: Behavioral instructions for the agent when the topic is triggered. This is where you use references.
 
 ## Example

--- a/src/poly/docs/topics.md
+++ b/src/poly/docs/topics.md
@@ -8,7 +8,7 @@ Topics are the agent's knowledge base, queried via RAG (retrieval-augmented gene
 
 `topics/`. One file per topic: `topics/{topic_name}.yaml`.
 
-Directory and file names are cleaned to lowercase snake_case. For example, a topic named `"Opening Hours & Locations"` is stored as `topics/opening_hours_locations.yaml`.
+File names are cleaned to lowercase snake_case. For example, a topic named `"Opening Hours & Locations"` is stored as `topics/opening_hours_locations.yaml`.
 
 ## Structure
 

--- a/src/poly/docs/topics.md
+++ b/src/poly/docs/topics.md
@@ -6,12 +6,15 @@ Topics are the agent's knowledge base, queried via RAG (retrieval-augmented gene
 
 ## Location
 
-`topics/`. One file per topic: `topics/{Topic Name}.yaml`.
+`topics/`. One file per topic: `topics/{topic_name}.yaml`.
+
+Directory and file names are cleaned to lowercase snake_case. For example, a topic named `"Opening Hours & Locations"` is stored as `topics/opening_hours_locations.yaml`.
 
 ## Structure
 
-Each topic has four fields:
+Each topic has six fields:
 
+- **name** (string): The display name of the topic. This is the canonical name — the filename is derived from it (cleaned to lowercase snake_case).
 - **enabled** (bool): Whether the topic is active. Default: `true`.
 - **example_queries**: List of example user inputs that should trigger this topic.
 - **content**: Factual information retrieved via RAG. No function calls or `$variables` allowed here.
@@ -19,6 +22,7 @@ Each topic has four fields:
 
 ## Example
 ```yaml
+name: Opening Hours & Locations
 enabled: true
 example_queries:
   - What are your opening hours?
@@ -37,6 +41,12 @@ actions: |-
   ## If the user wants to speak to someone
   Use {{fn:transfer_to_agent}} to connect them with a representative.
 ```
+
+## Naming and filenames
+
+- The `name` field in the YAML is the canonical topic name and can contain spaces, punctuation, and mixed case (e.g. `"Opening Hours & Locations"`).
+- The filename is cleaned to lowercase snake_case (e.g. `opening_hours_locations.yaml`).
+- The filename must match the cleaned version of `name` — a mismatch raises a validation error on `pull` or `push`.
 
 ## Example queries
 - Maximum **20 queries**.

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -20,6 +20,19 @@ class MigrationFlag(Enum):
     MIGRATED_LEGACY_TOPIC_FILES = "migrated_legacy_topic_files"
 
 
+def load_migration_flags(flags: list[str]) -> set[MigrationFlag]:
+    """Load a set of MigrationFlag from a list of strings. This can be used to
+    load the set of applied migrations from a file or other source.
+
+    Args:
+        flags: A list of strings representing the applied migration flags.
+    Returns:
+        A set of MigrationFlag values corresponding to the input strings.
+    """
+    valid_flags = set(flag.value for flag in MigrationFlag)
+    return set(MigrationFlag(flag) for flag in flags if flag in valid_flags)
+
+
 def get_all_migration_flags() -> set[MigrationFlag]:
     """Get a set of all migration flags. This can be used to initialize the set
     of applied migrations when first running the migrations.
@@ -66,41 +79,55 @@ def migrate_legacy_topic_files(root_path: str) -> None:
 
     topics = {}
     old_files = []
+    old_dirs = set()
 
-    for topic in os.listdir(topics_dir):
-        if not topic.endswith(".yaml"):
-            continue
+    # Walk recursively to catch legacy topics in nested subdirectories
+    # (e.g. topics/Billing/Refunds.yaml from a name containing "/")
+    for dirpath, _, filenames in os.walk(topics_dir):
+        for filename in filenames:
+            if not filename.endswith(".yaml"):
+                continue
 
-        topic_path = os.path.join(topics_dir, topic)
-        with open(topic_path, "r", encoding="utf-8") as f:
-            content = resource_utils.load_yaml(f.read())
+            topic_path = os.path.join(dirpath, filename)
+            with open(topic_path, "r", encoding="utf-8") as f:
+                content = resource_utils.load_yaml(f.read())
 
-        if "name" in content:
-            # Already in new format, skip
-            continue
+            if not isinstance(content, dict) or "name" in content:
+                # Already in new format, skip
+                continue
 
-        file_name = os.path.splitext(topic)[0]
-        clean_file_name = resource_utils.clean_name(file_name)
-        clean_file_path = os.path.join(topics_dir, f"{clean_file_name}.yaml")
-        if clean_file_path in topics:
-            raise ValueError(
-                "Cant migrate legacy topic files: multiple topics with the same file name after cleaning: "
-                + clean_file_name
-            )
+            # Reconstruct the original topic name from the relative path
+            # e.g. topics/Billing/Refunds.yaml -> "Billing/Refunds"
+            rel_path = os.path.relpath(topic_path, topics_dir)
+            file_name = os.path.splitext(rel_path)[0]
+            clean_file_name = resource_utils.clean_name(file_name)
+            clean_file_path = os.path.join(topics_dir, f"{clean_file_name}.yaml")
+            if clean_file_path in topics:
+                raise ValueError(
+                    "Can't migrate legacy topic files: "
+                    "multiple topics with the same file name after cleaning: " + clean_file_name
+                )
 
-        new_content = {"name": file_name, **content}
+            new_content = {"name": file_name, **content}
 
-        topics[clean_file_path] = new_content
-        old_files.append(topic_path)
+            topics[clean_file_path] = new_content
+            old_files.append(topic_path)
+            if dirpath != topics_dir:
+                old_dirs.add(dirpath)
 
-    # Write new files
+    # Write new files (always into the top-level topics/ dir)
     for clean_file_path, content in topics.items():
         with open(clean_file_path, "w", encoding="utf-8") as f:
             f.write(resource_utils.dump_yaml(content))
 
-    # Remove old file
+    # Remove old files
     for old_file in old_files:
         # Don't delete if old file is same as new file
         if old_file in topics:
             continue
         os.remove(old_file)
+
+    # Remove empty subdirectories left behind (deepest first)
+    for old_dir in sorted(old_dirs, key=lambda d: d.count(os.sep), reverse=True):
+        if os.path.isdir(old_dir) and not os.listdir(old_dir):
+            os.rmdir(old_dir)

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -81,7 +81,8 @@ def migrate_legacy_topic_files(root_path: str) -> None:
 
         file_name = os.path.splitext(topic)[0]
         clean_file_name = resource_utils.clean_name(file_name)
-        if clean_file_name in topics:
+        clean_file_path = os.path.join(topics_dir, f"{clean_file_name}.yaml")
+        if clean_file_path in topics:
             raise ValueError(
                 "Cant migrate legacy topic files: multiple topics with the same file name after cleaning: "
                 + clean_file_name
@@ -89,7 +90,6 @@ def migrate_legacy_topic_files(root_path: str) -> None:
 
         new_content = {"name": file_name, **content}
 
-        clean_file_path = os.path.join(topics_dir, f"{clean_file_name}.yaml")
         topics[clean_file_path] = new_content
         old_files.append(topic_path)
 

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -1,0 +1,106 @@
+"""Migration utilities for Agent Development Kit
+Tools to help with migrating from older versions of the Agent Development Kit to newer versions.
+
+Copyright PolyAI Limited
+"""
+
+from copy import deepcopy
+import os
+from poly.resources import resource_utils
+
+from enum import Enum
+
+
+class MigrationFlag(Enum):
+    """Flags to indicate which migrations have been applied. This can be used to
+    track which migrations have been run and prevent running the same migration
+    multiple times.
+    """
+
+    MIGRATED_LEGACY_TOPIC_FILES = "migrated_legacy_topic_files"
+
+
+def get_all_migration_flags() -> set[MigrationFlag]:
+    """Get a set of all migration flags. This can be used to initialize the set
+    of applied migrations when first running the migrations.
+
+    Returns:
+        A set of all MigrationFlag values.
+    """
+    return set(flag for flag in MigrationFlag)
+
+
+def run_migrations(root_path: str, applied_migrations: set[MigrationFlag]) -> set[MigrationFlag]:
+    """Run necessary migrations based on the current state of the project and
+    which migrations have already been applied.
+
+    Args:
+        root_path: The root path of the project.
+        applied_migrations: A set of MigrationFlag indicating which migrations have already been applied.
+
+    Returns:
+        A new set of MigrationFlag indicating which migrations have been applied after running this function.
+    """
+    new_flags = deepcopy(applied_migrations)
+    if MigrationFlag.MIGRATED_LEGACY_TOPIC_FILES not in applied_migrations:
+        migrate_legacy_topic_files(root_path)
+        new_flags.add(MigrationFlag.MIGRATED_LEGACY_TOPIC_FILES)
+
+    return new_flags
+
+
+def migrate_legacy_topic_files(root_path: str) -> None:
+    """Migrate topic files from legacy format (name as filename) to new format
+    (clean filename with name stored inside the YAML).
+
+    This handles the transition where topic files were previously saved as
+    ``topics/{name}.yaml`` and are now saved as ``topics/{clean_name}.yaml``
+    with a ``name`` key inside the YAML content.
+
+    Migrates both existing (pulled) topics and new local-only topic files.
+    """
+    topics_dir = os.path.join(root_path, "topics")
+
+    if not os.path.isdir(topics_dir):
+        return
+
+    topics = {}
+    old_files = []
+
+    for topic in os.listdir(topics_dir):
+        if not topic.endswith(".yaml"):
+            continue
+
+        topic_path = os.path.join(topics_dir, topic)
+        with open(topic_path, "r", encoding="utf-8") as f:
+            content = resource_utils.load_yaml(f.read())
+
+        if "name" in content:
+            # Already in new format, skip
+            continue
+
+        file_name = os.path.splitext(topic)[0]
+        clean_file_name = resource_utils.clean_name(file_name)
+        if clean_file_name in topics:
+            raise ValueError(
+                "Cant migrate legacy topic files: multiple topics with the same file name after cleaning: "
+                + clean_file_name
+            )
+
+        new_content = {"name": file_name, **content}
+
+        clean_file_path = os.path.join(topics_dir, f"{clean_file_name}.yaml")
+        topics[clean_file_path] = new_content
+        old_files.append(topic_path)
+
+    # Write new files
+    for clean_file_path, content in topics.items():
+        with open(clean_file_path, "w", encoding="utf-8") as f:
+            f.write(resource_utils.dump_yaml(content))
+
+    # Remove old file
+    for old_file in old_files:
+        # Don't delete if old file is same as new file
+        if old_file in topics:
+            continue
+        os.remove(old_file)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -239,7 +239,7 @@ class AgentStudioProject:
         else:
             last_updated = datetime.now()
 
-        utils._migrate_legacy_topic_files(root_path, resources)
+        utils._migrate_legacy_topic_files(root_path)
 
         return cls(
             region=config_dict.get("region", ""),
@@ -275,7 +275,7 @@ class AgentStudioProject:
         """Load whole project class from a dictionary"""
         resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
 
-        utils._migrate_legacy_topic_files(root_path, resources)
+        utils._migrate_legacy_topic_files(root_path)
 
         file_structure_info = cls.compute_file_structure_info(resources)
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -239,8 +239,6 @@ class AgentStudioProject:
         else:
             last_updated = datetime.now()
 
-        utils._migrate_legacy_topic_files(root_path)
-
         return cls(
             region=config_dict.get("region", ""),
             account_id=config_dict.get("account_id", ""),
@@ -274,8 +272,6 @@ class AgentStudioProject:
     def from_dict(cls, data: dict, root_path: str) -> "AgentStudioProject":
         """Load whole project class from a dictionary"""
         resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
-
-        utils._migrate_legacy_topic_files(root_path)
 
         file_structure_info = cls.compute_file_structure_info(resources)
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -57,7 +57,12 @@ from poly.resources import (
 )
 from poly.resources.resource import _parse_multi_resource_path
 from poly.utils import compute_variable_references
-from poly.migration_utils import run_migrations, get_all_migration_flags, MigrationFlag
+from poly.migration_utils import (
+    run_migrations,
+    get_all_migration_flags,
+    MigrationFlag,
+    load_migration_flags,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -240,9 +245,7 @@ class AgentStudioProject:
         else:
             last_updated = datetime.now()
 
-        migration_flags = set(
-            MigrationFlag(flag) for flag in status_dict.get("migration_flags", [])
-        )
+        migration_flags = load_migration_flags(status_dict.get("migration_flags", []))
         migration_flags = run_migrations(root_path, migration_flags)
 
         return cls(
@@ -285,7 +288,7 @@ class AgentStudioProject:
 
         file_structure_info = cls.compute_file_structure_info(resources)
 
-        migration_flags = set(MigrationFlag(flag) for flag in data.get("migration_flags", []))
+        migration_flags = load_migration_flags(data.get("migration_flags", []))
         migration_flags = run_migrations(root_path, migration_flags)
 
         return cls(

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -239,6 +239,8 @@ class AgentStudioProject:
         else:
             last_updated = datetime.now()
 
+        utils._migrate_legacy_topic_files(root_path, resources)
+
         return cls(
             region=config_dict.get("region", ""),
             account_id=config_dict.get("account_id", ""),
@@ -272,6 +274,8 @@ class AgentStudioProject:
     def from_dict(cls, data: dict, root_path: str) -> "AgentStudioProject":
         """Load whole project class from a dictionary"""
         resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
+
+        utils._migrate_legacy_topic_files(root_path, resources)
 
         file_structure_info = cls.compute_file_structure_info(resources)
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2127,7 +2127,10 @@ class AgentStudioProject:
                         resource_name = flow_name
 
                     # Resource name in file path is cleaned, so we need to get the original name
-                    if issubclass(resource_type, MultiResourceYamlResource):
+                    if (
+                        issubclass(resource_type, MultiResourceYamlResource)
+                        or resource_type == Topic
+                    ):
                         resource = self.read_local_resource(
                             ResourceMapping(
                                 resource_id="temp_id",

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -57,12 +57,12 @@ from poly.resources import (
 )
 from poly.resources.resource import _parse_multi_resource_path
 from poly.utils import compute_variable_references
+from poly.migration_utils import run_migrations, get_all_migration_flags, MigrationFlag
 
 logger = logging.getLogger(__name__)
 
 PROJECT_CONFIG_FILE = "project.yaml"
 STATUS_FILE = os.path.join("_gen", ".agent_studio_config")
-_LEGACY_STATUS_FILE = ".agent_studio_config"
 
 
 # New resources to be added here
@@ -144,6 +144,7 @@ class AgentStudioProject:
     branch_id: str = None
     _api_handler: AgentStudioInterface = None
     file_structure_info: dict[str, dict[str, str]] = None
+    _migration_flags: set[MigrationFlag] = None
 
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
@@ -239,6 +240,11 @@ class AgentStudioProject:
         else:
             last_updated = datetime.now()
 
+        migration_flags = set(
+            MigrationFlag(flag) for flag in status_dict.get("migration_flags", [])
+        )
+        migration_flags = run_migrations(root_path, migration_flags)
+
         return cls(
             region=config_dict.get("region", ""),
             account_id=config_dict.get("account_id", ""),
@@ -249,6 +255,7 @@ class AgentStudioProject:
             file_structure_info={},
             branch_id=status_dict.get("branch_id", "main"),
             _not_loaded_resources=not_loaded_resources,
+            _migration_flags=migration_flags,
         )
 
     def to_dict(self) -> dict:
@@ -266,6 +273,9 @@ class AgentStudioProject:
             "last_updated": (self.last_updated.isoformat() if self.last_updated else None),
             "file_structure_info": self.file_structure_info,
             "branch_id": self.branch_id,
+            "migration_flags": [flag.value for flag in self._migration_flags]
+            if self._migration_flags
+            else [],
         }
 
     @classmethod
@@ -274,6 +284,9 @@ class AgentStudioProject:
         resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
 
         file_structure_info = cls.compute_file_structure_info(resources)
+
+        migration_flags = set(MigrationFlag(flag) for flag in data.get("migration_flags", []))
+        migration_flags = run_migrations(root_path, migration_flags)
 
         return cls(
             region=data.get("region", ""),
@@ -284,6 +297,7 @@ class AgentStudioProject:
             last_updated=datetime.fromisoformat(data.get("last_updated", "1970-01-01T00:00:00")),
             file_structure_info=file_structure_info,
             branch_id=data.get("branch_id", "main"),
+            _migration_flags=migration_flags,
             _not_loaded_resources=not_loaded_resources,
         )
 
@@ -353,6 +367,7 @@ class AgentStudioProject:
             resources={},
             last_updated=datetime.now(),
             branch_id="main",
+            _migration_flags=get_all_migration_flags(),
         )
         project.resources, projection = project.api_handler.pull_resources(
             projection_json=projection_json

--- a/src/poly/resources/topic.py
+++ b/src/poly/resources/topic.py
@@ -53,12 +53,13 @@ class Topic(YamlResource):
     @cached_property
     def file_path(self) -> str:
         """Get the file path for the topic."""
-        file_name = f"{self.name}.yaml"
+        file_name = f"{utils.clean_name(self.name)}.yaml"
         return os.path.join("topics", file_name)
 
     def to_yaml_dict(self) -> dict:
         """Return a dictionary suitable for YAML serialization."""
         return {
+            "name": self.name,
             "enabled": self.enabled,
             "actions": self.actions,
             "content": self.content,
@@ -78,6 +79,34 @@ class Topic(YamlResource):
             example_queries=yaml_dict.get("example_queries", []),
             enabled=yaml_dict.get("enabled", True),
         )
+
+    @classmethod
+    def read_local_resource(
+        cls, file_path: str, resource_id: str, resource_name: str, **kwargs
+    ) -> "Topic":
+        """Read a local YAML resource from the given file path."""
+        content = cls.read_to_raw(file_path, resource_name=resource_name, **kwargs)
+        try:
+            yaml_dict = utils.load_yaml(content) or {}
+        except Exception as e:
+            raise ValueError(f"Error loading YAML file: {file_path}") from e
+
+        file_name = os.path.splitext(os.path.basename(file_path))[0]
+        yaml_name = yaml_dict.get("name")
+
+        if yaml_name:
+            # New format: name is in the YAML, validate against filename
+            if file_name != utils.clean_name(yaml_name):
+                raise ValueError(
+                    f"Topic name '{yaml_name}' in file {file_name}.yaml does not match "
+                    f"expected filename: {utils.clean_name(yaml_name)}.yaml"
+                )
+            name = yaml_name
+        else:
+            # Legacy format: name comes from filename
+            name = resource_name
+
+        return cls.from_yaml_dict(yaml_dict, resource_id=resource_id, name=name, **kwargs)
 
     @classmethod
     def to_pretty_dict(

--- a/src/poly/tests/migration_test.py
+++ b/src/poly/tests/migration_test.py
@@ -1,0 +1,96 @@
+"""Unit tests for migration utilities.
+
+Copyright PolyAI Limited
+"""
+
+import os
+import tempfile
+import unittest
+
+from poly.migration_utils import migrate_legacy_topic_files
+from poly.resources import resource_utils
+
+
+class TestMigrateLegacyTopicFiles(unittest.TestCase):
+    """Tests for migrate_legacy_topic_files."""
+
+    def _write_topic(self, topics_dir: str, filename: str, content: dict) -> str:
+        """Helper to write a topic YAML file."""
+        path = os.path.join(topics_dir, filename)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(resource_utils.dump_yaml(content))
+        return path
+
+    def test_no_topics_dir(self):
+        """Should be a no-op when topics/ doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            migrate_legacy_topic_files(tmp)
+            self.assertFalse(os.path.isdir(os.path.join(tmp, "topics")))
+
+    def test_renames_legacy_file(self):
+        """Legacy 'Topic Name.yaml' should become 'topic_name.yaml' with name key."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            self._write_topic(topics_dir, "Topic Name.yaml", {"enabled": True, "content": "hello"})
+
+            migrate_legacy_topic_files(tmp)
+
+            self.assertFalse(os.path.exists(os.path.join(topics_dir, "Topic Name.yaml")))
+            new_path = os.path.join(topics_dir, "topic_name.yaml")
+            self.assertTrue(os.path.exists(new_path))
+            with open(new_path, "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "Topic Name")
+            self.assertTrue(data["enabled"])
+            self.assertEqual(data["content"], "hello")
+
+    def test_skips_already_migrated_files(self):
+        """Files that already have a 'name' key should be left untouched."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            self._write_topic(topics_dir, "my_topic.yaml", {"name": "My Topic", "enabled": True})
+
+            migrate_legacy_topic_files(tmp)
+
+            with open(os.path.join(topics_dir, "my_topic.yaml"), "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "My Topic")
+
+    def test_clean_filename_not_deleted(self):
+        """Legacy file whose name is already clean should be updated in place, not deleted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            self._write_topic(topics_dir, "my_topic.yaml", {"enabled": True})
+
+            migrate_legacy_topic_files(tmp)
+
+            new_path = os.path.join(topics_dir, "my_topic.yaml")
+            self.assertTrue(os.path.exists(new_path))
+            with open(new_path, "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "my_topic")
+            self.assertTrue(data["enabled"])
+
+    def test_mixed_legacy_and_migrated(self):
+        """Migration should handle a mix of legacy and already-migrated files."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            self._write_topic(topics_dir, "existing.yaml", {"name": "Existing", "enabled": True})
+            self._write_topic(topics_dir, "New Topic.yaml", {"enabled": False})
+
+            migrate_legacy_topic_files(tmp)
+
+            files = sorted(os.listdir(topics_dir))
+            self.assertEqual(files, ["existing.yaml", "new_topic.yaml"])
+
+            with open(os.path.join(topics_dir, "existing.yaml"), "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "Existing")
+
+            with open(os.path.join(topics_dir, "new_topic.yaml"), "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "New Topic")

--- a/src/poly/tests/migration_test.py
+++ b/src/poly/tests/migration_test.py
@@ -94,3 +94,16 @@ class TestMigrateLegacyTopicFiles(unittest.TestCase):
             with open(os.path.join(topics_dir, "new_topic.yaml"), "r", encoding="utf-8") as f:
                 data = resource_utils.load_yaml(f.read())
             self.assertEqual(data["name"], "New Topic")
+
+    def test_duplicate_clean_names_raises(self):
+        """Two legacy files that clean to the same name should raise ValueError."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            # "Topic-A" and "Topic A" both clean to "topic_a"
+            self._write_topic(topics_dir, "Topic-A.yaml", {"enabled": True})
+            self._write_topic(topics_dir, "Topic A.yaml", {"enabled": True})
+
+            with self.assertRaises(ValueError) as ctx:
+                migrate_legacy_topic_files(tmp)
+            self.assertIn("topic_a", str(ctx.exception))

--- a/src/poly/tests/migration_test.py
+++ b/src/poly/tests/migration_test.py
@@ -15,8 +15,9 @@ class TestMigrateLegacyTopicFiles(unittest.TestCase):
     """Tests for migrate_legacy_topic_files."""
 
     def _write_topic(self, topics_dir: str, filename: str, content: dict) -> str:
-        """Helper to write a topic YAML file."""
+        """Helper to write a topic YAML file, creating parent dirs as needed."""
         path = os.path.join(topics_dir, filename)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w", encoding="utf-8") as f:
             f.write(resource_utils.dump_yaml(content))
         return path
@@ -107,3 +108,25 @@ class TestMigrateLegacyTopicFiles(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 migrate_legacy_topic_files(tmp)
             self.assertIn("topic_a", str(ctx.exception))
+
+    def test_migrates_nested_subdirectory_topics(self):
+        """Legacy topics with '/' in the name create nested dirs — migration should flatten them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            topics_dir = os.path.join(tmp, "topics")
+            os.makedirs(topics_dir)
+            # Simulates a topic named "Billing/Refunds" saved as topics/Billing/Refunds.yaml
+            self._write_topic(topics_dir, "Billing/Refunds.yaml", {"enabled": True})
+            self.assertTrue(os.path.exists(os.path.join(topics_dir, "Billing", "Refunds.yaml")))
+
+            migrate_legacy_topic_files(tmp)
+
+            # Nested file and directory removed
+            self.assertFalse(os.path.exists(os.path.join(topics_dir, "Billing", "Refunds.yaml")))
+            self.assertFalse(os.path.isdir(os.path.join(topics_dir, "Billing")))
+            # Flattened file created with cleaned name
+            new_path = os.path.join(topics_dir, "billing_refunds.yaml")
+            self.assertTrue(os.path.exists(new_path))
+            with open(new_path, "r", encoding="utf-8") as f:
+                data = resource_utils.load_yaml(f.read())
+            self.assertEqual(data["name"], "Billing/Refunds")
+            self.assertTrue(data["enabled"])

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -397,7 +397,7 @@ class FindNewKeptDeletedTest(unittest.TestCase):
         self.assertEqual(new_mapping.resource_name, "Topic 1")
         self.assertEqual(
             new_mapping.file_path,
-            os.path.join(TEST_DIR, "topics", "Topic 1.yaml"),
+            os.path.join(TEST_DIR, "topics", "topic_1.yaml"),
         )
         self.assertEqual(new_mapping.flow_name, None)
         self.assertEqual(new_mapping.resource_prefix, None)
@@ -502,7 +502,7 @@ class ProjectStatusTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         files_with_conflicts, modified_files, new_files, deleted_files = project.project_status()
         self.assertEqual(files_with_conflicts, [])
-        self.assertEqual(new_files, [os.path.join(TEST_DIR, "topics", "Topic 1.yaml")])
+        self.assertEqual(new_files, [os.path.join(TEST_DIR, "topics", "topic_1.yaml")])
         self.assertEqual(modified_files, [])
         self.assertEqual(deleted_files, [])
 
@@ -590,7 +590,7 @@ class ProjectStatusTest(unittest.TestCase):
             modified_files,
             [os.path.join(TEST_DIR, "flows", "test_flow", "steps", "start_step.yaml")],
         )
-        self.assertEqual(new_files, [os.path.join(TEST_DIR, "topics", "Topic 1.yaml")])
+        self.assertEqual(new_files, [os.path.join(TEST_DIR, "topics", "topic_1.yaml")])
         self.assertEqual(deleted_files, [os.path.join(TEST_DIR, "functions", "extra_function.py")])
 
 
@@ -609,7 +609,7 @@ class GetDiffsTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         diffs = project.get_diffs(all_files=True)
 
-        topic_path = "topics/Topic 1.yaml"
+        topic_path = "topics/topic_1.yaml"
         self.assertIn(topic_path, diffs)
 
         diff = diffs[topic_path]
@@ -678,7 +678,7 @@ class GetDiffsTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         diffs = project.get_diffs(all_files=True)
 
-        topic_path = "topics/Topic 1.yaml"
+        topic_path = "topics/topic_1.yaml"
         func_path = os.path.join(TEST_DIR, "functions", "extra_function.py")
         self.assertIn(topic_path, diffs)
         self.assertIn(func_path, diffs)
@@ -708,11 +708,11 @@ class GetDiffsTest(unittest.TestCase):
             "function_type": "global",
         }
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        requested_file = os.path.join(TEST_DIR, "topics", "Topic 1.yaml")
+        requested_file = os.path.join(TEST_DIR, "topics", "topic_1.yaml")
         diffs = project.get_diffs(files=[requested_file])
 
         # Topic diff
-        topic_path = "topics/Topic 1.yaml"
+        topic_path = "topics/topic_1.yaml"
         self.assertIn(topic_path, diffs)
         diff = diffs[topic_path]
         self.assertIn("--- original", diff)
@@ -2100,7 +2100,7 @@ class ValidateProjectTest(unittest.TestCase):
         with mock_read_from_file(
             {
                 os.path.join(
-                    TEST_DIR, "topics", "Topic 1.yaml"
+                    TEST_DIR, "topics", "topic_1.yaml"
                 ): 'name: Topic 1\ncontent: Topic 1 content\nexample_queries:\n- Topic 1 example query\nenabled: true\nactions: "{{fn:FUNCTION-missing_function}}"\n',
                 os.path.join(
                     TEST_DIR, "flows", "test_flow", "flow_config.yaml"

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -871,7 +871,8 @@ TEST_TOPIC = Topic(
     enabled=True,
 )
 
-TEST_TOPIC_RAW = """enabled: true
+TEST_TOPIC_RAW = """name: test_topic
+enabled: true
 actions: Run function {{fn:test_id}}
 content: Test content
 example_queries:
@@ -879,7 +880,8 @@ example_queries:
 - Who wrote '1984'?
 """
 
-TEST_TOPIC_PRETTY = """enabled: true
+TEST_TOPIC_PRETTY = """name: test_topic
+enabled: true
 actions: Run function {{fn:test_function}}
 content: Test content
 example_queries:

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -1084,6 +1084,9 @@
       }
     }
   },
-  "file_structure_info": {}
+  "file_structure_info": {},
+  "migration_flags": [
+    "migrated_legacy_topic_files"
+  ]
 }
 

--- a/src/poly/tests/test_projects/test_project/topics/topic_1.yaml
+++ b/src/poly/tests/test_projects/test_project/topics/topic_1.yaml
@@ -1,3 +1,4 @@
+name: Topic 1
 enabled: true
 actions: Use {{fn:test_function}} to handle this request and {{fn:format_date}}
   for dates. Access customer info via {{attr:customer-name}} and handoff with {{ho:handoff-1}} if

--- a/src/poly/tests/test_projects/test_project/topics/topic_2.yaml
+++ b/src/poly/tests/test_projects/test_project/topics/topic_2.yaml
@@ -1,3 +1,4 @@
+name: Topic 2
 enabled: true
 actions: Validate using {{fn:validate_email}} and process with {{fn:shared_helper}}. Check {{attr:email-address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:test_template_2}}.
 content: This topic handles email validation and processing.

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -12,9 +12,7 @@ import os
 import re
 from typing import Callable, Optional
 
-from poly.resources.flows import FunctionStep
-from poly.resources.function import Function
-from poly.resources.resource import Resource, ResourceMapping
+from poly.resources import resource_utils, Resource, ResourceMapping, Function, FunctionStep, Topic
 
 logger = logging.getLogger(__name__)
 
@@ -404,3 +402,41 @@ def compute_variable_references(
         for var_id in variable_references:
             var_refs.setdefault(var_id, {}).setdefault(field_name, {})[fn_id] = True
     return var_refs
+
+
+def _migrate_legacy_topic_files(
+    root_path: str, resources: dict[type[Resource], dict[str, Resource]]
+) -> None:
+    """Migrate topic files from legacy format (name as filename) to new format
+    (clean filename with name stored inside the YAML).
+
+    This handles the transition where topic files were previously saved as
+    ``topics/{name}.yaml`` and are now saved as ``topics/{clean_name}.yaml``
+    with a ``name`` key inside the YAML content.
+    """
+    if Topic not in resources:
+        return
+
+    topics_dir = os.path.join(root_path, "topics")
+    if not os.path.isdir(topics_dir):
+        return
+
+    for topic in resources[Topic].values():
+        new_path = os.path.join(root_path, topic.file_path)
+        if os.path.exists(new_path):
+            continue
+
+        # Check for legacy file at the old (unclean) path
+        legacy_path = os.path.join(root_path, "topics", f"{topic.name}.yaml")
+        if not os.path.exists(legacy_path):
+            continue
+
+        # Read content, insert name field, write to new path, remove old file
+        content = Resource.read_from_file(legacy_path)
+        yaml_dict = resource_utils.load_yaml(content) or {}
+        if "name" not in yaml_dict:
+            yaml_dict = {"name": topic.name, **yaml_dict}
+            new_content = resource_utils.dump_yaml(yaml_dict)
+            with open(new_path, "w", encoding="utf-8") as f:
+                f.write(new_content)
+            os.remove(legacy_path)

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -12,7 +12,7 @@ import os
 import re
 from typing import Callable, Optional
 
-from poly.resources import resource_utils, Resource, ResourceMapping, Function, FunctionStep
+from poly.resources import Resource, ResourceMapping, Function, FunctionStep
 
 logger = logging.getLogger(__name__)
 
@@ -402,57 +402,3 @@ def compute_variable_references(
         for var_id in variable_references:
             var_refs.setdefault(var_id, {}).setdefault(field_name, {})[fn_id] = True
     return var_refs
-
-
-def _migrate_legacy_topic_files(root_path: str) -> None:
-    """Migrate topic files from legacy format (name as filename) to new format
-    (clean filename with name stored inside the YAML).
-
-    This handles the transition where topic files were previously saved as
-    ``topics/{name}.yaml`` and are now saved as ``topics/{clean_name}.yaml``
-    with a ``name`` key inside the YAML content.
-
-    Migrates both existing (pulled) topics and new local-only topic files.
-    """
-    topics_dir = os.path.join(root_path, "topics")
-
-    if not os.path.isdir(topics_dir):
-        return
-
-    topics = {}
-    old_files = []
-
-    for topic in os.listdir(topics_dir):
-        if not topic.endswith(".yaml"):
-            continue
-
-        topic_path = os.path.join(topics_dir, topic)
-        with open(topic_path, "r", encoding="utf-8") as f:
-            content = resource_utils.load_yaml(f.read())
-
-        if "name" in content:
-            # Already in new format, skip
-            continue
-
-        file_name = os.path.splitext(topic)[0]
-        clean_file_name = resource_utils.clean_name(file_name)
-        if clean_file_name in topics:
-            raise ValueError(
-                "Cant migrate legacy topic files: multiple topics with the same file name after cleaning: "
-                + clean_file_name
-            )
-
-        new_content = {"name": file_name, **content}
-
-        topics[clean_file_name] = new_content
-        old_files.append(topic_path)
-
-    # Write new files
-    for clean_name, content in topics.items():
-        new_path = os.path.join(topics_dir, f"{clean_name}.yaml")
-        with open(new_path, "w", encoding="utf-8") as f:
-            f.write(resource_utils.dump_yaml(content))
-
-    # Remove old file
-    for old_file in old_files:
-        os.remove(old_file)

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -12,7 +12,7 @@ import os
 import re
 from typing import Callable, Optional
 
-from poly.resources import resource_utils, Resource, ResourceMapping, Function, FunctionStep, Topic
+from poly.resources import resource_utils, Resource, ResourceMapping, Function, FunctionStep
 
 logger = logging.getLogger(__name__)
 
@@ -404,39 +404,55 @@ def compute_variable_references(
     return var_refs
 
 
-def _migrate_legacy_topic_files(
-    root_path: str, resources: dict[type[Resource], dict[str, Resource]]
-) -> None:
+def _migrate_legacy_topic_files(root_path: str) -> None:
     """Migrate topic files from legacy format (name as filename) to new format
     (clean filename with name stored inside the YAML).
 
     This handles the transition where topic files were previously saved as
     ``topics/{name}.yaml`` and are now saved as ``topics/{clean_name}.yaml``
     with a ``name`` key inside the YAML content.
-    """
-    if Topic not in resources:
-        return
 
+    Migrates both existing (pulled) topics and new local-only topic files.
+    """
     topics_dir = os.path.join(root_path, "topics")
+
     if not os.path.isdir(topics_dir):
         return
 
-    for topic in resources[Topic].values():
-        new_path = os.path.join(root_path, topic.file_path)
-        if os.path.exists(new_path):
+    topics = {}
+    old_files = []
+
+    for topic in os.listdir(topics_dir):
+        if not topic.endswith(".yaml"):
             continue
 
-        # Check for legacy file at the old (unclean) path
-        legacy_path = os.path.join(root_path, "topics", f"{topic.name}.yaml")
-        if not os.path.exists(legacy_path):
+        topic_path = os.path.join(topics_dir, topic)
+        with open(topic_path, "r", encoding="utf-8") as f:
+            content = resource_utils.load_yaml(f.read())
+
+        if "name" in content:
+            # Already in new format, skip
             continue
 
-        # Read content, insert name field, write to new path, remove old file
-        content = Resource.read_from_file(legacy_path)
-        yaml_dict = resource_utils.load_yaml(content) or {}
-        if "name" not in yaml_dict:
-            yaml_dict = {"name": topic.name, **yaml_dict}
-            new_content = resource_utils.dump_yaml(yaml_dict)
-            with open(new_path, "w", encoding="utf-8") as f:
-                f.write(new_content)
-            os.remove(legacy_path)
+        file_name = os.path.splitext(topic)[0]
+        clean_file_name = resource_utils.clean_name(file_name)
+        if clean_file_name in topics:
+            raise ValueError(
+                "Cant migrate legacy topic files: multiple topics with the same file name after cleaning: "
+                + clean_file_name
+            )
+
+        new_content = {"name": file_name, **content}
+
+        topics[clean_file_name] = new_content
+        old_files.append(topic_path)
+
+    # Write new files
+    for clean_name, content in topics.items():
+        new_path = os.path.join(topics_dir, f"{clean_name}.yaml")
+        with open(new_path, "w", encoding="utf-8") as f:
+            f.write(resource_utils.dump_yaml(content))
+
+    # Remove old file
+    for old_file in old_files:
+        os.remove(old_file)


### PR DESCRIPTION
## Summary
Topic filenames now use `clean_name()` (e.g. `topics/topic_1.yaml`) with the real name stored inside the YAML, matching the flow step pattern. This prevents topics with `/` in their name from being created as nested directories. Existing projects are auto-migrated on load.

## Motivation

Topic names containing `/` (e.g. `"Billing/Refunds"`) were being used directly as filenames, causing `os.path.join("topics", "Billing/Refunds.yaml")` to create nested folder structures instead of a single file.

## Changes

- **`topic.py`**: `file_path` uses `clean_name()`, `to_yaml_dict()` includes `name` field, new `read_local_resource()` override reads name from YAML and validates it matches the filename (with legacy fallback for old-format files)
- **`project.py`**: Added `Topic` to the `find_new_kept_deleted` block that reads resource names from YAML content for newly discovered files; added `_migration_flags` field to track applied migrations, persisted via `to_dict`/`from_dict`/`from_status_dict`; fresh pulls start with all flags set (no migration needed)
- **`migration_utils.py`** (new): Migration framework with `MigrationFlag` enum, `run_migrations()` dispatcher, and `migrate_legacy_topic_files()` — renames old `Topic Name.yaml` files to `topic_name.yaml` and injects the `name` key into the YAML content
- **`migration_test.py`** (new): Tests for the legacy topic file migration — rename, skip already-migrated, in-place update for clean names, mixed files
- **Test fixtures**: Renamed topic fixtures to clean names, added `name` field, updated all path assertions

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)