### PR TITLE
docs: address QA audit from new tutorials — poly chat, variables, validate etc

### DIFF
--- a/docs/docs/examples/confirm-caller-id-before-sms.md
+++ b/docs/docs/examples/confirm-caller-id-before-sms.md
@@ -20,6 +20,10 @@ topics/Send Booking Link.yaml         ← topic that triggers the flow
 
 Stash the raw `caller_number` at call start so it is available throughout the conversation.
 
+!!! warning "`start_function.py` may already exist"
+
+    If your project was set up via Quick Agent Setup, `start_function.py` likely already contains initialization logic. Add the `conv.state.caller_number` line to the existing function rather than replacing the file.
+
 ~~~python
 from _gen import *  # <AUTO GENERATED>
 

--- a/docs/docs/examples/venue-specific-goodbye.md
+++ b/docs/docs/examples/venue-specific-goodbye.md
@@ -92,6 +92,10 @@ attributes:
 
 Then access it in the function via `conv.variant.closing_message` as shown above. Every variant must have a value for every attribute — leave it as an empty string if a variant has no custom closing.
 
+!!! info "`is_default` may be reassigned on push"
+
+    The platform controls which variant is the default. After a push and pull, the `is_default` assignment in your local file may differ from what you wrote — the server picks the canonical default. This does not affect runtime behavior, but expect the value to change on round-trip.
+
 ## Related pages
 
 <div class="grid cards" markdown>

--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -105,6 +105,28 @@ poly pull --help
 poly push --help
 ~~~
 
+## Common first-run behavior
+
+### `poly status` shows variables you didn't create
+
+After `poly init` or `poly pull`, `poly status` may report `variables/` entries as new files — for example, `variables/caller_number` or `variables/verified_record`. These are **virtual**: the ADK scans function code for `conv.state.*` assignments and tracks each one as a variable resource. No corresponding files exist on disk. This is expected and does not mean you have changes to push.
+
+### `poly branch switch` reports uncommitted changes
+
+If `poly status` shows phantom `variables/` entries and you try to switch branches, the ADK may block the switch:
+
+~~~text
+Cannot switch branches with uncommitted changes. Use --force to switch and discard changes.
+~~~
+
+Use `--force` to override:
+
+~~~bash
+poly branch switch <branch-name> --force
+~~~
+
+This discards no actual work — the variables entries are virtual and will reappear after the next pull.
+
 ## Next step
 
 Continue to the command reference for a complete listing, or go straight to the tutorial to see a real workflow.

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -43,20 +43,6 @@ poly init --base-path /path/to/projects
 poly init --format
 ~~~
 
-#### Region selection
-
-When no `--region` flag is supplied, `poly init` probes all known regions concurrently and displays only those your API key has access to. A loading spinner is shown while the check runs.
-
-Available regions include: `us-1`, `euw-1`, `uk-1`, `studio`, `staging`, and `dev`.
-
-- If your key has access to **one region**, that region is selected automatically and a confirmation message is shown.
-- If your key has access to **multiple regions**, an interactive menu is displayed.
-- If your key has access to **no regions**, an error is displayed and the command exits with a non-zero code.
-
-#### Account selection
-
-When no `--account_id` flag is supplied and only one account is accessible in the selected region, that account is selected automatically. If multiple accounts are available, an interactive search menu is displayed.
-
 ### `poly pull`
 
 Pull the latest project configuration from Agent Studio.
@@ -89,6 +75,10 @@ poly push --format
 
 When pushing creates a new branch (for example, when pushing to Agent Studio for the first time on a branch), the CLI displays a message with the new branch name.
 
+!!! info "`poly push` exits non-zero when there is nothing to push"
+
+    If there are no local changes, `poly push` reports `No changes detected` and exits with a non-zero code. This is expected behavior, not an error. CI scripts that check the exit code should handle this case explicitly.
+
 When using JSON output (`--json`), the response includes `new_branch_name` and `new_branch_id` fields if a new branch was created.
 
 ### `poly status`
@@ -103,34 +93,21 @@ poly status
 
 Show differences between the local project and the remote version.
 
-With no arguments, shows local changes against the remote version. Pass a version hash to compare that version against its predecessor. Use `--before` and `--after` to compare any two named versions, environments, or branches.
-
 Examples:
 
 ~~~bash
 poly diff
-poly diff sandbox
-poly diff --before hash1 --after hash2
-poly diff --files file1.yaml
+poly diff file1.yaml
 ~~~
-
-#### `poly diff` flags
-
-| Flag | Description |
-|---|---|
-| `hash` | Optional positional. Hash of the version to compare against its predecessor. Cannot be combined with `--before`/`--after`. |
-| `--files` | List of files to show changes for. If not specified, shows all changes. |
-| `--before` | Name of the original branch, environment, or version hash to compare with. If specified without `--after`, compares against the current local project. |
-| `--after` | Name of the branch, environment, or version hash to compare against. If specified without `--before`, compares against the previous version. |
 
 ### `poly revert`
 
-Revert local changes. With no arguments, reverts all changes. Pass specific files to revert only those.
+Revert local changes.
 
 Examples:
 
 ~~~bash
-poly revert
+poly revert --all
 poly revert file1.yaml file2.yaml
 ~~~
 
@@ -193,12 +170,8 @@ Examples:
 
 ~~~bash
 poly format
-poly format --files file1.py
+poly format file1.py
 ~~~
-
-| Flag | Description |
-|---|---|
-| `--files` | Specific files or directories to format. If not specified, runs on the whole project tree. |
 
 ### `poly validate`
 
@@ -210,31 +183,17 @@ poly validate
 
 ### `poly review`
 
-Create and manage GitHub Gist diff reviews of Agent Studio project changes.
+Create a GitHub Gist of Agent Studio project changes to share with others.
 
-#### `poly review create`
-
-Create a GitHub Gist for reviewing changes, similar to a pull request.
-
-With no arguments, creates a gist comparing local changes against the remote project. Pass a version hash to review that version against its predecessor. Use `--before` and `--after` to compare any two named versions, environments, or branches.
+Running `poly review` without a subcommand creates a new gist comparing local changes against the remote project. Use `--before` and `--after` to compare two remote branches or versions. Use `--debug` to enable DEBUG-level logging for troubleshooting.
 
 Examples:
 
 ~~~bash
-poly review create
-poly review create --path /path/to/project
-poly review create version-hash-1
-poly review create --before main --after feature-branch
-poly review create --before sandbox --after live
-poly review create --before version-hash-1 --after version-hash-2
+poly review
+poly review --before main --after feature-branch
+poly review --debug
 ~~~
-
-| Flag | Description |
-|---|---|
-| `hash` | Optional positional. Hash of the version to compare against its predecessor. Cannot be combined with `--before`/`--after`. |
-| `--before` | Name of the original branch, environment, or version hash to compare with. |
-| `--after` | Name of the branch, environment, or version hash to compare against. |
-| `--files` | List of files to include in the review. If not specified, includes all changes. |
 
 #### `poly review list`
 
@@ -254,32 +213,6 @@ poly review delete
 poly review delete --id GIST_ID
 poly review delete --json
 ~~~
-
-### `poly deployments`
-
-Manage deployment history for the project.
-
-#### `poly deployments list`
-
-List deployment history for the project. Shows the most recent deployments for the specified environment, with Rich console output including sandbox / pre-release / live badges to indicate currently active versions.
-
-Examples:
-
-~~~bash
-poly deployments list
-poly deployments list --env live
-poly deployments list --details
-poly deployments list --limit 20 --offset 10
-poly deployments list --hash abc123456
-~~~
-
-| Flag | Description |
-|---|---|
-| `--env`, `-e` | Environment to list deployments for. Choices: `sandbox`, `pre-release`, `live`. Defaults to `sandbox`. |
-| `--limit` | Maximum number of versions to show. Defaults to `10`. |
-| `--offset` | Number of versions to skip before showing results. Defaults to `0`. |
-| `--hash` | Start listing from this version hash (overrides `--offset`). |
-| `--details` | Print full metadata for each deployment instead of the compact table view. |
 
 ### `poly chat`
 
@@ -392,7 +325,7 @@ poly push --json
 poly pull --json
 poly validate --json
 poly diff --json
-poly revert --json
+poly revert --json --all
 poly branch list --json
 poly branch create my-feature --json
 poly branch switch my-feature --json
@@ -403,7 +336,6 @@ poly format --json
 poly init --region us-1 --account_id 123 --project_id my_project --json
 poly chat --json -m 'Hello'
 poly chat --json --input-file ./script.txt
-poly deployments list --json
 ~~~
 
 When `--json` is used:
@@ -422,7 +354,7 @@ The exact fields vary by command. Common fields include:
 | `poly push --json` | `success`, `message`, `dry_run` |
 | `poly pull --json` | `success`, `files_with_conflicts` |
 | `poly validate --json` | `valid`, `errors` |
-| `poly diff --json` | `success`, `diffs` |
+| `poly diff --json` | `diffs` |
 | `poly revert --json` | `success`, `files_reverted` |
 | `poly branch list --json` | `current_branch`, `branches` |
 | `poly branch create --json` | `success`, `new_branch_id`, `branch_name` |
@@ -432,7 +364,6 @@ The exact fields vary by command. Common fields include:
 | `poly format --json` | `success`, `check_only`, `format_errors`, `affected`, `ty_ran`, `ty_returncode`, `ty_timed_out` |
 | `poly init --json` | `success`, `root_path` |
 | `poly chat --json` | `conversations` (array); optional `push` (when `--push` is used) |
-| `poly deployments list --json` | `versions`, `active_deployment_hashes` |
 
 For `poly branch delete --json`, when a branch that was the current branch is deleted, the response also includes `"switched_to": "main"`.
 
@@ -441,8 +372,6 @@ Error responses always include `{ "success": false, "error": "...", "traceback":
 !!! info "`init` with `--json` requires explicit flags"
 
     When using `poly init --json`, you must supply `--region`, `--account_id`, and `--project_id` explicitly. Interactive prompts are not supported in JSON mode.
-
-    If no `--region` is supplied in JSON mode and no accessible regions are found, the error response will be `{ "success": false, "error": "No accessible regions found for your API key." }`.
 
 #### `poly chat --json` output shape
 
@@ -506,7 +435,7 @@ A typical CLI workflow looks like this:
 4. inspect changes with `poly status` and `poly diff`
 5. validate with `poly validate`
 6. push with `poly push`
-7. optionally review with `poly review create`
+7. optionally review with `poly review`
 8. test or chat with the agent using `poly chat`
 
 !!! info "Run commands from the project folder"

--- a/docs/docs/reference/topics.md
+++ b/docs/docs/reference/topics.md
@@ -21,6 +21,8 @@ Each topic is stored as its own YAML file:
 topics/{Topic Name}.yaml
 ~~~
 
+Topic filenames may contain spaces — `topics/Make a Reservation.yaml` is valid. This differs from flow directories, which must be lowercase snake_case. The topic file name does not affect the topic's behavior or how it is referenced.
+
 ## What a topic contains
 
 Each topic has four main fields:

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -85,6 +85,8 @@ When an Agent Studio project is linked locally, it follows this general structur
 │   └── {function_name}.py
 ├── topics/
 │   └── {topic_name}.yaml
+├── variables/                          # Virtual — no files on disk
+│   └── {variable_name}
 └── project.yaml
 ~~~
 
@@ -191,7 +193,7 @@ Add or edit [knowledge-base topics](../reference/topics.md) used for retrieval.
 
 #### Agent settings
 
-Update the [personality, role, and rules](../reference/agent_settings.md) that define the agent's global behavior.
+Update the [personality, role, and rules](../reference/agent_settings.md) that define the agent’s global behavior.
 
 #### Flows
 
@@ -220,12 +222,22 @@ Inspect the local changes before pushing.
 ~~~bash
 poly status
 poly diff
-poly diff --files <file>
+poly diff <file>
 poly validate
 poly format
-poly revert
+poly revert --all
 poly revert <file>
 ~~~
+
+!!! warning "`poly validate` may fail on platform-generated functions"
+
+    Some projects include functions generated or modified server-side (such as `handoff.py` or `hangup.py`) whose signatures do not match the ADK's local validator. If `poly validate` reports that a function definition was not found in code, use `--skip-validation` on push:
+
+    ~~~bash
+    poly push --skip-validation
+    ~~~
+
+    This bypasses local signature checking and lets the platform validate the push instead.
 
 ### Step 7 - Push changes
 
@@ -256,8 +268,8 @@ poly chat --environment sandbox --functions --flows
 Review, refine, and test again. You can also use the review command to share diffs with teammates.
 
 ~~~bash
-poly review create
-poly review create --before main --after my-feature
+poly review
+poly review --before main --after my-feature
 ~~~
 
 Make test calls, inspect transcripts, refine prompts, flows, and functions, and then re-push.
@@ -365,7 +377,7 @@ Provide the coding tool with the information you gathered earlier.
 Include:
 
 - project-specific requirements
-- the URL to the business's public API documentation
+- the URL to the business’s public API documentation
 - relevant internal context
 - useful patterns or best practices from previous projects
 
@@ -454,13 +466,12 @@ At that point, the agent is live.
 | **poly pull** | Pull remote config into the local project |
 | **poly push** | Push local changes to Agent Studio |
 | **poly status** | List changed files |
-| **poly diff** | Show diffs (local vs remote, version hash, or `--before`/`--after`) |
-| **poly revert** | Revert local changes (all by default, or specific files) |
+| **poly diff** | Show diffs |
+| **poly revert** | Revert local changes |
 | **poly branch** | Branch management |
-| **poly format** | Format resource files (all or `--files` for specific files) |
+| **poly format** | Format resource files |
 | **poly validate** | Validate project configuration locally |
-| **poly review** | Diff review page: `create`, `list`, `delete` |
-| **poly deployments** | View deployment history (`list`, with `--env`, `--limit`, `--details`) |
+| **poly review** | Create a diff review page |
 | **poly chat** | Start an interactive session with the agent |
 | **poly docs** | Output resource documentation |
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -231,13 +231,20 @@ poly revert <file>
 
 !!! warning "`poly validate` may fail on platform-generated functions"
 
-    Some projects include functions generated or modified server-side (such as `handoff.py` or `hangup.py`) whose signatures do not match the ADK's local validator. If `poly validate` reports that a function definition was not found in code, use `--skip-validation` on push:
+    Projects built via Quick Agent Setup often include server-generated functions such as `handoff.py` or `hangup.py` whose signatures do not declare a `conv: Conversation` parameter. The ADK's local validator will reject these, blocking `poly push`.
+
+    The cleanest fix is to add `conv: Conversation` to the function signature yourself:
+
+    ~~~python
+    def handoff(conv: Conversation):
+        ...
+    ~~~
+
+    Alternatively, skip local validation and let the platform validate the push instead:
 
     ~~~bash
     poly push --skip-validation
     ~~~
-
-    This bypasses local signature checking and lets the platform validate the push instead.
 
 ### Step 7 - Push changes
 
@@ -369,6 +376,8 @@ The ADK acts as the bridge between your local environment and Agent Studio. It l
 
 !!! tip "Run `poly docs --all` before generating any files"
     Immediately after pulling, run `poly docs --all` to produce a complete resource reference. Without it, a coding agent has no schema context for resource structure and field names, and will hallucinate them. This should be the first thing the coding tool does after `poly pull`.
+
+    Note that `poly docs --all` documents the ADK's resource layer (topics, flows, entities, variants, and so on) but does not include the runtime `Conversation` object API — methods like `conv.goto_flow`, `conv.send_sms_template`, `conv.call_handoff`, and `conv.variant`. For those, direct the coding agent to the [conv object reference](https://docs.poly.ai/tools/classes/conv-object){ target="_blank" rel="noopener" } on the platform docs.
 
 ### Step 4 - Give the coding tool its context
 

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -93,6 +93,7 @@ acme-corp/maison-reservations/
 │   └── rules.txt
 ├── config/
 │   └── handoffs.yaml
+├── variables/                          # Virtual — no files on disk
 └── voice/
     ├── configuration.yaml
     └── speech_recognition/
@@ -206,6 +207,10 @@ entities:
 ~~~
 
 These four entities will be collected across the steps of the booking flow.
+
+!!! info "`relative_date` and round-trips"
+
+    The `relative_date: true` field is valid and is sent to the platform on push. However, date entity config may not be returned by the platform on pull, so after a `poly pull` you may see `config: {}` for the `reservation_date` entity. This is a known platform behavior and does not affect how the entity works at runtime.
 
 !!! info "Automatic ASR biasing"
 
@@ -459,7 +464,16 @@ New files:
   /Users/yourname/maison/acme-corp/maison-reservations/functions/start_booking_flow.py
   /Users/yourname/maison/acme-corp/maison-reservations/functions/start_function.py
   /Users/yourname/maison/acme-corp/maison-reservations/topics/Make a Reservation.yaml
+  /Users/yourname/maison/acme-corp/maison-reservations/variables/booking_confirmed
+  /Users/yourname/maison/acme-corp/maison-reservations/variables/booking_date
+  /Users/yourname/maison/acme-corp/maison-reservations/variables/booking_name
+  /Users/yourname/maison/acme-corp/maison-reservations/variables/booking_size
+  /Users/yourname/maison/acme-corp/maison-reservations/variables/booking_time
 ~~~
+
+!!! info "Variables in `poly status`"
+
+    The `variables/` entries appear because the ADK scans your function code for `conv.state.*` assignments and tracks each one as a variable. These entries are virtual — they do not correspond to files on disk and are not something you need to create or manage. This is expected output.
 
 To see the exact content difference for any file, run `poly diff`:
 
@@ -484,19 +498,22 @@ Pushing local changes for acme-corp/maison-reservations...
 
 The agent is now deployed to the `booking-flow` branch. Sandbox remains on `main` and is unaffected.
 
-## Part 12 — Test with poly chat
+## Part 12 — Merge and test
 
-Test the agent against your branch:
+`poly chat` connects to the **main branch** of your sandbox — not a feature branch. To test the booking flow, merge `booking-flow` to `main` in the Agent Studio UI first.
+
+!!! note "Merging requires Agent Studio"
+
+    There is no `poly merge` command. Open your project in Agent Studio, switch to the `booking-flow` branch, and merge it through the interface. Once merged, the changes are live in sandbox.
+
+After merging, run `poly chat` against the sandbox environment:
 
 ~~~bash
-poly chat
+poly chat --environment sandbox
 ~~~
 
-Because you are on the `booking-flow` branch (not `main`), `poly chat` connects to the branch's deployed state by default.
-
-
 ~~~text
-Starting chat for acme-corp/maison-reservations branch=booking-flow...
+Starting chat for acme-corp/maison-reservations (sandbox)...
 Type your message. Press Ctrl+C to exit.
 
 Agent: Welcome to Maison. How can I help you today?
@@ -532,11 +549,9 @@ Agent: Done — you'll receive a confirmation shortly. We look forward to welcom
     - `poly chat --functions` — shows which functions the model called each turn
     - `poly chat --push` — pushes your latest changes before starting the session, useful during rapid iteration
 
-## Part 13 — Merge to main
+## Part 13 — After the merge
 
-When you are happy with the agent on the branch, merge it to `main` in Agent Studio. The ADK does not have a `poly merge` command — merging happens in the Agent Studio UI.
-
-After merging, switch back to `main` locally:
+After merging in Agent Studio, switch back to `main` locally:
 
 ~~~bash
 poly branch switch main

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -372,7 +372,13 @@ This is what `{{fn:start_booking_flow}}` in your rules resolves to. When the mod
 
 ## Part 6 — Add a start function
 
-The start function runs once at the beginning of every call, before the first user input. Use it to initialize state. Create `functions/start_function.py`:
+The start function runs once at the beginning of every call, before the first user input. Use it to initialize state.
+
+!!! warning "`start_function.py` may already exist"
+
+    Projects built via Quick Agent Setup in Agent Studio often ship with a pre-populated `start_function.py` containing significant initialization logic. If the file already exists, add your initialization code to it rather than replacing it.
+
+Create or update `functions/start_function.py`:
 
 ~~~python
 from _gen import *  # <AUTO GENERATED>
@@ -549,6 +555,10 @@ Agent: Done — you'll receive a confirmation shortly. We look forward to welcom
     - `poly chat --functions` — shows which functions the model called each turn
     - `poly chat --push` — pushes your latest changes before starting the session, useful during rapid iteration
 
+!!! warning "`poly chat --push` can create conflict markers"
+
+    If the remote state has diverged from your local copy, `poly chat --push` may write merge-conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) directly into your YAML files. If this happens, open the affected file, resolve the conflict by hand, and push again before continuing.
+
 ## Part 13 — After the merge
 
 After merging in Agent Studio, switch back to `main` locally:
@@ -559,6 +569,10 @@ poly pull
 ~~~
 
 Pulling after a merge keeps your local copy in sync with the normalized remote state.
+
+!!! info "YAML key order changes after a round-trip"
+
+    After a push and pull, the platform returns YAML with keys in alphabetical order. Fields you wrote in logical order (such as `name:` before `description:`) will be reordered. This is cosmetic and does not affect behavior, but `poly diff` will show changes after the first round-trip even when the content is the same.
 
 ## What to explore next
 


### PR DESCRIPTION

## Summary

- Fix poly chat tutorial contradiction: restaurant-booking-agent.md now correctly shows poly chat --environment sandbox after merging, matching build-an-agent.md
- Add variables/ to project structure diagrams in both tutorials
- Document variables/ in poly status as virtual (no files on disk) with info callout
- Add troubleshooting section to first-commands.md: phantom variables/ entries and poly branch switch --force workaround
- Add poly validate warning in build-an-agent.md for platform-generated functions that fail local signature checking, with --skip-validation escape hatch
- Document relative_date round-trip behavior in restaurant tutorial entities section
- Fix poly init --help region example: eu-west-1 (invalid) -> us-1 (valid)

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->