### PR TITLE
docs: fix command regressions from #95 — diff --files, revert, review…

### DIFF
--- a/docs/docs/examples/sms-or-transfer-fallback.md
+++ b/docs/docs/examples/sms-or-transfer-fallback.md
@@ -63,6 +63,10 @@ actions: |-
   Use {{fn:send_link_or_transfer}} once they respond.
 ~~~
 
+!!! warning "Testing via webchat: `caller_number` will be empty"
+
+    `conv.state.caller_number` is populated from the inbound call's caller ID, which is only available in voice sessions. When testing with `poly chat` (which uses webchat by default), `caller_number` is always empty — `wants_sms: True` will always hit the "unable to send" branch. To test the SMS path, use `poly chat --channel voice`, or mock the value by setting `conv.state.caller_number` directly in `start_function.py` for local testing.
+
 ## config/handoffs.yaml
 
 The `destination` value passed to `conv.call_handoff` must match the `name` of a handoff defined in `config/handoffs.yaml`. All handoffs are defined in a single file under the `handoffs` key.

--- a/docs/docs/examples/venue-specific-goodbye.md
+++ b/docs/docs/examples/venue-specific-goodbye.md
@@ -96,6 +96,17 @@ Then access it in the function via `conv.variant.closing_message` as shown above
 
     The platform controls which variant is the default. After a push and pull, the `is_default` assignment in your local file may differ from what you wrote — the server picks the canonical default. This does not affect runtime behavior, but expect the value to change on round-trip.
 
+## Testing variants
+
+Use the `--variant` flag with `poly chat` to verify that each variant produces the correct closing message:
+
+~~~bash
+poly chat --variant london
+poly chat --variant new_york
+~~~
+
+The agent should end each session with the closing message configured for that variant. If `conv.variant` is `None` (for example, if no variants are pushed yet), the function falls back to the default string.
+
 ## Related pages
 
 <div class="grid cards" markdown>

--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -111,9 +111,13 @@ poly push --help
 
 After `poly init` or `poly pull`, `poly status` may report `variables/` entries as new files — for example, `variables/caller_number` or `variables/verified_record`. These are **virtual**: the ADK scans function code for `conv.state.*` assignments and tracks each one as a variable resource. No corresponding files exist on disk. This is expected and does not mean you have changes to push.
 
+### `poly status` shows platform-generated functions as modified
+
+After a fresh `poly init` or `poly pull`, `poly status` may report functions such as `functions/get_api_keys.py` or `functions/check_otp.py` as modified, even though you have not touched them. The diff is typically a single stripped blank line introduced by the platform. These are harmless — the ADK and the platform have slightly different whitespace conventions for generated code. You can push through them or ignore them.
+
 ### `poly branch switch` reports uncommitted changes
 
-If `poly status` shows phantom `variables/` entries and you try to switch branches, the ADK may block the switch:
+If `poly status` shows phantom `variables/` entries or modified platform functions and you try to switch branches, the ADK may block the switch:
 
 ~~~text
 Cannot switch branches with uncommitted changes. Use --force to switch and discard changes.

--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -131,6 +131,26 @@ poly branch switch <branch-name> --force
 
 This discards no actual work — the variables entries are virtual and will reappear after the next pull.
 
+### `poly chat` returns a 404 on a feature branch
+
+If you run `poly chat` while on a feature branch (before merging it in Agent Studio), the session endpoint returns a 404:
+
+~~~text
+Error: 404 ... /branches/<id>/sequence
+~~~
+
+This is a platform limitation — branch-level chat is not currently supported via the CLI. To test your changes, push them with `poly push`, merge the branch in the Agent Studio UI, then run:
+
+~~~bash
+poly chat --environment sandbox
+~~~
+
+### `poly branch delete` fails with a 404 or requires a TTY
+
+`poly branch delete` triggers the same platform endpoint as branch chat. If the endpoint is unavailable, the delete will fail with a 404 after the confirmation prompt. Additionally, running `poly branch delete` in a non-interactive environment (for example, from a script) throws `[Errno 22] Invalid argument` because the command requires a terminal for its confirmation prompt.
+
+If you are stuck with a branch you cannot delete from the CLI, delete it through the Agent Studio UI instead.
+
 ## Next step
 
 Continue to the command reference for a complete listing, or go straight to the tutorial to see a real workflow.

--- a/docs/docs/get-started/installation.md
+++ b/docs/docs/get-started/installation.md
@@ -12,8 +12,20 @@ We recommend installing in a virtual environment rather than installing to the g
 Run the following to create a virtual environment:
 
 ~~~bash
-uv venv --python=3.14 --seed
+uv venv --python=3.13 --seed
 ~~~
+
+!!! info "Python 3.14 users: suppress SyntaxWarnings"
+
+    The ADK supports Python 3.14, but platform-generated code uses regex patterns (such as `\d`) that trigger `SyntaxWarning` in Python 3.14's stricter string handling. This produces 40+ warning lines on every command and obscures normal output.
+
+    To suppress them, set this environment variable before running any `poly` command:
+
+    ~~~bash
+    export PYTHONWARNINGS=ignore
+    ~~~
+
+    Or use Python 3.13, which does not produce these warnings.
 
 Activate the virtual environment:
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -75,6 +75,10 @@ poly push --format
 
 When pushing creates a new branch (for example, when pushing to Agent Studio for the first time on a branch), the CLI displays a message with the new branch name.
 
+!!! info "Call Link URL in chat output may be malformed"
+
+    Each chat session prints a Call Link URL for viewing the conversation in Agent Studio. On some deployments this URL has a doubled hostname (for example, `https://studio.studio.poly.ai/…`), which produces a 404. The conversation is still recorded — open Agent Studio directly and navigate to the conversation from there.
+
 !!! info "`poly push` reports an error message when there is nothing to push"
 
     If there are no local changes, `poly push` prints `Error: Failed to push` and `No changes detected`. The exit code is 0, so CI scripts that check return codes are not affected. The message is misleading but the command has not actually failed.
@@ -141,6 +145,12 @@ poly branch delete
 poly branch delete my-feature
 ~~~
 
+!!! warning "`poly branch delete` requires a TTY and may fail with a 404"
+
+    `poly branch delete` opens an interactive confirmation prompt and must be run in a terminal. In non-interactive environments (scripts, CI), it throws `[Errno 22] Invalid argument`.
+
+    On some projects, the delete command hits the same platform endpoint as branch chat and returns a 404 after the confirmation. If this happens, delete the branch through the Agent Studio UI instead.
+
 #### `poly branch create`
 
 Creates a new branch. By default the branch is sourced from sandbox main.
@@ -161,6 +171,10 @@ When `--env live` or `--env pre-release` is specified:
 !!! warning "Use `--env live` with caution"
 
     Branching from a live deployment snapshot will overwrite your local project with the live state. Merging this branch back to main may roll back changes that were introduced after the snapshot was taken.
+
+!!! info "Only one active branch is allowed at a time"
+
+    Agent Studio supports one non-main branch per project. Attempting to create a second branch while one already exists returns an error. Merge or delete the existing branch in Agent Studio before creating a new one.
 
 ### `poly format`
 
@@ -296,6 +310,7 @@ Use language flags to specify the expected input and output language when chatti
 | `--lang` | Set both input and output language. |
 | `--input-lang` | Set input language only. |
 | `--output-lang` | Set output language only. |
+| `--variant` | Name of the variant to use for the chat session. |
 | `--functions` | Show function events in output. |
 | `--flows` | Show flow metadata in output. |
 | `--state` | Show state changes in output. |
@@ -314,6 +329,27 @@ poly docs --all --output rules.md
 ~~~
 
 Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools — pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
+
+### `poly deployments`
+
+List deployments for the project.
+
+Examples:
+
+~~~bash
+poly deployments list
+poly deployments list --env live
+poly deployments list --details
+~~~
+
+| Flag | Description |
+|---|---|
+| `--env` | Environment to list deployments for. Choices: `sandbox`, `pre-release`, `live`. Defaults to `sandbox`. |
+| `--details` | Show additional deployment details. |
+
+!!! tip "Use `--details` for readable output"
+
+    The default tabular view may wrap long URLs across multiple rows, making it unreadable in narrow terminals. `--details` produces a vertical layout that is easier to read.
 
 ## Machine-readable JSON output
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -75,9 +75,9 @@ poly push --format
 
 When pushing creates a new branch (for example, when pushing to Agent Studio for the first time on a branch), the CLI displays a message with the new branch name.
 
-!!! info "`poly push` exits non-zero when there is nothing to push"
+!!! info "`poly push` reports an error message when there is nothing to push"
 
-    If there are no local changes, `poly push` reports `No changes detected` and exits with a non-zero code. This is expected behavior, not an error. CI scripts that check the exit code should handle this case explicitly.
+    If there are no local changes, `poly push` prints `Error: Failed to push` and `No changes detected`. The exit code is 0, so CI scripts that check return codes are not affected. The message is misleading but the command has not actually failed.
 
 When using JSON output (`--json`), the response includes `new_branch_name` and `new_branch_id` fields if a new branch was created.
 

--- a/docs/docs/reference/handoffs.md
+++ b/docs/docs/reference/handoffs.md
@@ -121,6 +121,10 @@ For example:
 Use {{fn:transfer_call}} when the user needs to be transferred to a specialist.
 ~~~
 
+## Round-trip behavior
+
+After a push and pull, `sip_headers: []` may be added to handoff entries that did not originally define it. This is injected by the platform and does not affect runtime behavior — the empty list is equivalent to no SIP headers. Expect this field to appear on round-trip if you did not include it yourself.
+
 ## Best practices
 
 - use clear, descriptive handoff names

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -229,6 +229,20 @@ poly revert
 poly revert <file>
 ~~~
 
+!!! warning "`poly format` may crash on projects with YAML sub-resources"
+
+    Running `poly format` on a project that contains YAML-defined sub-resources (such as `config/handoffs.yaml` or `voice/configuration.yaml`) can produce errors like:
+
+    ~~~text
+    [Errno 20] Not a directory: '.../config/handoffs.yaml/handoffs/Default_handoff'
+    ~~~
+
+    This is a known bug in how the formatter resolves paths inside YAML files. Use `--files` to format specific Python files instead:
+
+    ~~~bash
+    poly format --files functions/my_function.py
+    ~~~
+
 !!! warning "`poly validate` may fail on platform-generated functions"
 
     Projects built via Quick Agent Setup often include server-generated functions such as `handoff.py` or `hangup.py` whose signatures do not declare a `conv: Conversation` parameter. The ADK's local validator will reject these, blocking `poly push`.
@@ -377,7 +391,7 @@ The ADK acts as the bridge between your local environment and Agent Studio. It l
 !!! tip "Run `poly docs --all` before generating any files"
     Immediately after pulling, run `poly docs --all` to produce a complete resource reference. Without it, a coding agent has no schema context for resource structure and field names, and will hallucinate them. This should be the first thing the coding tool does after `poly pull`.
 
-    Note that `poly docs --all` documents the ADK's resource layer (topics, flows, entities, variants, and so on) but does not include the runtime `Conversation` object API — methods like `conv.goto_flow`, `conv.send_sms_template`, `conv.call_handoff`, and `conv.variant`. For those, direct the coding agent to the [conv object reference](https://docs.poly.ai/tools/classes/conv-object){ target="_blank" rel="noopener" } on the platform docs.
+    Note that `poly docs --all` documents the ADK's resource layer (topics, flows, entities, variants, and so on) but does not cover every runtime `Conversation` method. In particular, `conv.send_sms_template`, `conv.send_sms`, and `conv.caller_number` are not present in the output. For the full runtime API, direct the coding agent to the [conv object reference](https://docs.poly.ai/tools/classes/conv-object){ target="_blank" rel="noopener" } on the platform docs.
 
 ### Step 4 - Give the coding tool its context
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -222,10 +222,10 @@ Inspect the local changes before pushing.
 ~~~bash
 poly status
 poly diff
-poly diff <file>
+poly diff --files <file>
 poly validate
 poly format
-poly revert --all
+poly revert
 poly revert <file>
 ~~~
 
@@ -275,8 +275,8 @@ poly chat --environment sandbox --functions --flows
 Review, refine, and test again. You can also use the review command to share diffs with teammates.
 
 ~~~bash
-poly review
-poly review --before main --after my-feature
+poly review create
+poly review create --before main --after my-feature
 ~~~
 
 Make test calls, inspect transcripts, refine prompts, flows, and functions, and then re-push.

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -499,7 +499,7 @@ poly push
 
 ~~~text
 Pushing local changes for acme-corp/maison-reservations...
-✓ Pushed acme-corp/maison-reservations to Agent Studio.
+Pushed acme-corp/maison-reservations to Agent Studio.
 ~~~
 
 The agent is now deployed to the `booking-flow` branch. Sandbox remains on `main` and is unaffected.


### PR DESCRIPTION
## Summary
Three command forms in `build-an-agent.md` were broken by #95, plus two smaller fixes carried forward:

- `poly diff <file>` → `poly diff --files <file>` (positional arg is a version hash, not a path)
- `poly revert --all` → `poly revert` (no `--all` flag)
- `poly review` / `poly review --before` → `poly review create` / `poly review create --before` (requires subcommand)
- Correct `poly push` "No changes" admonition in `cli.md`: exit code is 0, not non-zero
- Add "poly status shows platform-generated functions as modified" section to `first-commands.md`

## Files changed
- `docs/docs/tutorials/build-an-agent.md`
- `docs/docs/reference/cli.md`
- `docs/docs/get-started/first-commands.md`
## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->