### PR TITLE
docs: fix install blocker and correct two testing notes

### DIFF
--- a/docs/docs/examples/sms-or-transfer-fallback.md
+++ b/docs/docs/examples/sms-or-transfer-fallback.md
@@ -63,9 +63,15 @@ actions: |-
   Use {{fn:send_link_or_transfer}} once they respond.
 ~~~
 
-!!! warning "Testing via webchat: `caller_number` will be empty"
+!!! warning "Testing via `poly chat`: `caller_number` will be empty"
 
-    `conv.state.caller_number` is populated from the inbound call's caller ID, which is only available in voice sessions. When testing with `poly chat` (which uses webchat by default), `caller_number` is always empty — `wants_sms: True` will always hit the "unable to send" branch. To test the SMS path, use `poly chat --channel voice`, or mock the value by setting `conv.state.caller_number` directly in `start_function.py` for local testing.
+    `conv.state.caller_number` is populated from inbound caller ID, which is only available on a real voice call. When testing with `poly chat`, `caller_number` is always empty regardless of `--channel` — `wants_sms: True` will always hit the "unable to send" branch.
+
+    To exercise the SMS path locally, mock the value in `start_function.py`:
+
+    ~~~python
+    conv.state.caller_number = "+15551234567"  # remove before deploying
+    ~~~
 
 ## config/handoffs.yaml
 

--- a/docs/docs/examples/venue-specific-goodbye.md
+++ b/docs/docs/examples/venue-specific-goodbye.md
@@ -107,6 +107,10 @@ poly chat --variant new_york
 
 The agent should end each session with the closing message configured for that variant. If `conv.variant` is `None` (for example, if no variants are pushed yet), the function falls back to the default string.
 
+!!! info "`--variant` resolves against the deployed environment"
+
+    `--variant` looks up the variant name in the environment you are chatting against (default: sandbox main). If you pushed `variant_attributes.yaml` on a feature branch but have not merged it yet, the variant names will not exist in sandbox and the flag will have no effect. Merge the branch in Agent Studio first, then run `poly chat --variant <name>`.
+
 ## Related pages
 
 <div class="grid cards" markdown>

--- a/docs/docs/get-started/installation.md
+++ b/docs/docs/get-started/installation.md
@@ -12,20 +12,18 @@ We recommend installing in a virtual environment rather than installing to the g
 Run the following to create a virtual environment:
 
 ~~~bash
-uv venv --python=3.13 --seed
+uv venv --python=3.14 --seed
 ~~~
 
-!!! info "Python 3.14 users: suppress SyntaxWarnings"
+!!! info "Suppress SyntaxWarnings from platform-generated code"
 
-    The ADK supports Python 3.14, but platform-generated code uses regex patterns (such as `\d`) that trigger `SyntaxWarning` in Python 3.14's stricter string handling. This produces 40+ warning lines on every command and obscures normal output.
+    Platform-generated code uses regex patterns (such as `\d`) that trigger `SyntaxWarning` in Python 3.14's stricter string handling. This produces 40+ warning lines on every `poly` command and obscures normal output.
 
-    To suppress them, set this environment variable before running any `poly` command:
+    To suppress them, set this before running any `poly` command:
 
     ~~~bash
     export PYTHONWARNINGS=ignore
     ~~~
-
-    Or use Python 3.13, which does not produce these warnings.
 
 Activate the virtual environment:
 


### PR DESCRIPTION
- installation.md: revert to Python 3.14 (polyai-adk requires >=3.14; 3.13 broke installation); keep PYTHONWARNINGS=ignore escape hatch for SyntaxWarning noise
- sms-or-transfer-fallback.md: remove incorrect --channel voice suggestion; caller_number is empty regardless of channel in poly chat; show mock-via-start_function pattern instead
- venue-specific-goodbye.md: add callout that --variant resolves against the deployed environment; branch must be merged before variant names exist in sandbox

## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->