### PR TITLE
docs: swap walkthrough video, tighten wording

### DIFF
--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -129,7 +129,7 @@ Use `--force` to override:
 poly branch switch <branch-name> --force
 ~~~
 
-This discards no actual work — the variables entries are virtual and will reappear after the next pull.
+This does not lose any real work — the `variables/` entries are virtual and will reappear after the next pull.
 
 ### `poly chat` returns a 404 on a feature branch
 

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -5,7 +5,7 @@ description: Learn how to build your first PolyAI agent in minutes, then connect
 
 # Not sure where to start?
 
-If you do not yet have an agent in Agent Studio, or if you are feeling stuck before diving into local development, you can build a personalized agent from your company website in a few minutes — no configuration required. The agent lives in Agent Studio as a normal project, which means you can pull it straight into the ADK and continue development locally the moment it is ready.
+If you do not yet have an agent in Agent Studio, or you want a working starting point before setting up the ADK, you can build a personalized agent from your company website in a few minutes — no configuration required. The agent lives in Agent Studio as a normal project, so you can pull it straight into the ADK and continue development locally as soon as it is ready.
 
 ---
 

--- a/docs/docs/get-started/walkthrough-video.md
+++ b/docs/docs/get-started/walkthrough-video.md
@@ -5,8 +5,6 @@ description: Watch a walkthrough of building a production-ready voice agent with
 
 This walkthrough shows how to build a production-ready voice agent with the **PolyAI ADK**.
 
-It demonstrates the end-to-end developer workflow and shows how the ADK fits alongside a coding tool such as Claude Code.
-
 ## Watch the video
 
 <div style="padding:64.98% 0 0 0; position:relative;">

--- a/docs/docs/get-started/walkthrough-video.md
+++ b/docs/docs/get-started/walkthrough-video.md
@@ -3,20 +3,20 @@ title: Walkthrough Video
 description: Watch a walkthrough of building a production-ready voice agent with the PolyAI ADK.
 ---
 
-This walkthrough shows how quickly a production-ready voice agent can be built using the **PolyAI ADK**.
+This walkthrough shows how to build a production-ready voice agent with the **PolyAI ADK**.
 
-It gives a practical look at the developer workflow and shows how the ADK fits into a coding-tool-assisted development process.
+It demonstrates the end-to-end developer workflow and shows how the ADK fits alongside a coding tool such as Claude Code.
 
 ## Watch the video
 
 <div style="padding:64.98% 0 0 0; position:relative;">
   <iframe
-    src="https://player.vimeo.com/video/1173322390?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
+    src="https://player.vimeo.com/video/1185280299?badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479"
     frameborder="0"
     allow="autoplay; fullscreen; picture-in-picture; clipboard-write; encrypted-media; web-share"
     referrerpolicy="strict-origin-when-cross-origin"
     style="position:absolute; top:0; left:0; width:100%; height:100%;"
-    title="Building a production-ready voice agent in less than 30 minutes with PolyAI ADK">
+    title="PolyAI ADK Walkthrough">
   </iframe>
 </div>
 

--- a/docs/docs/get-started/what-is-the-adk.md
+++ b/docs/docs/get-started/what-is-the-adk.md
@@ -20,15 +20,15 @@ It gives you a Git-like workflow for synchronizing project configuration between
 
 ## Why it exists
 
-The ADK moves development work out of the browser and into your local environment.
+The ADK moves most build-and-edit work out of the browser and into your local environment. You still use Agent Studio to merge branches, deploy, and monitor the agent in production — but you no longer have to edit resources there by hand.
 
 Instead of editing everything directly inside Agent Studio, you pull a project locally, make changes using your normal tools, and push those changes back to the platform.
 
 This makes it straightforward to:
 
-- iterate quickly without browser round-trips
+- edit resources in your own editor, with the tooling you already use
 - collaborate across a team without overwriting each other's work
-- validate and test changes before pushing them live
+- validate and review changes before pushing them live
 - automate repetitive build work with coding tools
 
 ## Multi-developer workflows

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,7 +5,7 @@ description: Documentation for the PolyAI Agent Development Kit.
 
 ![PolyAI ADK](assets/poly-ai-adk.png)
 
-Build, edit, and deploy Agent Studio projects locally with the **PolyAI ADK**.
+Build and edit Agent Studio projects locally with the **PolyAI ADK**, then push them back to Agent Studio to review and deploy.
 
 The ADK gives you a local, Git-like workflow for Agent Studio projects: pull, edit with standard tooling, validate, and push.
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -120,13 +120,13 @@ poly pull -f
 
     All CLI commands should be run from within the local project folder, unless you explicitly use the relevant path flag.
 
-### Step 3 - Run the agent locally
+### Step 3 - Chat with the agent
 
 Start an interactive chat session to confirm the connection works and inspect runtime behavior.
 
-!!! info "What poly chat connects to at this stage"
+!!! info "`poly chat` runs against Agent Studio, not your local files"
 
-    At this point in the setup you are on the main branch, so `poly chat` connects to your sandbox environment in Agent Studio — not local uncommitted files. This is useful for confirming the connection works. To chat against your own feature branch changes, push them first with `poly push`, then run `poly chat` from that branch (or use `poly chat --push` to push and chat in one step).
+    The ADK has no local runtime — `poly chat` talks to the agent running in Agent Studio. At this stage you are on `main`, so the session connects to your sandbox. To chat against a feature branch, push it first with `poly push` and then run `poly chat` (or use `poly chat --push` to do both in one step).
 
 ~~~bash
 poly chat

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -9,7 +9,7 @@ description: A complete walkthrough building a voice agent that takes table rese
 This tutorial builds a complete voice agent for a restaurant. By the end you will have a working agent that greets callers, collects a reservation, confirms the details, and sends an SMS confirmation.
 </p>
 
-You will use the ADK to define, iterate on, and test the agent entirely from your terminal.
+You will use the ADK to define the agent, iterate on it, and push it for testing. Merging and deployment still happen in Agent Studio.
 
 ## What you will build
 


### PR DESCRIPTION
Removes phrasing that implied the Agent Studio UI is never needed (merging, deploying, and monitoring still happen there), swaps the walkthrough video for https://vimeo.com/1185280299, and tightens a few confusing wordings across the get-started and tutorial pages.