### PR TITLE
docs: document VS Code/Cursor ADK extension as a first-class IDE route

### DIFF
--- a/docs/docs/concepts/working-locally.md
+++ b/docs/docs/concepts/working-locally.md
@@ -10,7 +10,7 @@ Your local filesystem becomes your primary editing surface. You can:
 - edit agent resources directly
 - review changes with Git-style workflows
 - validate changes before pushing
-- use [AI coding tools](../reference/tooling.md) such as **Cursor** or **Claude Code**
+- work in **VS Code** or **Cursor** with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor), or pair the ADK with [AI coding agents](../reference/tooling.md#claude-code) such as **Claude Code**
 - test and iterate before merging in Agent Studio
 
 <div class="grid cards" markdown>

--- a/docs/docs/get-started/walkthrough-video.md
+++ b/docs/docs/get-started/walkthrough-video.md
@@ -5,6 +5,8 @@ description: Watch a walkthrough of building a production-ready voice agent with
 
 This walkthrough shows how to build a production-ready voice agent with the **PolyAI ADK**.
 
+It demonstrates the end-to-end developer workflow and shows how the ADK fits alongside the [PolyAI ADK extension for VS Code and Cursor](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor), or a coding agent such as Claude Code.
+
 ## Watch the video
 
 <div style="padding:64.98% 0 0 0; position:relative;">
@@ -33,7 +35,7 @@ This walkthrough shows how to build a production-ready voice agent with the **Po
 
     ---
 
-    Watch the ADK used alongside tools such as Claude Code to accelerate implementation.
+    Watch the ADK used alongside the PolyAI ADK extension for VS Code or Cursor, or a coding agent such as Claude Code, to accelerate implementation.
 
 -   **Fast iteration**
 

--- a/docs/docs/get-started/walkthrough-video.md
+++ b/docs/docs/get-started/walkthrough-video.md
@@ -5,7 +5,7 @@ description: Watch a walkthrough of building a production-ready voice agent with
 
 This walkthrough shows how to build a production-ready voice agent with the **PolyAI ADK**.
 
-It demonstrates the end-to-end developer workflow and shows how the ADK fits alongside the [PolyAI ADK extension for VS Code and Cursor](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor), or a coding agent such as Claude Code.
+It demonstrates the end-to-end developer workflow and shows how the ADK fits alongside the [PolyAI ADK extension for VS Code and Cursor](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor).
 
 ## Watch the video
 
@@ -29,25 +29,13 @@ It demonstrates the end-to-end developer workflow and shows how the ADK fits alo
 
     ---
 
-    See how agent work can move from the browser into a local development environment.
-
--   **AI-assisted development**
-
-    ---
-
-    Watch the ADK used alongside the PolyAI ADK extension for VS Code or Cursor, or a coding agent such as Claude Code, to accelerate implementation.
+    Watch the ADK used alongside the PolyAI ADK extension for VS Code or Cursor to accelerate implementation.
 
 -   **Fast iteration**
 
     ---
 
     Follow the flow from setup to a working agent in a short amount of time.
-
--   **Production mindset**
-
-    ---
-
-    See how the ADK supports building agents that are intended for real deployment, not just demos.
 
 </div>
 

--- a/docs/docs/get-started/what-is-the-adk.md
+++ b/docs/docs/get-started/what-is-the-adk.md
@@ -15,7 +15,7 @@ It gives you a Git-like workflow for synchronizing project configuration between
 - Build and edit Agent Studio projects locally using standard tooling
 - Synchronize project configuration with Agent Studio using `poly push` and `poly pull`
 - Branch, validate, and review changes before deployment
-- Use [AI coding tools](../reference/tooling.md) such as **Claude Code** to generate and update project files
+- Edit and navigate projects in **VS Code** or **Cursor** with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor), or pair the ADK with [AI coding agents](../reference/tooling.md#claude-code) such as **Claude Code**
 - Collaborate across multiple developers on the same project
 
 ## Why it exists

--- a/docs/docs/reference/tooling.md
+++ b/docs/docs/reference/tooling.md
@@ -13,22 +13,45 @@ The ADK is especially useful when paired with tools that help developers inspect
 
 ## Recommended tooling
 
+There are two well-supported paths for working with the ADK. They are not mutually exclusive — many developers use both.
+
+### PolyAI ADK extension for VS Code and Cursor
+
+The **PolyAI ADK extension** brings ADK-aware editing into **VS Code** and **Cursor**. It is the recommended path if you prefer an IDE-first workflow.
+
+The extension helps with:
+
+- navigating and editing flows, functions, topics, entities, and agent settings with resource-aware tooling
+- catching common mistakes while you edit, before you push
+- driving `poly` commands without leaving the editor
+- pairing with your IDE's built-in AI features (Cursor's agent, VS Code Copilot, etc.) to generate and update project files
+
+#### Install the extension
+
+The extension is published on **Open VSX**, so it works in both VS Code and Cursor.
+
+1. Open the Extensions view in VS Code or Cursor.
+2. Search for `PolyAI ADK` and install it, or install it directly from the [Open VSX listing](https://open-vsx.org/extension/PolyAI/adk-extension){ target="_blank" rel="noopener" }.
+3. Open a project that has been pulled down with `poly pull`.
+
+Once installed, the extension auto-detects local ADK projects and exposes resource-aware navigation, validation, and commands.
+
 ### Claude Code
 
-PolyAI recommends using **Claude Code** for development with the ADK.
+**Claude Code** is a good alternative when you want an agentic CLI workflow — useful for generating a project from a brief, applying patterns across many files, or running longer build tasks end-to-end.
 
 The repository includes a `.claude/` directory with project-specific instructions and examples.
 
 Claude Code is particularly useful for:
 
 - generating project resources from structured requirements
-- updating flows and functions
+- updating flows and functions at scale
 - applying patterns reused across previous projects
 - speeding up repetitive implementation work
 
 #### Loading ADK rules into Claude Code
 
-Before starting a session with Claude Code or another coding tool, generate a documentation file and pass it as context:
+Before starting a session with Claude Code or another external coding tool, generate a documentation file and pass it as context:
 
 ~~~bash
 poly docs --all --output rules.md
@@ -36,9 +59,9 @@ poly docs --all --output rules.md
 
 Reference `rules.md` in your session prompt. This gives the coding tool accurate knowledge of ADK resource types, constraints, and conventions.
 
-### VS Code extension
+!!! tip "Use both where useful"
 
-A **PolyAI ADK VS Code extension** is available in the VS Code Marketplace. Search for `PolyAI.adk-extension` or install it directly from the [marketplace listing](https://marketplace.visualstudio.com/items?itemName=PolyAI.adk-extension){ target="_blank" rel="noopener" }.
+    The IDE extension and Claude Code cover different modes of work. You can edit in VS Code or Cursor day-to-day and still reach for Claude Code when you want an agent to generate or refactor a large slice of the project on your behalf.
 
 ## Other local tools
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -3,7 +3,7 @@ title: Build an agent with the ADK
 description: Follow the end-to-end workflow for going from a blank Agent Studio project to a production-ready voice agent with the PolyAI ADK.
 ---
 
-This guide walks through how to go from a blank slate to a production-ready voice agent using **Agent Studio**, the **PolyAI ADK**, and optionally a coding tool such as **Claude Code**.
+This guide walks through how to go from a blank slate to a production-ready voice agent using **Agent Studio**, the **PolyAI ADK**, and — optionally — the **PolyAI ADK extension** for **VS Code** or **Cursor**, or a coding agent such as **Claude Code**.
 
 There are two common ways to build with the ADK:
 
@@ -308,7 +308,7 @@ Use Agent Studio analytics to monitor containment, CSAT, handle time, and flagge
 
 ## Workflow 2 - AI-agent workflow
 
-The AI-agent workflow uses a coding tool such as **Claude Code** to run the same development loop on your behalf.
+The AI-agent workflow uses a coding agent — such as **Claude Code**, or an in-editor agent in **VS Code** or **Cursor** paired with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) — to run the same development loop on your behalf.
 
 <div class="grid cards" markdown>
 


### PR DESCRIPTION
Adds the PolyAI ADK extension for VS Code and Cursor (published on Open VSX) as a first-class tooling option, alongside Claude Code as an alternative coding-agent path. Reworks the reference tooling page with install instructions from https://open-vsx.org/extension/PolyAI/adk-extension, and updates prose in the walkthrough video, what-is-the-adk, working-locally, and build-an-agent pages so the IDE route is sustainable without requiring an AI coding agent.