### PR TITLE
docs: promote poly init, clarify ingress modes, and document personality Other correctly

### DIFF
--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -5,7 +5,27 @@ description: Learn the core PolyAI ADK commands and how to inspect the CLI.
 
 # First commands
 
-Once the ADK is installed, the fastest way to get oriented is to inspect the CLI directly.
+Once the ADK is installed and your API key is set, the very first thing to do is create a local project with `poly init`. After that, the fastest way to get oriented is to inspect the CLI directly from inside that project folder.
+
+## Create your local project with `poly init`
+
+~~~bash
+poly init --account_id <account_id> --project_id <project_id>
+~~~
+
+`poly init` creates a subdirectory at `{account_id}/{project_id}` in your current directory and immediately pulls the project configuration down from Agent Studio. When it completes, `cd` into that folder — every other `poly` command runs from inside the project directory.
+
+!!! tip "Find your account ID and project ID"
+
+    Both IDs appear in the Agent Studio URL when your project is open:
+
+    ~~~
+    https://studio.poly.ai/<account_id>/<project_id>/...
+    ~~~
+
+    If you do not have the IDs to hand, run `poly init` with no flags and the CLI prompts you to pick a workspace and project from the ones your API key can see.
+
+If the project has already been initialized locally at a previous point, use `poly pull` to refresh it in place instead of running `poly init` again.
 
 ## View top-level help
 

--- a/docs/docs/get-started/installation.md
+++ b/docs/docs/get-started/installation.md
@@ -37,6 +37,10 @@ Install the package with pip:
 pip install polyai-adk
 ~~~
 
+!!! tip "Optional — install the VS Code / Cursor extension"
+
+    If you plan to work in **VS Code** or **Cursor**, you can also install the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) for resource-aware editing on top of the CLI. The extension is additive — the `poly` command remains the source of truth for every workflow.
+
 ## Generate API key
 
 Log in to Agent Studio and open your workspace. In the **API Keys** tab (next to the **Users** tab), click **+ API key** in the top right to generate a key.
@@ -65,7 +69,7 @@ You should see the top-level command help if installation succeeded.
 
 ## Next step
 
-Continue to the first commands page to explore the CLI.
+With the ADK installed and your API key set, run `poly init` to create your local project and get familiar with the CLI.
 
 <div class="grid cards" markdown>
 
@@ -73,7 +77,7 @@ Continue to the first commands page to explore the CLI.
 
     ---
 
-    Learn the core ADK commands and how to inspect the CLI.
+    Start with `poly init`, then learn the rest of the core ADK commands.
     [Open first commands](./first-commands.md)
 
 </div>

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -19,7 +19,7 @@ export POLY_ADK_KEY=<your-api-key>
 poly init --account_id <account_id> --project_id <project_id>
 ~~~
 
-See [Prerequisites](get-started/prerequisites.md) for how to generate an API key, and [Initialize your project](get-started/initialize-your-project.md) for a short walkthrough of the third command.
+See [Prerequisites](get-started/prerequisites.md) for how to generate an API key, and [Initialize your project](get-started/first-commands.md) for a short walkthrough of the third command.
 
 ## Start here
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,6 +9,18 @@ Build and edit Agent Studio projects locally with the **PolyAI ADK**, then push 
 
 The ADK gives you a local, Git-like workflow for Agent Studio projects: pull, edit with standard tooling, validate, and push.
 
+## From zero to a local project
+
+Three commands take you from an empty machine to a working local copy of your agent:
+
+~~~bash
+pip install polyai-adk
+export POLY_ADK_KEY=<your-api-key>
+poly init --account_id <account_id> --project_id <project_id>
+~~~
+
+See [Prerequisites](get-started/prerequisites.md) for how to generate an API key, and [Initialize your project](get-started/initialize-your-project.md) for a short walkthrough of the third command.
+
 ## Start here
 
 <div class="grid cards" markdown>
@@ -60,5 +72,5 @@ If you are new to the ADK, follow this order:
 2. read **What is the PolyAI ADK?**
 3. complete **Prerequisites**
 4. follow **Installation**
-5. use **First commands**
+5. use **First commands** — run `poly init` to create your local project, then explore the rest of the CLI
 6. continue to **Build an agent with the ADK**

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -96,6 +96,8 @@ This structure mirrors the parts of the agent that Agent Studio understands: set
 
 The CLI workflow is the manual developer path. You use the ADK directly, edit the project locally, and push changes back to Agent Studio.
 
+You can run this workflow in whichever editing surface you prefer: a plain terminal, or **VS Code** / **Cursor** with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) for resource-aware navigation and validation. Both count as the CLI workflow — the difference is only the editing surface.
+
 ### Step 1 - Initialize your project
 
 Link a local folder to an existing Agent Studio project. The agent must already exist in Agent Studio.

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -136,11 +136,24 @@ adjectives:
 custom: ""
 ~~~
 
+The file has two fields:
+
+- **`adjectives`** — a map of preset tonal traits. Each is set to `true` or `false`; every selected trait is combined into the agent's personality.
+- **`custom`** — a free-text description that can extend or replace the adjectives. It accepts `{{attr:...}}` and `{{vrbl:...}}` references, so the personality can vary per [variant](../reference/variants.md) or per call.
+
 !!! info "Allowed adjective values"
 
-    The ADK validates adjectives against a fixed set. The allowed values are: `Polite`, `Calm`, `Kind`, `Funny`, `Energetic`, `Thoughtful`, and `Other`. Using any other value will cause `poly push` to fail with a validation error.
+    `adjectives` keys must come from a fixed set: `Polite`, `Calm`, `Kind`, `Funny`, `Energetic`, `Thoughtful`, and `Other`. Any other key causes `poly push` to fail with a validation error.
 
-    `Other` is a special case — it can only be set when no other adjective is selected.
+!!! tip "How `Other` works"
+
+    `Other` is the "none of the above" switch. When you set `Other: true`, every other adjective must be `false` (or omitted) — combining `Other: true` with any other adjective set to `true` fails validation with:
+
+    ~~~text
+    Other adjective can only be set if no other adjectives are selected.
+    ~~~
+
+    Use `Other: true` together with the `custom` field when the six presets do not capture the tone you want and you would rather describe the personality entirely in free form. You do **not** need `Other: true` just to use `custom` — `custom` can always be added on top of preset adjectives to refine them further.
 
 ### Role
 


### PR DESCRIPTION
Three related docs fixes. (1) Gives poly init a front-page moment: adds a three-command quickstart block under the front-page hero, makes poly init the lead section of First commands, and updates the Recommended path and Installation next-step so install → init → explore reads as one flow. (2) Sweeps the didactic flow for the three ingress modes (IDE, Claude Code, full terminal): the Installation page now points at the VS Code/Cursor extension at install time, and the build-an-agent tutorial clarifies that running the CLI workflow inside an IDE is still the CLI workflow. (3) Rewrites the personality section of the restaurant-booking tutorial so the Other adjective and the custom field are explained accurately — Other is a mutex switch over the six preset adjectives, and custom works independently of it (unlike Role, where custom is gated on value: other).