### PR TITLE
fix: Normalise local content on pull

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -868,7 +868,16 @@ class AgentStudioProject:
                     original_content = ""
                     local_file_path = incoming_resource.get_path(self.root_path)
                 try:
-                    local_content = resource_type.read_from_file(local_file_path)
+                    local_resource = resource_type.read_local_resource(
+                        local_file_path,
+                        resource_id=incoming_resource.resource_id,
+                        resource_name=incoming_resource.name,
+                        resource_mappings=incoming_resource_mappings,
+                    )
+                    local_content = local_resource.to_pretty(
+                        resource_name=incoming_resource.name,
+                        resource_mappings=incoming_resource_mappings,
+                    )
                 except FileNotFoundError:
                     # If local file doesn't exist:
                     # If no original content, save the incoming content
@@ -885,6 +894,8 @@ class AgentStudioProject:
                             format=format,
                         )
                     continue
+                except Exception:
+                    local_content = resource_type.read_from_file(local_file_path)
 
                 incoming_content = incoming_resource.to_pretty(
                     resource_name=incoming_resource.name,

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -868,6 +868,7 @@ class AgentStudioProject:
                     original_content = ""
                     local_file_path = incoming_resource.get_path(self.root_path)
                 try:
+                    # Normalise the local resource to ensure formatting differences don't cause unnecessary merge conflicts
                     local_resource = resource_type.read_local_resource(
                         local_file_path,
                         resource_id=incoming_resource.resource_id,
@@ -895,6 +896,7 @@ class AgentStudioProject:
                         )
                     continue
                 except Exception:
+                    # If can't read file but file exists, use local version
                     local_content = resource_type.read_from_file(local_file_path)
 
                 incoming_content = incoming_resource.to_pretty(

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -473,7 +473,7 @@ class FlowStep(BaseFlowStep, YamlResource):
             step_type=step_type,
             asr_biasing=asr_biasing,
             dtmf_config=dtmf_config,
-            prompt=yaml_dict.get("prompt"),
+            prompt=yaml_dict.get("prompt", "").strip(),
             conditions=conditions,
             position=known_position,
             extracted_entities=extracted_entities,

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -2330,6 +2330,46 @@ class PullProjectTest(unittest.TestCase):
         self.assertIn("Modified locally", saved_content)
         self.assertIn("Modified remotely", saved_content)
 
+    def test_pull_project_local_formatting_difference_no_false_conflict(self):
+        """Cosmetic formatting differences in the local file should not cause merge conflicts.
+
+        The local file has the same semantic content as the original but with trailing
+        whitespace in the description.  The normalisation step (read_local_resource +
+        to_pretty) should produce the same string as the canonical original, so when
+        the remote modifies the description the merge should apply cleanly.
+        """
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        original_resources = deepcopy(project.resources)
+
+        # Remote modifies the description
+        incoming_resources = deepcopy(original_resources)
+        flow_config_id = "FLOW_CONFIG-test_flow"
+        modified_flow_config = deepcopy(incoming_resources[FlowConfig][flow_config_id])
+        modified_flow_config.description = "Modified remotely"
+        incoming_resources[FlowConfig][flow_config_id] = modified_flow_config
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+
+        flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
+        # Local file: same semantic content as original but with trailing whitespace
+        local_with_cosmetic_diff = (
+            "name: test_flow\n"
+            "description: Test flow with advanced step as start   \n"
+            "start_step: start_step\n"
+        )
+
+        with mock_read_from_file({flow_config_path: local_with_cosmetic_diff}):
+            files_with_conflicts, _ = project.pull_project(force=False)
+
+        self.assertEqual(files_with_conflicts, [])
+        flow_config_calls = [
+            call
+            for call in self.mock_save_to_file.call_args_list
+            if len(call[0]) >= 2 and call[0][1] == flow_config_path
+        ]
+        saved_content = flow_config_calls[-1][0][0] if flow_config_calls else ""
+        self.assertNotIn("<<<<<<<", saved_content)
+        self.assertIn("Modified remotely", saved_content)
+
     def test_pull_project_modify_no_conflict(self):
         """Test pulling when a resource is modified both locally and remotely without conflicts"""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -2463,6 +2463,32 @@ class FlowStepTests(unittest.TestCase):
         self.assertEqual(step.asr_biasing, ASRBiasing(flow_id="flow-123", step_id="step-1"))
         self.assertEqual(step.dtmf_config, DTMFConfig(flow_id="flow-123", step_id="step-1"))
 
+    def test_prompt_whitespace_is_stripped(self):
+        """Prompts with leading/trailing whitespace are stripped on read."""
+        yaml_dict = yaml.safe_load("step_type: advanced_step\nname: Test Step\nprompt: '  Hello  '\n")
+        step = FlowStep.from_yaml_dict(
+            yaml_dict,
+            resource_id="Test Flow_step-1",
+            file_name="test_step",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            resource_mappings=[],
+        )
+        self.assertEqual(step.prompt, "Hello")
+
+    def test_missing_prompt_defaults_to_empty_string(self):
+        """Steps without a prompt field default to an empty string rather than None."""
+        yaml_dict = yaml.safe_load("step_type: advanced_step\nname: Test Step\n")
+        step = FlowStep.from_yaml_dict(
+            yaml_dict,
+            resource_id="Test Flow_step-1",
+            file_name="test_step",
+            flow_id="flow-123",
+            flow_name="Test Flow",
+            resource_mappings=[],
+        )
+        self.assertEqual(step.prompt, "")
+
     def test_function_name_swapping(self):
         """Test the core function name swapping functionality."""
         original_content = "prompt: Use {{fn:func-123}} and {{fn:func-456}}\n"


### PR DESCRIPTION
## Summary

Fixes issue where YAML formatting could cause irrelevant merge conflicts

## Motivation

When pulling, local YAML files could trigger conflicts purely due to formatting discrepancies

## Changes

- **`project.py`** — normalise the local resource through `read_local_resource` + `to_pretty` before feeding it into the three-way merge, so local and incoming content use the same canonical serialisation; falls back to raw file content if the resource can't be parsed
- **`flows.py`** — strip whitespace from the parsed `prompt` field. As this is stripped on the platform.

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)