### PR TITLE
fix: Read disclaimer enabled correctly

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -406,7 +406,7 @@ class SyncClientHandler:
                     resource_id="voice_disclaimer",
                     name="voice_disclaimer",
                     message=voice_disclaimer.get("message", ""),
-                    enabled=voice_disclaimer.get("enabled", False),
+                    enabled=voice_disclaimer.get("isEnabled", False),
                     language_code=voice_disclaimer.get("languageCode", "en-GB"),
                 )
             }


### PR DESCRIPTION
## Summary

Fixes the voice disclaimer `enabled` field always reading as `False` due to a wrong key name when parsing the API projection response.

## Motivation

The Agent Studio API returns voice disclaimer data with camelCase keys (`isEnabled`, `languageCode`), but the code was reading `enabled` instead of `isEnabled`. This caused the disclaimer to always be treated as disabled regardless of its actual state on the platform.

Closes #<!-- issue number -->

## Changes

- Fix key name mismatch in `_read_agent_settings_from_projection`: read `isEnabled` instead of `enabled` for voice disclaimer

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)