### PR TITLE
fix: Only end call on explicit end events or in interactive mode

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2816,6 +2816,7 @@ class AgentStudioCLI:
             if output_json and initial_response is not None
             else []
         )
+        end_call = False
         try:
             while True:
                 if input_messages is not None:
@@ -2835,9 +2836,11 @@ class AgentStudioCLI:
                 if user_input is None:
                     continue
                 if user_input.lower() == "/exit":
+                    end_call = True
                     break
                 if user_input.lower() == "/restart":
                     restart = True
+                    end_call = True
                     break
 
                 try:
@@ -2868,7 +2871,7 @@ class AgentStudioCLI:
                         plain("[muted]Conversation ended by agent.[/muted]")
                     break
         finally:
-            if not conversation_ended:
+            if end_call or (not conversation_ended and not output_json):
                 try:
                     project.end_chat(conversation_id, environment)
                     if not output_json:


### PR DESCRIPTION
## Summary

Fixes `end_chat` being called after every turn in `--json` mode, which was terminating the conversation and breaking `--conv-id` resumption.

## Motivation

`poly chat --json --conv-id <id> -m "..."` is the pattern for programmatic turn-by-turn conversations. The previous condition (`if not conversation_ended`) fired even in JSON mode when input was exhausted, killing the session after each turn.

Closes #<!-- issue number -->

## Changes

- Added `end_call` flag, set only on `/exit` or `/restart`
- `finally` now uses `if end_call or (not conversation_ended and not output_json)` — `end_chat` skipped in JSON mode unless explicitly triggered

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)