### PR TITLE
fix: scrub orphaned @func_parameter decorators when parameter is removed from signature

### DIFF
--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -584,7 +584,17 @@ class Function(Resource):
                 if decorator_name == "func_parameter" and len(decorator.args) == 2:
                     name, desc = (arg.value for arg in decorator.args)
                     matched_arg = next((arg for arg in target.args.args if arg.arg == name), None)
-                    if matched_arg is None or matched_arg.annotation is None:
+                    if matched_arg is None:
+                        # Parameter named in the decorator is not present in the function
+                        # signature — it was likely removed. Scrub the orphaned decorator.
+                        logger.warning(
+                            f"Scrubbing orphaned @func_parameter({name!r}, ...) decorator from "
+                            f"function {function_name!r}: parameter {name!r} is not in the "
+                            f"function signature."
+                        )
+                        removable_lines.update(range(decorator.lineno - 1, decorator.end_lineno))
+                        continue
+                    if matched_arg.annotation is None:
                         raise ValueError(
                             f"Parameter {name!r} has no type annotation. "
                             f"Supported types: str, int, float, bool."

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -861,6 +861,99 @@ def my_func(conv: Conversation, booking_ref: Optional[str]):
         self.assertIn("booking_ref", str(ctx.exception))
         self.assertIn("unsupported type annotation", str(ctx.exception))
 
+    # ------------------------------------------------------------------
+    # Orphaned @func_parameter scrubbing tests
+    # ------------------------------------------------------------------
+
+    def test_orphaned_func_parameter_decorator_is_scrubbed(self):
+        """A @func_parameter whose name is absent from the signature is silently removed."""
+        # Simulates a function where 'send_sms' was removed from the signature
+        # but its decorator was left behind (the bug described in the Slack thread).
+        code = """\
+@func_description('Exit the SST stop flow')
+@func_parameter('send_sms', 'Whether to send an SMS')
+def exit_sst_stop(conv: Conversation):
+    pass
+"""
+        cleaned_code, params, desc, lc = Function._extract_decorators(
+            code, "exit_sst_stop", []
+        )
+
+        # The orphaned decorator must be stripped from the code
+        self.assertNotIn("func_parameter", cleaned_code)
+        # No parameter should be extracted (it was orphaned)
+        self.assertEqual(params, [])
+        # The valid description decorator should still be extracted
+        self.assertEqual(desc, "Exit the SST stop flow")
+
+    def test_orphaned_func_parameter_does_not_block_valid_parameters(self):
+        """A stale decorator for a missing param is scrubbed; valid ones are kept."""
+        code = """\
+@func_description('My function')
+@func_parameter('stale_param', 'This param was removed')
+@func_parameter('active_param', 'This param still exists')
+def my_func(conv: Conversation, active_param: str):
+    pass
+"""
+        cleaned_code, params, desc, lc = Function._extract_decorators(
+            code, "my_func", []
+        )
+
+        # The stale decorator must be stripped
+        self.assertNotIn("stale_param", cleaned_code)
+        # The valid parameter must be extracted correctly
+        self.assertEqual(len(params), 1)
+        self.assertEqual(params[0].name, "active_param")
+        self.assertEqual(params[0].description, "This param still exists")
+        self.assertEqual(params[0].type, "string")
+
+    def test_orphaned_func_parameter_logged_as_warning(self):
+        """Scrubbing an orphaned decorator emits a warning log."""
+        import logging
+
+        code = """\
+@func_parameter('gone_param', 'No longer in signature')
+def my_func(conv: Conversation):
+    pass
+"""
+        with self.assertLogs("poly.resources.function", level=logging.WARNING) as log_ctx:
+            Function._extract_decorators(code, "my_func", [])
+
+        self.assertTrue(
+            any("gone_param" in msg and "orphaned" in msg for msg in log_ctx.output),
+            f"Expected orphaned-param warning in logs, got: {log_ctx.output}",
+        )
+
+    def test_read_local_resource_scrubs_orphaned_decorator(self):
+        """read_local_resource does not raise when a @func_parameter is orphaned."""
+        # This mirrors the real-world bug: exit_sst_stop had @func_parameter('send_sms', ...)
+        # but 'send_sms' was not in its signature, causing a hard validation error.
+        test_file_content = """\
+from _gen import *  # <AUTO GENERATED>
+
+@func_description('Stop the SST flow')
+@func_parameter('send_sms', 'Whether to send an SMS on exit')
+def exit_sst_stop(conv: Conversation):
+    return conv.end()
+"""
+        with mock_read_from_file(test_file_content):
+            result = Function.read_local_resource(
+                file_path="functions/exit_sst_stop.py",
+                resource_id="fn-abc",
+                resource_name="exit_sst_stop",
+                resource_mappings=[],
+                known_parameters=[],
+                known_latency_control=FunctionLatencyControl(),
+            )
+
+        # The orphaned decorator is gone from the stored code
+        self.assertNotIn("send_sms", result.code)
+        self.assertNotIn("func_parameter", result.code)
+        # No parameters extracted
+        self.assertEqual(result.parameters, [])
+        # Description still extracted correctly
+        self.assertEqual(result.description, "Stop the SST flow")
+
 
 TEST_TOPIC = Topic(
     resource_id="123",


### PR DESCRIPTION
## Summary

- **Bug**: When a function parameter is removed from a function signature, stale `@func_parameter` decorators referencing that parameter were left in the file. On the next `pull` or `push`, `_extract_decorators` tried to look up the parameter in the AST, found nothing, and raised a hard `ValueError` ("Parameter '...' has no type annotation") — blocking all merges for the project. Reported in [Slack thread](https://polyai.slack.com/archives/C0A8H5J8BQF/p1777042531512559) (confirmed by Ruari): stale `@func_parameter("send_sms", ...)` surviving on `exit_sst_stop` after `send_sms` was dropped from the signature.
- **Fix**: In `Function._extract_decorators` (`src/poly/resources/function.py`), when a `@func_parameter` decorator's named parameter is absent from the function's argument list, emit a `WARNING` log and add the decorator lines to `removable_lines` (scrubbing it), rather than raising a `ValueError`.
- **Tests**: 4 new tests in `FunctionTests` covering: orphaned decorator is removed, mixed valid+stale decorators (valid ones kept), warning log emitted, and end-to-end `read_local_resource` path that was broken in production.

## Test plan

- [ ] `ruff check .` passes
- [ ] `ruff format --check .` passes
- [ ] `uv run pytest src/poly/tests/ -v -q` — 501 tests pass (4 new)
- [ ] Manually verify a function file with a stale `@func_parameter` no longer blocks `poly push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)