### PR TITLE
docs: fix safety filters page rendering

### DIFF
--- a/docs/docs/reference/safety_filters.md
+++ b/docs/docs/reference/safety_filters.md
@@ -7,6 +7,7 @@ description: Configure project-level and per-channel content safety filtering fo
 
 <p class="lead">
 Safety filters block harmful content from entering or leaving the conversation in real time.
+</p>
 
 They run on user input and on agent output, scoring each turn against four content categories and blocking it before it affects the conversation.
 


### PR DESCRIPTION
## Summary

Closes the `<p class="lead">` tag at the top of `docs/docs/reference/safety_filters.md`. The closing `</p>` was lost during the merge of #111, which caused mkdocs-material to treat the rest of the file as raw HTML and skip markdown rendering — the page shipped without styling.

## Motivation

The page on the live docs site rendered as unstyled plain text. Every other reference page closes the lead `<p>` (e.g. [agent_settings.md](https://github.com/polyai/adk/blob/main/docs/docs/reference/agent_settings.md), [voice_settings.md](https://github.com/polyai/adk/blob/main/docs/docs/reference/voice_settings.md)) — this brings safety_filters in line.

## Changes

- Add closing `</p>` after the lead paragraph in `docs/docs/reference/safety_filters.md`.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Verified locally with `mkdocs build --strict`: lead paragraph now closes correctly, 3 grid card blocks and 10 H2 headings render in the output HTML.

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)