### PR TITLE
docs: align tutorials and CLI reference with actual ADK surface

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -121,7 +121,8 @@ Examples:
 
 ~~~bash
 poly diff
-poly diff file1.yaml
+poly diff --files file1.yaml
+poly diff --before main --after my-feature
 ~~~
 
 ### `poly revert`
@@ -131,9 +132,11 @@ Revert local changes.
 Examples:
 
 ~~~bash
-poly revert --all
+poly revert
 poly revert file1.yaml file2.yaml
 ~~~
+
+`poly revert` with no arguments reverts every change in the working tree; pass file paths to revert only those files.
 
 ### `poly branch`
 
@@ -257,7 +260,8 @@ Examples:
 
 ~~~bash
 poly format
-poly format file1.py
+poly format --check
+poly format --files src/functions/booking.py
 ~~~
 
 ### `poly validate`
@@ -272,14 +276,14 @@ poly validate
 
 Create a GitHub Gist of Agent Studio project changes to share with others.
 
-Running `poly review` without a subcommand creates a new gist comparing local changes against the remote project. Use `--before` and `--after` to compare two remote branches or versions. Use `--debug` to enable DEBUG-level logging for troubleshooting.
+`poly review` requires a subcommand: `create`, `list`, or `delete`. Use `poly review create` to compare your local changes against the remote project, or pass `--before` and `--after` to compare two remote branches or versions. Add `--verbose` for full error tracebacks while troubleshooting.
 
 Examples:
 
 ~~~bash
-poly review
-poly review --before main --after feature-branch
-poly review --debug
+poly review create
+poly review create --before main --after feature-branch
+poly review create --verbose
 ~~~
 
 #### `poly review list`
@@ -434,7 +438,7 @@ poly push --json
 poly pull --json
 poly validate --json
 poly diff --json
-poly revert --json --all
+poly revert --json
 poly branch list --json
 poly branch create my-feature --json
 poly branch switch my-feature --json

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -285,9 +285,9 @@ poly push --skip-validation
 
 Once your branch is merged in Agent Studio, test the agent by chatting with it against the sandbox environment.
 
-!!! warning "Merge before chatting"
+!!! note "Pushing before chatting"
 
-    `poly chat` connects to the **main branch** of your sandbox — not your feature branch. Push your changes with `poly push`, merge the branch in Agent Studio, then run `poly chat`.
+    By default, `poly chat` connects to your current branch's last pushed state — so push your latest changes first. On the `main` branch, `poly chat` falls back to the sandbox environment. To target a specific environment explicitly, pass `--environment sandbox`, `--environment pre-release`, or `--environment live`.
 
 ~~~bash
 poly chat --environment sandbox
@@ -309,8 +309,8 @@ Make test calls, inspect transcripts, refine prompts, flows, and functions, and 
 
 Once the changes are pushed and validated, merge the branch in Agent Studio and deploy the project.
 
-!!! note "Merging requires the Agent Studio web UI"
-    There is no `poly merge` command. To merge a branch, open the project in Agent Studio, switch to the branch, and merge it through the interface. After merging, run `poly chat --environment sandbox` to test.
+!!! note "Merging from the CLI or the Agent Studio web UI"
+    Merge from the CLI with `poly branch merge '<commit message>'`, which merges the current branch into `main` (use `--interactive` to resolve any conflicts in your `$EDITOR`). You can also merge through the Agent Studio web UI by switching to the branch and clicking **Merge**. After merging, run `poly chat --environment sandbox` to test.
 
 ### Step 11 - Monitor performance
 
@@ -486,7 +486,7 @@ Check that the key parts of the agent look correct:
 
 Once everything looks right:
 
-1. merge the branch into the main project through the Agent Studio web UI — there is no `poly merge` command
+1. merge the branch into `main` — either with `poly branch merge '<commit message>'` from the CLI or through the Agent Studio web UI
 2. deploy the project
 
 At that point, the agent is live.

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -601,11 +601,11 @@ The agent is now deployed to the `booking-flow` branch. Sandbox remains on `main
 
 ## Part 13 — Merge and test
 
-`poly chat` connects to the **main branch** of your sandbox — not a feature branch. To test the booking flow, merge `booking-flow` to `main` in the Agent Studio UI first.
+By default, `poly chat` connects to your current branch's last pushed state. On `main` it falls back to the sandbox environment. To test `booking-flow` against sandbox alongside the rest of the project, merge it into `main` first.
 
-!!! note "Merging requires Agent Studio"
+!!! note "Merging from the CLI or Agent Studio"
 
-    There is no `poly merge` command. Open your project in Agent Studio, switch to the `booking-flow` branch, and merge it through the interface. Once merged, the changes are live in sandbox.
+    Merge from the CLI with `poly branch merge '<commit message>'` (run from the `booking-flow` branch), or open the project in Agent Studio, switch to the `booking-flow` branch, and merge through the web UI. Pass `--interactive` to `poly branch merge` to resolve any conflicts in your `$EDITOR`.
 
 After merging, run `poly chat` against the sandbox environment:
 


### PR DESCRIPTION
## Summary

Audit fixes against `src/poly/cli.py` and `src/poly/project.py`. Several places in the tutorials and CLI reference described behavior that does not match the code — most visibly Naorin's flag that `build-an-agent.md` claims "there is no `poly merge` command" when `poly branch merge` exists.

## Motivation

- Naorin flagged `poly merge` references in `build-an-agent.md` step 7 and step 13. The audit found a third occurrence and the same staleness in `restaurant-booking-agent.md`.
- A wider sweep of recent merges turned up several `cli.md` examples that no longer parse against the real argparse definitions.

Closes Naorin's `#docs` thread on the `poly merge` references.

## Changes

### Tutorials
- **`build-an-agent.md`** L290 / L313 / L489: replace "there is no `poly merge` command" with the real story — `poly branch merge '<commit message>'` (CLI) or merge in Agent Studio. Reword the "main branch of your sandbox" claim about `poly chat`; the real default is `--environment branch` (current branch), falling back to sandbox on `main`.
- **`restaurant-booking-agent.md`** L604 / L608: same fixes.

### CLI reference (`reference/cli.md`)
- `poly diff file1.yaml` → `poly diff --files file1.yaml` (the positional is `hash`, not a path).
- `poly revert --all` → `poly revert` (no `--all` flag exists; bare invocation reverts everything).
- `poly format file1.py` → `poly format --files <path>`.
- `poly review` examples now use the required `create` subcommand. Bare `poly review` is a no-op — the dispatch only handles `create`/`list`/`delete`.
- `poly revert --json --all` → `poly revert --json` in the JSON examples.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Verified each corrected command against `poly <command> --help` output and the argparse definitions in `src/poly/cli.py`. `mkdocs build --strict` passes.

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)