### PR TITLE
docs: add standalone Branch merging reference page

### DIFF
--- a/docs/docs/concepts/multi-user-and-guardrails.md
+++ b/docs/docs/concepts/multi-user-and-guardrails.md
@@ -53,19 +53,19 @@ The ADK is designed to reduce those risks by combining local editing with valida
 A typical collaborative workflow looks like this:
 
 1. start from the `main` branch
-2. create a new branch with `poly branch create {name}`
-3. switch branches as needed with `poly branch switch {name}`
+2. create a new branch with [`poly branch create {name}`](../reference/cli.md#poly-branch-create)
+3. switch branches as needed with [`poly branch switch {name}`](../reference/cli.md#poly-branch)
 4. edit files locally
-5. inspect changes with `poly status` and `poly diff`
-6. validate the project with `poly validate`
-7. push changes with `poly push`
+5. inspect changes with [`poly status`](../reference/cli.md#poly-status) and [`poly diff`](../reference/cli.md#poly-diff)
+6. validate the project with [`poly validate`](../reference/cli.md#poly-validate)
+7. push changes with [`poly push`](../reference/cli.md#poly-push)
 8. review the branch in Agent Studio
 9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or through the Agent Studio UI when ready
 
 You can also use:
 
-- `poly branch list` to view available branches
-- `poly branch current` to check the active branch
+- [`poly branch list`](../reference/cli.md#poly-branch) to view available branches
+- [`poly branch current`](../reference/cli.md#poly-branch) to check the active branch
 
 ## Validation as a guardrail
 
@@ -84,7 +84,7 @@ Examples of what validation protects against include:
 
 ## Pulling and merge behavior
 
-If work is done to your branch in Agent Studio and you want to bring those changes into your local copy, you can run:
+If work is done to your branch in Agent Studio and you want to bring those changes into your local copy, you can run [`poly pull`](../reference/cli.md#poly-pull):
 
 ~~~bash
 poly pull
@@ -96,10 +96,10 @@ The local workflow is not isolated from Agent Studio UI work - both sides affect
 
 ## Review workflow
 
-When changes are ready for review, generate a review artifact:
+When changes are ready for review, generate a review artifact with [`poly review create`](../reference/cli.md#poly-review):
 
 ~~~bash
-poly review
+poly review create
 ~~~
 
 Use this to compare:

--- a/docs/docs/concepts/multi-user-and-guardrails.md
+++ b/docs/docs/concepts/multi-user-and-guardrails.md
@@ -60,7 +60,7 @@ A typical collaborative workflow looks like this:
 6. validate the project with `poly validate`
 7. push changes with `poly push`
 8. review the branch in Agent Studio
-9. merge the branch in Agent Studio when ready
+9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or through the Agent Studio UI when ready
 
 You can also use:
 
@@ -120,7 +120,7 @@ In practice, this means:
 
 - project resources must still conform to Agent Studio expectations
 - references between resources must remain valid
-- branch merges still happen in Agent Studio
+- branch merges happen either through the CLI ([`poly branch merge`](../reference/branch_merge.md)) or in Agent Studio
 - deployment still happens through Agent Studio
 
 !!! tip "Local flexibility, platform constraints"

--- a/docs/docs/concepts/working-locally.md
+++ b/docs/docs/concepts/working-locally.md
@@ -101,16 +101,16 @@ This means the local filesystem becomes your main editing surface, while Agent S
 
 The standard workflow is:
 
-1. initialize the local project with `poly init` if it is not already present
-2. pull the latest project configuration with `poly pull`
-3. create a branch with `poly branch create {name}`
+1. initialize the local project with [`poly init`](../reference/cli.md#poly-init) if it is not already present
+2. pull the latest project configuration with [`poly pull`](../reference/cli.md#poly-pull)
+3. create a branch with [`poly branch create {name}`](../reference/cli.md#poly-branch-create)
 4. edit files locally
-5. inspect changes with `poly diff` and `poly status`
-6. validate locally with `poly validate`
-7. push changes with `poly push`
-8. optionally generate a review gist with `poly review`
+5. inspect changes with [`poly diff`](../reference/cli.md#poly-diff) and [`poly status`](../reference/cli.md#poly-status)
+6. validate locally with [`poly validate`](../reference/cli.md#poly-validate)
+7. push changes with [`poly push`](../reference/cli.md#poly-push)
+8. optionally generate a review gist with [`poly review create`](../reference/cli.md#poly-review)
 9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or in Agent Studio
-10. test by chatting with the agent using `poly chat` — by default this connects to your current branch's pushed state. Use `poly push` first, or `poly chat --push` to push and start the session in one step. On the main branch it falls back to Sandbox.
+10. test by chatting with the agent using [`poly chat`](../reference/cli.md#poly-chat) — by default this connects to your current branch's pushed state. Use [`poly push`](../reference/cli.md#poly-push) first, or `poly chat --push` to push and start the session in one step. On the main branch it falls back to Sandbox.
 
 !!! tip "Run commands from the project folder"
 

--- a/docs/docs/concepts/working-locally.md
+++ b/docs/docs/concepts/working-locally.md
@@ -31,7 +31,7 @@ Your local filesystem becomes your primary editing surface. You can:
 
     ---
 
-    Agent Studio remains the source of deployment, preview, and branch merging.
+    Agent Studio remains the source of deployment and preview. Branches can be merged with [`poly branch merge`](../reference/branch_merge.md) from the CLI or through the Agent Studio UI.
 
 -   **Developer tooling**
 
@@ -109,7 +109,7 @@ The standard workflow is:
 6. validate locally with `poly validate`
 7. push changes with `poly push`
 8. optionally generate a review gist with `poly review`
-9. merge the branch in Agent Studio
+9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or in Agent Studio
 10. test by chatting with the agent using `poly chat` — by default this connects to your current branch's pushed state. Use `poly push` first, or `poly chat --push` to push and start the session in one step. On the main branch it falls back to Sandbox.
 
 !!! tip "Run commands from the project folder"

--- a/docs/docs/examples/venue-specific-goodbye.md
+++ b/docs/docs/examples/venue-specific-goodbye.md
@@ -109,7 +109,7 @@ The agent should end each session with the closing message configured for that v
 
 !!! info "`--variant` resolves against the deployed environment"
 
-    `--variant` looks up the variant name in the environment you are chatting against (default: sandbox main). If you pushed `variant_attributes.yaml` on a feature branch but have not merged it yet, the variant names will not exist in sandbox and the flag will have no effect. Merge the branch first — with [`poly branch merge`](../reference/branch_merge.md) or through Agent Studio — then run `poly chat --variant <name>`.
+    `--variant` looks up the variant name in the environment you are chatting against (default: `main` in sandbox). If you pushed `variant_attributes.yaml` on a feature branch but have not merged it yet, the variant names will not exist in sandbox and the flag will have no effect. Merge the branch first — with [`poly branch merge`](../reference/branch_merge.md) or through Agent Studio — then run `poly chat --variant <name>`.
 
 ## Related pages
 

--- a/docs/docs/examples/venue-specific-goodbye.md
+++ b/docs/docs/examples/venue-specific-goodbye.md
@@ -109,7 +109,7 @@ The agent should end each session with the closing message configured for that v
 
 !!! info "`--variant` resolves against the deployed environment"
 
-    `--variant` looks up the variant name in the environment you are chatting against (default: sandbox main). If you pushed `variant_attributes.yaml` on a feature branch but have not merged it yet, the variant names will not exist in sandbox and the flag will have no effect. Merge the branch in Agent Studio first, then run `poly chat --variant <name>`.
+    `--variant` looks up the variant name in the environment you are chatting against (default: sandbox main). If you pushed `variant_attributes.yaml` on a feature branch but have not merged it yet, the variant names will not exist in sandbox and the flag will have no effect. Merge the branch first — with [`poly branch merge`](../reference/branch_merge.md) or through Agent Studio — then run `poly chat --variant <name>`.
 
 ## Related pages
 

--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -153,13 +153,13 @@ This does not lose any real work — the `variables/` entries are virtual and wi
 
 ### `poly chat` returns a 404 on a feature branch
 
-If you run `poly chat` while on a feature branch (before merging it in Agent Studio), the session endpoint returns a 404:
+`poly chat` defaults to chatting against your current branch's last pushed state. On most projects this works fine; on some projects the branch deployment endpoint returns a 404:
 
 ~~~text
 Error: 404 ... /branches/<id>/sequence
 ~~~
 
-This is a platform limitation — branch-level chat is not currently supported via the CLI. To test your changes, push them with `poly push`, merge the branch with [`poly branch merge`](../reference/branch_merge.md) (or in the Agent Studio UI), then run:
+If you hit this, push your changes with [`poly push`](../reference/cli.md#poly-push), merge the branch with [`poly branch merge`](../reference/branch_merge.md) (or in the Agent Studio UI), then chat against sandbox instead:
 
 ~~~bash
 poly chat --environment sandbox

--- a/docs/docs/get-started/first-commands.md
+++ b/docs/docs/get-started/first-commands.md
@@ -159,7 +159,7 @@ If you run `poly chat` while on a feature branch (before merging it in Agent Stu
 Error: 404 ... /branches/<id>/sequence
 ~~~
 
-This is a platform limitation — branch-level chat is not currently supported via the CLI. To test your changes, push them with `poly push`, merge the branch in the Agent Studio UI, then run:
+This is a platform limitation — branch-level chat is not currently supported via the CLI. To test your changes, push them with `poly push`, merge the branch with [`poly branch merge`](../reference/branch_merge.md) (or in the Agent Studio UI), then run:
 
 ~~~bash
 poly chat --environment sandbox

--- a/docs/docs/get-started/what-is-the-adk.md
+++ b/docs/docs/get-started/what-is-the-adk.md
@@ -20,7 +20,7 @@ It gives you a Git-like workflow for synchronizing project configuration between
 
 ## Why it exists
 
-The ADK moves most build-and-edit work out of the browser and into your local environment. You still use Agent Studio to merge branches, deploy, and monitor the agent in production — but you no longer have to edit resources there by hand.
+The ADK moves most build-and-edit work out of the browser and into your local environment. You can [merge branches](../reference/branch_merge.md) and run reviews from the CLI, while Agent Studio remains the home for deployment and production monitoring — but you no longer have to edit resources there by hand.
 
 Instead of editing everything directly inside Agent Studio, you pull a project locally, make changes using your normal tools, and push those changes back to the platform.
 

--- a/docs/docs/reference/agent_settings.md
+++ b/docs/docs/reference/agent_settings.md
@@ -11,7 +11,7 @@ They live in <code>agent_settings/</code> and are made up of personality, role, 
 </p>
 
 !!! note "Personality and role are platform-provisioned — update only"
-    The personality and role resources are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If these files appear in a project directory without matching entries in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with `poly init` and `poly pull` rather than copying an existing directory.
+    The personality and role resources are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If these files appear in a project directory without matching entries in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
 
 These settings shape how the agent presents itself and how it should behave across the conversation.
 
@@ -24,8 +24,8 @@ agent_settings/
 ├── personality.yaml
 ├── role.yaml
 ├── rules.txt
-├── safety_filters.yaml
-└── experimental_config.json
+├── safety_filters.yaml             # Optional
+└── experimental_config.json        # Optional
 ~~~
 
 ## What agent settings control
@@ -149,11 +149,11 @@ The rules file supports the following references:
 
 | Syntax | Meaning |
 |---|---|
-| `{{fn:function_name}}` | Global function |
-| `{{twilio_sms:template_name}}` | SMS template |
-| `{{ho:handoff_name}}` | Handoff destination |
-| `{{attr:attribute_name}}` | Variant attribute |
-| `{{vrbl:variable_name}}` | State variable |
+| `{{fn:function_name}}` | [Global function](./functions.md) |
+| `{{twilio_sms:template_name}}` | [SMS template](./sms.md) |
+| `{{ho:handoff_name}}` | [Handoff destination](./handoffs.md) |
+| `{{attr:attribute_name}}` | [Variant attribute](./variants.md) |
+| `{{vrbl:variable_name}}` | [State variable](./variables.md) |
 
 ### Example
 

--- a/docs/docs/reference/branch_merge.md
+++ b/docs/docs/reference/branch_merge.md
@@ -1,0 +1,174 @@
+---
+title: Branch merging
+description: Merge ADK branches into main from the CLI, including conflict resolution flows.
+---
+
+# Branch merging
+
+<p class="lead">
+Merge a feature branch back into <code>main</code> with <code>poly branch merge</code>, including interactive and pre-defined conflict resolution.
+</p>
+
+`poly branch merge` is the CLI-native counterpart to merging in the Agent Studio web UI. It brings everything you've changed on the current branch back onto `main`, surfaces any conflicts in a structured table, and lets you resolve them either interactively or from a JSON file.
+
+For the broader branching workflow (creating, switching, listing, deleting branches), see the [`poly branch` section of the CLI reference](./cli.md#poly-branch). For the team-level guardrails around branching and merging, see [Multi-user workflows and guardrails](../concepts/multi-user-and-guardrails.md).
+
+## When to use it
+
+You'll typically reach for `poly branch merge` at the end of a feature loop:
+
+1. Create a branch with `poly branch create my-feature` (see [`poly branch create`](./cli.md#poly-branch-create)).
+2. Iterate locally, pushing with `poly push` (see [Working locally](../concepts/working-locally.md)).
+3. Test with `poly chat` against the branch's pushed state.
+4. Merge back to `main` with `poly branch merge '<message>'` — described on this page.
+5. Optionally deploy through Agent Studio.
+
+You can also merge from the Agent Studio web UI by switching to the branch and clicking **Merge**. The CLI command and the UI hit the same platform endpoint, so the result is identical.
+
+## Basic usage
+
+`poly branch merge` requires a merge message and merges the **current branch** into `main`. Switch to the source branch first if you aren't on it.
+
+~~~bash
+poly branch switch my-feature
+poly branch merge 'Merge my-feature into main'
+~~~
+
+If the merge has no conflicts, the branch is merged immediately and the CLI automatically switches your local checkout to `main`. Run `poly pull` afterwards if you need to refresh local state.
+
+| Argument | Required | Description |
+|---|---|---|
+| `message` | yes | Merge commit message. Quote it if it contains spaces. |
+| `--interactive`, `-i` | no | Resolve conflicts in an interactive prompt. |
+| `--resolutions <source>` | no | Pre-defined resolutions as a JSON file path, inline JSON string, or `-` for stdin. |
+| `--path <dir>` | no | Project base path. Defaults to the current working directory. |
+| `--json` | no | Print a single JSON object on stdout (machine-readable). |
+| `--verbose` | no | Show full error tracebacks for debugging. |
+
+## Conflicts
+
+If the merge has conflicts, the command prints a conflict table and exits with a non-zero status code. The table shows, for each conflicting field:
+
+- **Path** — the resource and field that conflicts (for example `topics > Booking > content`)
+- **Base / Ours / Theirs** — the original value and the two competing values
+- **Auto-merged value** — what the ADK would produce by line-merging the two sides
+- **Auto-mergeable** — whether the auto-merged value contains any unresolved markers
+
+If every conflict is auto-mergeable and you want to accept the auto-merge, re-run the command with `--interactive` and accept the suggestions, or pre-populate `--resolutions` with the auto-merge values.
+
+### `--interactive` / `-i`
+
+Interactive mode walks you through each conflict and asks how to resolve it. For every conflict you can:
+
+- accept the auto-merge (when available)
+- pick `main` (`ours`)
+- pick branch (`theirs`)
+- pick `base` (revert to the original value)
+- open the value in your `$EDITOR` or `$VISUAL` for free-form editing
+
+After you've answered every conflict the merge is re-attempted automatically.
+
+!!! tip "Set `$EDITOR` or `$VISUAL` before starting an interactive merge"
+
+    Interactive mode shells out to your editor for multiline or long values. If neither variable is set it falls back to `vi`. Setting `EDITOR=code --wait` (or your editor of choice) in your shell profile makes the experience much smoother.
+
+### `--resolutions <source>`
+
+Use `--resolutions` to supply pre-defined resolutions non-interactively. The source can be:
+
+- a path to a JSON file
+- a literal JSON string
+- `-` to read JSON from stdin
+
+If the resolutions cover every conflict the merge proceeds without prompting. Combine `--resolutions` with `--interactive` to seed an interactive session — pre-defined choices are applied automatically and you'll only be prompted for the conflicts they don't cover.
+
+#### Resolution file format
+
+`--resolutions` expects a JSON array of objects:
+
+~~~json
+[
+  {
+    "path": ["topics", "Booking", "content"],
+    "strategy": "theirs"
+  },
+  {
+    "path": ["agent_settings", "rules", "value"],
+    "strategy": "theirs",
+    "value": "Custom resolved content here"
+  },
+  {
+    "path": ["flows", "main_flow", "steps", "greet", "prompt"],
+    "strategy": "ours"
+  }
+]
+~~~
+
+| Field | Description |
+|---|---|
+| `path` | List of strings identifying the conflicted field. Match the `Path` column from the conflict table. |
+| `strategy` | One of `"ours"` (keep `main`), `"theirs"` (keep branch), or `"base"` (revert to the original). |
+| `value` | Optional custom value. Only honored with the `"theirs"` strategy. |
+
+You can capture the structure of a resolution file by running `poly branch merge` once to surface the conflicts, then writing a JSON file that addresses each `path` row.
+
+## After a successful merge
+
+- The CLI switches your local checkout to `main`.
+- Run [`poly pull`](./cli.md#poly-pull) if you need to refresh local state to match the post-merge `main`.
+- Run [`poly chat`](./cli.md#poly-chat) against `main` (which falls back to the sandbox environment) to smoke-test the merged result.
+- If you're ready to ship, follow up with [`poly deployments`](./cli.md#poly-deployments) to promote the merged state to a live environment.
+
+## Merging through the Agent Studio web UI
+
+You can also merge through the Agent Studio interface:
+
+1. Open the project in Agent Studio.
+2. Switch to the branch.
+3. Click **Merge**.
+
+The web UI surfaces the same conflicts as the CLI and lets you resolve them in the browser. Use whichever path fits your workflow — they hit the same platform endpoint, so there is no functional difference between them.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `Merge message is required` | You ran `poly branch merge` with no message argument. | Pass a quoted message: `poly branch merge 'Describe the merge'`. |
+| Conflict table appears and the command exits non-zero | One or more fields conflict between branch and `main`. | Re-run with `--interactive` or supply `--resolutions`. |
+| `[Errno 22] Invalid argument` during interactive prompt | The shell isn't a TTY (CI, scripts, non-interactive containers). | Run interactively, or use `--resolutions` with a pre-built JSON file. |
+| Editor doesn't open in interactive mode | `$EDITOR` and `$VISUAL` are unset. | Export one of them before running the merge. |
+| Local changes block the merge | You have unpushed work on the source branch. | Run [`poly push`](./cli.md#poly-push) first, or [`poly revert`](./cli.md#poly-revert) to discard. |
+
+## Related references
+
+<div class="grid cards" markdown>
+
+-   **CLI reference**
+
+    ---
+
+    Full surface of every `poly` command, including `poly branch` and its sibling subcommands.
+    [Open CLI reference](./cli.md)
+
+-   **Working locally**
+
+    ---
+
+    Where branching fits into the daily edit/push/test loop.
+    [Open working locally](../concepts/working-locally.md)
+
+-   **Multi-user workflows and guardrails**
+
+    ---
+
+    How branches, merges, and validation interact across a team.
+    [Open multi-user workflows](../concepts/multi-user-and-guardrails.md)
+
+-   **Build an agent tutorial**
+
+    ---
+
+    Walks through a feature-branch workflow end-to-end.
+    [Open the tutorial](../tutorials/build-an-agent.md)
+
+</div>

--- a/docs/docs/reference/chat_settings.md
+++ b/docs/docs/reference/chat_settings.md
@@ -11,7 +11,7 @@ They are defined in <code>chat/configuration.yaml</code>.
 </p>
 
 !!! note "Platform-provisioned — update only"
-    Chat settings (`chat/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with `poly init` and `poly pull` rather than copying an existing directory.
+    Chat settings (`chat/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
 
 ## Location
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -95,6 +95,13 @@ poly push --format
 
 When pushing creates a new branch (for example, when pushing to Agent Studio for the first time on a branch), the CLI displays a message with the new branch name.
 
+| Flag | Description |
+|---|---|
+| `--dry-run` | Run all validation and diff steps without sending changes to Agent Studio. |
+| `--skip-validation` | Bypass local validation. Use sparingly — for example, when a platform-generated resource fails a strict ADK check but is known to be valid on the platform. |
+| `--force`, `-f` | Force the push even when the local project diverges from the remote in unexpected ways. |
+| `--format` | Run [`poly format`](#poly-format) over the project before pushing. |
+
 !!! info "Call Link URL in chat output may be malformed"
 
     Each chat session prints a Call Link URL for viewing the conversation in Agent Studio. On some deployments this URL has a doubled hostname (for example, `https://studio.studio.poly.ai/…`), which produces a 404. The conversation is still recorded — open Agent Studio directly and navigate to the conversation from there.
@@ -190,11 +197,11 @@ poly branch delete my-feature
 
 #### `poly branch create`
 
-Creates a new branch. By default the branch is sourced from sandbox main.
+Creates a new branch. By default the branch is sourced from the project's `main` branch (the sandbox environment).
 
 | Flag | Description |
 |---|---|
-| `--env`, `--environment` | Source the new branch from a deployment snapshot instead of sandbox main. Choices: `sandbox`, `pre-release`, `live`. |
+| `--env`, `--environment` | Source the new branch from a deployed environment snapshot instead of `main`. Choices: `sandbox`, `pre-release`, `live`. |
 | `--force`, `-f` | Force branch creation even if there are uncommitted local changes on main. |
 
 When `--env live` or `--env pre-release` is specified:
@@ -224,6 +231,20 @@ poly format
 poly format --check
 poly format --files src/functions/booking.py
 ~~~
+
+!!! warning "`poly format` may crash on projects with YAML sub-resources"
+
+    Running `poly format` over a project that contains YAML-defined sub-resources (for example `config/handoffs.yaml` or `voice/configuration.yaml`) can produce errors like:
+
+    ~~~text
+    [Errno 20] Not a directory: '.../config/handoffs.yaml/handoffs/Default_handoff'
+    ~~~
+
+    This is a known issue in how the formatter resolves paths inside YAML files. Until it's fixed, scope the run with `--files` and pass specific Python files:
+
+    ~~~bash
+    poly format --files functions/my_function.py
+    ~~~
 
 ### `poly validate`
 
@@ -536,11 +557,25 @@ A typical CLI workflow looks like this:
     See how the CLI fits into a real workflow.
     [Open the tutorial](../tutorials/build-an-agent.md)
 
+-   **Branch merging**
+
+    ---
+
+    Conflict resolution, `--interactive` flow, and `--resolutions` JSON for `poly branch merge`.
+    [Open branch merging](./branch_merge.md)
+
 -   **Testing**
 
     ---
 
     Learn how to run tests for the project.
     [Open testing](./testing.md)
+
+-   **Working locally**
+
+    ---
+
+    How the CLI fits into the daily edit/push/test loop.
+    [Open working locally](../concepts/working-locally.md)
 
 </div>

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -160,7 +160,7 @@ poly branch delete my-feature
 
 #### `poly branch merge`
 
-Merge the current branch into main via the CLI. A merge message is required.
+Merge the current branch into `main` via the CLI. A merge message is required.
 
 ~~~bash
 poly branch merge 'Merge message'
@@ -168,46 +168,7 @@ poly branch merge 'Merge message' --interactive
 poly branch merge 'Merge message' --resolutions resolutions.json
 ~~~
 
-If the merge has no conflicts, the branch is merged immediately and the CLI switches to `main`.
-
-If there are conflicts, the command displays a conflict table showing each conflicting field and whether it can be auto-merged, then exits with a non-zero code. You can resolve conflicts using:
-
-- **`--interactive` / `-i`** — opens an interactive prompt for each conflict. For each one you can accept the auto-merge, pick main, pick branch, pick base, or open the value in your `$EDITOR` or `$VISUAL`. After resolving all conflicts the merge is re-attempted.
-- **`--resolutions <file>`** — supply pre-defined resolutions as a JSON file path, inline JSON string, or `-` for stdin. Resolutions that cover all conflicts allow the merge to proceed non-interactively.
-
-Both flags can be combined: `--resolutions` seeds the interactive session with your pre-defined choices while `--interactive` handles any remaining conflicts.
-
-!!! tip "Set `$EDITOR` or `$VISUAL` for the best interactive experience"
-
-    Interactive mode uses your `$EDITOR` or `$VISUAL` environment variable when opening multiline or long values for editing. If neither is set it falls back to `vi`. Set one in your shell profile to use your preferred editor.
-
-##### Resolution file format
-
-`--resolutions` accepts a JSON array. Each element must include `path` and `strategy`, and optionally `value`:
-
-~~~json
-[
-  {
-    "path": ["topics", "My Topic", "content"],
-    "strategy": "theirs"
-  },
-  {
-    "path": ["agent_settings", "rules", "value"],
-    "strategy": "theirs",
-    "value": "Custom resolved content here"
-  }
-]
-~~~
-
-| Field | Description |
-|---|---|
-| `path` | List of strings identifying the conflicted field |
-| `strategy` | Resolution strategy: `"ours"` (keep main), `"theirs"` (keep branch), or `"base"` (revert to original) |
-| `value` | Optional custom value. Only used with `"theirs"` strategy. |
-
-##### After a successful merge
-
-After a successful merge the CLI automatically switches to `main`. Run `poly pull` if you need to refresh your local state.
+For the full merge workflow — conflict tables, `--interactive` flow, the `--resolutions` JSON format, post-merge behavior, and troubleshooting — see the dedicated [Branch merging reference](./branch_merge.md).
 
 #### `poly branch delete`
 

--- a/docs/docs/reference/speech_recognition.md
+++ b/docs/docs/reference/speech_recognition.md
@@ -12,7 +12,7 @@ Speech recognition resources control how the agent processes user speech input o
 These resources live under `voice/speech_recognition/` and are used to tune how the agent listens, recognizes, and post-processes spoken input.
 
 !!! note "ASR settings are platform-provisioned — update only"
-    `asr_settings.yaml` is created automatically by the platform when a project is created. It always exists on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with `poly init` and `poly pull` rather than copying an existing directory.
+    `asr_settings.yaml` is created automatically by the platform when a project is created. It always exists on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
 
 ## Location
 

--- a/docs/docs/reference/topics.md
+++ b/docs/docs/reference/topics.md
@@ -127,11 +127,11 @@ This is the only place inside a topic where you should use references and behavi
 
 | Syntax | Meaning |
 |---|---|
-| `{{fn:function_name}}` | Call a global function |
-| `{{attr:attribute_name}}` | Read a variant attribute |
-| `{{twilio_sms:template_name}}` | Reference an SMS template |
-| `{{ho:handoff_name}}` | Reference a handoff |
-| `$variable` | Reference a state variable |
+| `{{fn:function_name}}` | Call a [global function](./functions.md) |
+| `{{attr:attribute_name}}` | Read a [variant attribute](./variants.md) |
+| `{{twilio_sms:template_name}}` | Reference an [SMS template](./sms.md) |
+| `{{ho:handoff_name}}` | Reference a [handoff](./handoffs.md) |
+| `$variable` | Reference a [state variable](./variables.md) |
 
 ### Writing good actions
 

--- a/docs/docs/reference/voice_settings.md
+++ b/docs/docs/reference/voice_settings.md
@@ -11,7 +11,7 @@ They are defined in <code>voice/configuration.yaml</code>.
 </p>
 
 !!! note "Platform-provisioned — update only"
-    Voice settings (`voice/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with `poly init` and `poly pull` rather than copying an existing directory.
+    Voice settings (`voice/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
 
 Voice settings control what the agent says at the start of a call and how it should sound throughout the conversation.
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -310,7 +310,7 @@ Make test calls, inspect transcripts, refine prompts, flows, and functions, and 
 Once the changes are pushed and validated, merge the branch in Agent Studio and deploy the project.
 
 !!! note "Merging from the CLI or the Agent Studio web UI"
-    Merge from the CLI with `poly branch merge '<commit message>'`, which merges the current branch into `main` (use `--interactive` to resolve any conflicts in your `$EDITOR`). You can also merge through the Agent Studio web UI by switching to the branch and clicking **Merge**. After merging, run `poly chat --environment sandbox` to test.
+    Merge from the CLI with `poly branch merge '<commit message>'`, which merges the current branch into `main`. You can also merge through the Agent Studio web UI by switching to the branch and clicking **Merge**. After merging, run `poly chat --environment sandbox` to test. See the [Branch merging reference](../reference/branch_merge.md) for the full conflict-resolution flow.
 
 ### Step 11 - Monitor performance
 
@@ -486,7 +486,7 @@ Check that the key parts of the agent look correct:
 
 Once everything looks right:
 
-1. merge the branch into `main` — either with `poly branch merge '<commit message>'` from the CLI or through the Agent Studio web UI
+1. merge the branch into `main` — either with [`poly branch merge`](../reference/branch_merge.md) from the CLI or through the Agent Studio web UI
 2. deploy the project
 
 At that point, the agent is live.

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -49,17 +49,18 @@ When an Agent Studio project is linked locally, it follows this general structur
 
 ~~~text
 <account>/<project>/
+├── _gen/                               # Generated stubs — do not edit
 ├── agent_settings/
 │   ├── personality.yaml
 │   ├── role.yaml
 │   ├── rules.txt
 │   ├── safety_filters.yaml             # Optional
-│   └── experimental_config.json
+│   └── experimental_config.json        # Optional
 ├── config/
-│   ├── entities.yaml
-│   ├── handoffs.yaml
-│   ├── sms_templates.yaml
-│   └── variant_attributes.yaml
+│   ├── entities.yaml                   # Optional
+│   ├── handoffs.yaml                   # Optional
+│   ├── sms_templates.yaml              # Optional
+│   └── variant_attributes.yaml         # Optional
 ├── voice/
 │   ├── configuration.yaml
 │   ├── safety_filters.yaml             # Optional

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -605,7 +605,7 @@ By default, `poly chat` connects to your current branch's last pushed state. On 
 
 !!! note "Merging from the CLI or Agent Studio"
 
-    Merge from the CLI with `poly branch merge '<commit message>'` (run from the `booking-flow` branch), or open the project in Agent Studio, switch to the `booking-flow` branch, and merge through the web UI. Pass `--interactive` to `poly branch merge` to resolve any conflicts in your `$EDITOR`.
+    Merge from the CLI with `poly branch merge '<commit message>'` (run from the `booking-flow` branch), or open the project in Agent Studio, switch to the `booking-flow` branch, and merge through the web UI. See the [Branch merging reference](../reference/branch_merge.md) for the full conflict-resolution flow, including `--interactive` and `--resolutions`.
 
 After merging, run `poly chat` against the sandbox environment:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
 
   - Reference:
       - CLI reference: reference/cli.md
+      - Branch merging: reference/branch_merge.md
       - Testing: reference/testing.md
       - Tooling: reference/tooling.md
 


### PR DESCRIPTION
## Summary

`poly branch merge` is rich enough to warrant its own page — conflict tables, `--interactive` flow, `--resolutions` JSON format, post-merge behavior, troubleshooting. This PR pulls that content out of `cli.md` into `reference/branch_merge.md` and threads cross-links into every other page that mentions branch merging.

## Motivation

Follow-up to #113. The merge story was buried five levels deep in `cli.md` and several other docs were either silent on the CLI path (`concepts/working-locally.md`, `get-started/what-is-the-adk.md`, `examples/venue-specific-goodbye.md`) or actively wrong about it ("branch merges still happen in Agent Studio"). A dedicated page makes it discoverable and gives the rest of the docs something to link to.

Also addresses the request to add inter-doc links throughout the ADK docs — every page that mentions branch merging now links into the new reference.

## Changes

### New page
- `reference/branch_merge.md` — standalone reference covering: when to use, basic usage, argument table, conflict tables, `--interactive` flow with editor tip, `--resolutions` source forms (file / inline / stdin), JSON schema with example, combining flags, post-merge behavior, Agent Studio UI alternative, troubleshooting matrix, related-pages grid.

### CLI reference slim-down
- `reference/cli.md` — `#### poly branch merge` keeps the three top-level examples and a stub link; the deep-dive content moves to the new page.

### Cross-links and stale-claim fixes
- `concepts/working-locally.md` — platform-sync card and workflow step now mention `poly branch merge`.
- `concepts/multi-user-and-guardrails.md` — workflow step and guardrails list updated; "branch merges still happen in Agent Studio" was wrong.
- `get-started/what-is-the-adk.md` — intro paragraph reflects the CLI merge path.
- `get-started/first-commands.md` — branch-chat troubleshooting links to the new page.
- `examples/venue-specific-goodbye.md` — variant-resolution callout links to the new page.
- `tutorials/build-an-agent.md` and `tutorials/restaurant-booking-agent.md` — merge callouts link to the new page for the conflict-resolution flow.

### Nav
- `docs/mkdocs.yml` — adds `Branch merging: reference/branch_merge.md` to the Reference section.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

`mkdocs build --strict` passes — every internal link resolves. Content cross-checked against `branch_merge_parser` in `src/poly/cli.py:628-657` and `merge_branch` in `src/poly/project.py:2662`.

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)