### PR TITLE
docs: document GITHUB_ACCESS_TOKEN requirement for poly review

### DIFF
--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -23,6 +23,16 @@ The `POLY_ADK_KEY` environment variable must be set before running any `poly` co
 
 Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
 
+!!! info "Optional: GitHub token for `poly review`"
+
+    [`poly review`](../reference/cli.md#poly-review) writes diffs to GitHub Gists, so it needs a personal access token with the `gist` scope. If you plan to use it, generate a token at <https://github.com/settings/tokens> (classic) and export it alongside your API key:
+
+    ~~~bash
+    export GITHUB_ACCESS_TOKEN=<your-github-token>
+    ~~~
+
+    Without this variable, `poly review create` exits with `GITHUB_ACCESS_TOKEN environment variable not set`.
+
 !!! warning "API keys are workspace-scoped"
     An API key grants access to one specific Agent Studio workspace. When you run `poly init`, it lists all projects visible to that key. If you see many projects that do not look like yours, you are likely using a key scoped to the wrong workspace — for example, an organization-wide key rather than one scoped to your personal workspace. Contact your PolyAI contact to confirm you have a key for the correct workspace.
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -260,6 +260,10 @@ Create a GitHub Gist of Agent Studio project changes to share with others.
 
 `poly review` requires a subcommand: `create`, `list`, or `delete`. Use `poly review create` to compare your local changes against the remote project, or pass `--before` and `--after` to compare two remote branches or versions. Add `--verbose` for full error tracebacks while troubleshooting.
 
+!!! info "Requires `GITHUB_ACCESS_TOKEN`"
+
+    `poly review` writes to GitHub Gists, so it needs a personal access token with the `gist` scope set as the `GITHUB_ACCESS_TOKEN` environment variable. Without it the command exits with `GITHUB_ACCESS_TOKEN environment variable not set`. Generate a token at <https://github.com/settings/tokens> (classic, `gist` scope) and add `export GITHUB_ACCESS_TOKEN=<token>` to your shell profile alongside `POLY_ADK_KEY`.
+
 Examples:
 
 ~~~bash


### PR DESCRIPTION
## Summary

Discovered while testing the ADK end-to-end against a live workspace: \`poly review create\` exits with \`GITHUB_ACCESS_TOKEN environment variable not set\` (see \`src/poly/handlers/github_api_handler.py:24-29\`) but no docs page mentioned the requirement.

## Motivation

Came up during the post-#114 walkthrough — first time a new user runs \`poly review create\` they hit a hard stop with no docs hint that an extra environment variable is needed.

## Changes

- \`get-started/prerequisites.md\` — adds an "Optional: GitHub token for \`poly review\`" callout next to the existing \`POLY_ADK_KEY\` instructions, with a link to the GitHub token settings page and the export line.
- \`reference/cli.md\` (\`poly review\` section) — adds an \`!!! info\` callout with the same export instructions and the full error message for searchability.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (\`poly <command>\`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Verified the error message matches the code exactly. \`mkdocs build --strict\` passes.

## Checklist

- [ ] \`ruff check .\` and \`ruff format --check .\` pass
- [ ] \`pytest\` passes
- [x] No breaking changes to the \`poly\` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)