### PR TITLE
fix: redact API key from debug log output

### DIFF
--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -102,7 +102,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} correlation_id={correlation_id!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -110,7 +110,7 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request. url={url!r} headers={headers!r} body={data!r}"
+                f"Error in request. url={url!r} correlation_id={correlation_id!r} body={data!r}"
                 f" status_code={api_response.status_code!r} response={api_response.text!r}"
             )
             raise


### PR DESCRIPTION
## Summary
- `PlatformAPIHandler.make_request()` logged the full `headers` dict at DEBUG level, which includes the `X-API-KEY` value
- When DEBUG logging is enabled, API keys are written to log files hence potential  credential leak
- Replaced `headers={headers!r}` with `correlation_id={correlation_id!r}` in both the success and error debug log lines, which preserves request traceability without exposing secrets
