### PR TITLE
fix: return actual API result from delete_branch

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2726,7 +2726,7 @@ class AgentStudioProject:
         success = self.api_handler.delete_branch(branches[branch_name])
         if success and self.branch_id == branches[branch_name]:
             self.switch_branch("main", force=True)
-        return True
+        return success
 
     def sync_ids_with_sandbox(self, email: str = None) -> bool:
         """Sync ids of resources in sandbox into current branch


### PR DESCRIPTION
## Summary
- `Project.delete_branch()` unconditionally returns`true` regardless of the API response
- Both CLI callers (`branch_delete` single and multi-select paths) check this value to display success/failure - a failed deletion was always reported as successful
- One-line fix: `return True` → `return success`
