### PR TITLE
ci: Fix coverage comment for fork PRs

### DIFF
--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -1,0 +1,74 @@
+name: Post Coverage Comment
+
+on:
+  workflow_run:
+    workflows: ["Coverage Report"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr_number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Minimize previous coverage comments
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+            });
+
+            const botComments = comments.data.filter(comment =>
+              comment.user.login === 'github-actions[bot]' &&
+              comment.body.includes('<!-- coverage-report -->')
+            );
+
+            for (const comment of botComments) {
+              try {
+                await github.graphql(`
+                  mutation MinimizeComment($subjectId: ID!, $classifier: ReportedContentClassifiers!) {
+                    minimizeComment(input: {subjectId: $subjectId, classifier: $classifier}) {
+                      minimizedComment {
+                        isMinimized
+                      }
+                    }
+                  }
+                `, {
+                  subjectId: comment.node_id,
+                  classifier: 'OUTDATED'
+                });
+              } catch (error) {
+                console.log(`Could not minimize comment ${comment.id}: ${error.message}`);
+              }
+            }
+
+      - name: Post coverage comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('coverage_comment.md', 'utf8');
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ steps.pr.outputs.number }},
+              body,
+            });

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -66,52 +65,13 @@ jobs:
             coverage-pr.json \
             "$BASE_REF" > coverage_comment.md
 
-      - name: Minimize previous coverage comments
-        uses: actions/github-script@v7
+      - name: Save PR number
+        run: echo "${{ github.event.number }}" > pr_number.txt
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const comments = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComments = comments.data.filter(comment =>
-              comment.user.login === 'github-actions[bot]' &&
-              comment.body.includes('<!-- coverage-report -->')
-            );
-
-            for (const comment of botComments) {
-              try {
-                await github.graphql(`
-                  mutation MinimizeComment($subjectId: ID!, $classifier: ReportedContentClassifiers!) {
-                    minimizeComment(input: {subjectId: $subjectId, classifier: $classifier}) {
-                      minimizedComment {
-                        isMinimized
-                      }
-                    }
-                  }
-                `, {
-                  subjectId: comment.node_id,
-                  classifier: 'OUTDATED'
-                });
-              } catch (error) {
-                console.log(`Could not minimize comment ${comment.id}: ${error.message}`);
-              }
-            }
-
-      - name: Post coverage comment
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('coverage_comment.md', 'utf8');
-
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body,
-            });
+          name: coverage-comment
+          path: |
+            coverage_comment.md
+            pr_number.txt


### PR DESCRIPTION
## Summary

Split the coverage workflow into two so the PR comment can be posted with write permissions, even on fork PRs.

## Motivation

Fork PRs run with a read-only `GITHUB_TOKEN`, so the "Post coverage comment" step fails with a 403. The `workflow_run` event runs in the base repo's context and has full write access.

## Changes

- Removed PR comment and minimize steps from `coverage.yml`; it now only generates coverage data and uploads it as an artifact
- Added `coverage-comment.yml` triggered by `workflow_run` to download the artifact and post/minimize comments with write permissions
- Dropped `pull-requests: write` from `coverage.yml` since it no longer needs it

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs