### PR TITLE
fix: handle Windows drive-letter paths in multi-resource path parsing

### DIFF
--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -384,7 +384,11 @@ def _parse_multi_resource_path(file_path: str) -> tuple[str, list[str]]:
             f"Invalid multi-resource path (expected segments after .yaml file): {file_path}"
         )
     # Preserve leading slash for absolute paths (parts[0] is '' for /foo/bar/...)
+    # On Windows, os.path.join('C:', 'foo') produces 'C:foo' (drive-relative),
+    # so append os.sep to bare drive letters.
     base_parts = parts[: yaml_idx + 1]
+    if base_parts[0].endswith(":"):
+        base_parts[0] += os.sep
     yaml_file_path = (
         os.path.join(*base_parts) if base_parts[0] else os.sep + os.path.join(*base_parts[1:])
     )

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -60,7 +60,11 @@ from poly.resources.handoff import Handoff
 from poly.resources.keyphrase_boosting import KeyphraseBoosting
 from poly.resources.phrase_filter import PhraseFilter
 from poly.resources.pronunciation import Pronunciation
-from poly.resources.resource import MultiResourceYamlResource, ResourceMapping
+from poly.resources.resource import (
+    MultiResourceYamlResource,
+    ResourceMapping,
+    _parse_multi_resource_path,
+)
 from poly.resources.sms import EnvPhoneNumbers, SMSTemplate
 from poly.resources.topic import (
     FUNCTION_REGEX,
@@ -6920,6 +6924,65 @@ class SafetyFiltersTests(unittest.TestCase):
         self.assertIn("Invalid level", error)
         self.assertIn("full", error)
         self.assertIn("hate", error)
+
+
+class ParseMultiResourcePathTests(unittest.TestCase):
+    """Tests for _parse_multi_resource_path including Windows drive-letter handling."""
+
+    def test_relative_path(self):
+        yaml_path, segments = _parse_multi_resource_path("config/entities.yaml/entities/name")
+        self.assertEqual(yaml_path, os.path.join("config", "entities.yaml"))
+        self.assertEqual(segments, ["entities", "name"])
+
+    def test_single_segment_after_yaml(self):
+        yaml_path, segments = _parse_multi_resource_path("voice/configuration.yaml/greeting")
+        self.assertEqual(yaml_path, os.path.join("voice", "configuration.yaml"))
+        self.assertEqual(segments, ["greeting"])
+
+    def test_absolute_unix_path(self):
+        yaml_path, segments = _parse_multi_resource_path(
+            "/home/user/project/voice/configuration.yaml/greeting"
+        )
+        self.assertEqual(yaml_path, "/home/user/project/voice/configuration.yaml")
+        self.assertEqual(segments, ["greeting"])
+
+    def test_no_yaml_extension_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_multi_resource_path("config/entities/name")
+
+    def test_no_segments_after_yaml_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_multi_resource_path("config/entities.yaml")
+
+    def test_windows_drive_letter_path(self):
+        """Regression: os.path.join('C:', 'foo') produces 'C:foo' on Windows."""
+        import ntpath
+        from unittest.mock import patch
+
+        win_path = "C:\\users\\bill\\project\\voice\\configuration.yaml\\greeting"
+        with (
+            patch("poly.resources.resource.os.sep", ntpath.sep),
+            patch("poly.resources.resource.os.path", ntpath),
+        ):
+            yaml_path, segments = _parse_multi_resource_path(win_path)
+
+        self.assertEqual(yaml_path, "C:\\users\\bill\\project\\voice\\configuration.yaml")
+        self.assertEqual(segments, ["greeting"])
+
+    def test_windows_drive_letter_multiple_segments(self):
+        """Windows path with multiple segments after .yaml."""
+        import ntpath
+        from unittest.mock import patch
+
+        win_path = "D:\\data\\entities.yaml\\entities\\customer_name"
+        with (
+            patch("poly.resources.resource.os.sep", ntpath.sep),
+            patch("poly.resources.resource.os.path", ntpath),
+        ):
+            yaml_path, segments = _parse_multi_resource_path(win_path)
+
+        self.assertEqual(yaml_path, "D:\\data\\entities.yaml")
+        self.assertEqual(segments, ["entities", "customer_name"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

On Windows, `poly validate`, `poly push`, and `poly status` fail with:

```
File not found: C:users\billlewis\...\voice\configuration.yaml
```

Note the missing `\` after `C:`.

### Root cause

`_parse_multi_resource_path` splits a path with `os.sep` then reassembles it with `os.path.join`. On Windows, `os.path.join('C:', 'users', ...)` produces a **drive-relative** path — `C:users\...` — not an absolute one.

```python
>>> import ntpath
>>> ntpath.join('C:', 'users', 'bill')
'C:users\\bill'          # wrong — drive-relative

>>> ntpath.join('C:\\', 'users', 'bill')
'C:\\users\\bill'        # correct — absolute
```

### Fix

Append `os.sep` to bare drive letters before joining:

```diff
  base_parts = parts[: yaml_idx + 1]
+ if base_parts[0].endswith(":"):
+     base_parts[0] += os.sep
  yaml_file_path = (
```

**Before:** `C:users\billlewis\project\voice\configuration.yaml` (broken)
**After:** `C:\users\billlewis\project\voice\configuration.yaml` (correct)

## Test plan
- [x] 7 new tests in `ParseMultiResourcePathTests` — Windows drive letters, Unix absolute paths, relative paths, error cases
- [x] Full test suite passes (547 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)