### PR TITLE
feat: add deployments show subcommand

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -17,7 +17,7 @@ from argparse import SUPPRESS, ArgumentParser, RawTextHelpFormatter
 from contextlib import nullcontext
 from importlib.metadata import version as get_package_version
 from collections import Counter
-from typing import Any, Optional, Any
+from typing import Any, Optional
 
 import argcomplete
 import requests
@@ -3255,9 +3255,9 @@ class AgentStudioCLI:
 
         Args:
             sandbox_versions: Full sandbox deployment list (newest first).
-            target_hash: Version hash of the deployment being promoted.
-            predecessor_hash: Version hash of the current active deployment in
-                the target env, or None if this is the first deployment.
+            target_hash: Version hash of the target deployment.
+            predecessor_hash: Version hash of the deployment being replaced
+                in the target env, or None if this is the first deployment.
 
         Returns:
             Tuple of (included deployments, is_rollback).

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -43,6 +43,7 @@ from poly.output.console import (
     output_merge_conflict_table,
     print_merge_conflict_interactive_header,
     print_deployments,
+    print_deployment_show,
 )
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
@@ -920,6 +921,33 @@ class AgentStudioCLI:
             help="Output each deployment with detailed information.",
         )
 
+        deployment_show_parser = deployments_subparsers.add_parser(
+            "show",
+            parents=[deployments_path_parent, json_parent],
+            help="Show details for a specific deployment.",
+            description=(
+                "Show detailed metadata and included deployments for a specific"
+                " version.\n\n"
+                "Examples:\n"
+                "  poly deployments show abc123def\n"
+                "  poly deployments show abc123def --env live\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        deployment_show_parser.add_argument(
+            "hash",
+            type=str,
+            help="Version hash (or prefix) of the deployment to show.",
+        )
+        deployment_show_parser.add_argument(
+            "--env",
+            "-e",
+            type=str,
+            default="sandbox",
+            choices=["sandbox", "pre-release", "live"],
+            help="Environment to query. Defaults to sandbox.",
+        )
+
         return parser
 
     @classmethod
@@ -1101,6 +1129,13 @@ class AgentStudioCLI:
                         args.hash,
                         args.json,
                         args.details,
+                    )
+                elif args.deployments_subcommand == "show":
+                    cls.deployments_show(
+                        args.path,
+                        args.hash,
+                        args.env,
+                        args.json,
                     )
 
         except Exception as e:
@@ -3006,6 +3041,118 @@ class AgentStudioCLI:
             success(f"Documentation written to {output_path}")
         else:
             plain(content)
+
+    @classmethod
+    def deployments_show(
+        cls,
+        base_path: str,
+        version_hash: str,
+        environment: str = "sandbox",
+        output_json: bool = False,
+    ) -> None:
+        """Show detailed metadata and included deployments for a single deployment.
+
+        Displays the deployment record and the sandbox deployments included since
+        the previous version in the given environment. Sandbox is always the source
+        of truth for the linear version history — pre-release/live only contain
+        promotions that reference the same version hashes.
+
+        Args:
+            base_path: Base path for the project.
+            version_hash: Full or prefix hash of the target deployment.
+            environment: Environment to query (sandbox, pre-release, live).
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = cls._load_project(base_path, output_json=output_json)
+        env_versions, active_deployment_hashes = project.get_deployments(client_env=environment)
+
+        if not env_versions:
+            error("No versions found.")
+            return
+
+        version_hash = version_hash[:9]
+        version_idx = next(
+            (
+                i
+                for i, v in enumerate(env_versions)
+                if (v.get("version_hash") or "")[:9] == version_hash
+            ),
+            None,
+        )
+        if version_idx is None:
+            error(f"Version hash '{version_hash}' not found.")
+            return
+
+        deployment = env_versions[version_idx]
+        target_full_hash = deployment.get("version_hash", "")
+
+        # Find predecessor in the same environment (next entry in the env list)
+        predecessor_full_hash = None
+        if version_idx < len(env_versions) - 1:
+            predecessor_full_hash = env_versions[version_idx + 1].get("version_hash", "")
+
+        # Resolve included deployments from sandbox (the linear history)
+        if environment == "sandbox":
+            sandbox_versions = env_versions
+        else:
+            sandbox_versions, _ = project.get_deployments(client_env="sandbox")
+
+        included = cls._resolve_included_deployments(
+            sandbox_versions, target_full_hash, predecessor_full_hash
+        )
+
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "deployment": deployment,
+                    "active_deployment_hashes": active_deployment_hashes,
+                    "included_deployments": included,
+                }
+            )
+            return
+
+        print_deployment_show(deployment, active_deployment_hashes, included)
+
+    @staticmethod
+    def _resolve_included_deployments(
+        sandbox_versions: list[dict[str, ty.Any]],
+        target_hash: str,
+        predecessor_hash: str | None,
+    ) -> list[dict[str, ty.Any]]:
+        """Slice sandbox history to find deployments included between two versions.
+
+        Args:
+            sandbox_versions: Full sandbox deployment list (newest first).
+            target_hash: Version hash of the deployment being shown.
+            predecessor_hash: Version hash of the previous deployment in the env,
+                or None if this is the first deployment.
+
+        Returns:
+            List of sandbox deployments from target (inclusive) to predecessor (exclusive).
+        """
+        target_idx = next(
+            (i for i, v in enumerate(sandbox_versions) if v.get("version_hash") == target_hash),
+            None,
+        )
+        if target_idx is None:
+            return []
+
+        if not predecessor_hash:
+            return sandbox_versions[target_idx:]
+
+        pred_idx = next(
+            (
+                i
+                for i, v in enumerate(sandbox_versions)
+                if v.get("version_hash") == predecessor_hash
+            ),
+            None,
+        )
+        if pred_idx is None:
+            return sandbox_versions[target_idx:]
+
+        return sandbox_versions[target_idx:pred_idx]
 
     @classmethod
     def deployments_list(

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -17,7 +17,7 @@ from argparse import SUPPRESS, ArgumentParser, RawTextHelpFormatter
 from contextlib import nullcontext
 from importlib.metadata import version as get_package_version
 from collections import Counter
-from typing import Any, Optional
+from typing import Any, Optional, Any
 
 import argcomplete
 import requests
@@ -3097,7 +3097,7 @@ class AgentStudioCLI:
         else:
             sandbox_versions, _ = project.get_deployments(client_env="sandbox")
 
-        included = cls._resolve_included_deployments(
+        included, is_rollback = cls._resolve_included_deployments(
             sandbox_versions, target_full_hash, predecessor_full_hash
         )
 
@@ -3108,38 +3108,45 @@ class AgentStudioCLI:
                     "deployment": deployment,
                     "active_deployment_hashes": active_deployment_hashes,
                     "included_deployments": included,
+                    "is_rollback": is_rollback,
                 }
             )
             return
 
-        print_deployment_show(deployment, active_deployment_hashes, included)
+        print_deployment_show(deployment, active_deployment_hashes, included, is_rollback)
 
     @staticmethod
     def _resolve_included_deployments(
-        sandbox_versions: list[dict[str, ty.Any]],
+        sandbox_versions: list[dict[str, Any]],
         target_hash: str,
         predecessor_hash: str | None,
-    ) -> list[dict[str, ty.Any]]:
-        """Slice sandbox history to find deployments included between two versions.
+    ) -> tuple[list[dict[str, Any]], bool]:
+        """Slice sandbox history to find deployments between two versions.
+
+        For promotions (target is newer), returns deployments from target
+        to predecessor (target inclusive, predecessor exclusive).
+        For rollbacks (target is older), returns deployments from predecessor
+        to target (predecessor inclusive, target exclusive) — the versions
+        being reverted.
 
         Args:
             sandbox_versions: Full sandbox deployment list (newest first).
-            target_hash: Version hash of the deployment being shown.
-            predecessor_hash: Version hash of the previous deployment in the env,
-                or None if this is the first deployment.
+            target_hash: Version hash of the deployment being promoted.
+            predecessor_hash: Version hash of the current active deployment in
+                the target env, or None if this is the first deployment.
 
         Returns:
-            List of sandbox deployments from target (inclusive) to predecessor (exclusive).
+            Tuple of (included deployments, is_rollback).
         """
         target_idx = next(
             (i for i, v in enumerate(sandbox_versions) if v.get("version_hash") == target_hash),
             None,
         )
         if target_idx is None:
-            return []
+            return [], False
 
         if not predecessor_hash:
-            return sandbox_versions[target_idx:]
+            return sandbox_versions[target_idx:], False
 
         pred_idx = next(
             (
@@ -3150,9 +3157,12 @@ class AgentStudioCLI:
             None,
         )
         if pred_idx is None:
-            return sandbox_versions[target_idx:]
+            return sandbox_versions[target_idx:], False
 
-        return sandbox_versions[target_idx:pred_idx]
+        if pred_idx < target_idx:
+            return sandbox_versions[pred_idx:target_idx], True
+
+        return sandbox_versions[target_idx:pred_idx], False
 
     @classmethod
     def deployments_list(

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -500,6 +500,59 @@ def print_deployments(
         return
 
 
+def print_deployment_show(
+    deployment: dict[str, Any],
+    active_deployment_hashes: dict[str, str],
+    included_deployments: list[dict[str, Any]],
+) -> None:
+    """Print detailed deployment metadata and included deployments.
+
+    Args:
+        deployment: Single deployment record dict.
+        active_deployment_hashes: Mapping of env names to active version hashes.
+        included_deployments: List of deployment versions included since predecessor.
+    """
+    meta = deployment.get("deployment_metadata", {})
+    version_hash = deployment.get("version_hash")
+    deployment_type = meta.get("deployment_type")
+    deployment_message = meta.get("deployment_message") or "-"
+    created_at = deployment.get("created_at", "")
+    created_by = deployment.get("created_by", "")
+    deployment_id = deployment.get("id")
+    client_env = deployment.get("client_env")
+    artifact_version = deployment.get("artifact_version")
+    lambda_deployment_version = deployment.get("function_deployment_version")
+
+    badges = []
+    if active_deployment_hashes.get("sandbox") == version_hash:
+        badges.append("[bold bright blue]sandbox[/bold bright blue]")
+    if active_deployment_hashes.get("pre-release") == version_hash:
+        badges.append("[bold yellow]pre-release[/bold yellow]")
+    if active_deployment_hashes.get("live") == version_hash:
+        badges.append("[bold green]live[/bold green]")
+    badges_str = " ".join(badges) if badges else ""
+
+    console.print(
+        f"([cyan]{deployment_type}[/cyan]) "
+        f"[bold][yellow]{version_hash}[/yellow][/bold] {badges_str}"
+    )
+    console.print(f"Date: {created_at}")
+    console.print(f"By: {created_by}")
+    console.print(f"Deployment ID: {deployment_id}")
+    console.print(f"Artifact Version: {artifact_version}")
+    console.print(f"Lambda Deployment Version: {lambda_deployment_version}")
+    console.print(f"Client Environment: {client_env}")
+    console.print(f"Message: {deployment_message}")
+    console.print()
+
+    if not included_deployments:
+        console.print("[muted]No intermediate deployments.[/muted]")
+    else:
+        count = len(included_deployments)
+        console.print(f"[label]Included deployments ({count}):[/label]")
+        print_deployments(included_deployments, {})
+
+
 # ── Error handling ───────────────────────────────────────────────────
 
 # Maps exception types to user-friendly prefixes

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -504,6 +504,7 @@ def print_deployment_show(
     deployment: dict[str, Any],
     active_deployment_hashes: dict[str, str],
     included_deployments: list[dict[str, Any]],
+    is_rollback: bool = False,
 ) -> None:
     """Print detailed deployment metadata and included deployments.
 
@@ -511,6 +512,7 @@ def print_deployment_show(
         deployment: Single deployment record dict.
         active_deployment_hashes: Mapping of env names to active version hashes.
         included_deployments: List of deployment versions included since predecessor.
+        is_rollback: Whether this deployment is a rollback to an older version.
     """
     meta = deployment.get("deployment_metadata", {})
     version_hash = deployment.get("version_hash")
@@ -549,7 +551,8 @@ def print_deployment_show(
         console.print("[muted]No intermediate deployments.[/muted]")
     else:
         count = len(included_deployments)
-        console.print(f"[label]Included deployments ({count}):[/label]")
+        label = "Reverted deployments" if is_rollback else "Included deployments"
+        console.print(f"[label]{label} ({count}):[/label]")
         print_deployments(included_deployments, {})
 
 

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -484,14 +484,14 @@ def print_deployments(
             artifact_version = version.get("artifact_version")
             lambda_deployment_version = version.get("function_deployment_version")
             console.print(
-                f"([cyan]{deployment_type}[/cyan]) [bold][yellow]{version_hash}[/yellow][/bold] {badges_str}"
+                f"([cyan]{deployment_type or '—'}[/cyan]) [bold][yellow]{(version_hash or '')[:9]}[/yellow][/bold] {badges_str}"
             )
             console.print(f"Date: {created_at}")
-            console.print(f"By: {created_by}")
-            console.print(f"Deployment ID: {deployment_id}")
-            console.print(f"Artifact Version: {artifact_version}")
-            console.print(f"Lambda Deployment Version: {lambda_deployment_version}")
-            console.print(f"Client Environment: {client_env}")
+            console.print(f"By: {created_by or '—'}")
+            console.print(f"Deployment ID: {deployment_id or '—'}")
+            console.print(f"Artifact Version: {artifact_version or '—'}")
+            console.print(f"Lambda Deployment Version: {lambda_deployment_version or '—'}")
+            console.print(f"Client Environment: {client_env or '—'}")
             console.print(f"Message: {deployment_message}")
             console.print()
 
@@ -535,15 +535,15 @@ def print_deployment_show(
     badges_str = " ".join(badges) if badges else ""
 
     console.print(
-        f"([cyan]{deployment_type}[/cyan]) "
-        f"[bold][yellow]{version_hash}[/yellow][/bold] {badges_str}"
+        f"([cyan]{deployment_type or '—'}[/cyan]) "
+        f"[bold][yellow]{(version_hash or '')[:9]}[/yellow][/bold] {badges_str}"
     )
     console.print(f"Date: {created_at}")
-    console.print(f"By: {created_by}")
-    console.print(f"Deployment ID: {deployment_id}")
-    console.print(f"Artifact Version: {artifact_version}")
-    console.print(f"Lambda Deployment Version: {lambda_deployment_version}")
-    console.print(f"Client Environment: {client_env}")
+    console.print(f"By: {created_by or '—'}")
+    console.print(f"Deployment ID: {deployment_id or '—'}")
+    console.print(f"Artifact Version: {artifact_version or '—'}")
+    console.print(f"Lambda Deployment Version: {lambda_deployment_version or '—'}")
+    console.print(f"Client Environment: {client_env or '—'}")
     console.print(f"Message: {deployment_message}")
     console.print()
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -607,6 +607,8 @@ class BranchMergeConflictHelpersTest(unittest.TestCase):
         table = rendered.renderable if isinstance(rendered, Panel) else rendered
         self.assertEqual(len(table.columns), 1)
         self.assertEqual(len(table.rows), 1)
+
+
 class ChatLoopTest(unittest.TestCase):
     """Tests for AgentStudioCLI._run_chat_loop.
 
@@ -616,7 +618,10 @@ class ChatLoopTest(unittest.TestCase):
 
     def setUp(self):
         self.proj = MagicMock()
-        self.proj.send_message.return_value = {"response": "Agent reply", "conversation_ended": False}
+        self.proj.send_message.return_value = {
+            "response": "Agent reply",
+            "conversation_ended": False,
+        }
         self.proj.end_chat.return_value = None
         self.proj.get_conversation_url.return_value = "https://example.com/conv-123"
 
@@ -1177,3 +1182,256 @@ class PrintDeploymentsTest(unittest.TestCase):
         mock_print_dep.assert_called_once()
         call_kwargs = mock_print_dep.call_args[1]
         self.assertTrue(call_kwargs["details"])
+
+
+def _make_version(index: int, env: str = "sandbox") -> dict:
+    """Build a realistic deployment version dict for tests."""
+    return {
+        "id": f"dep-{index}",
+        "version_hash": f"hash{index:05d}xxxx",
+        "created_at": f"Mon, 28 Apr 2026 14:{index:02d}:00 GMT",
+        "created_by": "user@example.com",
+        "artifact_version": str(40 + index),
+        "function_deployment_version": str(index),
+        "client_env": env,
+        "deployment_metadata": {
+            "deployment_type": "manual",
+            "deployment_message": f"Deploy {index}",
+        },
+    }
+
+
+class DeploymentsShowTest(unittest.TestCase):
+    """Tests for the deployments_show CLI method."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+
+        # Sandbox versions: [v0(newest), v1, v2, v3, v4(oldest)]
+        self.sandbox_versions = [_make_version(i) for i in range(5)]
+        self.active_hashes = {"sandbox": "hash00000xxxx"}
+
+    def tearDown(self):
+        patch.stopall()
+
+    # ── Error cases ──────────────────────────────────────────────────
+
+    @patch("poly.cli.error")
+    def test_no_versions_calls_error(self, mock_error):
+        """When the project has no versions, error is called."""
+        self.proj.get_deployments.return_value = ([], {})
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00000")
+
+        mock_error.assert_called_once()
+        self.assertIn("No versions found", mock_error.call_args[0][0])
+
+    @patch("poly.cli.error")
+    def test_hash_not_found_calls_error(self, mock_error):
+        """When the version hash doesn't match any version, error is called."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, self.active_hashes)
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="zzz999999")
+
+        mock_error.assert_called_once()
+        self.assertIn("not found", mock_error.call_args[0][0])
+
+    # ── JSON output structure ────────────────────────────────────────
+
+    @patch("poly.cli.json_print")
+    def test_json_output_contains_required_keys(self, mock_json):
+        """JSON output includes success, deployment, active_deployment_hashes, included."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, self.active_hashes)
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00000", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertIn("deployment", payload)
+        self.assertIn("active_deployment_hashes", payload)
+        self.assertIn("included_deployments", payload)
+
+    @patch("poly.cli.json_print")
+    def test_json_deployment_matches_target_version(self, mock_json):
+        """The deployment field in JSON output matches the requested version."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, self.active_hashes)
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00002", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["deployment"]["id"], "dep-2")
+        self.assertEqual(payload["deployment"]["version_hash"], "hash00002xxxx")
+
+    # ── Sandbox included deployments ─────────────────────────────────
+
+    @patch("poly.cli.json_print")
+    def test_sandbox_target_with_predecessor(self, mock_json):
+        """In sandbox, included = sandbox[target:predecessor].
+
+        sandbox: [v0, v1, v2, v3, v4]
+        target = v1, predecessor = v2 (next in list)
+        included = sandbox[1:2] = [v1]
+        """
+        self.proj.get_deployments.return_value = (self.sandbox_versions, {})
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00001", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-1"])
+
+    @patch("poly.cli.json_print")
+    def test_sandbox_last_version_no_predecessor(self, mock_json):
+        """The oldest sandbox version has no predecessor — included is just itself.
+
+        sandbox: [v0, v1, v2, v3, v4]
+        target = v4, no predecessor → included = sandbox[4:] = [v4]
+        """
+        self.proj.get_deployments.return_value = (self.sandbox_versions, {})
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00004", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-4"])
+
+    # ── Cross-env (pre-release/live) included deployments ────────────
+
+    @patch("poly.cli.json_print")
+    def test_live_resolves_included_from_sandbox(self, mock_json):
+        """For live, included deployments are resolved from sandbox history.
+
+        sandbox: [v0, v1, v2, v3, v4]
+        live:    [v0(promoted), v3(promoted)]
+        target = v0, predecessor in live = v3
+        → look up in sandbox: v0 at idx 0, v3 at idx 3
+        → included = sandbox[0:3] = [v0, v1, v2]
+        """
+        live_versions = [
+            _make_version(0, env="live"),
+            _make_version(3, env="live"),
+        ]
+        self.proj.get_deployments.side_effect = [
+            (live_versions, {"live": "hash00000xxxx"}),
+            (self.sandbox_versions, {}),
+        ]
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00000", environment="live", output_json=True
+        )
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-0", "dep-1", "dep-2"])
+
+    @patch("poly.cli.json_print")
+    def test_live_first_deployment_includes_all_sandbox(self, mock_json):
+        """First deployment in live has no predecessor — included is everything from target onward.
+
+        sandbox: [v0, v1, v2, v3, v4]
+        live:    [v2(promoted)]  (first ever live deployment)
+        target = v2, no predecessor
+        → included = sandbox[2:] = [v2, v3, v4]
+        """
+        live_versions = [_make_version(2, env="live")]
+        self.proj.get_deployments.side_effect = [
+            (live_versions, {"live": "hash00002xxxx"}),
+            (self.sandbox_versions, {}),
+        ]
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00002", environment="live", output_json=True
+        )
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-2", "dep-3", "dep-4"])
+
+    @patch("poly.cli.json_print")
+    def test_live_adjacent_versions_includes_only_target(self, mock_json):
+        """When live target and predecessor are adjacent in sandbox, included is just target.
+
+        sandbox: [v0, v1, v2, v3, v4]
+        live:    [v1(promoted), v2(promoted)]
+        target = v1, predecessor in live = v2
+        → included = sandbox[1:2] = [v1]
+        """
+        live_versions = [
+            _make_version(1, env="live"),
+            _make_version(2, env="live"),
+        ]
+        self.proj.get_deployments.side_effect = [
+            (live_versions, {"live": "hash00001xxxx"}),
+            (self.sandbox_versions, {}),
+        ]
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00001", environment="live", output_json=True
+        )
+
+        payload = mock_json.call_args[0][0]
+        included_ids = [d["id"] for d in payload["included_deployments"]]
+        self.assertEqual(included_ids, ["dep-1"])
+
+    # ── Environment routing ──────────────────────────────────────────
+
+    @patch("poly.cli.json_print")
+    def test_non_sandbox_env_fetches_sandbox_separately(self, mock_json):
+        """For non-sandbox envs, get_deployments is called twice: env + sandbox."""
+        live_versions = [_make_version(0, env="live")]
+        self.proj.get_deployments.side_effect = [
+            (live_versions, {}),
+            (self.sandbox_versions, {}),
+        ]
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00000", environment="live", output_json=True
+        )
+
+        calls = self.proj.get_deployments.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0].kwargs["client_env"], "live")
+        self.assertEqual(calls[1].kwargs["client_env"], "sandbox")
+
+    @patch("poly.cli.json_print")
+    def test_sandbox_env_does_not_fetch_twice(self, mock_json):
+        """For sandbox, get_deployments is only called once."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, {})
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00000", environment="sandbox", output_json=True
+        )
+
+        self.proj.get_deployments.assert_called_once_with(client_env="sandbox")
+
+    # ── Rich output path ─────────────────────────────────────────────
+
+    @patch("poly.cli.print_deployment_show")
+    def test_rich_output_calls_print_deployment_show(self, mock_show):
+        """Without output_json, the rich console function is called."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, self.active_hashes)
+
+        AgentStudioCLI.deployments_show(TEST_DIR, version_hash="hash00000")
+
+        mock_show.assert_called_once()
+        args = mock_show.call_args[0]
+        self.assertEqual(args[0]["id"], "dep-0")
+        self.assertEqual(args[1], self.active_hashes)
+
+    # ── Hash prefix truncation ───────────────────────────────────────
+
+    @patch("poly.cli.json_print")
+    def test_long_hash_is_truncated_to_nine_chars(self, mock_json):
+        """A hash longer than 9 characters still matches via its 9-char prefix."""
+        self.proj.get_deployments.return_value = (self.sandbox_versions, {})
+
+        AgentStudioCLI.deployments_show(
+            TEST_DIR, version_hash="hash00001xxxx_extra", output_json=True
+        )
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["deployment"]["id"], "dep-1")


### PR DESCRIPTION
## Summary

Adds `poly deployments show <hash>` subcommand to display detailed metadata for a specific deployment and the sandbox deployments included since the previous version in the given environment.

## Motivation

When reviewing deployment history, users need to drill into a specific version to see its full metadata (deployment ID, artifact version, lambda version, message, etc.) and understand which sandbox deployments were bundled into a promotion to pre-release or live.

## Changes

- Add `show` subparser under `deployments` with `hash` positional arg and `--env` flag (sandbox/pre-release/live)
- Add `deployments_show()` and `_resolve_included_deployments()` methods to `AgentStudioCLI`
- Add `print_deployment_show()` rich console output function
- Add comprehensive tests covering error cases, JSON output, cross-env resolution, hash prefix matching, and rich output path

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
Default sandbox:
<img width="856" height="171" alt="Screenshot 2026-05-01 at 16 23 20" src="https://github.com/user-attachments/assets/9287f99c-087f-40b9-b556-aff2f78a1556" />
Live push:
<img width="1075" height="238" alt="Screenshot 2026-05-01 at 16 23 13" src="https://github.com/user-attachments/assets/68b4205c-c9e3-4767-82ac-a5e3da0d8277" />

