### PR TITLE
fix: pass ADK region directly to SourcererSDK for correct API key lookup

### DIFF
--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -70,6 +70,11 @@ class SourcererSDK:
         self.project_id = project_id
         self.branch_id = branch_id
 
+        if environment == "prod":
+            self.key_region = region
+        else:
+            self.key_region = environment
+
         # Set base URL
         if base_url:
             self.base_url = base_url
@@ -87,7 +92,7 @@ class SourcererSDK:
         self.session.headers.update(
             {
                 "Content-Type": "application/json",
-                "X-API-KEY": retrieve_api_key(region),
+                "X-API-KEY": retrieve_api_key(self.key_region),
                 "X-PolyAI-Correlation-Id": correlation_id,
             }
         )
@@ -554,7 +559,7 @@ class SourcererSDK:
             # Update headers for protobuf content
             correlation_id = f"adk-{uuid.uuid4()}"
             headers = {
-                "X-API-KEY": retrieve_api_key(self.region),
+                "X-API-KEY": retrieve_api_key(self.key_region),
                 "X-PolyAI-Correlation-Id": correlation_id,
                 "Content-Type": "application/octet-stream",
             }

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -38,17 +38,16 @@ class SourcererSDK:
     # Environment to base URL mapping
     ENVIRONMENT_URLS = {
         "dev": "https://api.dev.poly.ai/adk/v1",
-        "us-staging": "https://api.staging.poly.ai/adk/v1",
-        "euw-prod": "https://api.eu.poly.ai/adk/v1",
-        "us-prod": "https://api.us.poly.ai/adk/v1",
-        "uk-prod": "https://api.uk.poly.ai/adk/v1",
-        "studio-prod": "https://api.studio.poly.ai/adk/v1",
+        "staging": "https://api.staging.poly.ai/adk/v1",
+        "euw-1": "https://api.eu.poly.ai/adk/v1",
+        "us-1": "https://api.us.poly.ai/adk/v1",
+        "uk-1": "https://api.uk.poly.ai/adk/v1",
+        "studio": "https://api.studio.poly.ai/adk/v1",
     }
 
     def __init__(
         self,
         region: str,
-        environment: str,
         account_id: str,
         project_id: str,
         branch_id: Optional[str] = None,
@@ -57,34 +56,26 @@ class SourcererSDK:
         """Initialize the Sourcerer SDK
 
         Args:
-            region: The region (e.g., 'us', 'euw', 'uk')
-            environment: The environment (e.g., 'dev', 'prod', 'staging')
+            region: The region (e.g., 'us-1', 'euw-1', 'uk-1', 'studio', 'staging', 'dev')
             account_id: The account ID
             project_id: The project ID
             branch_id: Optional branch ID. If not provided, will use the first available branch or create a new one
             base_url: Optional custom base URL. If not provided, will use the environment mapping
         """
         self.region = region
-        self.environment = environment
         self.account_id = account_id
         self.project_id = project_id
         self.branch_id = branch_id
-
-        if environment == "prod":
-            self.key_region = region
-        else:
-            self.key_region = environment
 
         # Set base URL
         if base_url:
             self.base_url = base_url
         else:
-            env_key = f"{region}-{environment}" if environment != "dev" else "dev"
-            if env_key not in self.ENVIRONMENT_URLS:
+            if region not in self.ENVIRONMENT_URLS:
                 raise ValueError(
-                    f"Unknown environment: {env_key}. Available environments: {list(self.ENVIRONMENT_URLS.keys())}"
+                    f"Unknown region: {region}. Available regions: {list(self.ENVIRONMENT_URLS.keys())}"
                 )
-            self.base_url = self.ENVIRONMENT_URLS[env_key]
+            self.base_url = self.ENVIRONMENT_URLS[region]
 
         # Initialize session with auth headers
         correlation_id = f"adk-{uuid.uuid4()}"
@@ -92,7 +83,7 @@ class SourcererSDK:
         self.session.headers.update(
             {
                 "Content-Type": "application/json",
-                "X-API-KEY": retrieve_api_key(self.key_region),
+                "X-API-KEY": retrieve_api_key(self.region),
                 "X-PolyAI-Correlation-Id": correlation_id,
             }
         )
@@ -559,7 +550,7 @@ class SourcererSDK:
             # Update headers for protobuf content
             correlation_id = f"adk-{uuid.uuid4()}"
             headers = {
-                "X-API-KEY": retrieve_api_key(self.key_region),
+                "X-API-KEY": retrieve_api_key(self.region),
                 "X-PolyAI-Correlation-Id": correlation_id,
                 "Content-Type": "application/octet-stream",
             }

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -66,15 +66,6 @@ RULES = "rules"
 class SyncClientHandler:
     """Sync client for Agent Studio content management"""
 
-    region_to_region_env = {
-        "euw-1": ("euw", "prod"),
-        "uk-1": ("uk", "prod"),
-        "us-1": ("us", "prod"),
-        "studio": ("studio", "prod"),
-        "staging": ("us", "staging"),
-        "dev": ("us", "dev"),
-    }
-
     _sdk: Optional[SourcererSDK] = None
     region: str
     account_id: str
@@ -92,17 +83,17 @@ class SyncClientHandler:
         project_id: str,
         branch_id: Optional[str] = None,
     ):
-        region_env = SyncClientHandler.region_to_region_env.get(region)
-        if not region_env:
-            raise ValueError(f"Unsupported region: {region}")
+        if region not in SourcererSDK.ENVIRONMENT_URLS:
+            raise ValueError(
+                f"Invalid region '{region}'. Valid regions are: {list(SourcererSDK.ENVIRONMENT_URLS.keys())}"
+            )
 
         self.region = region
         self.account_id = account_id
         self.project_id = project_id
 
         self._sdk = SourcererSDK(
-            region=region_env[0],
-            environment=region_env[1],
+            region=region,
             account_id=account_id,
             project_id=project_id,
             branch_id=branch_id,


### PR DESCRIPTION
## Summary

Pass the ADK region directly to `SourcererSDK` instead of decomposing it into `(region, environment)` tuples, fixing incorrect API key lookup for dev/staging environments.

## Motivation

When using `POLY_ADK_KEY_DEV`, the dev environment incorrectly called `retrieve_api_key("us")` (the decomposed region) instead of `retrieve_api_key("dev")`, falling back to the generic `POLY_ADK_KEY` and ignoring the per-region key.

## Changes

- Removed `region_to_region_env` mapping from `SyncClientHandler`
- `SourcererSDK` now takes the ADK region directly (`"dev"`, `"us-1"`, etc.) instead of separate `region`/`environment` params
- `ENVIRONMENT_URLS` keys updated to use ADK region names (`"us-1"` instead of `"us-prod"`)
- `retrieve_api_key()` now receives the correct region for all environments

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)