### PR TITLE
fix: key accounts/projects dicts by ID to prevent duplicate name collisions

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1278,17 +1278,21 @@ class AgentStudioCLI:
         if not account_id:
             accounts = api_handler.get_accounts(region)
             if len(accounts) == 1:
-                account_name, account_id = next(iter(accounts.items()))
+                account_id, account_name = next(iter(accounts.items()))
                 if not output_json:
                     info(f"Auto-selected account [bold]{account_name}[/bold].")
             else:
-                account_menu = questionary.select(
+                account_choices = [
+                    questionary.Choice(title=f"{name} ({acc_id})", value=acc_id)
+                    for acc_id, name in accounts.items()
+                ]
+                account_id = questionary.select(
                     "Select Account",
-                    choices=list(accounts.keys()),
+                    choices=account_choices,
                     use_search_filter=True,
                     use_jk_keys=False,
                 ).ask()
-                if not account_menu:
+                if not account_id:
                     if output_json:
                         json_print(
                             {
@@ -1299,17 +1303,23 @@ class AgentStudioCLI:
                         sys.exit(1)
                     warning("No account selected. Exiting.")
                     return
-                account_id = accounts[account_menu]
+                account_name = accounts[account_id]
 
         if not project_id:
             projects = api_handler.get_projects(region, account_id)
-            project_menu = questionary.select(
+
+            project_choices = [
+                questionary.Choice(title=f"{name} ({proj_id})", value=proj_id)
+                for proj_id, name in projects.items()
+            ]
+
+            project_id = questionary.select(
                 "Select Project",
-                choices=list(projects.keys()),
+                choices=project_choices,
                 use_search_filter=True,
                 use_jk_keys=False,
             ).ask()
-            if not project_menu:
+            if not project_id:
                 if output_json:
                     json_print(
                         {
@@ -1320,16 +1330,12 @@ class AgentStudioCLI:
                     sys.exit(1)
                 warning("No project selected. Exiting.")
                 return
-            project_name = project_menu
-            project_id = projects[project_menu]
+
+            project_name = projects.get(project_id)
         else:
             # project_id was passed directly — look up the name
             projects = api_handler.get_projects(region, account_id)
-            # Reverse lookup: find name for the given ID
-            project_name = next(
-                (name for name, pid in projects.items() if pid == project_id),
-                None,
-            )
+            project_name = projects.get(project_id)
 
         if not output_json:
             info(f"Initializing project [bold]{account_id}/{project_id}[/bold]...")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1277,6 +1277,17 @@ class AgentStudioCLI:
 
         if not account_id:
             accounts = api_handler.get_accounts(region)
+            if not accounts:
+                if output_json:
+                    json_print(
+                        {
+                            "success": False,
+                            "error": "No accounts found in the selected region.",
+                        }
+                    )
+                else:
+                    error("No accounts found in the selected region.")
+                sys.exit(1)
             if len(accounts) == 1:
                 account_id, account_name = next(iter(accounts.items()))
                 if not output_json:
@@ -1307,6 +1318,18 @@ class AgentStudioCLI:
 
         if not project_id:
             projects = api_handler.get_projects(region, account_id)
+
+            if not projects:
+                if output_json:
+                    json_print(
+                        {
+                            "success": False,
+                            "error": "No projects found in the selected account.",
+                        }
+                    )
+                else:
+                    error("No projects found in the selected account.")
+                sys.exit(1)
 
             project_choices = [
                 questionary.Choice(title=f"{name} ({proj_id})", value=proj_id)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -114,7 +114,7 @@ class AgentStudioInterface:
             region (str): The region name
 
         Returns:
-            dict[str, str]: A dictionary mapping account names to account IDs
+            dict[str, str]: A dictionary mapping account ids to account names
         """
         return PlatformAPIHandler.get_accounts(region)
 
@@ -127,7 +127,7 @@ class AgentStudioInterface:
             account_id (str): The account ID
 
         Returns:
-            dict[str, str]: A dictionary mapping project names to project IDs
+            dict[str, str]: A dictionary mapping project IDs to project names
         """
         return PlatformAPIHandler.get_projects(region, account_id)
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -161,7 +161,7 @@ class PlatformAPIHandler:
             region (str): The region name
 
         Returns:
-            dict[str, str]: A dictionary mapping account names to account IDs
+            dict[str, str]: A dictionary mapping account ids to account names
         """
         accounts = {}
         accounts_data = PlatformAPIHandler.make_request(region, ACCOUNTS_URL, "GET")
@@ -171,7 +171,7 @@ class PlatformAPIHandler:
 
         for account in accounts_data:
             if account.get("active", False) and account.get("id") and account.get("name"):
-                accounts[account.get("name")] = account.get("id")
+                accounts[account.get("id")] = account.get("name")
 
         return accounts
 
@@ -184,7 +184,7 @@ class PlatformAPIHandler:
             account_id (str): The account ID
 
         Returns:
-            dict[str, str]: A dictionary mapping project names to project IDs
+            dict[str, str]: A dictionary mapping project IDs to project names
         """
         projects = {}
         endpoint = PROJECTS_URL.format(account_id=account_id)
@@ -196,7 +196,7 @@ class PlatformAPIHandler:
 
         for project in projects_list:
             if project.get("id") and project.get("name"):
-                projects[project.get("name")] = project.get("id")
+                projects[project.get("id")] = project.get("name")
 
         return projects
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1177,3 +1177,57 @@ class PrintDeploymentsTest(unittest.TestCase):
         mock_print_dep.assert_called_once()
         call_kwargs = mock_print_dep.call_args[1]
         self.assertTrue(call_kwargs["details"])
+
+
+class PlatformAPIGetAccountsTest(unittest.TestCase):
+    """Tests for PlatformAPIHandler.get_accounts and get_projects dict orientation."""
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_get_accounts_returns_id_to_name_and_preserves_duplicates(self, mock_request):
+        """get_accounts keys by ID so duplicate names don't collide."""
+        from poly.handlers.platform_api import PlatformAPIHandler
+
+        mock_request.return_value = [
+            {"id": "acc_1", "name": "Same Name", "active": True},
+            {"id": "acc_2", "name": "Same Name", "active": True},
+            {"id": "acc_3", "name": "Inactive", "active": False},
+        ]
+
+        result = PlatformAPIHandler.get_accounts("eu-west-1")
+
+        self.assertEqual(result, {"acc_1": "Same Name", "acc_2": "Same Name"})
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_get_projects_returns_id_to_name_and_preserves_duplicates(self, mock_request):
+        """get_projects keys by ID so duplicate names don't collide."""
+        from poly.handlers.platform_api import PlatformAPIHandler
+
+        mock_request.return_value = {
+            "projects": [
+                {"id": "proj_1", "name": "Same Name"},
+                {"id": "proj_2", "name": "Same Name"},
+            ]
+        }
+
+        result = PlatformAPIHandler.get_projects("eu-west-1", "acc_1")
+
+        self.assertEqual(result, {"proj_1": "Same Name", "proj_2": "Same Name"})
+
+
+class InitProjectTest(unittest.TestCase):
+    """Tests for the init_project interactive selection flow."""
+
+    @patch("poly.cli.AgentStudioProject.init_project")
+    @patch("poly.cli.AgentStudioInterface")
+    def test_init_with_explicit_ids_looks_up_project_name(self, mock_iface_cls, mock_init):
+        """When all IDs are provided, project name is looked up by project_id key."""
+        api = mock_iface_cls.return_value
+        api.get_projects.return_value = {"proj_1": "My Project"}
+        mock_init.return_value = (MagicMock(), None)
+
+        AgentStudioCLI.init_project(
+            TEST_DIR, region="eu-west-1", account_id="acc_1", project_id="proj_1"
+        )
+
+        mock_init.assert_called_once()
+        self.assertEqual(mock_init.call_args[1]["project_name"], "My Project")

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1179,41 +1179,6 @@ class PrintDeploymentsTest(unittest.TestCase):
         self.assertTrue(call_kwargs["details"])
 
 
-class PlatformAPIGetAccountsTest(unittest.TestCase):
-    """Tests for PlatformAPIHandler.get_accounts and get_projects dict orientation."""
-
-    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
-    def test_get_accounts_returns_id_to_name_and_preserves_duplicates(self, mock_request):
-        """get_accounts keys by ID so duplicate names don't collide."""
-        from poly.handlers.platform_api import PlatformAPIHandler
-
-        mock_request.return_value = [
-            {"id": "acc_1", "name": "Same Name", "active": True},
-            {"id": "acc_2", "name": "Same Name", "active": True},
-            {"id": "acc_3", "name": "Inactive", "active": False},
-        ]
-
-        result = PlatformAPIHandler.get_accounts("eu-west-1")
-
-        self.assertEqual(result, {"acc_1": "Same Name", "acc_2": "Same Name"})
-
-    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
-    def test_get_projects_returns_id_to_name_and_preserves_duplicates(self, mock_request):
-        """get_projects keys by ID so duplicate names don't collide."""
-        from poly.handlers.platform_api import PlatformAPIHandler
-
-        mock_request.return_value = {
-            "projects": [
-                {"id": "proj_1", "name": "Same Name"},
-                {"id": "proj_2", "name": "Same Name"},
-            ]
-        }
-
-        result = PlatformAPIHandler.get_projects("eu-west-1", "acc_1")
-
-        self.assertEqual(result, {"proj_1": "Same Name", "proj_2": "Same Name"})
-
-
 class InitProjectTest(unittest.TestCase):
     """Tests for the init_project interactive selection flow."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1196,3 +1196,26 @@ class InitProjectTest(unittest.TestCase):
 
         mock_init.assert_called_once()
         self.assertEqual(mock_init.call_args[1]["project_name"], "My Project")
+
+    @patch("poly.cli.AgentStudioInterface")
+    def test_init_exits_when_no_accounts(self, mock_iface_cls):
+        """When get_accounts returns empty dict, init exits with error."""
+        api = mock_iface_cls.return_value
+        api.get_accounts.return_value = {}
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.init_project(TEST_DIR, region="eu-west-1")
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch("poly.cli.AgentStudioInterface")
+    def test_init_exits_when_no_projects(self, mock_iface_cls):
+        """When get_projects returns empty dict, init exits with error."""
+        api = mock_iface_cls.return_value
+        api.get_accounts.return_value = {"acc_1": "Only Account"}
+        api.get_projects.return_value = {}
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.init_project(TEST_DIR, region="eu-west-1")
+
+        self.assertEqual(ctx.exception.code, 1)

--- a/uv.lock
+++ b/uv.lock
@@ -332,7 +332,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.4.0"
+version = "0.16.1"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

Fix `get_accounts` and `get_projects` to key by ID instead of name, preventing silent data loss when accounts or projects share the same name. Also adds error handling when no accounts or projects are found.

## Motivation

When two accounts (or projects) had the same display name, the old `name → id` dict would silently overwrite one entry. This caused missing options during `poly init` interactive selection. Additionally, empty account/project lists would fall through to `questionary.select` with no choices, causing an unhelpful crash.

## Changes

- `PlatformAPIHandler.get_accounts` and `get_projects` now return `{id: name}` instead of `{name: id}`
- `init_project` uses `questionary.Choice` objects to display `"name (id)"` while selecting by ID
- Added early exit with clear error message when no accounts or projects are found
- Simplified project name lookup to `projects.get(project_id)`
- Updated docstrings in `interface.py` and `platform_api.py`

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)