### PR TITLE
feat: use Agents API for project creation and offer create on empty

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1457,9 +1457,21 @@ class AgentStudioCLI:
                             "error": "No projects found in the selected account.",
                         }
                     )
-                else:
-                    error("No projects found in the selected account.")
-                sys.exit(1)
+                    sys.exit(1)
+
+                should_create = questionary.confirm(
+                    "No projects found in this account. Would you like to create one?"
+                ).ask()
+                if not should_create:
+                    return
+
+                cls.create_project(
+                    base_path,
+                    region=region,
+                    account_id=account_id,
+                    output_json=False,
+                )
+                return
 
             project_choices = [
                 questionary.Choice(title=f"{name} ({proj_id})", value=proj_id)

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1209,16 +1209,49 @@ class InitProjectTest(unittest.TestCase):
         self.assertEqual(ctx.exception.code, 1)
 
     @patch("poly.cli.AgentStudioInterface")
-    def test_init_exits_when_no_projects(self, mock_iface_cls):
-        """When get_projects returns empty dict, init exits with error."""
+    def test_init_exits_when_no_projects_json_mode(self, mock_iface_cls):
+        """When get_projects returns empty dict in JSON mode, init exits with error."""
         api = mock_iface_cls.return_value
         api.get_accounts.return_value = {"acc_1": "Only Account"}
         api.get_projects.return_value = {}
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.init_project(TEST_DIR, region="eu-west-1")
+            AgentStudioCLI.init_project(
+                TEST_DIR, region="eu-west-1", account_id="acc_1", output_json=True
+            )
 
         self.assertEqual(ctx.exception.code, 1)
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.AgentStudioInterface")
+    def test_init_offers_create_when_no_projects(self, mock_iface_cls, mock_q):
+        """When get_projects returns empty dict, user is offered to create a project."""
+        api = mock_iface_cls.return_value
+        api.get_accounts.return_value = {"acc_1": "Only Account"}
+        api.get_projects.return_value = {}
+        mock_q.confirm.return_value.ask.return_value = False
+
+        AgentStudioCLI.init_project(TEST_DIR, region="eu-west-1")
+
+        mock_q.confirm.assert_called_once()
+
+    @patch("poly.cli.AgentStudioCLI.create_project")
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.AgentStudioInterface")
+    def test_init_delegates_to_create_project_when_accepted(
+        self, mock_iface_cls, mock_q, mock_create
+    ):
+        """When user accepts create prompt, create_project is called."""
+        api = mock_iface_cls.return_value
+        api.get_accounts.return_value = {"acc_1": "Only Account"}
+        api.get_projects.return_value = {}
+        mock_q.confirm.return_value.ask.return_value = True
+
+        AgentStudioCLI.init_project(TEST_DIR, region="eu-west-1")
+
+        mock_create.assert_called_once_with(
+            TEST_DIR, region="eu-west-1", account_id="acc_1", output_json=False
+        )
 
 
 class CreateProjectTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Switch `create_project` from the Sourcerer API to `POST /v1/agents` (Agents API)
- In `poly init`, when no projects are found in the selected account, prompt the user to create one instead of erroring out (interactive mode only; JSON mode still exits with error)
- Fix pre-existing syntax errors: duplicate `get_deployments` definitions in `platform_api.py`/`interface.py`, and broken indentation in `cli.py`

## Test plan

- [x] Existing `create_project` CLI tests pass (mocked at interface level, return shape unchanged)
- [x] New test: JSON mode still exits with code 1 when no projects found
- [x] New test: interactive mode shows confirmation prompt when no projects found
- [x] New test: accepting the prompt delegates to `create_project` with correct args
- [x] Full suite passes (568 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)