### PR TITLE
fix: Handle non-string merge conflict values

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -43,6 +43,7 @@ from poly.output.console import (
     output_merge_conflict_table,
     print_merge_conflict_interactive_header,
     print_deployments,
+    prompt_typed_edit,
 )
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
@@ -2247,11 +2248,10 @@ class AgentStudioCLI:
         def _is_heavy_content(c: dict[str, Any]) -> bool:
             for key in ("baseValue", "theirsValue", "oursValue"):
                 v = c.get(key, "")
-                if not isinstance(v, str):
+                s = v if isinstance(v, str) else str(v)
+                if "\n" in s:
                     return True
-                if "\n" in v:
-                    return True
-                if len(v) > _BRANCH_MERGE_LONG_LINE_THRESHOLD:
+                if len(s) > _BRANCH_MERGE_LONG_LINE_THRESHOLD:
                     return True
             return False
 
@@ -2304,7 +2304,8 @@ class AgentStudioCLI:
                     {"name": "Use original (base)", "value": "base"},
                 ]
             )
-            if merged_version is not None:
+            original = conflict.get("theirsValue", conflict.get("oursValue"))
+            if not isinstance(original, dict):
                 choices.append({"name": "Edit manually", "value": "edit"})
 
             extension = ".py" if path[-1] == "code" else ".txt"
@@ -2319,9 +2320,18 @@ class AgentStudioCLI:
                 if answer == "merged":
                     resolutions.append(_auto_merge_resolution(path, merged_version))
                     break
-                if answer == "edit" and merged_version is not None:
+                if answer == "edit":
+                    if isinstance(original, (bool, int, float, list)):
+                        edited_val = prompt_typed_edit(original)
+                        if edited_val is None:
+                            return []
+                        resolutions.append(
+                            {"path": path, "value": edited_val, "strategy": "theirs"}
+                        )
+                        break
+
                     try:
-                        if heavy:
+                        if heavy and merged_version is not None:
                             edited = edit_in_editor(
                                 merged_version, extension=extension, filename=fk
                             )

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -88,7 +88,9 @@ def enrich_branch_merge_conflicts(conflicts: list[dict[str, Any]]) -> list[dict[
         if not path or path[-1] in {"updatedAt", "createdAt"}:
             out.append(row)
             continue
-        merged = merge_strings(row["baseValue"], row["theirsValue"], row["oursValue"])
+        merged = merge_strings(
+            row.get("baseValue", ""), row.get("theirsValue", ""), row.get("oursValue", "")
+        )
         fk = _branch_merge_conflict_file_key(path)
         row["visual_path"] = os.sep.join(path)
         row["merged_value"] = merged
@@ -2259,7 +2261,9 @@ class AgentStudioCLI:
             existing_resolution = existing_resolutions.get(clean_path)
             if merged_version is None:
                 merged_version = merge_strings(
-                    conflict["baseValue"], conflict["theirsValue"], conflict["oursValue"]
+                    conflict.get("baseValue", ""),
+                    conflict.get("theirsValue", ""),
+                    conflict.get("oursValue", ""),
                 )
             auto_merged = conflict.get("can_auto_merge")
             if auto_merged is None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -88,15 +88,20 @@ def enrich_branch_merge_conflicts(conflicts: list[dict[str, Any]]) -> list[dict[
         if not path or path[-1] in {"updatedAt", "createdAt"}:
             out.append(row)
             continue
-        merged = merge_strings(
-            row.get("baseValue", ""), row.get("theirsValue", ""), row.get("oursValue", "")
-        )
+        base_value = row.get("baseValue") or ""
+        theirs_value = row.get("theirsValue") or ""
+        ours_value = row.get("oursValue") or ""
         fk = _branch_merge_conflict_file_key(path)
         row["visual_path"] = os.sep.join(path)
-        row["merged_value"] = merged
-        row["can_auto_merge"] = not contains_merge_conflict(merged)
         row["file_key"] = fk
         row["conflicts_in_resource"] = counts[fk]
+        if all(isinstance(v, str) for v in [base_value, theirs_value, ours_value]):
+            merged = merge_strings(base_value, theirs_value, ours_value)
+            row["merged_value"] = merged
+            row["can_auto_merge"] = not contains_merge_conflict(merged)
+        else:
+            row["merged_value"] = None
+            row["can_auto_merge"] = False
         out.append(row)
     return out
 
@@ -2259,17 +2264,8 @@ class AgentStudioCLI:
             clean_path = conflict.get("visual_path") or os.sep.join(path)
             merged_version = conflict.get("merged_value")
             existing_resolution = existing_resolutions.get(clean_path)
-            if merged_version is None:
-                merged_version = merge_strings(
-                    conflict.get("baseValue", ""),
-                    conflict.get("theirsValue", ""),
-                    conflict.get("oursValue", ""),
-                )
             auto_merged = conflict.get("can_auto_merge")
-            if auto_merged is None:
-                auto_merged = not contains_merge_conflict(merged_version)
-
-            fk = conflict.get("file_key") or _branch_merge_conflict_file_key(path)
+            fk = conflict.get("file_key")
             index_in_resource[fk] = index_in_resource.get(fk, 0) + 1
             idx = index_in_resource[fk]
             total = int(conflict.get("conflicts_in_resource") or 1)
@@ -2306,9 +2302,10 @@ class AgentStudioCLI:
                     {"name": "Use main", "value": "ours"},
                     {"name": f"Use branch — {branch_label}", "value": "theirs"},
                     {"name": "Use original (base)", "value": "base"},
-                    {"name": "Edit in editor", "value": "edit"},
                 ]
             )
+            if merged_version is not None:
+                choices.append({"name": "Edit manually", "value": "edit"})
 
             extension = ".py" if path[-1] == "code" else ".txt"
 
@@ -2322,7 +2319,7 @@ class AgentStudioCLI:
                 if answer == "merged":
                     resolutions.append(_auto_merge_resolution(path, merged_version))
                     break
-                if answer == "edit":
+                if answer == "edit" and merged_version is not None:
                     try:
                         if heavy:
                             edited = edit_in_editor(

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -407,6 +407,60 @@ def edit_in_editor(initial_content: str, extension: str = ".txt", filename: str 
     return edited
 
 
+# ── TYPED MERGE EDITING ──────────────────────────────────────────────
+
+
+def _validate_int(v: str) -> bool | str:
+    """Questionary validator for integer input."""
+    return True if v.lstrip("-").isdigit() else "Please enter a valid integer"
+
+
+def _validate_float(v: str) -> bool | str:
+    """Questionary validator for float input."""
+    try:
+        float(v)
+        return True
+    except ValueError:
+        return "Please enter a valid number"
+
+
+def _validate_json_list(v: str) -> bool | str:
+    """Questionary validator for JSON list input."""
+    try:
+        return True if isinstance(json.loads(v), list) else "Please enter a valid JSON list"
+    except json.JSONDecodeError:
+        return "Please enter valid JSON"
+
+
+def prompt_typed_edit(original: Any) -> Any | None:
+    """Prompt the user for a custom value, using a type-appropriate questionary widget.
+
+    Returns the edited value cast to the original type, or ``None`` if the user cancels.
+    """
+    import questionary
+
+    if isinstance(original, bool):
+        return questionary.confirm("Custom resolution (true/false)", default=original).ask()
+    if isinstance(original, int):
+        raw = questionary.text(
+            "Custom resolution (integer)", default=str(original), validate=_validate_int
+        ).ask()
+        return int(raw) if raw is not None else None
+    if isinstance(original, float):
+        raw = questionary.text(
+            "Custom resolution (number)", default=str(original), validate=_validate_float
+        ).ask()
+        return float(raw) if raw is not None else None
+    if isinstance(original, list):
+        raw = questionary.text(
+            "Custom resolution (JSON list)",
+            default=json.dumps(original),
+            validate=_validate_json_list,
+        ).ask()
+        return json.loads(raw) if raw is not None else None
+    return None
+
+
 # ── DEPLOYMENTS ───────────────────────────────────────────────────────
 
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -559,6 +559,126 @@ class BranchMergeConflictHelpersTest(unittest.TestCase):
         out = enrich_branch_merge_conflicts(conflicts)
         self.assertNotIn("merged_value", out[0])
 
+    def test_enrich_dict_values_skips_merge_and_marks_not_auto_mergeable(self):
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["entities", "TOPIC-1", "content"],
+                "baseValue": {"id": 1, "name": "base"},
+                "theirsValue": {"id": 1, "name": "theirs"},
+                "oursValue": {"id": 1, "name": "ours"},
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+        self.assertEqual(out[0]["visual_path"], os.path.join("entities", "TOPIC-1", "content"))
+
+    def test_enrich_none_base_with_string_theirs_ours_auto_merges(self):
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["user", "city"],
+                "baseValue": None,
+                "theirsValue": "NYC",
+                "oursValue": "Boston",
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNotNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+
+    def test_enrich_numeric_values_skips_merge(self):
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["products", "0", "price"],
+                "baseValue": 10,
+                "theirsValue": 12,
+                "oursValue": 15,
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+
+    def test_enrich_array_values_skips_merge(self):
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["tags", "list"],
+                "baseValue": ["javascript", "react"],
+                "theirsValue": ["javascript", "vue"],
+                "oursValue": ["javascript", "typescript"],
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+
+    def test_enrich_missing_base_with_string_theirs_ours_auto_merges(self):
+        """Add conflicts where baseValue is absent but theirs/ours are strings."""
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["user", "name"],
+                "theirsValue": "Alice",
+                "oursValue": "Bob",
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNotNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+
+    def test_enrich_none_base_with_non_string_theirs_ours_skips_merge(self):
+        """Delete-vs-update where the surviving values are dicts, not strings."""
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["user"],
+                "baseValue": {"id": 1, "name": "John"},
+                "oursValue": None,
+                "theirsValue": {"id": 1, "name": "John", "age": 35},
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+
+    def test_enrich_mixed_string_and_non_string_conflicts(self):
+        from poly.cli import enrich_branch_merge_conflicts
+
+        conflicts = [
+            {
+                "path": ["kb", "t1", "name"],
+                "baseValue": "old",
+                "theirsValue": "new-theirs",
+                "oursValue": "new-ours",
+            },
+            {
+                "path": ["kb", "t1", "metadata"],
+                "baseValue": {"key": "val"},
+                "theirsValue": {"key": "val2"},
+                "oursValue": {"key": "val3"},
+            },
+        ]
+        out = enrich_branch_merge_conflicts(conflicts)
+        self.assertIsNotNone(out[0]["merged_value"])
+        self.assertFalse(out[0]["can_auto_merge"])
+        self.assertIsNone(out[1]["merged_value"])
+        self.assertFalse(out[1]["can_auto_merge"])
+        fk = os.path.join("kb", "t1")
+        self.assertEqual(out[0]["conflicts_in_resource"], 2)
+        self.assertEqual(out[1]["conflicts_in_resource"], 2)
+        self.assertEqual(out[0]["file_key"], fk)
+        self.assertEqual(out[1]["file_key"], fk)
+
     def test_auto_merge_resolution_payload(self):
         from poly.cli import _auto_merge_resolution
 


### PR DESCRIPTION
## Summary

Branch merge conflicts can contain non-string values (ints, bools, dicts, lists, None) from the platform's conflict resolver. Previously the CLI crashed or showed useless output for these types.

## Motivation

The conflict resolution UI called `merge_strings()` on all values regardless of type, crashing on dicts/ints/None. Merge values can also be empty or missing entirely, which caused similar failures. Non-string conflicts also showed a blank "Needs decision" panel with no values displayed.

## Changes

- Fix crash when merge values are empty or None
- Gate `merge_strings()` behind a type check — only called when theirs/ours are strings; None/missing base falls back to empty string
- Show non-string values inline in the conflict panel instead of hiding behind "Multiline or long values"
- Add type-appropriate edit prompts: `confirm` for bools, validated text for ints/floats, JSON input for lists
- Hide "Edit manually" for dict values (pick a side only)
- Extract `prompt_typed_edit` and validators into `console.py`
- Remove redundant fallback merge logic from the interactive handler

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
<img width="872" height="322" alt="Screenshot 2026-05-06 at 15 49 49" src="https://github.com/user-attachments/assets/0c651da5-dd41-4e07-92ea-57cc7f3cf5f4" />

<!-- Tested with numeric entity min/max conflicts on a live project -->