### PR TITLE
docs: feat: support per-region API keys via POLY_ADK_KEY_{REGION}

### DIFF
--- a/docs/docs/get-started/installation.md
+++ b/docs/docs/get-started/installation.md
@@ -55,6 +55,28 @@ export POLY_ADK_KEY=<your-api-key>
 
 The `POLY_ADK_KEY` environment variable must be set before running any `poly` commands. To make it permanent, add the export line to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
 
+### Per-region API keys
+
+If you need a separate API key for a specific region, you can set a region-scoped variable alongside `POLY_ADK_KEY`. The ADK checks for the region-specific key first and falls back to `POLY_ADK_KEY` if it is not set.
+
+| Region | Environment variable |
+|---|---|
+| `us-1` | `POLY_ADK_KEY_US` |
+| `euw-1` | `POLY_ADK_KEY_EUW` |
+| `uk-1` | `POLY_ADK_KEY_UK` |
+| `studio` | `POLY_ADK_KEY_STUDIO` |
+| `staging` | `POLY_ADK_KEY_STAGING` |
+| `dev` | `POLY_ADK_KEY_DEV` |
+
+For example, to use a dedicated key for the US region:
+
+~~~bash
+export POLY_ADK_KEY_US=<your-us-api-key>
+export POLY_ADK_KEY=<your-fallback-api-key>   # used for any other region
+~~~
+
+`POLY_ADK_KEY` is still required as the fallback. If neither the region-specific key nor `POLY_ADK_KEY` is set, the CLI will raise an error.
+
 Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
 
 ## Verify the installation


### PR DESCRIPTION
## Summary

This relates to commit https://github.com/polyai/adk/commit/94cb27b607ffdabcea75896ffbcc01f0406b90c0

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->