### PR TITLE
docs: fix: key accounts/projects dicts by ID to prevent duplicate name collisions

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -35,8 +35,8 @@ Initialize a new Agent Studio project locally.
 Run with no arguments and `poly init` walks you through interactive dropdowns:
 
 1. **Region** — auto-selected if your API key only has access to one.
-2. **Account** — auto-selected if there's only one in the region; otherwise pick from a searchable list.
-3. **Project** — pick from a searchable list of every project the API key can see.
+2. **Account** — auto-selected if there's only one in the region; otherwise pick from a searchable list. Each entry is shown as `"name (id)"` to disambiguate accounts that share the same display name.
+3. **Project** — pick from a searchable list of every project the API key can see. Each entry is shown as `"name (id)"` for the same reason.
 
 After selection, `poly init` creates the project directory at `{base_path}/{account_id}/{project_id}` and immediately pulls the current configuration from Agent Studio. Change into the project directory before running any other commands.
 
@@ -68,6 +68,8 @@ If the account or project ID is invalid or inaccessible, `poly init` returns a d
 | Situation | Error message |
 |---|---|
 | `POLY_ADK_KEY` not set | `POLY_ADK_KEY environment variable is not set. Export your API key with: export POLY_ADK_KEY=<your-api-key>` |
+| No accounts found in the region | `No accounts found in the selected region.` |
+| No projects found in the account | `No projects found in the selected account.` |
 | Project not found | `Project '<project_id>' not found in account '<account_id>'.` |
 | Permission denied | `Forbidden: you do not have permission to access project '<project_id>' in account '<account_id>'.` |
 


### PR DESCRIPTION
## Summary

This relates to work from commit https://github.com/polyai/adk/commit/b71b6a70aaa0939a437da5500f0727a5d6e86d0d

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->