### PR TITLE
fix: normalize local resources during pull merge

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -915,10 +915,9 @@ class AgentStudioProject:
                     local_file_path = incoming_resource.get_path(self.root_path)
                 try:
                     # Normalise the local resource to ensure formatting differences don't cause unnecessary merge conflicts
-                    local_resource = resource_type.read_local_resource(
-                        local_file_path,
-                        resource_id=incoming_resource.resource_id,
-                        resource_name=incoming_resource.name,
+                    incoming_resource_mapping = self._make_resource_mapping(incoming_resource)
+                    local_resource = self.read_local_resource(
+                        resource=incoming_resource_mapping,
                         resource_mappings=incoming_resource_mappings,
                     )
                     local_content = local_resource.to_pretty(
@@ -2070,6 +2069,10 @@ class AgentStudioProject:
                 resource_mappings=resource_mappings,
                 **additional_kwargs,
             )
+        except FileNotFoundError as e:
+            raise FileNotFoundError(
+                f"File not found for resource {resource.resource_name} at {resource.file_path}"
+            ) from e
         except Exception as e:
             raise ValueError(
                 f"Error reading resource {resource.resource_name} at {resource.file_path}: {str(e)}"
@@ -2510,24 +2513,24 @@ class AgentStudioProject:
 
     def _make_resource_mappings(self, resources: ResourceMap) -> list[ResourceMapping]:
         resource_mappings: list[ResourceMapping] = []
-        for resource_type, resources_dict in resources.items():
-            for resource_id, resource in resources_dict.items():
-                resource_path = resource.get_path(self.root_path)
-                resource_mappings.append(
-                    ResourceMapping(
-                        resource_id=resource_id,
-                        resource_type=resource_type,
-                        resource_name=resource.name,
-                        file_path=resource_path,
-                        flow_name=(
-                            resource.name
-                            if isinstance(resource, FlowConfig)
-                            else getattr(resource, "flow_name", None)
-                        ),
-                        resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
-                    )
-                )
+        for resources_dict in resources.values():
+            for resource in resources_dict.values():
+                resource_mappings.append(self._make_resource_mapping(resource))
         return resource_mappings
+
+    def _make_resource_mapping(self, resource: Resource) -> ResourceMapping:
+        return ResourceMapping(
+            resource_id=resource.resource_id,
+            resource_type=type(resource),
+            resource_name=resource.name,
+            file_path=resource.get_path(self.root_path),
+            flow_name=(
+                resource.name
+                if isinstance(resource, FlowConfig)
+                else getattr(resource, "flow_name", None)
+            ),
+            resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
+        )
 
     def format_files(
         self, files: list[str] = None, check_only: bool = False

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -2282,7 +2282,7 @@ class PullProjectTest(unittest.TestCase):
         ]
         # Check that the saved content contains merge conflict
         saved_content = test_func_calls[0][0][0] if test_func_calls else ""
-        merged_content = 'from _gen import *  # <AUTO GENERATED>\n\n@func_description(\'A test function for global use.\')\ndef test_function(conv: Conversation):\n<<<<<<<\n    """Modified locally."""\n    return "Local change"\n=======\n    """Modified remotely."""\n    return "Remote change"\n>>>>>>>\n'
+        merged_content = 'from _gen import *  # <AUTO GENERATED>\n\n\n@func_description(\'A test function for global use.\')\ndef test_function(conv: Conversation):\n<<<<<<<\n    """Modified locally."""\n    return "Local change"\n=======\n    """Modified remotely."""\n    return "Remote change"\n>>>>>>>\n'
         self.assertEqual(saved_content, merged_content)
 
     def test_pull_project_modify_flow_config_conflict(self):
@@ -2404,7 +2404,7 @@ class PullProjectTest(unittest.TestCase):
         ]
         # Check that the saved content contains merged version
         saved_content = test_func_calls[0][0][0] if test_func_calls else ""
-        merged_content = 'from _gen import *  # <AUTO GENERATED>\n\ndef added_extra_function():\n    pass\n\n@func_description(\'A test function for global use.\')\ndef test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Remote change"\n'
+        merged_content = 'from _gen import *  # <AUTO GENERATED>\n\n\ndef added_extra_function():\n    pass\n\n@func_description(\'A test function for global use.\')\ndef test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Remote change"\n'
         self.assertEqual(saved_content, merged_content)
 
     def test_pull_project_force(self):


### PR DESCRIPTION
## Summary

Fix `_update_pulled_resources` to properly normalize local Function resources before three-way merge, preventing `TypeError` from missing `known_parameters`.

## Motivation

The direct `resource_type.read_local_resource()` call in `_update_pulled_resources` bypassed the `read_local_resource` wrapper that supplies required kwargs like `known_parameters` for Functions. This caused a `TypeError` on push/pull when Function resources existed locally.

## Changes

- Extract `_make_resource_mapping` helper from `_make_resource_mappings` for single-resource use
- Use `self.read_local_resource()` in `_update_pulled_resources` instead of calling the class method directly, so Function/FlowStep/FunctionStep resources get their required kwargs
- Re-raise `FileNotFoundError` from `read_local_resource` so the existing `except FileNotFoundError` handler in `_update_pulled_resources` catches it (previously wrapped in `ValueError`)
- Update pull merge test expectations to match the canonical `to_pretty` format (extra newline after header when content doesn't start with an import)

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly push`)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)