### PR TITLE
fix: deepcopy FlowConfig before dummy start step swap

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -4,6 +4,7 @@ Copyright PolyAI Limited
 """
 
 import base64
+import copy
 import json
 import logging
 import os
@@ -1461,8 +1462,10 @@ class AgentStudioProject:
                     step_type=StepType.DEFAULT_STEP,
                     prompt="temp prompt",
                 )
-                flow_config.steps.append(dummy)
-                flow_config.start_step = dummy.step_id
+                push_flow_config = copy.deepcopy(flow_config)
+                push_flow_config.steps.append(dummy)
+                push_flow_config.start_step = dummy.step_id
+                new_resources[FlowConfig][flow_config_id] = push_flow_config
                 reset_flow_config = FlowConfig(
                     resource_id=flow_config.resource_id,
                     name=flow_config.name,


### PR DESCRIPTION
## Summary

Prevents `_start_step_temp` suffix from leaking into local state after pushing flows with a FunctionStep as start step.

## Motivation

When creating a flow whose start step is a FunctionStep, `_clean_resources_before_push` creates a temporary dummy default step and mutates `flow_config.start_step` and `flow_config.steps` in-place. After push, `self.resources = new_state` saves this mutated config — persisting the `_start_step_temp` suffix into `flow_config.yaml`. Subsequent pushes then fail with "Old start step not found".

## Changes

- Use `copy.deepcopy(flow_config)` before the dummy step swap so the original FlowConfig stays clean
- Only the copy gets the dummy step and temp start_step ID

## Test strategy

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] Manual CLI testing (`poly push --dry-run`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)