### PR TITLE
feat: add `poly start` onboarding command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ pip install polyai-adk
 Once installed, use the `poly` command to manage your projects:
 
 ```bash
-poly init       # Initialize a project (interactive)
+poly start      # Create an account, access token and new project
+poly init       # Initialize a project
+poly project    # Manage poly projects
 poly pull       # Pull latest configuration
 poly push       # Push local changes
 poly status     # View project status
@@ -57,7 +59,7 @@ poly branch     # Manage branches
 poly format     # Format resources
 poly validate   # Validate configuration
 poly review     # Create a review gist
-poly deployments  # List deployment history
+poly deployments  # Manage deployments
 poly docs       # Output reference documentation
 ```
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3875,10 +3875,14 @@ class AgentStudioCLI:
     def start(cls, base_path: str) -> None:
         """Authenticate via device flow, obtain a JWT, and initialise a project."""
         print_welcome_message()
+        plain(
+            "This will guide you through setting up your API key and creating a new project in Agent Studio."
+        )
+        questionary.press_any_key_to_continue("Press any key to continue...").ask()
 
         # --- 1. Check for existing API key ---
         try:
-            retrieve_api_key()
+            key = retrieve_api_key()
             warning("An existing API key was found in your environment.")
             use_existing = questionary.confirm(
                 "Do you want to continue with the existing key?",
@@ -3887,7 +3891,15 @@ class AgentStudioCLI:
             ).ask()
             if use_existing:
                 success("Continuing with existing API key.")
-                cls.create_project(base_path)
+                create_project = questionary.confirm(
+                    "Would you like to create a new project in Agent Studio now?",
+                    auto_enter=False,
+                    default=True,
+                ).ask()
+                if create_project:
+                    cls.create_project(base_path, region="studio")
+                else:
+                    info("You can create a new project later by running 'poly project create'")
                 return
         except ValueError:
             pass
@@ -3934,8 +3946,16 @@ class AgentStudioCLI:
         )
         info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
         info("setx POLY_ADK_KEY your_token_here  # on Windows")
-
-        cls.create_project(base_path, region="studio")
+        plain("")
+        create_project = questionary.confirm(
+            "Would you like to create a new project in Agent Studio now?",
+            auto_enter=False,
+            default=True,
+        ).ask()
+        if create_project:
+            cls.create_project(base_path, region="studio")
+        else:
+            info("You can create a new project later by running 'poly project create'")
 
     @classmethod
     def _signin(cls) -> str:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -25,7 +25,7 @@ import requests
 import questionary
 import traceback
 
-from poly.utils import retrieve_api_key
+from poly.utils import retrieve_api_key, merge_strings
 import time
 
 from poly.output.console import (
@@ -57,7 +57,6 @@ from poly.handlers.interface import (
     REGIONS,
     AgentStudioInterface,
 )
-from poly.utils import merge_strings
 from poly.resources.resource_utils import contains_merge_conflict
 from poly.project import (
     PROJECT_CONFIG_FILE,
@@ -3897,7 +3896,7 @@ class AgentStudioCLI:
                     default=True,
                 ).ask()
                 if create_project:
-                    cls.create_project(base_path, region="studio")
+                    cls.create_project(base_path)
                 else:
                     info("You can create a new project later by running 'poly project create'")
                 return
@@ -3939,6 +3938,11 @@ class AgentStudioCLI:
                     except Exception:
                         attempts += 1
                         time.sleep(1)
+                else:
+                    error(
+                        "API key was created but is not active yet. Please wait a moment and try again."
+                    )
+                    sys.exit(1)
 
             success(f"Created a new API Token: {pat}")
         plain(

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3882,7 +3882,7 @@ class AgentStudioCLI:
 
         # --- 1. Check for existing API key ---
         try:
-            key = retrieve_api_key()
+            retrieve_api_key()
             warning("An existing API key was found in your environment.")
             use_existing = questionary.confirm(
                 "Do you want to continue with the existing key?",
@@ -3904,12 +3904,12 @@ class AgentStudioCLI:
         except ValueError:
             pass
 
-        # --- 2. Authenticate via device flow ---
+        # --- 2. Create account/signin via device flow ---
         jwt_access_token = cls._signin()
 
         api_handler = AgentStudioInterface()
 
-        # --- 3. Authorise user (creates account if needed) ---
+        # --- 3. Authorise user  ---
         info("Setting up your account...")
         api_handler.authorise(region="studio", jwt_token=jwt_access_token)
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3886,8 +3886,7 @@ class AgentStudioCLI:
         questionary.press_any_key_to_continue("Press any key to continue...").ask()
 
         # --- 1. Check for existing API key ---
-        try:
-            any_credentials_exist()
+        if any_credentials_exist():
             warning("An existing API key was found in your environment.")
             use_existing = questionary.confirm(
                 "Do you want to continue with the existing key?",
@@ -3906,8 +3905,6 @@ class AgentStudioCLI:
                 else:
                     info("You can create a new project later by running 'poly project create'")
                 return
-        except ValueError:
-            pass
 
         # --- 2. Create account/signin via device flow ---
         jwt_access_token = cls._signin()

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -56,11 +56,6 @@ from poly.handlers.interface import (
     REGIONS,
     AgentStudioInterface,
 )
-from poly.constants import (
-    MIN_PASSWORD_LENGTH,
-    PRIVACY_POLICY_URL,
-    TRIAL_AGREEMENT_URL,
-)
 from poly.utils import merge_strings
 from poly.resources.resource_utils import contains_merge_conflict
 from poly.project import (
@@ -75,55 +70,6 @@ logger = logging.getLogger(__name__)
 _BRANCH_MERGE_LONG_LINE_THRESHOLD = 800
 
 DOCUMENT_CHOICES = AgentStudioProject.discover_docs()
-
-
-def _validate_name(name: str) -> bool | str:
-    """Questionary validator for full name input."""
-    if not name or not name.strip():
-        return "Name is required."
-    return True
-
-
-def _validate_email(email: str) -> bool | str:
-    """Questionary validator for email input."""
-    email = email.strip().lower()
-    if not email:
-        return "Email is required."
-    if "@" not in email:
-        return "Invalid email format."
-    parts = email.split("@")
-    if len(parts) != 2 or not parts[1]:
-        return "Invalid email format."
-    return True
-
-
-def _validate_password(password: str) -> bool | str:
-    """Questionary validator for password input."""
-    if not password:
-        return "Password is required."
-
-    failed: list[str] = []
-
-    if len(password) < MIN_PASSWORD_LENGTH:
-        failed.append("length")
-
-    categories = sum(
-        [
-            any(c.islower() for c in password),
-            any(c.isupper() for c in password),
-            any(c.isdigit() for c in password),
-            any(not c.isalnum() for c in password),
-        ]
-    )
-    if categories < 3:
-        failed.append("complexity")
-
-    if any(password[i] == password[i + 1] == password[i + 2] for i in range(len(password) - 2)):
-        failed.append("repeated characters")
-
-    if failed:
-        return "Password does not meet requirements: " + ", ".join(failed) + "."
-    return True
 
 
 def _branch_merge_conflict_file_key(path: list[str]) -> str:
@@ -3772,33 +3718,33 @@ class AgentStudioCLI:
             f"  URL:  {verification_uri}\n"
             f"  Code: [bold]{user_code}[/bold]"
         )
-        # webbrowser.open(verification_uri)
+        webbrowser.open(verification_uri)
 
-        info("Waiting for authorization...")
         access_token = None
-        while not access_token:
-            time.sleep(interval)
-            try:
-                token_response = auth0_handler.poll_device_token(device_code)
-                access_token = token_response.get("access_token")
-            except requests.HTTPError as e:
+        with console.status("[info]Waiting for authorization...[/info]"):
+            while not access_token:
+                time.sleep(interval)
                 try:
-                    body = e.response.json()
-                except (ValueError, AttributeError):
-                    error(f"Authorization failed: {e}")
-                    sys.exit(1)
-                err_code = body.get("error")
-                if err_code == "authorization_pending":
-                    continue
-                elif err_code == "slow_down":
-                    interval += 5
-                    continue
-                elif err_code == "expired_token":
-                    error("Authorization timed out. Please try again.")
-                    sys.exit(1)
-                else:
-                    error(f"Authorization failed: {body.get('error_description', e)}")
-                    sys.exit(1)
+                    token_response = auth0_handler.poll_device_token(device_code)
+                    access_token = token_response.get("access_token")
+                except requests.HTTPError as e:
+                    try:
+                        body = e.response.json()
+                    except (ValueError, AttributeError):
+                        error(f"Authorization failed: {e}")
+                        sys.exit(1)
+                    err_code = body.get("error")
+                    if err_code == "authorization_pending":
+                        continue
+                    elif err_code == "slow_down":
+                        interval += 5
+                        continue
+                    elif err_code == "expired_token":
+                        error("Authorization timed out. Please try again.")
+                        sys.exit(1)
+                    else:
+                        error(f"Authorization failed: {body.get('error_description', e)}")
+                        sys.exit(1)
 
         success("Authenticated successfully!")
         return access_token

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -25,7 +25,12 @@ import requests
 import questionary
 import traceback
 
-from poly.utils import retrieve_api_key, merge_strings
+from poly.utils import (
+    any_credentials_exist,
+    merge_strings,
+    save_api_key_credential_file,
+    CREDENTIALS_FILE_PATH,
+)
 import time
 
 from poly.output.console import (
@@ -49,6 +54,7 @@ from poly.output.console import (
     print_deployments,
     print_deployment_show,
     print_welcome_message,
+    mask_api_key,
 )
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
@@ -3881,7 +3887,7 @@ class AgentStudioCLI:
 
         # --- 1. Check for existing API key ---
         try:
-            retrieve_api_key()
+            any_credentials_exist()
             warning("An existing API key was found in your environment.")
             use_existing = questionary.confirm(
                 "Do you want to continue with the existing key?",
@@ -3918,7 +3924,7 @@ class AgentStudioCLI:
         if user_pats:
             pat = user_pats[0].get("key")
             os.environ["POLY_ADK_KEY"] = pat
-            success(f"Found existing API Token: {pat}")
+            success(f"Found existing API Token: {mask_api_key(pat)}")
         else:
             info("No existing API key found in your account.")
             ctx = console.status("[info]Creating a new API key...[/info]")
@@ -3944,13 +3950,13 @@ class AgentStudioCLI:
                     )
                     sys.exit(1)
 
-            success(f"Created a new API Token: {pat}")
-        plain(
-            "Set this in your environment variables as POLY_ADK_KEY to authenticate future commands"
-        )
-        info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
-        info("setx POLY_ADK_KEY your_token_here  # on Windows")
+            success(f"Created a new API Key: {mask_api_key(pat)}")
+
+        save_api_key_credential_file(pat, region="studio")
+        plain("API key has been saved to your credential file for future use.")
+        info(f"Credential file path: {CREDENTIALS_FILE_PATH}")
         plain("")
+
         create_project = questionary.confirm(
             "Would you like to create a new project in Agent Studio now?",
             auto_enter=False,

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3887,7 +3887,7 @@ class AgentStudioCLI:
             ).ask()
             if use_existing:
                 success("Continuing with existing API key.")
-                cls.init_project(base_path)
+                cls.create_project(base_path)
                 return
         except ValueError:
             pass
@@ -3935,7 +3935,7 @@ class AgentStudioCLI:
         info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
         info("setx POLY_ADK_KEY your_token_here  # on Windows")
 
-        cls.init_project(base_path, region="studio")
+        cls.create_project(base_path, region="studio")
 
     @classmethod
     def _signin(cls) -> str:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -24,6 +24,9 @@ import requests
 import questionary
 import traceback
 
+from poly.utils import retrieve_api_key
+import time
+
 from poly.output.console import (
     console,
     error,
@@ -44,14 +47,21 @@ from poly.output.console import (
     print_merge_conflict_interactive_header,
     print_deployments,
     print_deployment_show,
+    print_welcome_message,
 )
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
+from poly.handlers.auth0_handler import Auth0Handler
 from poly.handlers.interface import (
     REGIONS,
     AgentStudioInterface,
 )
-from poly.utils import merge_strings, retrieve_api_key
+from poly.constants import (
+    MIN_PASSWORD_LENGTH,
+    PRIVACY_POLICY_URL,
+    TRIAL_AGREEMENT_URL,
+)
+from poly.utils import merge_strings
 from poly.resources.resource_utils import contains_merge_conflict
 from poly.project import (
     PROJECT_CONFIG_FILE,
@@ -65,6 +75,55 @@ logger = logging.getLogger(__name__)
 _BRANCH_MERGE_LONG_LINE_THRESHOLD = 800
 
 DOCUMENT_CHOICES = AgentStudioProject.discover_docs()
+
+
+def _validate_name(name: str) -> bool | str:
+    """Questionary validator for full name input."""
+    if not name or not name.strip():
+        return "Name is required."
+    return True
+
+
+def _validate_email(email: str) -> bool | str:
+    """Questionary validator for email input."""
+    email = email.strip().lower()
+    if not email:
+        return "Email is required."
+    if "@" not in email:
+        return "Invalid email format."
+    parts = email.split("@")
+    if len(parts) != 2 or not parts[1]:
+        return "Invalid email format."
+    return True
+
+
+def _validate_password(password: str) -> bool | str:
+    """Questionary validator for password input."""
+    if not password:
+        return "Password is required."
+
+    failed: list[str] = []
+
+    if len(password) < MIN_PASSWORD_LENGTH:
+        failed.append("length")
+
+    categories = sum(
+        [
+            any(c.islower() for c in password),
+            any(c.isupper() for c in password),
+            any(c.isdigit() for c in password),
+            any(not c.isalnum() for c in password),
+        ]
+    )
+    if categories < 3:
+        failed.append("complexity")
+
+    if any(password[i] == password[i + 1] == password[i + 2] for i in range(len(password) - 2)):
+        failed.append("repeated characters")
+
+    if failed:
+        return "Password does not meet requirements: " + ", ".join(failed) + "."
+    return True
 
 
 def _branch_merge_conflict_file_key(path: list[str]) -> str:
@@ -206,6 +265,22 @@ class AgentStudioCLI:
             help="Write output to FILE_PATH instead of stdout.",
         )
 
+        # Start
+        start_parser = subparsers.add_parser(
+            "start",
+            parents=[verbose_parent, debug_parent],
+            help="Get started with PolyAI Agent Studio",
+            description=(
+                "Create a new Agent Studio Account, set up API key and create a first project with a single command.\n\n"
+            ),
+        )
+        start_parser.add_argument(
+            "--base-path",
+            type=str,
+            default=os.getcwd(),
+            help="Base path to initialize the project. Defaults to current working directory.",
+        )
+
         # INIT
         init_parser = subparsers.add_parser(
             "init",
@@ -218,9 +293,7 @@ class AgentStudioCLI:
             "--base-path",
             type=str,
             default=os.getcwd(),
-            help="""
-            Base path to initialize the project. Defaults to current working directory.
-            """,
+            help="Base path to initialize the project. Defaults to current working directory.",
         )
         init_parser.add_argument(
             "--region",
@@ -1232,6 +1305,11 @@ class AgentStudioCLI:
                         output_json=args.json,
                         dry_run=args.dry_run,
                     )
+
+            elif args.command == "start":
+                cls.start(
+                    base_path=args.base_path,
+                )
 
         except Exception as e:
             if hasattr(args, "json") and args.json:
@@ -3605,6 +3683,125 @@ class AgentStudioCLI:
             else:
                 error(f"Failed to rollback deployment: {e}")
             sys.exit(1)
+
+    @classmethod
+    def start(cls, base_path: str) -> None:
+        """Authenticate via device flow, obtain a JWT, and initialise a project."""
+        print_welcome_message()
+
+        # --- 1. Check for existing API key ---
+        try:
+            retrieve_api_key()
+            warning("An existing API key was found in your environment.")
+            use_existing = questionary.confirm(
+                "Do you want to continue with the existing key?",
+                auto_enter=False,
+                default=True,
+            ).ask()
+            if use_existing:
+                success("Continuing with existing API key.")
+                cls.init_project(base_path)
+                return
+        except ValueError:
+            pass
+
+        # --- 2. Authenticate via device flow ---
+        jwt_access_token = cls._signin()
+
+        api_handler = AgentStudioInterface()
+
+        # --- 3. Authorise user (creates account if needed) ---
+        info("Setting up your account...")
+        api_handler.authorise(region="studio", jwt_token=jwt_access_token)
+
+        # --- 4. Generate PAT token ---
+        info("Fetching API key...")
+        user_pats = api_handler.get_pats(region="studio", jwt_token=jwt_access_token)
+        if user_pats:
+            pat = user_pats[0].get("key")
+            os.environ["POLY_ADK_KEY"] = pat
+            success("An existing API key was found in your account and will be used.")
+        else:
+            info("No existing API key found in your account.")
+            ctx = console.status("[info]Creating a new API key...[/info]")
+            with ctx:
+                pat = api_handler.create_pat(
+                    region="studio", jwt_token=jwt_access_token, name="adk-key"
+                )
+                os.environ["POLY_ADK_KEY"] = pat
+
+                attempts = 0
+                # After creating a new PAT, there may be a short delay before it's active.
+                # Poll the accounts endpoint until it works or we hit a timeout.
+                while attempts < 10:
+                    try:
+                        api_handler.get_accounts(region="studio")
+                        break
+                    except Exception:
+                        attempts += 1
+                        time.sleep(1)
+
+            success(f"Created a new API Token: {pat}")
+            plain(
+                "Set this in your environment variables as POLY_ADK_KEY to authenticate future commands"
+            )
+            info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
+            info("setx POLY_ADK_KEY your_token_here  # on Windows")
+
+        cls.init_project(base_path, region="studio")
+
+    @classmethod
+    def _signin(cls) -> str:
+        """Sign in via the Auth0 device authorization flow and return a JWT access token."""
+        auth0_handler = Auth0Handler()
+
+        try:
+            device_response = auth0_handler.request_device_code()
+        except Exception as e:
+            error(f"Failed to start authorization: {e}")
+            sys.exit(1)
+
+        user_code = device_response["user_code"]
+        verification_uri = device_response["verification_uri_complete"]
+        device_code = device_response["device_code"]
+        interval = device_response.get("interval", 5)
+
+        info(
+            "To sign in or create an account, open the following link in your browser\n"
+            "and enter the code when prompted.\n\n"
+            f"  URL:  {verification_uri}\n"
+            f"  Code: [bold]{user_code}[/bold]"
+        )
+        # webbrowser.open(verification_uri)
+
+        info("Waiting for authorization...")
+        access_token = None
+        while not access_token:
+            time.sleep(interval)
+            try:
+                token_response = auth0_handler.poll_device_token(device_code)
+                access_token = token_response.get("access_token")
+            except requests.HTTPError as e:
+                try:
+                    body = e.response.json()
+                except (ValueError, AttributeError):
+                    error(f"Authorization failed: {e}")
+                    sys.exit(1)
+                err_code = body.get("error")
+                if err_code == "authorization_pending":
+                    continue
+                elif err_code == "slow_down":
+                    interval += 5
+                    continue
+                elif err_code == "expired_token":
+                    error("Authorization timed out. Please try again.")
+                    sys.exit(1)
+                else:
+                    error(f"Authorization failed: {body.get('error_description', e)}")
+                    sys.exit(1)
+
+        success("Authenticated successfully!")
+        return access_token
 
 
 def main():

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3666,7 +3666,7 @@ class AgentStudioCLI:
         if user_pats:
             pat = user_pats[0].get("key")
             os.environ["POLY_ADK_KEY"] = pat
-            success("An existing API key was found in your account and will be used.")
+            success(f"Found existing API Token: {pat}")
         else:
             info("No existing API key found in your account.")
             ctx = console.status("[info]Creating a new API key...[/info]")
@@ -3688,11 +3688,11 @@ class AgentStudioCLI:
                         time.sleep(1)
 
             success(f"Created a new API Token: {pat}")
-            plain(
-                "Set this in your environment variables as POLY_ADK_KEY to authenticate future commands"
-            )
-            info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
-            info("setx POLY_ADK_KEY your_token_here  # on Windows")
+        plain(
+            "Set this in your environment variables as POLY_ADK_KEY to authenticate future commands"
+        )
+        info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
+        info("setx POLY_ADK_KEY your_token_here  # on Windows")
 
         cls.init_project(base_path, region="studio")
 

--- a/src/poly/constants.py
+++ b/src/poly/constants.py
@@ -3,10 +3,6 @@
 Copyright PolyAI Limited
 """
 
-TRIAL_AGREEMENT_URL = "https://poly.ai/trial-agreement"
-PRIVACY_POLICY_URL = "https://poly.ai/privacy-policy/"
-MIN_PASSWORD_LENGTH = 12
-
 PERMISSIONS = [
     "home",
     "conversations",

--- a/src/poly/constants.py
+++ b/src/poly/constants.py
@@ -9,6 +9,7 @@ DEFAULT_VOICE_IDS: dict[str, str] = {
     "uk-1": "VOICE-37966683",  # Ben
     "dev": "VOICE-e2b01d55",  # Anne
     "staging": "VOICE-e2b01d55",  # Anne
+    "studio": "VOICE-071db756",  # Aria
 }
 
 DEFAULT_VOICE_ID_FALLBACK = "VOICE-afe2b8e8"

--- a/src/poly/constants.py
+++ b/src/poly/constants.py
@@ -3,6 +3,10 @@
 Copyright PolyAI Limited
 """
 
+TRIAL_AGREEMENT_URL = "https://poly.ai/trial-agreement"
+PRIVACY_POLICY_URL = "https://poly.ai/privacy-policy/"
+MIN_PASSWORD_LENGTH = 12
+
 PERMISSIONS = [
     "home",
     "conversations",

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -39,7 +39,7 @@ class Auth0Handler:
         )
 
         cleaned_data = {
-            k: ("<redacted>" if k in {"password", "client_id"} else v)
+            k: ("<redacted>" if k in {"password", "client_id", "device_code"} else v)
             for k, v in (data or {}).items()
         }
 

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -1,0 +1,116 @@
+"""Client for the PolyAI Auth0 tenant, used for authentication in the PolyAI ADK CLI.
+
+Copyright PolyAI Limited
+"""
+
+import json
+import logging
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://login.studio.poly.ai"
+DEVICE_CLIENT_ID = "6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd"
+STUDIO_CLIENT_ID = "v7NO1stPOf28i9FCdbuhs5WSUbOHTVtG"
+STUDIO_CONNECTION = "Self-Serve-Signup-Headless"
+
+
+class Auth0Handler:
+    """Handler for authentication with the PolyAI Auth0 tenant."""
+
+    @staticmethod
+    def make_request(
+        endpoint: str, method: str, data: Optional[dict] = None, params: Optional[dict] = None
+    ) -> dict:
+        """Make a request to the Auth0 API."""
+        url = BASE_URL + endpoint
+
+        headers = {"Content-Type": "application/json"}
+
+        api_response = requests.request(
+            method=method,
+            url=url,
+            headers=headers,
+            params=params,
+            allow_redirects=False,
+            data=json.dumps(data) if data else None,
+        )
+
+        cleaned_data = {
+            k: ("<redacted>" if k in {"password", "client_id"} else v)
+            for k, v in (data or {}).items()
+        }
+
+        try:
+            api_response.raise_for_status()
+            logger.debug(
+                f"Request/response url={url!r} body={cleaned_data!r}"
+                f" status_code={api_response.status_code!r} response={api_response.text!r}"
+            )
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request url={url!r} body={cleaned_data!r}"
+                f" status_code={api_response.status_code!r} response={api_response.text!r}"
+            )
+            raise
+
+        try:
+            api_response = api_response.json()
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Failed to parse JSON response: {e}")
+
+        logger.info(f"Request to {url} successful")
+        return api_response
+
+    @classmethod
+    def register_user(cls, email: str, password: str, name: str) -> dict:
+        """Register a new user with the Auth0 tenant."""
+        data = {
+            "client_id": STUDIO_CLIENT_ID,
+            "connection": STUDIO_CONNECTION,
+            "email": email,
+            "password": password,
+            "name": name,
+            "user_metadata": {
+                "terms_accepted_via_api": "on",
+            },
+        }
+        return cls.make_request("/dbconnections/signup", method="POST", data=data)
+
+    @classmethod
+    def request_device_code(cls) -> dict:
+        """Start the device authorization flow.
+
+        Returns:
+            Dict containing device_code, user_code, verification_uri,
+            verification_uri_complete, expires_in, and interval.
+        """
+        data = {
+            "client_id": DEVICE_CLIENT_ID,
+            "scope": "openid profile email",
+            "audience": "https://platform.polyai.app/api",
+        }
+        return cls.make_request("/oauth/device/code", method="POST", data=data)
+
+    @classmethod
+    def poll_device_token(cls, device_code: str) -> dict:
+        """Poll for a token after the user has authorized the device.
+
+        Args:
+            device_code: The device_code from request_device_code.
+
+        Returns:
+            Dict containing access_token, id_token, etc. on success.
+
+        Raises:
+            requests.HTTPError: 403 with 'authorization_pending' or 'slow_down'
+                while the user hasn't authorized yet.
+        """
+        data = {
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "client_id": DEVICE_CLIENT_ID,
+            "device_code": device_code,
+        }
+        return cls.make_request("/oauth/token", method="POST", data=data)

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -65,21 +65,6 @@ class Auth0Handler:
         return api_response
 
     @classmethod
-    def register_user(cls, email: str, password: str, name: str) -> dict:
-        """Register a new user with the Auth0 tenant."""
-        data = {
-            "client_id": STUDIO_CLIENT_ID,
-            "connection": STUDIO_CONNECTION,
-            "email": email,
-            "password": password,
-            "name": name,
-            "user_metadata": {
-                "terms_accepted_via_api": "on",
-            },
-        }
-        return cls.make_request("/dbconnections/signup", method="POST", data=data)
-
-    @classmethod
     def request_device_code(cls) -> dict:
         """Start the device authorization flow.
 

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -607,15 +607,14 @@ class AgentStudioInterface:
 
     @staticmethod
     def get_pats(region: str, jwt_token: str) -> list[dict]:
-        """Create a new Personal Access Token (PAT) for the user.
+        """Get all Personal Access Tokens for the authenticated user.
 
         Args:
             region: The region name
             jwt_token: The user's JWT access token
-            name: A name for the new PAT
 
         Returns:
-            str: The newly created PAT token
+            list[dict]: List of PAT records.
         """
         return PlatformAPIHandler.get_pats_internal(region, jwt_token)
 

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -591,3 +591,44 @@ class AgentStudioInterface:
             dict: The API response
         """
         return PlatformAPIHandler.rollback_deployment(region, project_id, deployment_id, message)
+
+    @staticmethod
+    def authorise(region: str, jwt_token: str) -> dict:
+        """Authorise the user via JWT, creating their account if needed.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+
+        Returns:
+            dict: The user record.
+        """
+        return PlatformAPIHandler.authorise(region, jwt_token)
+
+    @staticmethod
+    def get_pats(region: str, jwt_token: str) -> list[dict]:
+        """Create a new Personal Access Token (PAT) for the user.
+
+        Args:
+            region: The region name
+            jwt_token: The user's JWT access token
+            name: A name for the new PAT
+
+        Returns:
+            str: The newly created PAT token
+        """
+        return PlatformAPIHandler.get_pats_internal(region, jwt_token)
+
+    @staticmethod
+    def create_pat(region: str, jwt_token: str, name: str) -> str:
+        """Create a new Personal Access Token (PAT) for the user.
+
+        Args:
+            region: The region name
+            jwt_token: The user's JWT access token
+            name: A name for the new PAT
+
+        Returns:
+            str: The newly created PAT token
+        """
+        return PlatformAPIHandler.create_pat_internal(region, jwt_token, name)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -596,7 +596,7 @@ class PlatformAPIHandler:
         )
 
     @staticmethod
-    def create_pat_internal(region: str, jwt_token: str, name: str) -> dict:
+    def create_pat_internal(region: str, jwt_token: str, name: str) -> str:
         """Create a Personal Access Token using a JWT for authentication.
 
         Args:
@@ -605,7 +605,7 @@ class PlatformAPIHandler:
             name: A label for the PAT.
 
         Returns:
-            dict: The PAT response including the token.
+            str: The PAT token.
         """
         correlation_id = f"adk-{uuid.uuid4()}"
         headers = {

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 
 from poly.constants import DEFAULT_VOICE_ID_FALLBACK, DEFAULT_VOICE_IDS
-from poly.utils import retrieve_api_key
+from poly.utils import retrieve_api_key, any_credentials_exist
 
 logger = logging.getLogger(__name__)
 ACCOUNTS_URL = "/adk/v1/accounts"
@@ -151,7 +151,9 @@ class PlatformAPIHandler:
                 the original ordering.
         """
 
-        retrieve_api_key()
+        if not any_credentials_exist():
+            # Will raise a ValueError with instructions on how to set the API key
+            retrieve_api_key(region="studio")
 
         accessible: set[str] = set()
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -42,17 +42,31 @@ class PlatformAPIHandler:
         "studio": "https://api.studio.poly.ai",
     }
 
+    jupiter_region_to_base_url = {
+        "euw-1": "https://jupiter-api.euw-1.platform.polyai.app",
+        "uk-1": "https://jupiter-api.uk-1.platform.polyai.app",
+        "us-1": "https://jupiter-api.us-1.platform.polyai.app",
+        "dev": "https://jupiter-api.dev.polyai.app",
+        "staging": "https://jupiter-api.staging.us-1.platform.polyai.app",
+        "studio": "https://jupiter-api.plg-us-1-prod.polyai.app",
+    }
+
     @staticmethod
-    def get_base_url(region: str) -> str:
+    def get_base_url(region: str, use_jupiter_api: bool = False) -> str:
         """Get the base URL for the Platform API based on the region.
 
         Args:
             region (str): The region name
+            use_jupiter_api (bool): Whether to use the Jupiter API
         Returns:
             str: The base URL for the Platform API
         """
-        if base_url := PlatformAPIHandler.region_to_base_url.get(region):
-            return base_url
+        if use_jupiter_api:
+            if base_url := PlatformAPIHandler.jupiter_region_to_base_url.get(region):
+                return base_url
+        else:
+            if base_url := PlatformAPIHandler.region_to_base_url.get(region):
+                return base_url
         raise ValueError(f"Unknown region: {region}")
 
     @staticmethod
@@ -62,6 +76,8 @@ class PlatformAPIHandler:
         method: str = "GET",
         data: ty.Optional[dict] = None,
         params: ty.Optional[dict] = None,
+        headers: ty.Optional[dict] = None,
+        use_jupiter_api: bool = False,
     ) -> dict:
         """Make a request to the Platform API.
 
@@ -75,14 +91,15 @@ class PlatformAPIHandler:
         Returns:
             dict: The response JSON
         """
-        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        url = PlatformAPIHandler.get_base_url(region, use_jupiter_api) + endpoint
         correlation_id = f"adk-{uuid.uuid4()}"
 
-        headers = {
-            "X-API-KEY": retrieve_api_key(region),
-            "X-PolyAI-Correlation-Id": correlation_id,
-            "Content-Type": "application/json",
-        }
+        if headers is None:
+            headers = {
+                "X-API-KEY": retrieve_api_key(region),
+                "X-PolyAI-Correlation-Id": correlation_id,
+                "Content-Type": "application/json",
+            }
 
         logger.info(f"Making {method} request to {url}")
 
@@ -97,7 +114,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} body={data!r}"
+            f"Request/response url={url!r} headers={headers!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 
@@ -482,3 +499,76 @@ class PlatformAPIHandler:
         endpoint = ROLLBACK_URL.format(project_id=project_id, deployment_id=deployment_id)
         body = {"deploymentMessage": message}
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
+
+    @staticmethod
+    def authorise(region: str, jwt_token: str) -> dict:
+        """Authorise the user via JWT, creating their account if needed.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+
+        Returns:
+            dict: The user record.
+        """
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "X-PolyAI-Correlation-Id": correlation_id,
+        }
+
+        return PlatformAPIHandler.make_request(
+            region, "/jupiter/v1/authorise", "GET", headers=headers, use_jupiter_api=True
+        )
+
+    @staticmethod
+    def get_pats_internal(region: str, jwt_token: str) -> list[dict]:
+        """Get all Personal Access Tokens for the authenticated user.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+
+        Returns:
+            list[dict]: List of PAT records.
+        """
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "X-PolyAI-Correlation-Id": correlation_id,
+        }
+
+        return PlatformAPIHandler.make_request(
+            region, "/jupiter/v2/pats", "GET", headers=headers, use_jupiter_api=True
+        )
+
+    @staticmethod
+    def create_pat_internal(region: str, jwt_token: str, name: str) -> dict:
+        """Create a Personal Access Token using a JWT for authentication.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            name: A label for the PAT.
+
+        Returns:
+            dict: The PAT response including the token.
+        """
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "X-PolyAI-Correlation-Id": correlation_id,
+        }
+
+        response = PlatformAPIHandler.make_request(
+            region,
+            "/jupiter/v2/pats",
+            "POST",
+            data={"name": name},
+            headers=headers,
+            use_jupiter_api=True,
+        )
+        return response.get("key")

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -115,7 +115,7 @@ class PlatformAPIHandler:
         )
 
         logger.debug(
-            f"Request/response url={url!r} headers={headers!r} body={data!r}"
+            f"Request/response url={url!r} body={data!r}"
             f" status_code={api_response.status_code!r} response={api_response.text!r}"
         )
 

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 import requests
 
 from poly.utils import retrieve_api_key
+
 from .protobuf.commands_pb2 import Command, CommandBatch
 
 logger = logging.getLogger(__name__)

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -4,11 +4,11 @@ Tools to help with migrating from older versions of the Agent Development Kit to
 Copyright PolyAI Limited
 """
 
-from copy import deepcopy
 import os
-from poly.resources import resource_utils
-
+from copy import deepcopy
 from enum import Enum
+
+from poly.resources import resource_utils
 
 
 class MigrationFlag(Enum):

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -585,8 +585,8 @@ def print_welcome_message() -> None:
     console.print()
     console.print(
         Panel(
-            f"[bold black on #D9EE50]{_POLY_LOGO}[/bold black on #D9EE50]",
-            style="on #D9EE50",
+            f"[bold #D9EE50]{_POLY_LOGO}[/bold #D9EE50]",
+            style="on black",
             border_style="#D9EE50",
             padding=(1, 6),
         )

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -597,6 +597,12 @@ def print_welcome_message() -> None:
     console.print()
 
 
+def mask_api_key(key: str) -> str:
+    """Display masked API key"""
+    masked = key[:4] + "****" + key[-4:] if len(key) > 8 else "****"
+    return f"[yellow]{masked}[/yellow]"
+
+
 def handle_exception(exc: Exception) -> None:
     """Print a clean error message, or full traceback in verbose mode."""
     if _verbose:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -569,6 +569,34 @@ _ERROR_MESSAGES: dict[type, str] = {
 }
 
 
+_POLY_LOGO = """\
+        ●
+    ●   ●   ●      ██████   ██████  ██   ██    ██   █████  ██
+      ●   ●        ██   ██ ██    ██ ██    ██  ██   ██   ██ ██
+    ●   ●   ●      ██████  ██    ██ ██     ████    ███████ ██
+      ●   ●        ██      ██    ██ ██      ██     ██   ██ ██
+    ●   ●   ●      ██       ██████  ██████  ██     ██   ██ ██
+        ●\
+"""
+
+
+def print_welcome_message() -> None:
+    """Display a welcome banner for the ADK onboarding flow."""
+    console.print()
+    console.print(
+        Panel(
+            f"[bold black on #D9EE50]{_POLY_LOGO}[/bold black on #D9EE50]",
+            style="on #D9EE50",
+            border_style="#D9EE50",
+            padding=(1, 6),
+        )
+    )
+    console.print("[bold]Welcome to the PolyAI Agent Development Kit (ADK)![/bold]")
+    console.print("Build and edit Agent Studio projects locally with the PolyAI ADK")
+    console.print("Documentation: https://polyai.github.io/adk/")
+    console.print()
+
+
 def handle_exception(exc: Exception) -> None:
     """Print a clean error message, or full traceback in verbose mode."""
     if _verbose:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -18,9 +18,14 @@ from google.protobuf.message import Message
 
 import poly.resources.resource_utils as resource_utils
 import poly.utils as utils
-
 from poly.handlers.interface import (
     AgentStudioInterface,
+)
+from poly.migration_utils import (
+    MigrationFlag,
+    get_all_migration_flags,
+    load_migration_flags,
+    run_migrations,
 )
 from poly.resources import (
     ApiIntegration,
@@ -36,6 +41,7 @@ from poly.resources import (
     FlowStep,
     Function,
     FunctionStep,
+    GeneralSafetyFilters,
     Handoff,
     KeyphraseBoosting,
     MultiResourceYamlResource,
@@ -43,7 +49,6 @@ from poly.resources import (
     Pronunciation,
     Resource,
     ResourceMapping,
-    GeneralSafetyFilters,
     SettingsPersonality,
     SettingsRole,
     SettingsRules,
@@ -62,12 +67,6 @@ from poly.resources import (
 )
 from poly.resources.resource import _parse_multi_resource_path
 from poly.utils import compute_variable_references
-from poly.migration_utils import (
-    run_migrations,
-    get_all_migration_flags,
-    MigrationFlag,
-    load_migration_flags,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/poly/resources/__init__.py
+++ b/src/poly/resources/__init__.py
@@ -46,12 +46,6 @@ from poly.resources.handoff import (
 )
 from poly.resources.keyphrase_boosting import KeyphraseBoosting
 from poly.resources.phrase_filter import PhraseFilter
-from poly.resources.safety_filters import (
-    ChatSafetyFilters,
-    GeneralSafetyFilters,
-    VoiceSafetyFilters,
-    SafetyFilterCategory,
-)
 from poly.resources.pronunciation import Pronunciation
 from poly.resources.resource import (
     BaseResource,
@@ -59,6 +53,12 @@ from poly.resources.resource import (
     Resource,
     ResourceMapping,
     SubResource,
+)
+from poly.resources.safety_filters import (
+    ChatSafetyFilters,
+    GeneralSafetyFilters,
+    SafetyFilterCategory,
+    VoiceSafetyFilters,
 )
 from poly.resources.sms import SMSTemplate
 from poly.resources.topic import Topic

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -9,6 +9,7 @@ import unittest
 import yaml
 from jsonschema import ValidationError
 
+from poly.handlers.sync_client import SyncClientHandler
 from poly.resources.agent_settings import (
     SettingsPersonality,
     SettingsRole,
@@ -24,12 +25,6 @@ from poly.resources.api_integration import (
     ApiIntegrationOperation,
 )
 from poly.resources.asr_settings import AsrSettings
-from poly.resources.safety_filters import (
-    ChatSafetyFilters,
-    GeneralSafetyFilters,
-    VoiceSafetyFilters,
-    SafetyFilterCategory,
-)
 from poly.resources.channel_settings import (
     ChatGreeting,
     ChatStylePrompt,
@@ -65,12 +60,17 @@ from poly.resources.resource import (
     ResourceMapping,
     _parse_multi_resource_path,
 )
+from poly.resources.safety_filters import (
+    ChatSafetyFilters,
+    GeneralSafetyFilters,
+    SafetyFilterCategory,
+    VoiceSafetyFilters,
+)
 from poly.resources.sms import EnvPhoneNumbers, SMSTemplate
 from poly.resources.topic import (
     FUNCTION_REGEX,
     Topic,
 )
-from poly.handlers.sync_client import SyncClientHandler
 from poly.resources.transcript_correction import RegularExpressionRule, TranscriptCorrection
 from poly.resources.variable import Variable
 from poly.resources.variant_attributes import Variant, VariantAttribute

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import os
 import re
+import json
 from typing import Callable, Optional
 
 from poly.resources import Function, FunctionStep, Resource, ResourceMapping
@@ -29,8 +30,48 @@ _REGION_TO_KEY_SUFFIX: dict[str, str] = {
     "dev": "DEV",
 }
 
+CREDENTIALS_FILE_PATH = os.path.expanduser("~/.poly/credentials.json")
 
-def retrieve_api_key(region: Optional[str] = None) -> str:
+
+def save_api_key_credential_file(api_key: str, region: str) -> None:
+    """Save the API key to a credential file in the user's home directory."""
+    credentials = {}
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+            try:
+                credentials = json.load(f)
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Could not parse existing credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                    "It will be overwritten with the new API key."
+                )
+
+    credentials[region] = api_key
+
+    os.makedirs(os.path.dirname(CREDENTIALS_FILE_PATH), exist_ok=True)
+    with open(CREDENTIALS_FILE_PATH, "w", encoding="utf-8") as f:
+        json.dump(credentials, f, indent=4)
+
+    # Set file permissions to be readable/writeable only by the user
+    os.chmod(CREDENTIALS_FILE_PATH, 0o600)
+
+
+def _load_api_key_from_credential_file(region: str) -> Optional[str]:
+    """Load the API key for the given region from the credential file, if it exists."""
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+            try:
+                credentials = json.load(f)
+                return credentials.get(region)
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Could not parse credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                    "It will be ignored when looking for the API key."
+                )
+    return None
+
+
+def retrieve_api_key(region: str) -> str:
     """Return an API key, preferring a per-region key when available.
 
     Resolution order:
@@ -39,12 +80,15 @@ def retrieve_api_key(region: Optional[str] = None) -> str:
 
     Raises ``ValueError`` with a helpful message when no key is found.
     """
-    if region:
-        suffix = _REGION_TO_KEY_SUFFIX.get(region)
-        if suffix:
-            per_region_key = os.getenv(f"{_API_KEY_ENV_VAR}_{suffix}")
-            if per_region_key:
-                return per_region_key
+    api_key = _load_api_key_from_credential_file(region)
+    if api_key:
+        return api_key
+
+    suffix = _REGION_TO_KEY_SUFFIX.get(region)
+    if suffix:
+        per_region_key = os.getenv(f"{_API_KEY_ENV_VAR}_{suffix}")
+        if per_region_key:
+            return per_region_key
 
     api_key = os.getenv(_API_KEY_ENV_VAR)
     if not api_key:
@@ -53,6 +97,28 @@ def retrieve_api_key(region: Optional[str] = None) -> str:
             f"Export your API key with: export {_API_KEY_ENV_VAR}=<your-api-key>"
         )
     return api_key
+
+
+def any_credentials_exist() -> bool:
+    """Check if any API key credentials are available via environment variables or credential file."""
+    if os.getenv(_API_KEY_ENV_VAR):
+        return True
+    for region in _REGION_TO_KEY_SUFFIX.keys():
+        if os.getenv(f"{_API_KEY_ENV_VAR}_{_REGION_TO_KEY_SUFFIX[region]}"):
+            return True
+
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        try:
+            with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+                credentials = json.load(f)
+                if any(region in credentials for region in _REGION_TO_KEY_SUFFIX.keys()):
+                    return True
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Could not parse credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                "It will be ignored when checking for API key credentials."
+            )
+    return False
 
 
 # Matches cross-package imports e.g. "from runtime.foo import" or "from utils.foo import"

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -12,7 +12,7 @@ import os
 import re
 from typing import Callable, Optional
 
-from poly.resources import Resource, ResourceMapping, Function, FunctionStep
+from poly.resources import Function, FunctionStep, Resource, ResourceMapping
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

Adds a new `poly start` command that provides a guided onboarding flow: authenticate via Auth0 device flow, set up an API key (PAT), and optionally create a first Agent Studio project — all in a single command.

## Motivation

New users currently need to manually create an account, obtain an API key, and configure their environment before they can use the ADK. `poly start` streamlines this into one interactive flow.

## Changes

- New `poly start` CLI subcommand with `--base-path` option
- Auth0 device authorization flow via new `Auth0Handler` (`src/poly/handlers/auth0_handler.py`)
- Jupiter API support in `PlatformAPIHandler` (new base URL map, JWT-based `authorise`, PAT CRUD)
- Corresponding high-level methods in `AgentStudioInterface`
- Welcome banner and branding in `console.py`
- Added `studio` region default voice ID in `constants.py`

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly start`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
<img width="1824" height="534" alt="Screenshot 2026-05-12 at 18 42 05" src="https://github.com/user-attachments/assets/5482321d-a0cc-4e6a-8d58-3d2701e5f823" />

