### PR TITLE
fix: eliminate phantom diffs after poly pull --force

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -373,7 +373,7 @@ class FlowStep(BaseFlowStep, YamlResource):
             output["conditions"] = [condition.to_yaml_dict() for condition in self.conditions]
             output["extracted_entities"] = sorted(self.extracted_entities)
 
-        output["prompt"] = self.prompt
+        output["prompt"] = self.prompt.strip()
         return output
 
     @classmethod

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -364,7 +364,7 @@ class Function(Resource):
                 after_docstring.startswith("from ") or after_docstring.startswith("import ")
             ):
                 # There are imports right after, add header with single newline
-                code = before_docstring + "\n" + FUNCTION_HEADER + after_docstring
+                code = before_docstring + "\n\n" + FUNCTION_HEADER + after_docstring
             else:
                 # No imports right after, add header with two newlines
                 code = before_docstring + "\n" + FUNCTION_HEADER + "\n" + after_docstring

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -145,7 +145,7 @@ class FunctionTests(unittest.TestCase):
             function_type=None,
         )
         pretty_code = function_with_docstring.to_pretty(resource_mappings=[])
-        expected_code = '"""This is a docstring."""\n' + TEST_CODE_PRETTY
+        expected_code = '"""This is a docstring."""\n\n' + TEST_CODE_PRETTY
         self.assertEqual(pretty_code, expected_code)
 
     def test_to_pretty_convert_flow_import(self):


### PR DESCRIPTION
## Summary

Fixes two serialization bugs that caused `poly diff` to show spurious changes immediately after `poly pull --force`.

## Motivation

After a force pull, users expect `poly diff` to show no changes. Instead, it showed blank line removals in Python files and `|` → `|-` changes in YAML step prompts.

## Changes

- **function.py**: Preserve blank line between docstring and imports in `make_pretty` so the local file matches the remote `.raw` format
- **flows.py**: Normalize prompt in `to_yaml_dict()` with `.strip()` so remote and local resources produce identical YAML output (both use `|-`)
- **resources_test.py**: Update `test_to_pretty_import_after_docstring` expected value to include the preserved blank line

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Before: `poly pull --force && poly diff` showed 12 phantom diffs (blank line removals in .py files, `|` → `|-` in .yaml files).
After: `poly pull --force && poly diff` should show no diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)