### PR TITLE
perf: speed up read_local_resource by eliminating redundant YAML parsing

### DIFF
--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -250,9 +250,9 @@ class SettingsRules(Resource):
         """Replace resource IDs with resource names in the provided contents."""
         return utils.replace_resource_ids_with_names(contents, resource_mappings or [])
 
-    @staticmethod
+    @classmethod
     def from_pretty(
-        contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> str:
         """Replace resource names with resource IDs in the provided contents."""
         return utils.replace_resource_names_with_ids(contents, resource_mappings or [])

--- a/src/poly/resources/experimental_config.py
+++ b/src/poly/resources/experimental_config.py
@@ -37,8 +37,8 @@ class ExperimentalConfig(Resource):
     def make_pretty(contents: str, **kwargs) -> str:
         return contents
 
-    @staticmethod
-    def from_pretty(contents: str, **kwargs) -> str:
+    @classmethod
+    def from_pretty(cls, contents: str, **kwargs) -> str:
         return contents
 
     @classmethod

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -173,18 +173,6 @@ class FlowConfig(YamlResource):
                     break
         return yaml_dict
 
-    @classmethod
-    def from_pretty(
-        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> str:
-        """Replace resource names with resource IDs in the provided contents."""
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError("Error loading YAML content") from e
-        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
-        return utils.dump_yaml(yaml_dict)
-
     def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs):
         """Validate the flow config resource."""
         if not self.start_step:

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -118,6 +118,7 @@ class FlowConfig(YamlResource):
         flow_config: FlowConfig = super().read_local_resource(
             file_path, resource_id=resource_id, resource_name=resource_name, **kwargs
         )
+
         # Just check flow folder name (one level up from file) matches flow name
         file_path_part_flow_folder = utils.get_flow_name_from_path(file_path)
         expected_flow_folder = utils.clean_name(flow_config.name)
@@ -149,20 +150,15 @@ class FlowConfig(YamlResource):
                     break
         return d
 
-    @staticmethod
-    def from_pretty(
-        contents: str,
-        resource_name: str = None,
+    @classmethod
+    def from_pretty_dict(
+        cls,
+        yaml_dict: dict,
         resource_mappings: list[ResourceMapping] = None,
+        resource_name: str = None,
         **kwargs,
-    ) -> str:
-        """Replace resource names with resource IDs in the provided contents."""
-        # Replace start_step name with ID if step from same flow
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML content for {resource_name}") from e
-
+    ) -> dict:
+        """Replace start_step name with ID in a parsed YAML dict."""
         start_step_name = yaml_dict.get("start_step")
         if start_step_name:
             for resource in resource_mappings or []:
@@ -175,6 +171,18 @@ class FlowConfig(YamlResource):
                         resource.flow_name + "_"
                     )
                     break
+        return yaml_dict
+
+    @classmethod
+    def from_pretty(
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace resource names with resource IDs in the provided contents."""
+        try:
+            yaml_dict = utils.load_yaml(contents) or {}
+        except Exception as e:
+            raise ValueError("Error loading YAML content") from e
+        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
         return utils.dump_yaml(yaml_dict)
 
     def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs):
@@ -531,23 +539,19 @@ class FlowStep(BaseFlowStep, YamlResource):
                     ]
         return d
 
-    @staticmethod
-    def from_pretty(
-        contents: str,
-        file_path: str = None,
+    @classmethod
+    def from_pretty_dict(
+        cls,
+        yaml_dict: dict,
         resource_mappings: list[ResourceMapping] = None,
+        file_path: str = None,
         **kwargs,
-    ) -> str:
-        """Replace resource names with resource IDs in the provided contents."""
+    ) -> dict:
+        """Replace resource names with IDs in a parsed YAML dict."""
         flow_folder_name = utils.get_flow_name_from_path(file_path)
 
         if not flow_folder_name:
             raise ValueError("flow_name could not be determined from file_path")
-
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML content for {file_path}") from e
 
         if prompt := yaml_dict.get("prompt"):
             yaml_dict["prompt"] = utils.replace_resource_names_with_ids(
@@ -589,6 +593,18 @@ class FlowStep(BaseFlowStep, YamlResource):
                     ]
                     condition["required_entities"] = new_required_entities
 
+        return yaml_dict
+
+    @classmethod
+    def from_pretty(
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace resource names with resource IDs in the provided contents."""
+        try:
+            yaml_dict = utils.load_yaml(contents) or {}
+        except Exception as e:
+            raise ValueError("Error loading YAML content") from e
+        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
         return utils.dump_yaml(yaml_dict)
 
     @cached_property
@@ -618,16 +634,15 @@ class FlowStep(BaseFlowStep, YamlResource):
         # Extract flow_id from resource mappings
         flow_id, flow_name = utils.get_flow_id_from_flow_name(flow_folder_name, resource_mappings)
 
-        content = cls.read_to_raw(
-            file_path,
-            resource_mappings=resource_mappings,
-            flow_name=flow_name,
-            **kwargs,
-        )
+        contents = cls.read_from_file(file_path)
         try:
-            yaml_dict = utils.load_yaml(content) or {}
+            yaml_dict = utils.load_yaml(contents) or {}
         except Exception as e:
             raise ValueError(f"Error loading YAML file: {file_path}") from e
+
+        yaml_dict = cls.from_pretty_dict(
+            yaml_dict, resource_mappings=resource_mappings, file_path=file_path
+        )
 
         # Get file name from file_path
         file_name = os.path.splitext(os.path.basename(file_path))[0]

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -386,9 +386,13 @@ class Function(Resource):
 
         return code
 
-    @staticmethod
+    @classmethod
     def from_pretty(
-        contents: str, resource_mappings: list[ResourceMapping], resource_name: str = None, **kwargs
+        cls,
+        contents: str,
+        resource_mappings: list[ResourceMapping],
+        resource_name: str = None,
+        **kwargs,
     ) -> str:
         """Undo formatting or changes made to the local resource."""
         # Remove typing import if it exists

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -11,7 +11,7 @@ import typing as ty
 import uuid
 from dataclasses import dataclass, field
 from enum import Enum
-from functools import cached_property
+from functools import cached_property, lru_cache
 from typing import Literal, Optional, Union
 
 from google.protobuf.message import Message
@@ -540,6 +540,7 @@ class Function(Resource):
                         )
 
     @staticmethod
+    @lru_cache(maxsize=2048)
     def _get_target_function(
         code: str, function_name: str
     ) -> Optional[Union[ast.FunctionDef, ast.AsyncFunctionDef]]:

--- a/src/poly/resources/phrase_filter.py
+++ b/src/poly/resources/phrase_filter.py
@@ -118,18 +118,6 @@ class PhraseFilter(MultiResourceYamlResource):
                     break
         return yaml_dict
 
-    @classmethod
-    def from_pretty(
-        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> str:
-        """Replace function name with ID. Returns original contents on invalid YAML."""
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception:
-            return contents
-        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
-        return utils.dump_yaml(yaml_dict)
-
     @property
     def command_type(self) -> str:
         return "stop_keywords"

--- a/src/poly/resources/phrase_filter.py
+++ b/src/poly/resources/phrase_filter.py
@@ -101,16 +101,11 @@ class PhraseFilter(MultiResourceYamlResource):
                     break
         return d
 
-    @staticmethod
-    def from_pretty(
-        contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> str:
-        """Replace human-readable function name with function ID."""
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception:
-            return contents
-
+    @classmethod
+    def from_pretty_dict(
+        cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> dict:
+        """Replace function name with ID in a parsed YAML dict."""
         function_name = yaml_dict.get("function")
         if function_name:
             for resource in resource_mappings or []:
@@ -121,7 +116,18 @@ class PhraseFilter(MultiResourceYamlResource):
                 ):
                     yaml_dict["function"] = resource.resource_id
                     break
+        return yaml_dict
 
+    @classmethod
+    def from_pretty(
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace function name with ID. Returns original contents on invalid YAML."""
+        try:
+            yaml_dict = utils.load_yaml(contents) or {}
+        except Exception:
+            return contents
+        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
         return utils.dump_yaml(yaml_dict)
 
     @property

--- a/src/poly/resources/pronunciation.py
+++ b/src/poly/resources/pronunciation.py
@@ -133,23 +133,17 @@ class Pronunciation(MultiResourceYamlResource):
         yaml_list = list(top_level_yaml_dict.get(top_level_name, []))
 
         position = 0
-        contents = None
+        yaml_dict = None
         for i, item in enumerate(yaml_list):
             if i == int(resource_clean_name):
                 position = i
-                contents = utils.dump_yaml(item)
+                yaml_dict = item
                 break
 
-        if not contents:
+        if yaml_dict is None:
             raise FileNotFoundError(
                 f"Resource with name {resource_clean_name} not found in {true_file_path}"
             )
-
-        content = cls.from_pretty(contents, file_path=file_path, **kwargs)
-        try:
-            yaml_dict = utils.load_yaml(content) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML file: {file_path}") from e
 
         return cls.from_yaml_dict(
             yaml_dict, resource_id=resource_id, name="", position=position, **kwargs

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -324,6 +324,13 @@ class YamlResource(Resource, ABC):
             )
         )
 
+    @classmethod
+    def from_pretty_dict(
+        cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> dict:
+        """Replace resource names with IDs in a parsed YAML dict. Override in subclasses."""
+        return yaml_dict
+
     @staticmethod
     def from_pretty(
         contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
@@ -336,12 +343,27 @@ class YamlResource(Resource, ABC):
         cls, file_path: str, resource_id: str, resource_name: str, **kwargs
     ) -> "YamlResource":
         """Read a local YAML resource from the given file path."""
-        content = cls.read_to_raw(file_path, resource_name=resource_name, **kwargs)
+        contents = cls.read_from_file(file_path)
+        resource_mappings = kwargs.pop("resource_mappings", None)
+        contents = utils.replace_resource_names_with_ids(contents, resource_mappings or [])
         try:
-            yaml_dict = utils.load_yaml(content) or {}
+            yaml_dict = utils.load_yaml(contents) or {}
         except Exception as e:
             raise ValueError(f"Error loading YAML file: {file_path}") from e
-        return cls.from_yaml_dict(yaml_dict, resource_id=resource_id, name=resource_name, **kwargs)
+        yaml_dict = cls.from_pretty_dict(
+            yaml_dict,
+            resource_mappings=resource_mappings,
+            resource_name=resource_name,
+            file_path=file_path,
+            **kwargs,
+        )
+        return cls.from_yaml_dict(
+            yaml_dict,
+            resource_id=resource_id,
+            name=resource_name,
+            resource_mappings=resource_mappings,
+            **kwargs,
+        )
 
     @abstractmethod
     def to_yaml_dict(self) -> dict:
@@ -563,12 +585,27 @@ class MultiResourceYamlResource(YamlResource, ABC):
         cls, file_path: str, resource_id: str, resource_name: str, **kwargs
     ) -> "YamlResource":
         """Read a local YAML resource from the given file path."""
-        content = cls.read_to_raw(file_path, resource_name=resource_name, **kwargs)
+        contents = cls.read_from_file(file_path)
+        resource_mappings = kwargs.pop("resource_mappings", None)
+        contents = utils.replace_resource_names_with_ids(contents, resource_mappings or [])
         try:
-            yaml_dict = utils.load_yaml(content) or {}
+            yaml_dict = utils.load_yaml(contents) or {}
         except Exception as e:
             raise ValueError(f"Error loading YAML file: {file_path}") from e
-        return cls.from_yaml_dict(yaml_dict, resource_id=resource_id, name=resource_name, **kwargs)
+        yaml_dict = cls.from_pretty_dict(
+            yaml_dict,
+            resource_mappings=resource_mappings,
+            resource_name=resource_name,
+            file_path=file_path,
+            **kwargs,
+        )
+        return cls.from_yaml_dict(
+            yaml_dict,
+            resource_id=resource_id,
+            name=resource_name,
+            resource_mappings=resource_mappings,
+            **kwargs,
+        )
 
     @abstractmethod
     def to_yaml_dict(self) -> dict:

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -109,9 +109,9 @@ class Resource(BaseResource, ABC):
         """Format the raw representation of the resource."""
         return self.make_pretty(self.raw, **kwargs)
 
-    @staticmethod
+    @classmethod
     @abstractmethod
-    def from_pretty(contents: str, **kwargs) -> str:
+    def from_pretty(cls, contents: str, **kwargs) -> str:
         """Undo formatting or changes made to the local resource."""
         pass
 
@@ -331,12 +331,18 @@ class YamlResource(Resource, ABC):
         """Replace resource names with IDs in a parsed YAML dict. Override in subclasses."""
         return yaml_dict
 
-    @staticmethod
+    @classmethod
     def from_pretty(
-        contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> str:
         """Replace resource names with resource IDs in the provided contents."""
-        return utils.replace_resource_names_with_ids(contents, resource_mappings or [])
+        contents = utils.replace_resource_names_with_ids(contents, resource_mappings or [])
+        try:
+            yaml_dict = utils.load_yaml(contents) or {}
+        except Exception:
+            return contents
+        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
+        return utils.dump_yaml(yaml_dict)
 
     @classmethod
     def read_local_resource(
@@ -579,33 +585,6 @@ class MultiResourceYamlResource(YamlResource, ABC):
         cls._update_cache_after_write(true_file_path, top_level_yaml_dict)
         if not save_to_cache:
             cls.save_to_file(utils.dump_yaml(top_level_yaml_dict), true_file_path)
-
-    @classmethod
-    def read_local_resource(
-        cls, file_path: str, resource_id: str, resource_name: str, **kwargs
-    ) -> "YamlResource":
-        """Read a local YAML resource from the given file path."""
-        contents = cls.read_from_file(file_path)
-        resource_mappings = kwargs.pop("resource_mappings", None)
-        contents = utils.replace_resource_names_with_ids(contents, resource_mappings or [])
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML file: {file_path}") from e
-        yaml_dict = cls.from_pretty_dict(
-            yaml_dict,
-            resource_mappings=resource_mappings,
-            resource_name=resource_name,
-            file_path=file_path,
-            **kwargs,
-        )
-        return cls.from_yaml_dict(
-            yaml_dict,
-            resource_id=resource_id,
-            name=resource_name,
-            resource_mappings=resource_mappings,
-            **kwargs,
-        )
 
     @abstractmethod
     def to_yaml_dict(self) -> dict:

--- a/src/poly/resources/topic.py
+++ b/src/poly/resources/topic.py
@@ -71,9 +71,10 @@ class Topic(YamlResource):
         cls, yaml_dict: dict, resource_id: str, name: str, **kwargs
     ) -> "YamlResource":
         """Create an instance from YAML data and identity fields."""
+        resolved_name = yaml_dict.get("name") or name
         return cls(
             resource_id=resource_id,
-            name=name,
+            name=resolved_name,
             actions=yaml_dict.get("actions", ""),
             content=yaml_dict.get("content", ""),
             example_queries=yaml_dict.get("example_queries", []),
@@ -84,29 +85,20 @@ class Topic(YamlResource):
     def read_local_resource(
         cls, file_path: str, resource_id: str, resource_name: str, **kwargs
     ) -> "Topic":
-        """Read a local YAML resource from the given file path."""
-        content = cls.read_to_raw(file_path, resource_name=resource_name, **kwargs)
-        try:
-            yaml_dict = utils.load_yaml(content) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML file: {file_path}") from e
+        """Read a local YAML resource, validating name against filename."""
+        topic: Topic = super().read_local_resource(
+            file_path, resource_id=resource_id, resource_name=resource_name, **kwargs
+        )
 
         file_name = os.path.splitext(os.path.basename(file_path))[0]
-        yaml_name = yaml_dict.get("name")
+        yaml_name = topic.name if topic.name != resource_name else None
 
-        if yaml_name:
-            # New format: name is in the YAML, validate against filename
-            if file_name != utils.clean_name(yaml_name):
-                raise ValueError(
-                    f"Topic name '{yaml_name}' in file {file_name}.yaml does not match "
-                    f"expected filename: {utils.clean_name(yaml_name)}.yaml"
-                )
-            name = yaml_name
-        else:
-            # Legacy format: name comes from filename
-            name = resource_name
-
-        return cls.from_yaml_dict(yaml_dict, resource_id=resource_id, name=name, **kwargs)
+        if yaml_name and file_name != utils.clean_name(yaml_name):
+            raise ValueError(
+                f"Topic name '{yaml_name}' in file {file_name}.yaml does not match "
+                f"expected filename: {utils.clean_name(yaml_name)}.yaml"
+            )
+        return topic
 
     @classmethod
     def to_pretty_dict(

--- a/src/poly/resources/topic.py
+++ b/src/poly/resources/topic.py
@@ -91,12 +91,12 @@ class Topic(YamlResource):
         )
 
         file_name = os.path.splitext(os.path.basename(file_path))[0]
-        yaml_name = topic.name if topic.name != resource_name else None
+        expected_file_name = utils.clean_name(topic.name)
 
-        if yaml_name and file_name != utils.clean_name(yaml_name):
+        if file_name != expected_file_name:
             raise ValueError(
-                f"Topic name '{yaml_name}' in file {file_name}.yaml does not match "
-                f"expected filename: {utils.clean_name(yaml_name)}.yaml"
+                f"Topic name '{topic.name}' in file {file_name}.yaml does not match "
+                f"expected filename: {expected_file_name}.yaml"
             )
         return topic
 

--- a/src/poly/resources/variable.py
+++ b/src/poly/resources/variable.py
@@ -87,9 +87,9 @@ class Variable(Resource):
         """Replace resource IDs with resource names in the provided contents."""
         return contents
 
-    @staticmethod
+    @classmethod
     def from_pretty(
-        contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> str:
         """Replace resource names with resource IDs in the provided contents."""
         return contents

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -216,19 +216,11 @@ class VariantAttribute(MultiResourceYamlResource):
         d["values"] = new_mapping
         return d
 
-    @staticmethod
-    def from_pretty(
-        contents: str,
-        file_path: str = None,
-        resource_mappings: list[ResourceMapping] = None,
-        **kwargs,
-    ) -> str:
-        """Replace resource names with resource IDs in the provided contents."""
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML content for {file_path}") from e
-
+    @classmethod
+    def from_pretty_dict(
+        cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> dict:
+        """Replace variant names with IDs in a parsed YAML dict."""
         variant_names_to_ids = {
             resource.resource_name: resource.resource_id
             for resource in resource_mappings or []
@@ -240,7 +232,18 @@ class VariantAttribute(MultiResourceYamlResource):
             new_mapping[variant_names_to_ids.get(variant_name, variant_name)] = variant_value
 
         yaml_dict["values"] = new_mapping
+        return yaml_dict
 
+    @classmethod
+    def from_pretty(
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace variant names with IDs in the provided contents."""
+        try:
+            yaml_dict = utils.load_yaml(contents) or {}
+        except Exception as e:
+            raise ValueError("Error loading YAML content") from e
+        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
         return utils.dump_yaml(yaml_dict)
 
     @property

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -234,18 +234,6 @@ class VariantAttribute(MultiResourceYamlResource):
         yaml_dict["values"] = new_mapping
         return yaml_dict
 
-    @classmethod
-    def from_pretty(
-        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> str:
-        """Replace variant names with IDs in the provided contents."""
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError("Error loading YAML content") from e
-        yaml_dict = cls.from_pretty_dict(yaml_dict, resource_mappings=resource_mappings, **kwargs)
-        return utils.dump_yaml(yaml_dict)
-
     @property
     def command_type(self) -> str:
         return "variant_attribute"


### PR DESCRIPTION
## Summary

Optimizes `read_local_resource` by eliminating redundant YAML parse/dump cycles and caching repeated `ast.parse` calls. Reduces `poly diff` / `poly status` / `poly push` time by ~15% across all projects.

## Motivation

Profiling `poly diff` on large projects revealed two bottlenecks in `read_local_resource`, which is called for every resource during diff, status, and push operations:
- **YAML double-parse (67% of time):** `from_pretty` would load YAML → transform → dump back to string, then `read_local_resource` would immediately re-parse that string
- **Redundant `ast.parse` (8% of time):** `_get_target_function` re-parsed the same Python source multiple times per Function resource

## Changes

- Add `from_pretty_dict` to base `YamlResource` as a standardized dict→dict transform hook (mirrors existing `to_pretty_dict`), wired into `read_local_resource` for a single-parse path
- Override `from_pretty_dict` in FlowStep, FlowConfig, VariantAttribute, PhraseFilter for their name→ID transformations
- Base `read_local_resource` now does: `read_from_file` → string regex → `load_yaml` → `from_pretty_dict` → `from_yaml_dict` (one YAML parse, zero dumps)
- Subclasses that need YAML transforms in `from_pretty` (for `read_to_raw` callers) override it with: `load_yaml` → `from_pretty_dict` → `dump_yaml`
- Add `@lru_cache` to `Function._get_target_function` to avoid redundant `ast.parse` calls
- Simplify `Pronunciation.read_local_resource` to pass the dict directly instead of dump→re-parse
- Simplify `Topic.read_local_resource` to use `super()` and validate after

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly diff`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

All 608 existing tests pass. Profiled and benchmarked across 43 projects.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Benchmarks

Benchmarked `poly diff` (no local changes) across 43 projects:

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| **Total time (43 projects)** | 27.56s | 23.55s | **-14.5%** |
| Largest project | 4.38s | 3.06s | **-30%** |

Per-resource improvements (profiled on largest project):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| `load_yaml` calls | 954 | 642 | -33% |
| `dump_yaml` calls | 570 | 0 | -100% |
| `ast.parse` calls | 1,896 | 805 | -58% |
| Total function calls | 18.8M | 10.3M | -45% |

Savings scale with project size. Small projects (~0.2s) are dominated by import time; large projects (1s+) see 20-30% improvement.