### PR TITLE
docs: deduplicate content and trim bloat across ADK docs

### DIFF
--- a/docs/docs/concepts/anti-patterns.md
+++ b/docs/docs/concepts/anti-patterns.md
@@ -161,22 +161,7 @@ If the user is expected to answer, put the full question in the utterance and le
 
 ## Don't copy project directories between projects
 
-Copying an existing ADK project directory and pointing it at a different Agent Studio project will cause push failures.
-
-The `.agent_studio_config` file contains resource IDs from the source project. When the ADK compares local files against the target project, those IDs do not match what the remote has registered. Resources that are not registered on the target project get classified as new creates — and several resources (voice settings, chat settings, personality, role, and ASR settings) cannot be created through the ADK because they are provisioned automatically by the platform when a project is created.
-
-### Wrong
-
-Copying a project directory, updating `project.yaml` or `project.json` with new IDs, then running `poly push` against a different project.
-
-### Right
-
-~~~bash
-poly init
-poly pull
-~~~
-
-Start every new project fresh with `poly init` and `poly pull`. `poly init` will walk you through dropdowns to pick the right project; pass `--account_id` / `--project_id` if you want to skip the prompts. If you need to reuse flows, functions, or topics from an existing project, copy those individual resource files into the new directory — do not copy `.agent_studio_config` or the whole project directory.
+Never copy a whole project directory to start a new project — the `.agent_studio_config` IDs won't match the target and platform-provisioned resources will fail to push. Always start with `poly init` + `poly pull`. If you need to reuse resources, copy individual files into the new directory. See the [platform-provisioned note on agent settings](../reference/agent_settings.md) for details.
 
 ## Quick reference
 

--- a/docs/docs/concepts/anti-patterns.md
+++ b/docs/docs/concepts/anti-patterns.md
@@ -161,7 +161,20 @@ If the user is expected to answer, put the full question in the utterance and le
 
 ## Don't copy project directories between projects
 
-Never copy a whole project directory to start a new project — the `.agent_studio_config` IDs won't match the target and platform-provisioned resources will fail to push. Always start with `poly init` + `poly pull`. If you need to reuse resources, copy individual files into the new directory. See the [platform-provisioned note on agent settings](../reference/agent_settings.md) for details.
+Copying an existing ADK project directory and pointing it at a different Agent Studio project will cause push failures. The `.agent_studio_config` file contains resource IDs from the source project, and platform-provisioned resources (voice settings, chat settings, personality, role, ASR settings) cannot be created through the ADK.
+
+### Wrong
+
+Copying a project directory, updating `project.yaml` with new IDs, then running `poly push` against a different project.
+
+### Right
+
+~~~bash
+poly init
+poly pull
+~~~
+
+Start every new project with `poly init` and `poly pull`. Copy individual resource files if you need to reuse them — never copy `.agent_studio_config` or the whole directory.
 
 ## Quick reference
 

--- a/docs/docs/concepts/multi-user-and-guardrails.md
+++ b/docs/docs/concepts/multi-user-and-guardrails.md
@@ -50,22 +50,7 @@ The ADK is designed to reduce those risks by combining local editing with valida
 
 ## Branch workflow
 
-A typical collaborative workflow looks like this:
-
-1. start from the `main` branch
-2. create a new branch with [`poly branch create {name}`](../reference/cli.md#poly-branch-create)
-3. switch branches as needed with [`poly branch switch {name}`](../reference/cli.md#poly-branch)
-4. edit files locally
-5. inspect changes with [`poly status`](../reference/cli.md#poly-status) and [`poly diff`](../reference/cli.md#poly-diff)
-6. validate the project with [`poly validate`](../reference/cli.md#poly-validate)
-7. push changes with [`poly push`](../reference/cli.md#poly-push)
-8. review the branch in Agent Studio
-9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or through the Agent Studio UI when ready
-
-You can also use:
-
-- [`poly branch list`](../reference/cli.md#poly-branch) to view available branches
-- [`poly branch current`](../reference/cli.md#poly-branch) to check the active branch
+The collaborative workflow follows the standard [CLI working pattern](../reference/cli.md#working-pattern), with each developer working on their own branch. Create a branch with [`poly branch create`](../reference/cli.md#poly-branch-create), edit and push, then merge with [`poly branch merge`](../reference/branch_merge.md) or through the Agent Studio UI when ready.
 
 ## Validation as a guardrail
 

--- a/docs/docs/concepts/working-locally.md
+++ b/docs/docs/concepts/working-locally.md
@@ -99,18 +99,7 @@ This means the local filesystem becomes your main editing surface, while Agent S
 
 ## Standard CLI workflow
 
-The standard workflow is:
-
-1. initialize the local project with [`poly init`](../reference/cli.md#poly-init) if it is not already present
-2. pull the latest project configuration with [`poly pull`](../reference/cli.md#poly-pull)
-3. create a branch with [`poly branch create {name}`](../reference/cli.md#poly-branch-create)
-4. edit files locally
-5. inspect changes with [`poly diff`](../reference/cli.md#poly-diff) and [`poly status`](../reference/cli.md#poly-status)
-6. validate locally with [`poly validate`](../reference/cli.md#poly-validate)
-7. push changes with [`poly push`](../reference/cli.md#poly-push)
-8. optionally generate a review gist with [`poly review create`](../reference/cli.md#poly-review)
-9. merge the branch with [`poly branch merge`](../reference/branch_merge.md) or in Agent Studio
-10. test by chatting with the agent using [`poly chat`](../reference/cli.md#poly-chat) — by default this connects to your current branch's pushed state. Use [`poly push`](../reference/cli.md#poly-push) first, or `poly chat --push` to push and start the session in one step. On the main branch it falls back to Sandbox.
+See the [CLI working pattern](../reference/cli.md#working-pattern) for the full step-by-step. The short version: init → pull → branch → edit → validate → push → review → merge → chat.
 
 !!! tip "Run commands from the project folder"
 
@@ -137,27 +126,6 @@ These references let settings, prompts, and behaviors point to resources by name
 !!! tip "A Git-like workflow for Agent Studio"
 
     Think of the ADK as a synchronization layer between your local files and the Agent Studio platform.
-
-## Development setup from source
-
-If you are contributing to the ADK itself or working directly from the repository, you can set it up locally from source instead.
-
-~~~bash
-git clone https://github.com/polyai/adk.git
-cd adk
-uv venv --python=3.14 --seed
-source .venv/bin/activate
-uv pip install -e ".[dev]"
-pre-commit install
-~~~
-
-This installs the project in editable mode and enables the repository's development hooks. To run the test suite:
-
-~~~bash
-pytest
-~~~
-
-Test files are located in `src/poly/tests/`.
 
 ## Related pages
 

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -3,20 +3,7 @@ title: Examples
 description: Focused examples for common PolyAI ADK patterns and workflows.
 ---
 
-This section contains small, focused examples that can be copied, adapted, and reused when building with the **PolyAI ADK**.
-
-Examples are intended to show practical patterns rather than explain every concept in depth.
-
-## What examples are for
-
-Use examples when you want to:
-
-- see a pattern in a compact form
-- copy a starting point into a project
-- compare one implementation approach with another
-- understand how a resource is typically structured
-
-Examples work best alongside the conceptual and reference documentation.
+Small, focused examples that can be copied and adapted when building with the **PolyAI ADK**.
 
 <div class="grid cards" markdown>
 
@@ -31,7 +18,7 @@ Examples work best alongside the conceptual and reference documentation.
 
     ---
 
-    Look up the exact fields, structures, and command behavior.
+    Look up exact fields, structures, and command behavior.
     [Open CLI reference](../reference/cli.md)
 
 -   **Tutorials**
@@ -40,35 +27,5 @@ Examples work best alongside the conceptual and reference documentation.
 
     Follow a complete workflow from start to finish.
     [Open tutorials](../tutorials/build-an-agent.md)
-
-</div>
-
-## What will appear here
-
-Over time, this section can include examples such as:
-
-- simple flow structures
-- common function patterns
-- topic and action examples
-- entity collection patterns
-- variant-based configuration examples
-- review and validation workflows
-
-!!! info "Examples are intentionally small"
-
-    A good example should be easy to scan, easy to copy, and easy to adapt. Larger workflows belong in tutorials.
-
-## Suggested next step
-
-If you are looking for a full end-to-end workflow, start with the tutorial instead.
-
-<div class="grid cards" markdown>
-
--   **Build an agent with the ADK**
-
-    ---
-
-    Follow the main tutorial for the complete workflow from setup to deployment.
-    [Open the tutorial](../tutorials/build-an-agent.md)
 
 </div>

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -57,17 +57,7 @@ Copy both values — you will need them in the next step.
 
 ![Go back to key](../assets/go-back-to-key.png)
 
-The ADK uses an API key to authenticate with Agent Studio. Click **Back to agents** to return to your **workspace**, open the **API Keys** tab (next to the **Users** tab) and click **+ API key** to generate one.
-
-![Generating an API key in Agent Studio — API Keys tab with the + API key button highlighted](../assets/api-key-data-access.png)
-
-Then set it as an environment variable:
-
-~~~bash
-export POLY_ADK_KEY=<your-api-key>
-~~~
-
-To make it permanent, add the export line to your shell profile (`~/.zshrc` or `~/.bashrc`).
+The ADK uses an API key to authenticate with Agent Studio. Click **Back to agents** to return to your **workspace**, then follow the steps in [Prerequisites — Generate API key](./prerequisites.md#generate-api-key) to create and export your key.
 
 ### Step 6 — Pull the agent into the ADK
 
@@ -77,13 +67,7 @@ Once the [ADK is installed](./installation.md), link your local folder to the pr
 poly init
 ```
 
-[`poly init`](../reference/cli.md#poly-init) walks you through interactive dropdowns to pick a region, account, and project — single options are auto-selected. It creates a subdirectory at `{account_id}/{project_id}` inside your current directory and pulls the current configuration down automatically. [`poly pull`](../reference/cli.md#poly-pull) can be used to refresh it at any time. Change into the project directory before running any further commands.
-
-If you already know the IDs (or want to script the call), pass them as flags to skip the prompts:
-
-```bash
-poly init --account_id <account_id> --project_id <project_id>
-```
+[`poly init`](../reference/cli.md#poly-init) walks you through interactive dropdowns to pick a region, account, and project. It creates a subdirectory and pulls the configuration automatically. Change into the project directory before running any further commands. See [First commands](./first-commands.md) for the full walkthrough.
 
 You now have a fully editable local copy of your agent.
 
@@ -121,7 +105,7 @@ If you already have an agent in Agent Studio — built in the browser editor, by
     poly init
     ~~~
 
-    `poly init` shows a searchable dropdown of every project visible to your API key — pick the one you want to work on. If you'd rather pass the IDs directly (they're in the Agent Studio URL), use `poly init --account_id <account_id> --project_id <project_id>`.
+    `poly init` shows interactive dropdowns to pick your project. See [First commands](./first-commands.md) for details.
 
 Your local folder will mirror the project in Agent Studio and you can begin editing immediately.
 

--- a/docs/docs/get-started/installation.md
+++ b/docs/docs/get-started/installation.md
@@ -41,19 +41,9 @@ pip install polyai-adk
 
     If you plan to work in **VS Code** or **Cursor**, you can also install the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) for resource-aware editing on top of the CLI. The extension is additive — the `poly` command remains the source of truth for every workflow.
 
-## Generate API key
+## Set your API key
 
-Log in to Agent Studio and open your workspace. In the **API Keys** tab (next to the **Users** tab), click **+ API key** in the top right to generate a key.
-
-![Generating an API key in Agent Studio — API Keys tab with the + API key button highlighted](../assets/api-key-data-access.png)
-
-Then set it as an environment variable:
-
-~~~bash
-export POLY_ADK_KEY=<your-api-key>
-~~~
-
-The `POLY_ADK_KEY` environment variable must be set before running any `poly` commands. To make it permanent, add the export line to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
+If you haven't generated an API key yet, follow the steps in [Prerequisites — Generate API key](./prerequisites.md#generate-api-key).
 
 ### Per-region API keys
 
@@ -76,8 +66,6 @@ export POLY_ADK_KEY=<your-fallback-api-key>   # used for any other region
 ~~~
 
 `POLY_ADK_KEY` is still required as the fallback. If neither the region-specific key nor `POLY_ADK_KEY` is set, the CLI will raise an error.
-
-Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
 
 ## Verify the installation
 

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -31,7 +31,7 @@ Install the following tools before continuing:
 | Tool | Version | Notes |
 |---|---|---|
 | **uv** | latest | Manages Python and virtual environments |
-| **Git** | any | Required to clone the repository or contribute |
+| **Git** | any | Optional — recommended for version control of your local project files |
 
 ### Install uv
 
@@ -56,7 +56,6 @@ Before continuing, confirm:
 - You have access to an **Agent Studio workspace**
 - You have generated an **API key** in Agent Studio
 - `uv` is installed
-- `git` is available locally
 
 ## Next step
 

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -21,8 +21,6 @@ export POLY_ADK_KEY=<your-api-key>
 
 The `POLY_ADK_KEY` environment variable must be set before running any `poly` commands. To make it permanent, add the export line to your shell profile (for example, `~/.zshrc` or `~/.bashrc`).
 
-Once the ADK is installed and your API key is set, you can use the `poly` command to interact with Agent Studio projects locally.
-
 !!! warning "API keys are workspace-scoped"
     An API key grants access to one specific Agent Studio workspace. When you run `poly init`, it lists all projects visible to that key. If you see many projects that do not look like yours, you are likely using a key scoped to the wrong workspace — for example, an organization-wide key rather than one scoped to your personal workspace. Contact your PolyAI contact to confirm you have a key for the correct workspace.
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -11,15 +11,17 @@ The ADK gives you a local, Git-like workflow for Agent Studio projects: pull, ed
 
 ## From zero to a local project
 
-Three commands take you from an empty machine to a working local copy of your agent:
+A few commands take you from an empty machine to a working local copy of your agent:
 
 ~~~bash
+uv venv --python=3.14 --seed
+source .venv/bin/activate
 pip install polyai-adk
 export POLY_ADK_KEY=<your-api-key>
 poly init
 ~~~
 
-`poly init` walks you through interactive dropdowns to pick a region, account, and project — single options are auto-selected. See [Prerequisites](get-started/prerequisites.md) for how to generate an API key, and [Initialize your project](get-started/first-commands.md) for a short walkthrough of the third command.
+See [Prerequisites](get-started/prerequisites.md) for how to install `uv` and generate an API key, [Installation](get-started/installation.md) for environment setup, and [First commands](get-started/first-commands.md) for a walkthrough of `poly init`.
 
 ## Start here
 

--- a/docs/docs/reference/agent_settings.md
+++ b/docs/docs/reference/agent_settings.md
@@ -153,7 +153,7 @@ The rules file supports the following references:
 | `{{twilio_sms:template_name}}` | [SMS template](./sms.md) |
 | `{{ho:handoff_name}}` | [Handoff destination](./handoffs.md) |
 | `{{attr:attribute_name}}` | [Variant attribute](./variants.md) |
-| `{{vrbl:variable_name}}` | [State variable](./variables.md) |
+| `{{vrbl:variable_name}}` or `$variable_name` | [State variable](./variables.md) |
 
 ### Example
 

--- a/docs/docs/reference/agent_settings.md
+++ b/docs/docs/reference/agent_settings.md
@@ -207,25 +207,7 @@ That kind of logic belongs in flows and Python functions.
 
 The `safety_filters.yaml` file configures project-level content safety filtering. It controls whether harmful content is filtered across all channels by default.
 
-See the [Safety filters reference](./safety_filters.md) for full field descriptions, schema, and examples. The equivalent UI lives on the [General settings page on docs.poly.ai](https://docs.poly.ai/settings/introduction){ target="_blank" rel="noopener" }.
-
-### Example
-
-~~~yaml
-categories:
-  violence:
-    enabled: true
-    level: medium
-  hate:
-    enabled: true
-    level: medium
-  sexual:
-    enabled: true
-    level: medium
-  self_harm:
-    enabled: true
-    level: medium
-~~~
+See the [Safety filters reference](./safety_filters.md) for field descriptions, schema, and examples.
 
 ## Best practices
 

--- a/docs/docs/reference/chat_settings.md
+++ b/docs/docs/reference/chat_settings.md
@@ -11,7 +11,7 @@ They are defined in <code>chat/configuration.yaml</code>.
 </p>
 
 !!! note "Platform-provisioned — update only"
-    Chat settings (`chat/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
+    Chat settings are created automatically when a project is created. They can be updated with `poly push` but not created from scratch. See the [equivalent note on agent settings](./agent_settings.md) for details.
 
 ## Location
 
@@ -97,26 +97,7 @@ style_prompt:
 
 `chat/safety_filters.yaml` is an optional file that overrides the project-level safety filter settings for the chat channel. When present, it takes precedence over `agent_settings/safety_filters.yaml` for chat interactions.
 
-See the [Safety filters reference](./safety_filters.md) for the full schema, field descriptions, and examples. The equivalent UI lives in the [Chat configuration page on docs.poly.ai](https://docs.poly.ai/webchat/chat-configuration#safety-filters){ target="_blank" rel="noopener" }.
-
-### Example
-
-~~~yaml
-enabled: true
-categories:
-  violence:
-    enabled: true
-    level: medium
-  hate:
-    enabled: true
-    level: medium
-  sexual:
-    enabled: true
-    level: medium
-  self_harm:
-    enabled: true
-    level: medium
-~~~
+See the [Safety filters reference](./safety_filters.md) for the full schema, field descriptions, and examples.
 
 ## Full example
 

--- a/docs/docs/reference/functions.md
+++ b/docs/docs/reference/functions.md
@@ -233,45 +233,7 @@ Decorate that main function and have it return a utility-module message. Helper 
 
 ## State
 
-`conv.state` is preserved between turns.
-
-### In code
-
-Set a state value:
-
-~~~python
-conv.state.variable_name = value
-~~~
-
-Read a state value:
-
-~~~python
-conv.state.variable_name
-~~~
-
-### In prompts
-
-Use:
-
-- `$variable`
-- `{{vrbl:variable}}`
-
-Do not use:
-
-- `conv.state.variable`
-- `$var.attribute`
-
-If you need complex structured data in prompts, stringify it in Python first and store the string in state.
-
-## Counters
-
-State counters are useful for limiting retries and preventing loops.
-
-For example:
-
-- initialize a counter
-- increment it after each retry
-- hand off or exit after a defined limit
+Functions read and write conversation state via `conv.state`. See the [Variables reference](./variables.md) for the full details on setting, reading, and referencing state in prompts.
 
 ## Metrics and logging
 
@@ -303,21 +265,6 @@ conv.log.error(...)
 - use grouped naming patterns where helpful
 - use `write_once=True` for one-time events
 - log important outcomes around external calls and failures
-
-## Quick reference
-
-| Task | Code |
-|---|---|
-| State in prompt | `$variable` or `{{vrbl:variable}}` |
-| State in code | `conv.state.variable` |
-| Persist data | `conv.state.variable = value` |
-| Track event | `conv.write_metric("NAME", value)` |
-| Call global function | `conv.functions.my_function(...)` |
-| Call flow function | `flow.functions.my_function(...)` |
-| Navigate to flow | `conv.goto_flow("Flow Name")` |
-| Navigate to step | `flow.goto_step("Step Name", "reason")` |
-| Exit flow | `conv.exit_flow()` |
-| Transfer call | `conv.call_handoff(destination="...", reason="...")` |
 
 ## Related pages
 

--- a/docs/docs/reference/speech_recognition.md
+++ b/docs/docs/reference/speech_recognition.md
@@ -12,7 +12,7 @@ Speech recognition resources control how the agent processes user speech input o
 These resources live under `voice/speech_recognition/` and are used to tune how the agent listens, recognizes, and post-processes spoken input.
 
 !!! note "ASR settings are platform-provisioned — update only"
-    `asr_settings.yaml` is created automatically by the platform when a project is created. It always exists on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
+    ASR settings are created automatically when a project is created. They can be updated with `poly push` but not created from scratch. See the [equivalent note on agent settings](./agent_settings.md) for details.
 
 ## Location
 

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -43,6 +43,20 @@ Testing is useful when you want to:
 
 Testing sits between validation and merge in the standard [CLI workflow](./cli.md#working-pattern). Edit locally, validate with `poly validate`, push, then test the branch in Agent Studio or with `poly chat`.
 
+## What to test
+
+- function logic and return values
+- state transitions across turns
+- API integration helpers
+- formatting or normalization utilities
+- project-specific edge cases
+
+## Best practices
+
+- validate as part of the normal workflow, not just before merge
+- test important error paths, not only success cases
+- combine `poly chat` with interactive review when behavior depends on conversation flow
+
 ## Related pages
 
 <div class="grid cards" markdown>

--- a/docs/docs/reference/testing.md
+++ b/docs/docs/reference/testing.md
@@ -41,29 +41,7 @@ Testing is useful when you want to:
 
 ## Testing in the workflow
 
-A typical development loop looks like this:
-
-1. edit files locally
-2. inspect changes with `poly status` and `poly diff`
-3. run `poly validate`
-4. push changes with `poly push`
-5. test the branch in Agent Studio
-
-## What to test
-
-The exact tests will depend on the kind of work you are doing, but common areas include:
-
-- function logic
-- state transitions
-- API integration helpers
-- formatting or normalization utilities
-- project-specific edge cases
-
-## Best practices
-
-- use validation as part of the normal workflow, not just before merge
-- test important error paths, not only success cases
-- combine interactive review when behavior depends on conversation flow
+Testing sits between validation and merge in the standard [CLI workflow](./cli.md#working-pattern). Edit locally, validate with `poly validate`, push, then test the branch in Agent Studio or with `poly chat`.
 
 ## Related pages
 

--- a/docs/docs/reference/tooling.md
+++ b/docs/docs/reference/tooling.md
@@ -99,6 +99,10 @@ The ADK also fits well with standard local development tooling such as:
 
 Tooling slots into the standard [CLI workflow](./cli.md#working-pattern): pull or init, edit with your tool of choice, validate, push, and review in Agent Studio.
 
+!!! tip "Tooling should reduce friction, not reduce scrutiny"
+
+    Faster editing and generation are valuable, but project review, validation, and testing still matter.
+
 ## Related pages
 
 <div class="grid cards" markdown>

--- a/docs/docs/reference/tooling.md
+++ b/docs/docs/reference/tooling.md
@@ -97,25 +97,7 @@ The ADK also fits well with standard local development tooling such as:
 
 ## How tooling fits into the workflow
 
-A common pattern looks like this:
-
-1. use the ADK to pull or initialize a project locally
-2. open the project in your editor or IDE
-3. use an AI coding tool or standard editing workflow to make changes
-4. inspect and validate those changes locally
-5. push them back to Agent Studio
-
-## Best practices
-
-- use the CLI as the source of truth for project operations
-- keep AI-assisted generation grounded in real project requirements
-- validate generated output before pushing
-- review changes in Agent Studio before merging
-- treat tooling as an accelerator, not a substitute for review
-
-!!! tip "Tooling should reduce friction, not reduce scrutiny"
-
-    Faster editing and generation are valuable, but project review, validation, and testing still matter.
+Tooling slots into the standard [CLI workflow](./cli.md#working-pattern): pull or init, edit with your tool of choice, validate, push, and review in Agent Studio.
 
 ## Related pages
 

--- a/docs/docs/reference/voice_settings.md
+++ b/docs/docs/reference/voice_settings.md
@@ -11,7 +11,7 @@ They are defined in <code>voice/configuration.yaml</code>.
 </p>
 
 !!! note "Platform-provisioned — update only"
-    Voice settings (`voice/configuration.yaml`) are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If this file appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](./cli.md#poly-init) and [`poly pull`](./cli.md#poly-pull) rather than copying an existing directory.
+    Voice settings are created automatically when a project is created. They can be updated with `poly push` but not created from scratch. See the [equivalent note on agent settings](./agent_settings.md) for details.
 
 Voice settings control what the agent says at the start of a call and how it should sound throughout the conversation.
 
@@ -133,26 +133,7 @@ disclaimer_messages:
 
 `voice/safety_filters.yaml` is an optional file that overrides the project-level safety filter settings for the voice channel. When present, it takes precedence over `agent_settings/safety_filters.yaml` for voice interactions.
 
-See the [Safety filters reference](./safety_filters.md) for the full schema, field descriptions, and examples. The equivalent UI lives in the [Voice configuration page on docs.poly.ai](https://docs.poly.ai/voice/voice-configuration#safety-filters){ target="_blank" rel="noopener" }.
-
-### Example
-
-~~~yaml
-enabled: true
-categories:
-  violence:
-    enabled: true
-    level: medium
-  hate:
-    enabled: true
-    level: medium
-  sexual:
-    enabled: true
-    level: medium
-  self_harm:
-    enabled: true
-    level: medium
-~~~
+See the [Safety filters reference](./safety_filters.md) for the full schema, field descriptions, and examples.
 
 ## Full example
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -45,56 +45,7 @@ There are two common ways to build with the ADK:
 
 ## Local project structure
 
-When an Agent Studio project is linked locally, it follows this general structure:
-
-~~~text
-<account>/<project>/
-├── _gen/                               # Generated stubs — do not edit
-├── agent_settings/
-│   ├── personality.yaml
-│   ├── role.yaml
-│   ├── rules.txt
-│   ├── safety_filters.yaml             # Optional
-│   └── experimental_config.json        # Optional
-├── config/
-│   ├── entities.yaml                   # Optional
-│   ├── handoffs.yaml                   # Optional
-│   ├── sms_templates.yaml              # Optional
-│   └── variant_attributes.yaml         # Optional
-├── voice/
-│   ├── configuration.yaml
-│   ├── safety_filters.yaml             # Optional
-│   ├── speech_recognition/
-│   │   ├── asr_settings.yaml
-│   │   ├── keyphrase_boosting.yaml
-│   │   └── transcript_corrections.yaml
-│   └── response_control/
-│       ├── pronunciations.yaml
-│       └── phrase_filtering.yaml
-├── chat/                               # Optional - chat channel settings
-│   ├── configuration.yaml
-│   └── safety_filters.yaml             # Optional
-├── flows/
-│   └── {flow_name}/
-│       ├── flow_config.yaml
-│       ├── steps/
-│       │   └── {step_name}.yaml
-│       ├── function_steps/
-│       │   └── {function_step}.py
-│       └── functions/
-│           └── {function_name}.py
-├── functions/
-│   ├── start_function.py
-│   ├── end_function.py
-│   └── {function_name}.py
-├── topics/
-│   └── {topic_name}.yaml
-├── variables/                          # Virtual — no files on disk
-│   └── {variable_name}
-└── project.yaml
-~~~
-
-This structure mirrors the parts of the agent that Agent Studio understands: settings, flows, functions, topics, channel configuration, and supporting resources.
+See [Working locally — What a local project contains](../concepts/working-locally.md#what-a-local-project-contains) for the full directory tree. In short, the project mirrors what Agent Studio understands: `agent_settings/`, `flows/`, `functions/`, `topics/`, `voice/`, `chat/`, and `config/`.
 
 ## Workflow 1 - CLI workflow
 
@@ -110,18 +61,11 @@ Link a local folder to an existing Agent Studio project. The agent must already 
 poly init
 ~~~
 
-`poly init` walks you through interactive dropdowns for region, account, and project — single options are auto-selected. It creates the project directory at `{account_id}/{project_id}` inside your current working directory, pulls the current configuration, and writes the metadata needed to connect the folder to Agent Studio. Change into the project directory before running any further commands.
-
-For scripted runs you can pass any of the IDs directly to skip the matching prompt:
-
-~~~bash
-poly init --account_id <account_id> --project_id <project_id>
-poly init --region <region> --account_id <account_id> --project_id <project_id>
-~~~
+`poly init` walks you through interactive dropdowns for region, account, and project. It creates the project directory and pulls the current configuration. Change into the project directory before running any further commands. See [First commands](../get-started/first-commands.md) for flag options and details.
 
 ### Step 2 - Set up the environment
 
-Configure any API keys or environment variables needed for the project. Use `poly pull` at any time to refresh the local project with the latest remote configuration.
+Configure any API keys or environment variables needed for the project. `poly init` pulls the current configuration automatically, but you can run `poly pull` at any time to refresh it:
 
 ~~~bash
 poly pull
@@ -138,7 +82,7 @@ Start an interactive chat session to confirm the connection works and inspect ru
 
 !!! info "`poly chat` runs against Agent Studio, not your local files"
 
-    The ADK has no local runtime — `poly chat` talks to the agent running in Agent Studio. At this stage you are on `main`, so the session connects to your sandbox. To chat against a feature branch, push it first with `poly push` and then run `poly chat` (or use `poly chat --push` to do both in one step).
+    `poly chat` connects to the last pushed state of your current branch (or sandbox on `main`). Push first, or use `poly chat --push`.
 
 ~~~bash
 poly chat
@@ -294,7 +238,7 @@ Once your branch is merged in Agent Studio, test the agent by chatting with it a
 
 !!! note "Pushing before chatting"
 
-    By default, `poly chat` connects to your current branch's last pushed state — so push your latest changes first. On the `main` branch, `poly chat` falls back to the sandbox environment. To target a specific environment explicitly, pass `--environment sandbox`, `--environment pre-release`, or `--environment live`.
+    Push your latest changes before chatting — `poly chat` connects to the last pushed state. Target a specific environment with `--environment sandbox`, `--environment pre-release`, or `--environment live`.
 
 ~~~bash
 poly chat --environment sandbox
@@ -325,33 +269,7 @@ Use Agent Studio analytics to monitor containment, CSAT, handle time, and flagge
 
 ## Workflow 2 - AI-agent workflow
 
-The AI-agent workflow uses a coding agent — such as **Claude Code**, or an in-editor agent in **VS Code** or **Cursor** paired with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) — to run the same development loop on your behalf.
-
-<div class="grid cards" markdown>
-
--   **You provide the brief**
-
-    ---
-
-    Requirements, business rules, integrations, and API documentation.
-
--   **The coding tool generates the project**
-
-    ---
-
-    It uses the ADK to read documentation, generate files, and push the result.
-
--   **You review and deploy**
-
-    ---
-
-    Agent Studio remains the place where the work is checked, merged, and deployed.
-
-</div>
-
-!!! info "No manual flow-building required"
-
-    In this workflow, the coding tool generates the project files. Agent Studio is where the output is reviewed, tested, and deployed.
+The AI-agent workflow uses a coding agent — such as **Claude Code**, or an in-editor agent in **VS Code** or **Cursor** paired with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) — to run the same development loop on your behalf. You provide the brief, the coding tool generates and pushes project files, and you review and deploy in Agent Studio.
 
 ### Step 1 - Gather requirements
 

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -269,7 +269,29 @@ Use Agent Studio analytics to monitor containment, CSAT, handle time, and flagge
 
 ## Workflow 2 - AI-agent workflow
 
-The AI-agent workflow uses a coding agent — such as **Claude Code**, or an in-editor agent in **VS Code** or **Cursor** paired with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) — to run the same development loop on your behalf. You provide the brief, the coding tool generates and pushes project files, and you review and deploy in Agent Studio.
+The AI-agent workflow uses a coding agent — such as **Claude Code**, or an in-editor agent in **VS Code** or **Cursor** paired with the [PolyAI ADK extension](../reference/tooling.md#polyai-adk-extension-for-vs-code-and-cursor) — to run the same development loop on your behalf.
+
+<div class="grid cards" markdown>
+
+-   **You provide the brief**
+
+    ---
+
+    Requirements, business rules, integrations, and API documentation.
+
+-   **The coding tool generates the project**
+
+    ---
+
+    It uses the ADK to read documentation, generate files, and push the result.
+
+-   **You review and deploy**
+
+    ---
+
+    Agent Studio remains the place where the work is checked, merged, and deployed.
+
+</div>
 
 ### Step 1 - Gather requirements
 
@@ -318,13 +340,12 @@ At this stage:
 
 ~~~bash
 poly init --region <region> --account_id <account_id> --project_id <project_id>
-poly pull
 ~~~
 
-The ADK acts as the bridge between your local environment and Agent Studio. It lets the coding tool read from and write back to the project.
+`poly init` pulls the current configuration automatically — there is no need to run `poly pull` separately. The ADK acts as the bridge between your local environment and Agent Studio, letting the coding tool read from and write back to the project.
 
 !!! tip "Run `poly docs --all` before generating any files"
-    Immediately after pulling, run `poly docs --all` to produce a complete resource reference. Without it, a coding agent has no schema context for resource structure and field names, and will hallucinate them. This should be the first thing the coding tool does after `poly pull`.
+    Immediately after initializing, run `poly docs --all` to produce a complete resource reference. Without it, a coding agent has no schema context for resource structure and field names, and will hallucinate them.
 
     Note that `poly docs --all` documents the ADK's resource layer (topics, flows, entities, variants, and so on) but does not cover every runtime `Conversation` method. In particular, `conv.send_sms_template`, `conv.send_sms`, and `conv.caller_number` are not present in the output. For the full runtime API, direct the coding agent to the [conv object reference](https://docs.poly.ai/tools/classes/conv-object){ target="_blank" rel="noopener" } on the platform docs.
 


### PR DESCRIPTION
## Summary

**Deduplication (-340 lines net across 16 files):**
- Consolidate API key generation instructions in prerequisites.md; other pages cross-reference
- Consolidate platform-provisioned notes in agent_settings.md; voice/chat/speech pages cross-reference
- Move safety filter YAML examples to safety_filters.md only
- Move state/variable docs from functions.md to variables.md
- Replace duplicated CLI workflow steps (5 files) with cross-references to cli.md#working-pattern
- Shorten repeated poly init dropdown descriptions
- Remove duplicated project directory tree from build-an-agent.md
- Trim examples/index.md meta-content
- Remove misplaced dev-setup-from-source from working-locally.md (already in CONTRIBUTING.md)

**Informational inconsistencies fixed:**
- **index.md quickstart** now includes venv setup (was contradicting installation.md)
- **build-an-agent.md Workflow 2 Step 3** no longer shows a separate `poly pull` after `poly init` (poly init pulls automatically)
- **prerequisites.md** Git marked as optional/recommended, not required — the ADK itself doesn't use git
- **agent_settings.md** rules reference table now includes `$variable_name` syntax alongside `{{vrbl:...}}` (was inconsistent with variables.md and topics.md)

Visual formatting (cards, grids, admonitions) preserved throughout.

## Files changed

| Area | Files |
|---|---|
| Get started | `index.md`, `get-started.md`, `prerequisites.md`, `installation.md` |
| Reference | `agent_settings.md`, `voice_settings.md`, `chat_settings.md`, `speech_recognition.md`, `functions.md`, `testing.md`, `tooling.md` |
| Concepts | `working-locally.md`, `multi-user-and-guardrails.md`, `anti-patterns.md` |
| Tutorials | `build-an-agent.md` |
| Examples | `index.md` |

## Test plan

- [ ] Run `mkdocs serve` and verify all cross-reference links resolve
- [ ] Spot-check that each deduplicated section still has a working link to the canonical content
- [ ] Confirm no broken anchors (e.g. `cli.md#working-pattern`, `prerequisites.md#generate-api-key`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)