### PR TITLE
feat: save API key to credential file and mask display

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -25,7 +25,12 @@ import requests
 import questionary
 import traceback
 
-from poly.utils import retrieve_api_key, merge_strings
+from poly.utils import (
+    any_credentials_exist,
+    merge_strings,
+    save_api_key_credential_file,
+    CREDENTIALS_FILE_PATH,
+)
 import time
 
 from poly.output.console import (
@@ -49,6 +54,7 @@ from poly.output.console import (
     print_deployments,
     print_deployment_show,
     print_welcome_message,
+    mask_api_key,
 )
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
@@ -3881,7 +3887,7 @@ class AgentStudioCLI:
 
         # --- 1. Check for existing API key ---
         try:
-            retrieve_api_key()
+            any_credentials_exist()
             warning("An existing API key was found in your environment.")
             use_existing = questionary.confirm(
                 "Do you want to continue with the existing key?",
@@ -3918,7 +3924,7 @@ class AgentStudioCLI:
         if user_pats:
             pat = user_pats[0].get("key")
             os.environ["POLY_ADK_KEY"] = pat
-            success(f"Found existing API Token: {pat}")
+            success(f"Found existing API Token: {mask_api_key(pat)}")
         else:
             info("No existing API key found in your account.")
             ctx = console.status("[info]Creating a new API key...[/info]")
@@ -3944,13 +3950,13 @@ class AgentStudioCLI:
                     )
                     sys.exit(1)
 
-            success(f"Created a new API Token: {pat}")
-        plain(
-            "Set this in your environment variables as POLY_ADK_KEY to authenticate future commands"
-        )
-        info("export POLY_ADK_KEY=your_token_here  # on Linux/MacOS")
-        info("setx POLY_ADK_KEY your_token_here  # on Windows")
+            success(f"Created a new API Key: {mask_api_key(pat)}")
+
+        save_api_key_credential_file(pat, region="studio")
+        plain("API key has been saved to your credential file for future use.")
+        info(f"Credential file path: {CREDENTIALS_FILE_PATH}")
         plain("")
+
         create_project = questionary.confirm(
             "Would you like to create a new project in Agent Studio now?",
             auto_enter=False,

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 
 from poly.constants import DEFAULT_VOICE_ID_FALLBACK, DEFAULT_VOICE_IDS
-from poly.utils import retrieve_api_key
+from poly.utils import retrieve_api_key, any_credentials_exist
 
 logger = logging.getLogger(__name__)
 ACCOUNTS_URL = "/adk/v1/accounts"
@@ -151,7 +151,9 @@ class PlatformAPIHandler:
                 the original ordering.
         """
 
-        retrieve_api_key()
+        if not any_credentials_exist():
+            # Will raise a ValueError with instructions on how to set the API key
+            retrieve_api_key(region="studio")
 
         accessible: set[str] = set()
 

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -597,6 +597,12 @@ def print_welcome_message() -> None:
     console.print()
 
 
+def mask_api_key(key: str) -> str:
+    """Display masked API key"""
+    masked = key[:4] + "****" + key[-4:] if len(key) > 8 else "****"
+    return f"[yellow]{masked}[/yellow]"
+
+
 def handle_exception(exc: Exception) -> None:
     """Print a clean error message, or full traceback in verbose mode."""
     if _verbose:

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import os
 import re
+import json
 from typing import Callable, Optional
 
 from poly.resources import Function, FunctionStep, Resource, ResourceMapping
@@ -29,8 +30,48 @@ _REGION_TO_KEY_SUFFIX: dict[str, str] = {
     "dev": "DEV",
 }
 
+CREDENTIALS_FILE_PATH = os.path.expanduser("~/.poly/credentials.json")
 
-def retrieve_api_key(region: Optional[str] = None) -> str:
+
+def save_api_key_credential_file(api_key: str, region: str) -> None:
+    """Save the API key to a credential file in the user's home directory."""
+    credentials = {}
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+            try:
+                credentials = json.load(f)
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Could not parse existing credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                    "It will be overwritten with the new API key."
+                )
+
+    credentials[region] = api_key
+
+    os.makedirs(os.path.dirname(CREDENTIALS_FILE_PATH), exist_ok=True)
+    with open(CREDENTIALS_FILE_PATH, "w", encoding="utf-8") as f:
+        json.dump(credentials, f, indent=4)
+
+    # Set file permissions to be readable/writeable only by the user
+    os.chmod(CREDENTIALS_FILE_PATH, 0o600)
+
+
+def _load_api_key_from_credential_file(region: str) -> Optional[str]:
+    """Load the API key for the given region from the credential file, if it exists."""
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+            try:
+                credentials = json.load(f)
+                return credentials.get(region)
+            except json.JSONDecodeError:
+                logger.warning(
+                    f"Could not parse credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                    "It will be ignored when looking for the API key."
+                )
+    return None
+
+
+def retrieve_api_key(region: str) -> str:
     """Return an API key, preferring a per-region key when available.
 
     Resolution order:
@@ -39,12 +80,15 @@ def retrieve_api_key(region: Optional[str] = None) -> str:
 
     Raises ``ValueError`` with a helpful message when no key is found.
     """
-    if region:
-        suffix = _REGION_TO_KEY_SUFFIX.get(region)
-        if suffix:
-            per_region_key = os.getenv(f"{_API_KEY_ENV_VAR}_{suffix}")
-            if per_region_key:
-                return per_region_key
+    api_key = _load_api_key_from_credential_file(region)
+    if api_key:
+        return api_key
+
+    suffix = _REGION_TO_KEY_SUFFIX.get(region)
+    if suffix:
+        per_region_key = os.getenv(f"{_API_KEY_ENV_VAR}_{suffix}")
+        if per_region_key:
+            return per_region_key
 
     api_key = os.getenv(_API_KEY_ENV_VAR)
     if not api_key:
@@ -53,6 +97,28 @@ def retrieve_api_key(region: Optional[str] = None) -> str:
             f"Export your API key with: export {_API_KEY_ENV_VAR}=<your-api-key>"
         )
     return api_key
+
+
+def any_credentials_exist() -> bool:
+    """Check if any API key credentials are available via environment variables or credential file."""
+    if os.getenv(_API_KEY_ENV_VAR):
+        return True
+    for region in _REGION_TO_KEY_SUFFIX.keys():
+        if os.getenv(f"{_API_KEY_ENV_VAR}_{_REGION_TO_KEY_SUFFIX[region]}"):
+            return True
+
+    if os.path.isfile(CREDENTIALS_FILE_PATH):
+        try:
+            with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
+                credentials = json.load(f)
+                if any(region in credentials for region in _REGION_TO_KEY_SUFFIX.keys()):
+                    return True
+        except json.JSONDecodeError:
+            logger.warning(
+                f"Could not parse credentials file at {CREDENTIALS_FILE_PATH!r}. "
+                "It will be ignored when checking for API key credentials."
+            )
+    return False
 
 
 # Matches cross-package imports e.g. "from runtime.foo import" or "from utils.foo import"


### PR DESCRIPTION
## Summary

- Save API keys to `~/.poly/credentials.json` instead of requiring manual env var setup
- Mask API keys in CLI output (show first/last 4 chars only)
- Add `retrieve_api_key` fallback to read from credential file
- Set `0o600` permissions on credential file for security

## Motivation

Improves the `poly start` onboarding flow by removing the manual `export POLY_ADK_KEY=...` step and avoiding printing full API keys to the terminal.

## Changes

- `src/poly/utils.py`: Add credential file save/load/check functions, update `retrieve_api_key` resolution order
- `src/poly/output/console.py`: Add `mask_api_key` helper
- `src/poly/cli.py`: Use masked keys in output, auto-save to credential file after creation
- `src/poly/handlers/platform_api.py`: Use `any_credentials_exist()` check

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly start`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

<img width="691" height="506" alt="Screenshot 2026-05-14 at 16 43 27" src="https://github.com/user-attachments/assets/9756f07b-435c-48bf-a6f4-070c341121a0" />

