### PR TITLE
refactor: Update auth SDK

### DIFF
--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -9,7 +9,7 @@ import requests
 from google.protobuf.message import Message
 
 from poly.handlers.platform_api import PlatformAPIHandler
-from poly.handlers.sdk import SourcererAPIError
+from poly.handlers.sdk import SourcererAPIError, SourcererSDK
 from poly.handlers.sync_client import SyncClientHandler
 from poly.resources import BaseResource, Resource
 
@@ -90,12 +90,15 @@ class AgentStudioInterface:
         account_id: Optional[str] = None,
         project_id: Optional[str] = None,
         branch_id: Optional[str] = None,
+        sdk_class: Optional[type[SourcererSDK]] = None,
     ):
         self.region = region
         self.account_id = account_id
         self.project_id = project_id
         if region and account_id and project_id:
-            self.sync_client = SyncClientHandler(region, account_id, project_id, branch_id)
+            self.sync_client = SyncClientHandler(
+                region, account_id, project_id, branch_id, sdk_class=sdk_class
+            )
 
     @staticmethod
     def get_accessible_regions() -> list[str]:

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -16,6 +16,7 @@ from typing import Any, Optional
 
 import requests
 
+from poly.utils import retrieve_api_key
 from .protobuf.commands_pb2 import Command, CommandBatch
 
 logger = logging.getLogger(__name__)
@@ -82,7 +83,9 @@ class SourcererSDK:
 
     def _get_auth_headers(self) -> dict[str, str]:
         """Return the authentication headers for this SDK instance."""
-        return {"Authorization": f"Bearer {self._access_token}"}
+        return {
+            "X-API-KEY": retrieve_api_key(self.region),
+        }
 
     def _initialise_session(self, region: str, base_url: Optional[str] = None):
         """Initialize the requests session with authentication headers."""

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -16,7 +16,6 @@ from typing import Any, Optional
 
 import requests
 
-from poly.utils import retrieve_api_key
 from .protobuf.commands_pb2 import Command, CommandBatch
 
 logger = logging.getLogger(__name__)
@@ -67,26 +66,8 @@ class SourcererSDK:
         self.project_id = project_id
         self.branch_id = branch_id
 
-        # Set base URL
-        if base_url:
-            self.base_url = base_url
-        else:
-            if region not in self.ENVIRONMENT_URLS:
-                raise ValueError(
-                    f"Unknown region: {region}. Available regions: {list(self.ENVIRONMENT_URLS.keys())}"
-                )
-            self.base_url = self.ENVIRONMENT_URLS[region]
-
-        # Initialize session with auth headers
-        correlation_id = f"adk-{uuid.uuid4()}"
-        self.session = requests.Session()
-        self.session.headers.update(
-            {
-                "Content-Type": "application/json",
-                "X-API-KEY": retrieve_api_key(self.region),
-                "X-PolyAI-Correlation-Id": correlation_id,
-            }
-        )
+        # Initialize session with auth headers and base URL
+        self._initialise_session(region, base_url)
 
         # Cache for projection and sequence number
         self._projection_cache: Optional[dict[str, Any]] = None
@@ -98,6 +79,31 @@ class SourcererSDK:
         # Initialize branch_id if not provided
         if self.branch_id is None:
             self.branch_id = self._initialize_branch()
+
+    def _get_auth_headers(self) -> dict[str, str]:
+        """Return the authentication headers for this SDK instance."""
+        return {"Authorization": f"Bearer {self._access_token}"}
+
+    def _initialise_session(self, region: str, base_url: Optional[str] = None):
+        """Initialize the requests session with authentication headers."""
+        if base_url:
+            self.base_url = base_url
+        else:
+            if region not in self.ENVIRONMENT_URLS:
+                raise ValueError(
+                    f"Unknown region: {region}. Available regions: {list(self.ENVIRONMENT_URLS.keys())}"
+                )
+            self.base_url = self.ENVIRONMENT_URLS[region]
+
+        correlation_id = f"adk-{uuid.uuid4()}"
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Content-Type": "application/json",
+                **self._get_auth_headers(),
+                "X-PolyAI-Correlation-Id": correlation_id,
+            }
+        )
 
     def create_metadata(self):
         """Create metadata with the current user's email from JWT token
@@ -550,7 +556,7 @@ class SourcererSDK:
             # Update headers for protobuf content
             correlation_id = f"adk-{uuid.uuid4()}"
             headers = {
-                "X-API-KEY": retrieve_api_key(self.region),
+                **self._get_auth_headers(),
                 "X-PolyAI-Correlation-Id": correlation_id,
                 "Content-Type": "application/octet-stream",
             }

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -82,17 +82,21 @@ class SyncClientHandler:
         account_id: str,
         project_id: str,
         branch_id: Optional[str] = None,
+        sdk_class: Optional[type[SourcererSDK]] = None,
     ):
-        if region not in SourcererSDK.ENVIRONMENT_URLS:
+        if sdk_class is None:
+            sdk_class = SourcererSDK
+
+        if region not in sdk_class.ENVIRONMENT_URLS:
             raise ValueError(
-                f"Invalid region '{region}'. Valid regions are: {list(SourcererSDK.ENVIRONMENT_URLS.keys())}"
+                f"Invalid region '{region}'. Valid regions are: {list(sdk_class.ENVIRONMENT_URLS.keys())}"
             )
 
         self.region = region
         self.account_id = account_id
         self.project_id = project_id
 
-        self._sdk = SourcererSDK(
+        self._sdk = sdk_class(
             region=region,
             account_id=account_id,
             project_id=project_id,


### PR DESCRIPTION
## Summary
Refactor auth/base url setting for SDK so it's easier to subclass

## Motivation
Allow usage of JWT tokens with different endpoints  

## Changes
- Subclass base path and header setting

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->