### PR TITLE
fix: Send empty parameters

### DIFF
--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -792,7 +792,7 @@ class Function(Resource):
             "code": self.code,
             "description": self.description,
         }
-        if self.function_type in (FunctionType.GLOBAL, FunctionType.FUNCTION_STEP):
+        if self.function_type in (FunctionType.GLOBAL, FunctionType.TRANSITION):
             fn_proto["parameters"] = params_update
 
         if self.function_type != FunctionType.TRANSITION:

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -783,19 +783,16 @@ class Function(Resource):
     ]:
         """Create a proto for updating the resource."""
 
-        if self.parameters:
-            params_update = ParametersUpdate(
-                parameters=self._create_function_param_updates(self.parameters)
-            )
-        else:
-            params_update = None
+        params_update = ParametersUpdate(
+            parameters=self._create_function_param_updates(self.parameters)
+        )
 
         fn_proto = {
             "id": self.resource_id,
             "code": self.code,
             "description": self.description,
         }
-        if params_update is not None:
+        if self.function_type in (FunctionType.GLOBAL, FunctionType.FUNCTION_STEP):
             fn_proto["parameters"] = params_update
 
         if self.function_type != FunctionType.TRANSITION:


### PR DESCRIPTION
## Summary
Send an empty list of parameters when no parameters

## Motivation
Couldn't delete function parameters

## Changes
- Send parameters for function types that accept it, even when empty

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->