### PR TITLE
docs: add Discord community page

### DIFF
--- a/docs/docs/community/discord.md
+++ b/docs/docs/community/discord.md
@@ -1,0 +1,19 @@
+---
+title: Discord
+description: Join the PolyAI ADK Discord server to ask questions, share what you're building, and collaborate with the community.
+---
+
+# Join us on Discord
+
+We have a Discord server where ADK users and contributors hang out. Whether you're just getting started or building something advanced, it's the fastest way to get help, share ideas, and stay in the loop on what's new.
+
+**[:fontawesome-brands-discord: Join the ADK Discord](https://discord.gg/nzGcCt6SE){ .md-button .md-button--primary }**
+
+## What you'll find there
+
+- **Help & troubleshooting** — get unstuck with setup, CLI commands, or resource configuration.
+- **Show & tell** — share agents you've built, interesting patterns, or cool integrations.
+- **Feature discussion** — chat about what you'd like to see next in the ADK.
+- **Announcements** — hear about new releases and breaking changes early.
+
+Come say hello — we'd love to hear what you're working on.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,5 +139,8 @@ nav:
           - Speech recognition: reference/speech_recognition.md
           - Response control: reference/response_control.md
 
+  - Community:
+      - Discord: community/discord.md
+
   - Legal:
       - Licensing: legal/licensing.md


### PR DESCRIPTION
## Summary
- Adds a new **Community > Discord** page to the ADK docs inviting users to join the Discord server (`https://discord.gg/nzGcCt6SE`).
- Wires the page into the mkdocs nav between Examples and Legal.

## Test plan
- [ ] `mkdocs serve` renders the new page correctly
- [ ] Discord invite link resolves
- [ ] Navigation shows the Community section in the right position

🤖 Generated with [Claude Code](https://claude.com/claude-code)