### PR TITLE
docs: discord page invisible button and broken icon

### DIFF
--- a/docs/docs/community/discord.md
+++ b/docs/docs/community/discord.md
@@ -1,0 +1,19 @@
+---
+title: Discord
+description: Join the PolyAI ADK Discord server to ask questions, share what you're building, and collaborate with the community.
+---
+
+# Join us on Discord
+
+We have a Discord server where ADK users and contributors hang out. Whether you're just getting started or building something advanced, it's the fastest way to get help, share ideas, and stay in the loop on what's new.
+
+**[:fontawesome-brands-discord: Join the ADK Discord](https://discord.gg/nzGcCt6SE){ .md-button .md-button--primary }**
+
+## What you'll find there
+
+- **Help & troubleshooting** — get unstuck with setup, CLI commands, or resource configuration.
+- **Show & tell** — share agents you've built, interesting patterns, or cool integrations.
+- **Feature discussion** — chat about what you'd like to see next in the ADK.
+- **Announcements** — hear about new releases and breaking changes early.
+
+Come say hello — we'd love to hear what you're working on.

--- a/docs/docs/community/discord.md
+++ b/docs/docs/community/discord.md
@@ -7,7 +7,7 @@ description: Join the PolyAI ADK Discord server to ask questions, share what you
 
 We have a Discord server where ADK users and contributors hang out. Whether you're just getting started or building something advanced, it's the fastest way to get help, share ideas, and stay in the loop on what's new.
 
-**[:fontawesome-brands-discord: Join the ADK Discord](https://discord.gg/nzGcCt6SE){ .md-button .md-button--primary }**
+[Join the ADK Discord](https://discord.gg/nzGcCt6SE){ .discord-btn }
 
 ## What you'll find there
 

--- a/docs/docs/stylesheets/components.css
+++ b/docs/docs/stylesheets/components.css
@@ -116,6 +116,30 @@
    ADMONITIONS
    ============================================================================= */
 
+/* =============================================================================
+   BUTTONS
+   ============================================================================= */
+
+.md-typeset .discord-btn {
+  display: inline-block;
+  padding: 0.6rem 1.4rem;
+  border-radius: var(--radius-m);
+  background: #5865F2;
+  color: #fff !important;
+  font-weight: var(--font-weight-semi);
+  font-size: var(--font-size-base);
+  text-decoration: none !important;
+  transition: background 120ms ease;
+}
+
+.md-typeset .discord-btn:hover {
+  background: #4752C4;
+}
+
+/* =============================================================================
+   ADMONITIONS
+   ============================================================================= */
+
 .md-typeset .admonition,
 .md-typeset details {
   border-radius: 0.3rem;

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -139,5 +139,8 @@ nav:
           - Speech recognition: reference/speech_recognition.md
           - Response control: reference/response_control.md
 
+  - Community:
+      - Discord: community/discord.md
+
   - Legal:
       - Licensing: legal/licensing.md


### PR DESCRIPTION
## Summary
- The `.md-button--primary` class used `--md-primary-fg-color` for its background, which resolves to `#fff` in the custom light theme — white button on white page.
- The `:fontawesome-brands-discord:` inline icon syntax requires the `pymdownx.emoji` extension, which isn't enabled — rendered as literal text.
- Replaced with a `.discord-btn` class in `components.css` using Discord's brand purple (`#5865F2`), and removed the icon reference.

## Test plan
- [ ] `mkdocs serve` — button is visible in both light and dark mode
- [ ] Button hover darkens to `#4752C4`
- [ ] Discord invite link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)