### PR TITLE
fix: Remove project_id prompt for Studio region

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1534,7 +1534,7 @@ class AgentStudioCLI:
                 return
             project_name = project_name.strip()
 
-        if not project_id and region is not "studio":
+        if not project_id and region != "studio":
             project_id = questionary.text(
                 "Enter project ID (leave empty to let the platform generate one):",
                 validate=lambda val: (

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -312,7 +312,7 @@ class AgentStudioCLI:
             "--project_id",
             type=str,
             dest="project_id",
-            help="Optional slug/ID for the project. Defaults to a slugified version of the name.",
+            help="Optional unique slug/ID for the project. If not provided the platform will generate one",
         )
         project_create_parser.add_argument(
             "--greeting",
@@ -1534,12 +1534,9 @@ class AgentStudioCLI:
                 return
             project_name = project_name.strip()
 
-        if not project_id:
-            default_id = re.sub(r"[^a-zA-Z0-9-]", "", project_name.lower().replace(" ", "-"))
-            default_id = default_id.strip("-") or ""
+        if not project_id and region is not "studio":
             project_id = questionary.text(
                 "Enter project ID (leave empty to let the platform generate one):",
-                default=default_id,
                 validate=lambda val: (
                     True
                     if not val or re.fullmatch(r"[a-zA-Z0-9-]+", val)


### PR DESCRIPTION
## Summary

Removes the default project_id slug generation and skips the project_id prompt entirely for Studio (`--region studio`), since project_id must be unique across all projects in the region and prompting for it in PLG causes friction.

## Motivation

- `project_id` must be globally unique per region — if the user picks a taken ID, the API errors. We can't validate uniqueness client-side.
- For PLG (Studio) we expect many projects, so defaulting to empty and letting the platform generate the ID avoids collisions.
- The default slugified name was often not useful and led to conflicts.

## Changes

- Remove default slug generation from `project_name` for the `project_id` field
- Skip the `project_id` interactive prompt when `--region studio`
- Update help text to clarify the platform generates the ID if omitted
- Fix `is not` → `!=` for string comparison (identity vs equality bug)

## Test strategy

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)