### PR TITLE
chore: Remove client ID of unused connections

### DIFF
--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -13,8 +13,6 @@ logger = logging.getLogger(__name__)
 
 BASE_URL = "https://login.studio.poly.ai"
 DEVICE_CLIENT_ID = "6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd"
-STUDIO_CLIENT_ID = "v7NO1stPOf28i9FCdbuhs5WSUbOHTVtG"
-STUDIO_CONNECTION = "Self-Serve-Signup-Headless"
 
 
 class Auth0Handler:


### PR DESCRIPTION
## Summary
Remove client ID and connection of unused Auth0 Connection

## Motivation
Dead code which was confusing

## Changes
Remove unused constants

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)