### PR TITLE
docs: remove Early Access notice from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,24 +12,12 @@ A CLI and Python package for managing [Agent Studio](https://studio.us.poly.ai) 
 
 **[Documentation](https://polyai.github.io/adk/)**
 
-## Early Access
-
-⚠️ **The PolyAI ADK is currently in Early Access.**
-
-Changes may be pushed frequently while the platform evolves. If you encounter issues, please ensure you are running the **latest version** of the ADK before reporting them.
-
-[Request access to the PolyAI ADK](https://fehky.share-eu1.hsforms.com/2oSGLpUctRvyqXcb6K44DAQ)
-
-Once approved, the PolyAI team will provide the credentials required to use the ADK.
-
 ## Prerequisites
 
 Before using the ADK you must:
 
 - have access to a **PolyAI Agent Studio workspace**
 - obtain an **ADK API key** from the PolyAI team
-
-Access to both is granted through the Early Access Program.
 
 Store your API key as an environment variable named: `POLY_ADK_KEY`
 


### PR DESCRIPTION
## Summary

Removes the Early Access notice from the top of the README, as the ADK is no longer gated behind the Early Access Program.

## Motivation

The Early Access banner is stale and the access-request form is no longer the path to onboarding ADK users. The Prerequisites section also had a trailing line ("Access to both is granted through the Early Access Program.") that referenced this program — removed alongside to avoid a dangling reference.

## Changes

- Delete the `## Early Access` section from `README.md`
- Remove the trailing "Access to both is granted through the Early Access Program." line under Prerequisites

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass (no code changed)
- [x] `pytest` passes (no code changed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)