### PR TITLE
fix: Correct merge_branch return type annotations in project.py

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2700,7 +2700,7 @@ class AgentStudioProject:
 
     def merge_branch(
         self, message: str, conflict_resolutions: list[dict[str, Any]] = None
-    ) -> tuple[bool, list[str], list[str]]:
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
         """Merge the current branch into main in the project.
 
         Args:
@@ -2713,8 +2713,8 @@ class AgentStudioProject:
 
         Returns:
             bool: True if the merge was successful, False otherwise
-            list[str]: A list of conflict paths if the merge failed, empty list if successful
-            list[str]: A list of error messages if the merge failed, empty list if successful
+            list[dict[str, str]]: A list of conflicts
+            list[dict[str, str]]: A list of errors
         """
         branches = self.api_handler.get_branches()
         if self.branch_id not in branches.values():


### PR DESCRIPTION
## Summary

Fixes the return type annotation on `AgentStudioProject.merge_branch()` to match the actual return type from the handler layer.

## Motivation

The `project.py` method declared `list[str]` for the conflicts and errors return values, but the handlers (`interface.py`, `sync_client.py`) correctly return `list[dict[str, str]]`. This mismatch could mislead type checkers and developers.

## Changes

- Updated `merge_branch` return type from `tuple[bool, list[str], list[str]]` to `tuple[bool, list[dict[str, str]], list[dict[str, str]]]`
- Updated docstring to match

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)