### PR TITLE
fix: Use dynamic key for experimental config

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -621,13 +621,15 @@ class SyncClientHandler:
             .get("experimentalConfigs", {})
             .get("entities", {})
         )
-        # Only get the default experimental config
-        default_experimental_config = experimental_configs.get("default", {})
+        config_id, config_data = (
+            next(iter(experimental_configs.items()), {}) if experimental_configs else {}
+        )
+        # Only get the first experimental config
         return {
-            "default": ExperimentalConfig(
-                resource_id="default",
+            config_id: ExperimentalConfig(
+                resource_id=config_id,
                 name="experimental_config",
-                config=default_experimental_config.get("features", {}),
+                config=config_data.get("features", {}),
             )
         }
 


### PR DESCRIPTION
## Summary

Stop hardcoding `"default"` as the experimental config key — use the actual key from the projection dict instead.

## Motivation

Projects with a non-default experimental config identifier fail because `_read_experimental_config_from_projection` always looks up `"default"`. This dynamically reads the first config entry.

## Changes

- Read the first key-value pair from the experimental configs dict instead of hardcoding `"default"`
- Use the actual config ID as both the dict key and `resource_id`

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)