### PR TITLE
feat: add poly login command for multi-region auth

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -258,7 +258,6 @@ class AgentStudioCLI:
                 "Examples:\n"
                 "  poly login\n"
                 "  poly login --region us-1\n"
-                "Note: Enterprise clients should specify a region."
             ),
         )
         login_parser.add_argument(

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -248,7 +248,7 @@ class AgentStudioCLI:
         signin_parser = subparsers.add_parser(
             "signin",
             parents=[verbose_parent, debug_parent],
-            help="Sign in to your Agent Studio account and save API key credentials for CLI access.",
+            help="Sign in to an existing Agent Studio account",
             description=(
                 "Sign in to your existing Agent Studio account and save API key credentials"
                 " for CLI access.\n\n"
@@ -265,8 +265,8 @@ class AgentStudioCLI:
             "--region",
             type=str,
             choices=REGIONS,
-            default="studio",
-            help="Region to sign in to. Defaults to 'studio' (the free-tier region). Enterprise clients should specify their region.",
+            default=None,
+            help="Region to sign in to. If omitted, you will be prompted to select one.",
         )
 
         # INIT
@@ -3962,7 +3962,7 @@ class AgentStudioCLI:
             info("You can create a new project later by running 'poly project create'")
 
     @classmethod
-    def signin(cls, region: str = "studio") -> None:
+    def signin(cls, region: str | None = None) -> None:
         """Sign in to an existing Agent Studio account and save API key credentials."""
         print_welcome_message()
         plain(
@@ -3971,11 +3971,19 @@ class AgentStudioCLI:
         )
         questionary.press_any_key_to_continue("Press any key to continue...").ask()
 
+        if region is None:
+            region = questionary.select(
+                "Select your region:",
+                choices=REGIONS,
+                default="studio",
+            ).ask()
+
         jwt_access_token = cls._signin(region)
         cls._authenticate_and_save_key(jwt_access_token, region=region)
+        success("Signed in successfully!")
 
     @classmethod
-    def _authenticate_and_save_key(cls, jwt_access_token: str, region: str) -> str:
+    def _authenticate_and_save_key(cls, jwt_access_token: str, region: str) -> None:
         """Authorise the user, fetch or create a PAT, and save it to the credential file."""
         api_handler = AgentStudioInterface()
 
@@ -3986,6 +3994,9 @@ class AgentStudioCLI:
         user_pats = api_handler.get_pats(region=region, jwt_token=jwt_access_token)
         if user_pats:
             pat = user_pats[0].get("key")
+            if not pat:
+                error("API key not found in account data. Please contact support.")
+                sys.exit(1)
             os.environ["POLY_ADK_KEY"] = pat
             success(f"Found existing API Token: {mask_api_key(pat)}")
         else:
@@ -4019,7 +4030,6 @@ class AgentStudioCLI:
         plain("API key has been saved to your credential file for future use.")
         info(f"Credential file path: {CREDENTIALS_FILE_PATH}")
         plain("")
-        return pat
 
     @classmethod
     def _signin(cls, region: str) -> str:
@@ -4050,7 +4060,7 @@ class AgentStudioCLI:
             while not access_token:
                 time.sleep(interval)
                 try:
-                    token_response = auth0_handler.poll_device_token(device_code, region)
+                    token_response = auth0_handler.poll_device_token(region, device_code)
                     access_token = token_response.get("access_token")
                 except requests.HTTPError as e:
                     try:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -225,13 +225,16 @@ class AgentStudioCLI:
             help="Write output to FILE_PATH instead of stdout.",
         )
 
-        # Start
+        # Start (new free-tier users)
         start_parser = subparsers.add_parser(
             "start",
             parents=[verbose_parent, debug_parent],
             help="Get started with PolyAI Agent Studio",
             description=(
-                "Create a new Agent Studio Account, set up API key and create a first project with a single command.\n\n"
+                "Create a new Agent Studio account, set up your API key, and create a first project"
+                " with a single command.\n\n"
+                "Examples:\n"
+                "  poly start\n"
             ),
         )
         start_parser.add_argument(
@@ -239,6 +242,31 @@ class AgentStudioCLI:
             type=str,
             default=os.getcwd(),
             help="Base path to initialize the project. Defaults to current working directory.",
+        )
+
+        # Signin (existing enterprise users)
+        signin_parser = subparsers.add_parser(
+            "signin",
+            parents=[verbose_parent, debug_parent],
+            help="Sign in to your Agent Studio account and save API key credentials for CLI access.",
+            description=(
+                "Sign in to your existing Agent Studio account and save API key credentials"
+                " for CLI access.\n\n"
+                "This command will open a browser window for you to authenticate and authorize"
+                " the CLI. After successful authentication, the necessary API key credentials"
+                " will be saved to a local credential file for future CLI commands.\n\n"
+                "Examples:\n"
+                "  poly signin\n"
+                "  poly signin --region us-1\n"
+                "Note: Enterprise clients should specify a region."
+            ),
+        )
+        signin_parser.add_argument(
+            "--region",
+            type=str,
+            choices=REGIONS,
+            default="studio",
+            help="Region to sign in to. Defaults to 'studio' (the free-tier region). Enterprise clients should specify their region.",
         )
 
         # INIT
@@ -1351,9 +1379,10 @@ class AgentStudioCLI:
                     )
 
             elif args.command == "start":
-                cls.start(
-                    base_path=args.base_path,
-                )
+                cls.start(base_path=args.base_path)
+
+            elif args.command == "signin":
+                cls.signin(region=args.region)
 
         except Exception as e:
             if hasattr(args, "json") and args.json:
@@ -3886,10 +3915,11 @@ class AgentStudioCLI:
 
     @classmethod
     def start(cls, base_path: str) -> None:
-        """Authenticate via device flow, obtain a JWT, and initialise a project."""
+        """Create an Agent Studio account, set up API key, and create a first project."""
         print_welcome_message()
         plain(
-            "This will guide you through setting up your API key and creating a new project in Agent Studio."
+            "This will guide you through setting up your API key"
+            " and creating a new project in Agent Studio."
         )
         questionary.press_any_key_to_continue("Press any key to continue...").ask()
 
@@ -3914,54 +3944,13 @@ class AgentStudioCLI:
                     info("You can create a new project later by running 'poly project create'")
                 return
 
-        # --- 2. Create account/signin via device flow ---
+        # --- 2. Sign in via device flow ---
         jwt_access_token = cls._signin()
 
-        api_handler = AgentStudioInterface()
+        # --- 3. Authorise and save API key ---
+        cls._authenticate_and_save_key(jwt_access_token, region="studio")
 
-        # --- 3. Authorise user  ---
-        info("Setting up your account...")
-        api_handler.authorise(region="studio", jwt_token=jwt_access_token)
-
-        # --- 4. Generate PAT token ---
-        info("Fetching API key...")
-        user_pats = api_handler.get_pats(region="studio", jwt_token=jwt_access_token)
-        if user_pats:
-            pat = user_pats[0].get("key")
-            os.environ["POLY_ADK_KEY"] = pat
-            success(f"Found existing API Token: {mask_api_key(pat)}")
-        else:
-            info("No existing API key found in your account.")
-            ctx = console.status("[info]Creating a new API key...[/info]")
-            with ctx:
-                pat = api_handler.create_pat(
-                    region="studio", jwt_token=jwt_access_token, name="adk-key"
-                )
-                os.environ["POLY_ADK_KEY"] = pat
-
-                attempts = 0
-                # After creating a new PAT, there may be a short delay before it's active.
-                # Poll the accounts endpoint until it works or we hit a timeout.
-                while attempts < 10:
-                    try:
-                        api_handler.get_accounts(region="studio")
-                        break
-                    except Exception:
-                        attempts += 1
-                        time.sleep(1)
-                else:
-                    error(
-                        "API key was created but is not active yet. Please wait a moment and try again."
-                    )
-                    sys.exit(1)
-
-            success(f"Created a new API Key: {mask_api_key(pat)}")
-
-        save_api_key_credential_file(pat, region="studio")
-        plain("API key has been saved to your credential file for future use.")
-        info(f"Credential file path: {CREDENTIALS_FILE_PATH}")
-        plain("")
-
+        # --- 4. Optionally create a project ---
         create_project = questionary.confirm(
             "Would you like to create a new project in Agent Studio now?",
             auto_enter=False,
@@ -3971,6 +3960,66 @@ class AgentStudioCLI:
             cls.create_project(base_path, region="studio")
         else:
             info("You can create a new project later by running 'poly project create'")
+
+    @classmethod
+    def signin(cls, region: str = "studio") -> None:
+        """Sign in to an existing Agent Studio account and save API key credentials."""
+        print_welcome_message()
+        plain(
+            "This will guide you through signing in to your Agent Studio account"
+            " and setting up your API key for use with the ADK."
+        )
+        questionary.press_any_key_to_continue("Press any key to continue...").ask()
+
+        jwt_access_token = cls._signin()
+        cls._authenticate_and_save_key(jwt_access_token, region=region)
+
+    @classmethod
+    def _authenticate_and_save_key(cls, jwt_access_token: str, region: str) -> str:
+        """Authorise the user, fetch or create a PAT, and save it to the credential file."""
+        api_handler = AgentStudioInterface()
+
+        info("Setting up your account...")
+        api_handler.authorise(region=region, jwt_token=jwt_access_token)
+
+        info("Fetching API key...")
+        user_pats = api_handler.get_pats(region=region, jwt_token=jwt_access_token)
+        if user_pats:
+            pat = user_pats[0].get("key")
+            os.environ["POLY_ADK_KEY"] = pat
+            success(f"Found existing API Token: {mask_api_key(pat)}")
+        else:
+            info("No existing API key found in your account.")
+            ctx = console.status("[info]Creating a new API key...[/info]")
+            with ctx:
+                pat = api_handler.create_pat(
+                    region=region, jwt_token=jwt_access_token, name="adk-key"
+                )
+                os.environ["POLY_ADK_KEY"] = pat
+
+                attempts = 0
+                # After creating a new PAT, there may be a short delay before it's active.
+                while attempts < 10:
+                    try:
+                        api_handler.get_accounts(region=region)
+                        break
+                    except Exception:
+                        attempts += 1
+                        time.sleep(1)
+                else:
+                    error(
+                        "API key was created but is not active yet."
+                        " Please wait a moment and try again."
+                    )
+                    sys.exit(1)
+
+            success(f"Created a new API Key: {mask_api_key(pat)}")
+
+        save_api_key_credential_file(pat, region=region)
+        plain("API key has been saved to your credential file for future use.")
+        info(f"Credential file path: {CREDENTIALS_FILE_PATH}")
+        plain("")
+        return pat
 
     @classmethod
     def _signin(cls) -> str:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -244,29 +244,29 @@ class AgentStudioCLI:
             help="Base path to initialize the project. Defaults to current working directory.",
         )
 
-        # Signin (existing enterprise users)
-        signin_parser = subparsers.add_parser(
-            "signin",
+        # Login (existing enterprise users)
+        login_parser = subparsers.add_parser(
+            "login",
             parents=[verbose_parent, debug_parent],
-            help="Sign in to an existing Agent Studio account",
+            help="Log in to an existing Agent Studio account",
             description=(
-                "Sign in to your existing Agent Studio account and save API key credentials"
+                "Log in to your existing Agent Studio account and save API key credentials"
                 " for CLI access.\n\n"
                 "This command will open a browser window for you to authenticate and authorize"
                 " the CLI. After successful authentication, the necessary API key credentials"
                 " will be saved to a local credential file for future CLI commands.\n\n"
                 "Examples:\n"
-                "  poly signin\n"
-                "  poly signin --region us-1\n"
+                "  poly login\n"
+                "  poly login --region us-1\n"
                 "Note: Enterprise clients should specify a region."
             ),
         )
-        signin_parser.add_argument(
+        login_parser.add_argument(
             "--region",
             type=str,
             choices=REGIONS,
             default=None,
-            help="Region to sign in to. If omitted, you will be prompted to select one.",
+            help="Region to log in to. If omitted, you will be prompted to select one.",
         )
 
         # INIT
@@ -1381,8 +1381,8 @@ class AgentStudioCLI:
             elif args.command == "start":
                 cls.start(base_path=args.base_path)
 
-            elif args.command == "signin":
-                cls.signin(region=args.region)
+            elif args.command == "login":
+                cls.login(region=args.region)
 
         except Exception as e:
             if hasattr(args, "json") and args.json:
@@ -3962,11 +3962,11 @@ class AgentStudioCLI:
             info("You can create a new project later by running 'poly project create'")
 
     @classmethod
-    def signin(cls, region: str | None = None) -> None:
-        """Sign in to an existing Agent Studio account and save API key credentials."""
+    def login(cls, region: str | None = None) -> None:
+        """Log in to an existing Agent Studio account and save API key credentials."""
         print_welcome_message()
         plain(
-            "This will guide you through signing in to your Agent Studio account"
+            "This will guide you through logging in to your Agent Studio account"
             " and setting up your API key for use with the ADK."
         )
         questionary.press_any_key_to_continue("Press any key to continue...").ask()
@@ -3985,7 +3985,7 @@ class AgentStudioCLI:
 
         jwt_access_token = cls._signin(region)
         cls._authenticate_and_save_key(jwt_access_token, region=region)
-        success("Signed in successfully!")
+        success("Logged in successfully!")
 
     @classmethod
     def _authenticate_and_save_key(cls, jwt_access_token: str, region: str) -> None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3949,7 +3949,23 @@ class AgentStudioCLI:
         # --- 3. Authorise and save API key ---
         cls._authenticate_and_save_key(jwt_access_token, region="studio")
 
-        # --- 4. Optionally create a project ---
+        # --- 4. Wait for the new PAT to become active (needed for project creation) ---
+        api_handler = AgentStudioInterface()
+        with console.status("[info]Verifying API key is active...[/info]"):
+            for attempt in range(20):
+                try:
+                    api_handler.get_accounts(region="studio")
+                    break
+                except Exception:
+                    time.sleep(1)
+            else:
+                error(
+                    "API key was created but is not active yet."
+                    " Please wait a moment and try 'poly project create'."
+                )
+                return
+
+        # --- 5. Optionally create a project ---
         create_project = questionary.confirm(
             "Would you like to create a new project in Agent Studio now?",
             auto_enter=False,
@@ -4011,22 +4027,6 @@ class AgentStudioCLI:
                     region=region, jwt_token=jwt_access_token, name="adk-key"
                 )
                 os.environ["POLY_ADK_KEY"] = pat
-
-                attempts = 0
-                # After creating a new PAT, there may be a short delay before it's active.
-                while attempts < 10:
-                    try:
-                        api_handler.get_accounts(region=region)
-                        break
-                    except Exception:
-                        attempts += 1
-                        time.sleep(1)
-                else:
-                    error(
-                        "API key was created but is not active yet."
-                        " Please wait a moment and try again."
-                    )
-                    sys.exit(1)
 
             success(f"Created a new API Key: {mask_api_key(pat)}")
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3952,7 +3952,7 @@ class AgentStudioCLI:
         # --- 4. Wait for the new PAT to become active (needed for project creation) ---
         api_handler = AgentStudioInterface()
         with console.status("[info]Verifying API key is active...[/info]"):
-            for attempt in range(20):
+            for _ in range(20):
                 try:
                     api_handler.get_accounts(region="studio")
                     break

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3974,7 +3974,12 @@ class AgentStudioCLI:
         if region is None:
             region = questionary.select(
                 "Select your region:",
-                choices=REGIONS,
+                choices=[
+                    questionary.Choice("Studio", value="studio"),
+                    questionary.Choice("US (us-1) — Enterprise", value="us-1"),
+                    questionary.Choice("UK (uk-1) — Enterprise", value="uk-1"),
+                    questionary.Choice("EU West (euw-1) — Enterprise", value="euw-1"),
+                ],
                 default="studio",
             ).ask()
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3945,7 +3945,7 @@ class AgentStudioCLI:
                 return
 
         # --- 2. Sign in via device flow ---
-        jwt_access_token = cls._signin()
+        jwt_access_token = cls._signin("studio")
 
         # --- 3. Authorise and save API key ---
         cls._authenticate_and_save_key(jwt_access_token, region="studio")
@@ -3971,7 +3971,7 @@ class AgentStudioCLI:
         )
         questionary.press_any_key_to_continue("Press any key to continue...").ask()
 
-        jwt_access_token = cls._signin()
+        jwt_access_token = cls._signin(region)
         cls._authenticate_and_save_key(jwt_access_token, region=region)
 
     @classmethod
@@ -4022,12 +4022,12 @@ class AgentStudioCLI:
         return pat
 
     @classmethod
-    def _signin(cls) -> str:
+    def _signin(cls, region: str) -> str:
         """Sign in via the Auth0 device authorization flow and return a JWT access token."""
         auth0_handler = Auth0Handler()
 
         try:
-            device_response = auth0_handler.request_device_code()
+            device_response = auth0_handler.request_device_code(region)
         except Exception as e:
             error(f"Failed to start authorization: {e}")
             sys.exit(1)
@@ -4050,7 +4050,7 @@ class AgentStudioCLI:
             while not access_token:
                 time.sleep(interval)
                 try:
-                    token_response = auth0_handler.poll_device_token(device_code)
+                    token_response = auth0_handler.poll_device_token(device_code, region)
                     access_token = token_response.get("access_token")
                 except requests.HTTPError as e:
                     try:

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -21,7 +21,8 @@ class AuthDetails:
 
 REGION_TO_AUTH_DETAILS = {
     "studio": AuthDetails(
-        base_url="https://login.studio.poly.ai", device_client_id="6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd"
+        base_url="https://login.studio.poly.ai",
+        device_client_id="6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd",
     ),
     "us-1": AuthDetails(
         base_url="https://login.us-1.polyai.app",
@@ -36,7 +37,8 @@ REGION_TO_AUTH_DETAILS = {
         device_client_id="SjDXzApQAQ9TkJHSDlASLkw7lBOe2QA4",
     ),
     "dev": AuthDetails(
-        base_url="https://login.dev.polyai.app", device_client_id="xkHpmZsOmINkW5Khe406tHJPm9XkDVdf"
+        base_url="https://login.dev.polyai.app",
+        device_client_id="xkHpmZsOmINkW5Khe406tHJPm9XkDVdf",
     ),
     "staging": AuthDetails(
         base_url="https://login.staging.polyai.app",
@@ -50,14 +52,14 @@ class Auth0Handler:
 
     @staticmethod
     def make_request(
-        region: str,
+        base_url: str,
         endpoint: str,
         method: str,
         data: Optional[dict] = None,
         params: Optional[dict] = None,
     ) -> dict:
         """Make a request to the Auth0 API."""
-        url = REGION_TO_AUTH_DETAILS.get(region).base_url + endpoint
+        url = base_url + endpoint
 
         headers = {"Content-Type": "application/json"}
 
@@ -104,18 +106,26 @@ class Auth0Handler:
             Dict containing device_code, user_code, verification_uri,
             verification_uri_complete, expires_in, and interval.
         """
+        auth_details = REGION_TO_AUTH_DETAILS.get(region)
+        if auth_details is None:
+            raise ValueError(
+                f"Unknown region '{region}'. Valid regions: {', '.join(REGION_TO_AUTH_DETAILS)}"
+            )
         data = {
-            "client_id": REGION_TO_AUTH_DETAILS.get(region).device_client_id,
+            "client_id": auth_details.device_client_id,
             "scope": "openid profile email",
             "audience": "https://platform.polyai.app/api",
         }
-        return cls.make_request(region, "/oauth/device/code", method="POST", data=data)
+        return cls.make_request(
+            auth_details.base_url, "/oauth/device/code", method="POST", data=data
+        )
 
     @classmethod
-    def poll_device_token(cls, device_code: str, region: str) -> dict:
+    def poll_device_token(cls, region: str, device_code: str) -> dict:
         """Poll for a token after the user has authorized the device.
 
         Args:
+            region: The Auth0 region to poll.
             device_code: The device_code from request_device_code.
 
         Returns:
@@ -125,9 +135,14 @@ class Auth0Handler:
             requests.HTTPError: 403 with 'authorization_pending' or 'slow_down'
                 while the user hasn't authorized yet.
         """
+        auth_details = REGION_TO_AUTH_DETAILS.get(region)
+        if auth_details is None:
+            raise ValueError(
+                f"Unknown region '{region}'. Valid regions: {', '.join(REGION_TO_AUTH_DETAILS)}"
+            )
         data = {
-            "client_id": REGION_TO_AUTH_DETAILS.get(region).device_client_id,
+            "client_id": auth_details.device_client_id,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
             "device_code": device_code,
         }
-        return cls.make_request(region, "/oauth/token", method="POST", data=data)
+        return cls.make_request(auth_details.base_url, "/oauth/token", method="POST", data=data)

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -5,9 +5,9 @@ Copyright PolyAI Limited
 
 import json
 import logging
+from dataclasses import dataclass
 from typing import Optional
 
-from dataclasses import dataclass
 import requests
 
 logger = logging.getLogger(__name__)

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -7,12 +7,42 @@ import json
 import logging
 from typing import Optional
 
+from dataclasses import dataclass
 import requests
 
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://login.studio.poly.ai"
-DEVICE_CLIENT_ID = "6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd"
+
+@dataclass
+class AuthDetails:
+    base_url: str
+    device_client_id: str
+
+
+REGION_TO_AUTH_DETAILS = {
+    "studio": AuthDetails(
+        base_url="https://login.studio.poly.ai", device_client_id="6uLCbsn6UxXJlnGKE4ypqwQqt3UqTUnd"
+    ),
+    "us-1": AuthDetails(
+        base_url="https://login.us-1.polyai.app",
+        device_client_id="kjV5BoAXagNnK6aGiUnJQ6xJ3hbphwE2",
+    ),
+    "uk-1": AuthDetails(
+        base_url="https://login.uk-1.polyai.app",
+        device_client_id="uHdlq2JZZoZ3RAzYDvl0o0R2E3glxj1q",
+    ),
+    "euw-1": AuthDetails(
+        base_url="https://login.euw-1.polyai.app",
+        device_client_id="SjDXzApQAQ9TkJHSDlASLkw7lBOe2QA4",
+    ),
+    "dev": AuthDetails(
+        base_url="https://login.dev.polyai.app", device_client_id="xkHpmZsOmINkW5Khe406tHJPm9XkDVdf"
+    ),
+    "staging": AuthDetails(
+        base_url="https://login.staging.polyai.app",
+        device_client_id="lnq8WDCLLJ5uacDIrhnOFQAkohg6PJkB",
+    ),
+}
 
 
 class Auth0Handler:
@@ -20,10 +50,14 @@ class Auth0Handler:
 
     @staticmethod
     def make_request(
-        endpoint: str, method: str, data: Optional[dict] = None, params: Optional[dict] = None
+        region: str,
+        endpoint: str,
+        method: str,
+        data: Optional[dict] = None,
+        params: Optional[dict] = None,
     ) -> dict:
         """Make a request to the Auth0 API."""
-        url = BASE_URL + endpoint
+        url = REGION_TO_AUTH_DETAILS.get(region).base_url + endpoint
 
         headers = {"Content-Type": "application/json"}
 
@@ -63,7 +97,7 @@ class Auth0Handler:
         return api_response
 
     @classmethod
-    def request_device_code(cls) -> dict:
+    def request_device_code(cls, region: str) -> dict:
         """Start the device authorization flow.
 
         Returns:
@@ -71,14 +105,14 @@ class Auth0Handler:
             verification_uri_complete, expires_in, and interval.
         """
         data = {
-            "client_id": DEVICE_CLIENT_ID,
+            "client_id": REGION_TO_AUTH_DETAILS.get(region).device_client_id,
             "scope": "openid profile email",
             "audience": "https://platform.polyai.app/api",
         }
-        return cls.make_request("/oauth/device/code", method="POST", data=data)
+        return cls.make_request(region, "/oauth/device/code", method="POST", data=data)
 
     @classmethod
-    def poll_device_token(cls, device_code: str) -> dict:
+    def poll_device_token(cls, device_code: str, region: str) -> dict:
         """Poll for a token after the user has authorized the device.
 
         Args:
@@ -92,8 +126,8 @@ class Auth0Handler:
                 while the user hasn't authorized yet.
         """
         data = {
+            "client_id": REGION_TO_AUTH_DETAILS.get(region).device_client_id,
             "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            "client_id": DEVICE_CLIENT_ID,
             "device_code": device_code,
         }
-        return cls.make_request("/oauth/token", method="POST", data=data)
+        return cls.make_request(region, "/oauth/token", method="POST", data=data)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -12,7 +12,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 
 from poly.constants import DEFAULT_VOICE_ID_FALLBACK, DEFAULT_VOICE_IDS
-from poly.utils import retrieve_api_key, any_credentials_exist
+from poly.utils import any_credentials_exist, retrieve_api_key
 
 logger = logging.getLogger(__name__)
 ACCOUNTS_URL = "/adk/v1/accounts"

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -7,10 +7,10 @@ import ast
 import difflib
 import importlib.resources
 import inspect
+import json
 import logging
 import os
 import re
-import json
 from typing import Callable, Optional
 
 from poly.resources import Function, FunctionStep, Resource, ResourceMapping


### PR DESCRIPTION
## Summary

Add a new `poly login` command that allows existing enterprise users to authenticate against any region, alongside the existing `poly start` flow for free-tier users.

## Motivation

Enterprise clients need to authenticate against their specific region (us-1, uk-1, euw-1) rather than the default studio region. Previously only `poly start` existed, which was hardcoded to the studio region.

## Changes

- Add `poly login` command with `--region` flag and interactive region selector
- Extract `_authenticate_and_save_key` helper from `start` to share auth logic between `start` and `login`
- Add `REGION_TO_AUTH_DETAILS` mapping in `Auth0Handler` with per-region base URLs and client IDs
- Validate region in auth methods with clear error messages
- `make_request` now takes `base_url` directly instead of resolving region internally
- Hide dev/staging regions from interactive prompt (still accessible via `--region` flag)
- Guard against `None` PAT from API response

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly login`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)