### PR TITLE
fix: add tab-completion for branch switch and misc CLI fixes

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -135,9 +135,8 @@ def _format_gist_choice(g: dict) -> str:
 class AgentStudioCLI:
     """CLI Interface for Agent Studio."""
 
-    @classmethod
+    @staticmethod
     def _branch_name_completer(
-        cls,
         prefix: str,
         action: Any = None,
         parser: Any = None,
@@ -147,7 +146,7 @@ class AgentStudioCLI:
         """Return deletable branch names for argcomplete tab-completion."""
         try:
             base_path = getattr(parsed_args, "path", None) or os.getcwd()
-            project = cls.read_project_config(base_path)
+            project = AgentStudioCLI.read_project_config(base_path)
             if project is None:
                 return []
             _, branches = project.get_branches()
@@ -565,7 +564,7 @@ class AgentStudioCLI:
             help="Base path to the project. Defaults to current working directory.",
         )
 
-        review_subparsers = review_parser.add_subparsers(dest="review_subcommand")
+        review_subparsers = review_parser.add_subparsers(dest="review_subcommand", required=True)
 
         review_create_parser = review_subparsers.add_parser(
             "create",
@@ -683,7 +682,7 @@ class AgentStudioCLI:
         )
         branch_switch_parser.add_argument(
             "branch_name", nargs="?", help="Name of the branch to switch to."
-        )
+        ).completer = cls._branch_name_completer
         branch_switch_parser.add_argument(
             "--format",
             action="store_true",

--- a/uv.lock
+++ b/uv.lock
@@ -218,6 +218,15 @@ wheels = [
 ]
 
 [[package]]
+name = "langcodes"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/75/f9edc5d72945019312f359e69ded9f82392a81d49c5051ed3209b100c0d2/langcodes-3.5.1.tar.gz", hash = "sha256:40bff315e01b01d11c2ae3928dd4f5cbd74dd38f9bd912c12b9a3606c143f731", size = 191084, upload-time = "2025-12-02T16:22:01.627Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/c1/d10b371bcba7abce05e2b33910e39c33cfa496a53f13640b7b8e10bb4d2b/langcodes-3.5.1-py3-none-any.whl", hash = "sha256:b6a9c25c603804e2d169165091d0cdb23934610524a21d226e4f463e8e958a72", size = 183050, upload-time = "2025-12-02T16:21:59.954Z" },
+]
+
+[[package]]
 name = "licensecheck"
 version = "2024.3"
 source = { registry = "https://pypi.org/simple" }
@@ -332,11 +341,12 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.16.1"
+version = "0.20.4"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
     { name = "jsonschema" },
+    { name = "langcodes" },
     { name = "protobuf" },
     { name = "python-dateutil" },
     { name = "questionary" },
@@ -363,6 +373,7 @@ requires-dist = [
     { name = "argcomplete", specifier = ">=3.0.0" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "jsonschema", specifier = ">=4.20.0" },
+    { name = "langcodes", specifier = "==3.5.1" },
     { name = "licensecheck", marker = "extra == 'dev'", specifier = ">=2024.3" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },


### PR DESCRIPTION
## Summary

Adds tab-completion support for `poly branch switch` and fixes related CLI issues.

## Motivation

Branch names weren't being tab-completed on the `switch` subcommand, making it harder to quickly switch branches. The `_branch_name_completer` was also a classmethod which caused issues with argcomplete's expected function signature.

## Changes

- Changed `_branch_name_completer` from `@classmethod` to `@staticmethod` (argcomplete expects a plain callable, not a bound method)
- Attached `.completer` to the `branch_name` argument on `branch switch` for tab-completion
- Made `review` subcommand `required=True` so it shows help instead of silently doing nothing

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)