### PR TITLE
feat: add poly conversations list/get/get-audio

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1227,7 +1227,7 @@ class AgentStudioCLI:
 
         conv_audio_parser = conversations_subparsers.add_parser(
             "get-audio",
-            parents=[conversations_path_parent, verbose_parent],
+            parents=[conversations_path_parent, json_parent, verbose_parent],
             help="Download audio recording for a conversation.",
             description=(
                 "Download the audio recording for a conversation as a WAV file.\n\n"
@@ -1505,6 +1505,7 @@ class AgentStudioCLI:
                         direction=args.direction,
                         redacted=args.redacted,
                         output_path=args.output,
+                        output_json=args.json,
                     )
 
             elif args.command == "start":
@@ -4112,6 +4113,7 @@ class AgentStudioCLI:
         direction: str = "combined",
         redacted: bool = False,
         output_path: Optional[str] = None,
+        output_json: bool = False,
     ) -> None:
         """Download audio recording for a conversation.
 
@@ -4121,8 +4123,9 @@ class AgentStudioCLI:
             direction: Audio direction — combined, user, or agent.
             redacted: Whether to download redacted audio.
             output_path: Output file path. Defaults to <conversation_id>.wav.
+            output_json: If True, emit machine-readable JSON.
         """
-        project = cls._load_project(base_path)
+        project = cls._load_project(base_path, output_json=output_json)
         audio_data = AgentStudioInterface.get_conversation_audio(
             region=project.region,
             project_id=project.project_id,
@@ -4137,8 +4140,21 @@ class AgentStudioCLI:
         with open(output_path, "wb") as f:
             f.write(audio_data)
 
-        size_mb = len(audio_data) / 1_000_000
-        success(f"Audio saved to {output_path} ({size_mb:.1f} MB)")
+        size_bytes = len(audio_data)
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "conversation_id": conversation_id,
+                    "direction": direction,
+                    "redacted": redacted,
+                    "output_path": output_path,
+                    "size_bytes": size_bytes,
+                }
+            )
+        else:
+            size_mb = size_bytes / 1_000_000
+            success(f"Audio saved to {output_path} ({size_mb:.1f} MB)")
 
     @classmethod
     def start(cls, base_path: str) -> None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -40,6 +40,8 @@ from poly.output.console import (
     info,
     plain,
     print_branches,
+    print_conversations,
+    print_conversation_detail,
     print_diff,
     print_file_list,
     print_status,
@@ -1154,6 +1156,112 @@ class AgentStudioCLI:
             help="Show what would be rolled back without actually rolling back. Displays the target deployment and reverted deployments.",
         )
 
+        # CONVERSATIONS
+        conversations_path_parent = ArgumentParser(add_help=False)
+        conversations_path_parent.add_argument(
+            "--path",
+            type=str,
+            default=os.getcwd(),
+            help="Base path to the project. Defaults to current working directory.",
+        )
+
+        conversations_parser = subparsers.add_parser(
+            "conversations",
+            parents=[verbose_parent],
+            help="List and inspect conversations.",
+            description=(
+                "List and inspect conversations for the project.\n\n"
+                "Examples:\n"
+                "  poly conversations list\n"
+                "  poly conversations get <conversation_id>\n"
+                "  poly conversations get-audio <conversation_id> -o recording.wav\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        conversations_subparsers = conversations_parser.add_subparsers(
+            dest="conversations_subcommand", required=True
+        )
+
+        conv_list_parser = conversations_subparsers.add_parser(
+            "list",
+            parents=[conversations_path_parent, json_parent, verbose_parent],
+            help="List conversations for the project.",
+            description=(
+                "List conversations for the project.\n\n"
+                "Examples:\n"
+                "  poly conversations list\n"
+                "  poly conversations list --limit 20 --offset 10\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        conv_list_parser.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Max number of conversations to return. Defaults to 50.",
+        )
+        conv_list_parser.add_argument(
+            "--offset",
+            type=int,
+            default=0,
+            help="Number of conversations to skip. Defaults to 0.",
+        )
+
+        conv_get_parser = conversations_subparsers.add_parser(
+            "get",
+            parents=[conversations_path_parent, json_parent, verbose_parent],
+            help="Get details for a specific conversation.",
+            description=(
+                "Get detailed information for a conversation including turns.\n\n"
+                "Examples:\n"
+                "  poly conversations get <conversation_id>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        conv_get_parser.add_argument(
+            "conversation_id",
+            type=str,
+            help="The conversation ID.",
+        )
+
+        conv_audio_parser = conversations_subparsers.add_parser(
+            "get-audio",
+            parents=[conversations_path_parent, verbose_parent],
+            help="Download audio recording for a conversation.",
+            description=(
+                "Download the audio recording for a conversation as a WAV file.\n\n"
+                "Examples:\n"
+                "  poly conversations get-audio <conversation_id>\n"
+                "  poly conversations get-audio <conversation_id> --direction user\n"
+                "  poly conversations get-audio <conversation_id> --redacted -o redacted.wav\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        conv_audio_parser.add_argument(
+            "conversation_id",
+            type=str,
+            help="The conversation ID.",
+        )
+        conv_audio_parser.add_argument(
+            "--direction",
+            type=str,
+            default="combined",
+            choices=["combined", "user", "agent"],
+            help="Audio direction. Defaults to combined.",
+        )
+        conv_audio_parser.add_argument(
+            "--redacted",
+            action="store_true",
+            help="Download redacted audio.",
+        )
+        conv_audio_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            help="Output file path. Defaults to <conversation_id>.wav.",
+        )
+
         return parser
 
     @classmethod
@@ -1374,6 +1482,29 @@ class AgentStudioCLI:
                         force=args.force,
                         output_json=args.json,
                         dry_run=args.dry_run,
+                    )
+
+            elif args.command == "conversations":
+                if args.conversations_subcommand == "list":
+                    cls.conversations_list(
+                        args.path,
+                        args.limit,
+                        args.offset,
+                        output_json=args.json,
+                    )
+                elif args.conversations_subcommand == "get":
+                    cls.conversations_get(
+                        args.path,
+                        args.conversation_id,
+                        output_json=args.json,
+                    )
+                elif args.conversations_subcommand == "get-audio":
+                    cls.conversations_get_audio(
+                        args.path,
+                        args.conversation_id,
+                        direction=args.direction,
+                        redacted=args.redacted,
+                        output_path=args.output,
                     )
 
             elif args.command == "start":
@@ -3910,6 +4041,104 @@ class AgentStudioCLI:
             else:
                 error(f"Failed to rollback deployment: {e}")
             sys.exit(1)
+
+    # ── conversations ────────────────────────────────────────────────
+
+    @classmethod
+    def conversations_list(
+        cls,
+        base_path: str,
+        limit: int = 50,
+        offset: int = 0,
+        output_json: bool = False,
+    ) -> None:
+        """List conversations for the project.
+
+        Args:
+            base_path: Base path for the project.
+            limit: Max number of conversations to return.
+            offset: Number of conversations to skip.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = cls._load_project(base_path, output_json=output_json)
+        result = AgentStudioInterface.list_conversations(
+            region=project.region,
+            project_id=project.project_id,
+            limit=limit,
+            offset=offset,
+        )
+        conversations = result.get("conversations", [])
+
+        if output_json:
+            json_print(result)
+        else:
+            if not conversations:
+                info("No conversations found.")
+                return
+            print_conversations(conversations, url_builder=project.get_conversation_url)
+
+    @classmethod
+    def conversations_get(
+        cls,
+        base_path: str,
+        conversation_id: str,
+        output_json: bool = False,
+    ) -> None:
+        """Get details for a specific conversation.
+
+        Args:
+            base_path: Base path for the project.
+            conversation_id: The conversation ID to look up.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = cls._load_project(base_path, output_json=output_json)
+        conversation = AgentStudioInterface.get_conversation(
+            region=project.region,
+            project_id=project.project_id,
+            conversation_id=conversation_id,
+        )
+
+        if output_json:
+            json_print(conversation)
+        else:
+            studio_url = project.get_conversation_url(conversation_id)
+            print_conversation_detail(conversation, studio_url=studio_url)
+
+    @classmethod
+    def conversations_get_audio(
+        cls,
+        base_path: str,
+        conversation_id: str,
+        direction: str = "combined",
+        redacted: bool = False,
+        output_path: Optional[str] = None,
+    ) -> None:
+        """Download audio recording for a conversation.
+
+        Args:
+            base_path: Base path for the project.
+            conversation_id: The conversation ID.
+            direction: Audio direction — combined, user, or agent.
+            redacted: Whether to download redacted audio.
+            output_path: Output file path. Defaults to <conversation_id>.wav.
+        """
+        project = cls._load_project(base_path)
+        audio_data = AgentStudioInterface.get_conversation_audio(
+            region=project.region,
+            project_id=project.project_id,
+            conversation_id=conversation_id,
+            direction=direction,
+            redacted=redacted,
+        )
+
+        if output_path is None:
+            output_path = f"{conversation_id}.wav"
+
+        with open(output_path, "wb") as f:
+            f.write(audio_data)
+
+        size_mb = len(audio_data) / 1_000_000
+        success(f"Audio saved to {output_path} ({size_mb:.1f} MB)")
 
     @classmethod
     def start(cls, base_path: str) -> None:

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -659,3 +659,65 @@ class AgentStudioInterface:
             str: The newly created PAT token
         """
         return PlatformAPIHandler.create_pat_internal(region, jwt_token, name)
+
+    @staticmethod
+    def list_conversations(
+        region: str,
+        project_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict:
+        """List conversations for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of conversations to return.
+            offset: Number of conversations to skip.
+
+        Returns:
+            dict: The API response with conversations, count, limit, offset.
+        """
+        return PlatformAPIHandler.list_conversations(region, project_id, limit, offset)
+
+    @staticmethod
+    def get_conversation(
+        region: str,
+        project_id: str,
+        conversation_id: str,
+    ) -> dict:
+        """Get a conversation by ID.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            conversation_id: The conversation ID.
+
+        Returns:
+            dict: The conversation detail response.
+        """
+        return PlatformAPIHandler.get_conversation(region, project_id, conversation_id)
+
+    @staticmethod
+    def get_conversation_audio(
+        region: str,
+        project_id: str,
+        conversation_id: str,
+        direction: str = "combined",
+        redacted: bool = False,
+    ) -> bytes:
+        """Get audio recording for a conversation.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            conversation_id: The conversation ID.
+            direction: Audio direction — combined, user, or agent.
+            redacted: Whether to return redacted audio.
+
+        Returns:
+            bytes: The raw WAV audio data.
+        """
+        return PlatformAPIHandler.get_conversation_audio(
+            region, project_id, conversation_id, direction, redacted
+        )

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -29,6 +29,9 @@ CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conver
 # These use public APIs not /adk endpoints
 PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/promote"
 ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/rollback"
+CONVERSATIONS_URL = "/v1/agents/{project_id}/conversations"
+CONVERSATION_URL = "/v1/agents/{project_id}/conversations/{conversation_id}"
+CONVERSATION_AUDIO_URL = "/v1/agents/{project_id}/conversations/{conversation_id}/audio"
 
 
 class PlatformAPIHandler:
@@ -625,3 +628,94 @@ class PlatformAPIHandler:
             use_jupiter_api=True,
         )
         return response.get("key")
+
+    @staticmethod
+    def list_conversations(
+        region: str,
+        project_id: str,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict:
+        """List conversations for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of conversations to return.
+            offset: Number of conversations to skip.
+
+        Returns:
+            dict: The API response with conversations, count, limit, offset.
+        """
+        endpoint = CONVERSATIONS_URL.format(project_id=project_id)
+        return PlatformAPIHandler.make_request(
+            region, endpoint, "GET", params={"limit": limit, "offset": offset}
+        )
+
+    @staticmethod
+    def get_conversation(
+        region: str,
+        project_id: str,
+        conversation_id: str,
+    ) -> dict:
+        """Get a conversation by ID.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            conversation_id: The conversation ID.
+
+        Returns:
+            dict: The conversation detail response.
+        """
+        endpoint = CONVERSATION_URL.format(project_id=project_id, conversation_id=conversation_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
+
+    @staticmethod
+    def get_conversation_audio(
+        region: str,
+        project_id: str,
+        conversation_id: str,
+        direction: str = "combined",
+        redacted: bool = False,
+    ) -> bytes:
+        """Get audio recording for a conversation.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            conversation_id: The conversation ID.
+            direction: Audio direction — combined, user, or agent.
+            redacted: Whether to return redacted audio.
+
+        Returns:
+            bytes: The raw WAV audio data.
+        """
+        endpoint = CONVERSATION_AUDIO_URL.format(
+            project_id=project_id, conversation_id=conversation_id
+        )
+        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "X-API-KEY": retrieve_api_key(region),
+            "X-PolyAI-Correlation-Id": correlation_id,
+        }
+        params = {"direction": direction, "redacted": str(redacted).lower()}
+
+        logger.info(f"Making GET request to {url}")
+        response = requests.get(url, headers=headers, params=params, allow_redirects=False)
+
+        logger.debug(
+            f"Request/response url={url!r}"
+            f" status_code={response.status_code!r} content_length={len(response.content)}"
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request status_code={response.status_code!r} response={response.text!r}"
+            )
+            raise
+
+        return response.content

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -657,13 +657,16 @@ def print_conversations(
         conversations: List of conversation summary dicts.
         url_builder: Optional callable(conversation_id) -> str that returns a Studio URL.
     """
+    show_variant = any(c.get("variantId") for c in conversations)
+
     table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
     table.add_column("Conversation ID", style="bold yellow", no_wrap=True)
     table.add_column("Started", no_wrap=True)
     table.add_column("Duration", no_wrap=True, justify="right")
     table.add_column("From", no_wrap=True)
     table.add_column("Channel", no_wrap=True)
-    table.add_column("Variant", no_wrap=True)
+    if show_variant:
+        table.add_column("Variant", no_wrap=True)
     table.add_column("Handoff", no_wrap=True)
     table.add_column("Summary", overflow="fold")
 
@@ -674,7 +677,6 @@ def print_conversations(
         duration = _format_duration(c.get("duration"))
         from_number = c.get("fromNumber") or "—"
         channel = c.get("channel") or "—"
-        variant = c.get("variantId") or "—"
         handoff = ""
         if c.get("handoff"):
             dest = c.get("handoffDestination") or ""
@@ -688,16 +690,11 @@ def print_conversations(
         else:
             cid_display = cid
 
-        table.add_row(
-            cid_display,
-            started,
-            duration,
-            from_number,
-            channel,
-            variant,
-            handoff,
-            summary,
-        )
+        row = [cid_display, started, duration, from_number, channel]
+        if show_variant:
+            row.append(c.get("variantId") or "—")
+        row.extend([handoff, summary])
+        table.add_row(*row)
 
     console.print(table)
 

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -8,6 +8,7 @@ Copyright PolyAI Limited
 import json
 import os
 import sys
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
@@ -608,6 +609,175 @@ def print_deployment_show(
         label = "Reverted deployments" if is_rollback else "Included deployments"
         console.print(f"[label]{label} ({count}):[/label]")
         print_deployments(included_deployments, {})
+
+
+# ── Conversations ────────────────────────────────────────────────────
+
+
+def _format_iso_timestamp(ts: str) -> str:
+    """Format an ISO 8601 timestamp into a compact local-time string."""
+    try:
+        dt = datetime.fromisoformat(ts).astimezone()
+        return dt.strftime("%d %b %y %H:%M %Z")
+    except (TypeError, ValueError):
+        return ts
+
+
+def _extract_summary_heading(short_summary: Any) -> str:
+    """Extract the heading from a shortSummary field (may be a JSON string, dict, or plain string)."""
+    if not short_summary:
+        return "—"
+    if isinstance(short_summary, dict):
+        return short_summary.get("heading") or "—"
+    text = str(short_summary)
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed.get("heading") or "—"
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return text
+
+
+def _format_duration(seconds: int | None) -> str:
+    """Format duration in seconds to a human-readable string."""
+    if seconds is None:
+        return "—"
+    m, s = divmod(seconds, 60)
+    return f"{m}m{s:02d}s" if m else f"{s}s"
+
+
+def print_conversations(
+    conversations: list[dict[str, Any]],
+    url_builder: Callable[[str], str] | None = None,
+) -> None:
+    """Print a table of conversation summaries.
+
+    Args:
+        conversations: List of conversation summary dicts.
+        url_builder: Optional callable(conversation_id) -> str that returns a Studio URL.
+    """
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("Conversation ID", style="bold yellow", no_wrap=True)
+    table.add_column("Started", no_wrap=True)
+    table.add_column("Duration", no_wrap=True, justify="right")
+    table.add_column("From", no_wrap=True)
+    table.add_column("Channel", no_wrap=True)
+    table.add_column("Variant", no_wrap=True)
+    table.add_column("Handoff", no_wrap=True)
+    table.add_column("Summary", overflow="fold")
+
+    for c in conversations:
+        started = c.get("startedAt") or "—"
+        if started != "—":
+            started = _format_iso_timestamp(started)
+        duration = _format_duration(c.get("duration"))
+        from_number = c.get("fromNumber") or "—"
+        channel = c.get("channel") or "—"
+        variant = c.get("variantId") or "—"
+        handoff = ""
+        if c.get("handoff"):
+            dest = c.get("handoffDestination") or ""
+            handoff = f"[yellow]{dest}[/yellow]" if dest else "[yellow]yes[/yellow]"
+        summary = _extract_summary_heading(c.get("shortSummary"))
+
+        cid = c.get("conversationId", "—")
+        if url_builder and cid != "—":
+            url = url_builder(cid)
+            cid_display = f"[link={url}]{cid}[/link]"
+        else:
+            cid_display = cid
+
+        table.add_row(
+            cid_display,
+            started,
+            duration,
+            from_number,
+            channel,
+            variant,
+            handoff,
+            summary,
+        )
+
+    console.print(table)
+
+
+def print_conversation_detail(conversation: dict[str, Any], studio_url: str | None = None) -> None:
+    """Print detailed conversation information including turns.
+
+    Args:
+        conversation: The conversation detail dict from the API.
+        studio_url: Optional Agent Studio URL for the conversation.
+    """
+    cid = conversation.get("conversationId", "—")
+    if studio_url:
+        cid_display = f"[link={studio_url}]{cid}[/link]"
+    else:
+        cid_display = cid
+    console.print(f"[bold]Conversation[/bold] [yellow]{cid_display}[/yellow]")
+    console.print()
+
+    fields = [
+        ("Channel", "channel"),
+        ("Direction", "direction"),
+        ("Language", "language"),
+        ("From", "fromNumber"),
+        ("To", "toNumber"),
+        ("Started", "startedAt"),
+        ("Finished", "finishedAt"),
+        ("Duration", None),
+        ("In Progress", "inProgress"),
+        ("Variant", "variantId"),
+        ("Deployment", "deploymentId"),
+    ]
+    for label, key in fields:
+        if key is None:
+            val = _format_duration(conversation.get("duration"))
+        else:
+            val = conversation.get(key)
+            if val is None:
+                continue
+            if isinstance(val, bool):
+                val = "yes" if val else "no"
+            elif key in ("startedAt", "finishedAt"):
+                val = _format_iso_timestamp(str(val))
+            else:
+                val = str(val)
+        console.print(f"  [bold]{label}:[/bold] {val}")
+
+    if conversation.get("handoff"):
+        dest = conversation.get("handoffDestination") or "—"
+        reason = conversation.get("handoffReason") or "—"
+        console.print(f"  [bold]Handoff:[/bold] {dest} ({reason})")
+
+    tags = conversation.get("tags")
+    if tags:
+        console.print(f"  [bold]Tags:[/bold] {', '.join(tags)}")
+
+    score = conversation.get("polyScore")
+    if score is not None:
+        console.print(f"  [bold]PolyScore:[/bold] {score}")
+
+    summary_heading = _extract_summary_heading(conversation.get("shortSummary"))
+    if summary_heading != "—":
+        console.print(f"\n  [bold]Summary:[/bold] {summary_heading}")
+
+    note = conversation.get("note")
+    if note:
+        console.print(f"  [bold]Note:[/bold] {note}")
+
+    turns = conversation.get("turns")
+    if turns:
+        console.print(f"\n[bold]Turns ({len(turns)}):[/bold]")
+        for turn in turns:
+            user_input = turn.get("user_input", "")
+            agent_response = turn.get("agent_response", "")
+            if user_input:
+                console.print(f"  [green]user:[/green] {user_input}")
+            if agent_response:
+                console.print(f"  [cyan]agent:[/cyan] {agent_response}")
+
+    console.print()
 
 
 # ── Error handling ───────────────────────────────────────────────────

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2422,3 +2422,125 @@ class CreateProjectTest(unittest.TestCase):
             "Hello, how can I help you?",
             None,
         )
+
+
+class ConversationsCommandTest(unittest.TestCase):
+    """Tests for the conversations list/get/get-audio CLI commands."""
+
+    SAMPLE_CONVERSATIONS = {
+        "conversations": [
+            {
+                "conversationId": "KA-123",
+                "startedAt": "2026-05-26T10:00:00+00:00",
+                "duration": 90,
+                "channel": "VOICE-SIP",
+                "variantId": "Voice",
+                "handoff": False,
+                "shortSummary": '{"heading": "Test call", "content": "Details here"}',
+            }
+        ],
+        "count": 1,
+        "limit": 50,
+        "offset": 0,
+    }
+
+    SAMPLE_DETAIL = {
+        "conversationId": "KA-123",
+        "channel": "VOICE-SIP",
+        "startedAt": "2026-05-26T10:00:00+00:00",
+        "duration": 90,
+        "turns": [
+            {"user_input": "", "agent_response": "Hello!"},
+            {"user_input": "Hi", "agent_response": "How can I help?"},
+        ],
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.region = "us-1"
+        self.proj.project_id = "test-project"
+        self.proj.get_conversation_url.return_value = "https://studio.us.poly.ai/conv"
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli.AgentStudioInterface.list_conversations")
+    @patch("poly.cli.print_conversations")
+    def test_list_calls_api_with_params(self, mock_print, mock_api):
+        """conversations list passes limit/offset to the API."""
+        mock_api.return_value = self.SAMPLE_CONVERSATIONS
+
+        AgentStudioCLI.conversations_list(TEST_DIR, limit=20, offset=5)
+
+        mock_api.assert_called_once_with(
+            region="us-1", project_id="test-project", limit=20, offset=5
+        )
+        mock_print.assert_called_once()
+
+    @patch("poly.cli.AgentStudioInterface.list_conversations")
+    @patch("poly.cli.json_print")
+    def test_list_json_outputs_raw_response(self, mock_json, mock_api):
+        """conversations list --json outputs the full API response."""
+        mock_api.return_value = self.SAMPLE_CONVERSATIONS
+
+        AgentStudioCLI.conversations_list(TEST_DIR, output_json=True)
+
+        mock_json.assert_called_once_with(self.SAMPLE_CONVERSATIONS)
+
+    @patch("poly.cli.AgentStudioInterface.list_conversations")
+    @patch("poly.cli.info")
+    def test_list_empty_shows_info(self, mock_info, mock_api):
+        """conversations list with no results shows info message."""
+        mock_api.return_value = {"conversations": [], "count": 0, "limit": 50, "offset": 0}
+
+        AgentStudioCLI.conversations_list(TEST_DIR)
+
+        mock_info.assert_called_once()
+
+    @patch("poly.cli.AgentStudioInterface.get_conversation")
+    @patch("poly.cli.print_conversation_detail")
+    def test_get_calls_api_and_prints(self, mock_print, mock_api):
+        """conversations get calls API with conversation_id and prints detail."""
+        mock_api.return_value = self.SAMPLE_DETAIL
+
+        AgentStudioCLI.conversations_get(TEST_DIR, "KA-123")
+
+        mock_api.assert_called_once_with(
+            region="us-1", project_id="test-project", conversation_id="KA-123"
+        )
+        mock_print.assert_called_once()
+        self.assertEqual(mock_print.call_args[1]["studio_url"], "https://studio.us.poly.ai/conv")
+
+    @patch("poly.cli.AgentStudioInterface.get_conversation")
+    @patch("poly.cli.json_print")
+    def test_get_json_outputs_raw_response(self, mock_json, mock_api):
+        """conversations get --json outputs the full API response."""
+        mock_api.return_value = self.SAMPLE_DETAIL
+
+        AgentStudioCLI.conversations_get(TEST_DIR, "KA-123", output_json=True)
+
+        mock_json.assert_called_once_with(self.SAMPLE_DETAIL)
+
+    @patch("builtins.open", create=True)
+    @patch("poly.cli.AgentStudioInterface.get_conversation_audio")
+    @patch("poly.cli.success")
+    def test_get_audio_writes_file(self, mock_success, mock_api, mock_open):
+        """conversations get-audio downloads and writes a WAV file."""
+        mock_open.return_value.__enter__ = MagicMock()
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        mock_api.return_value = b"\x00" * 2_000_000
+
+        AgentStudioCLI.conversations_get_audio(TEST_DIR, "KA-123", output_path="/tmp/test.wav")
+
+        mock_api.assert_called_once_with(
+            region="us-1",
+            project_id="test-project",
+            conversation_id="KA-123",
+            direction="combined",
+            redacted=False,
+        )
+        mock_success.assert_called_once()
+        self.assertIn("2.0 MB", mock_success.call_args[0][0])


### PR DESCRIPTION
## Summary

Adds `poly conversations list`, `poly conversations get`, and `poly conversations get-audio` commands that use the public Conversations API to list, inspect, and download conversations

## Motivation

Enables users to browse and debug conversations directly from the CLI without needing to open Agent Studio in a browser.

Closes #DEVP-181

## Changes

- Added `CONVERSATIONS_URL`, `CONVERSATION_URL`, `CONVERSATION_AUDIO_URL` endpoint constants and three new static methods (`list_conversations`, `get_conversation`, `get_conversation_audio`) to `PlatformAPIHandler`
- Added corresponding passthrough methods to `AgentStudioInterface`
- Added `conversations` command group to the CLI parser with `list`, `get`, and `get-audio` subcommands
- Added `print_conversations` (table view) and `print_conversation_detail` (detailed view with turns) to console output
- Conversation IDs are rendered as clickable Agent Studio links (same pattern as `poly chat`)
- `shortSummary` JSON string is parsed to extract only the heading
- `get-audio` downloads WAV binary directly (bypasses `make_request` JSON parsing)
- All three subcommands support `--json` for machine-readable output (except `get-audio`)

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

`poly conversations list`
<img width="978" height="103" alt="Screenshot 2026-05-27 at 16 36 35" src="https://github.com/user-attachments/assets/f3a9aae2-fa66-488b-8d67-17ef8a5affac" />

`poly conversations get`
<img width="971" height="399" alt="Screenshot 2026-05-27 at 16 37 06" src="https://github.com/user-attachments/assets/d76b7677-b27c-4f15-a14b-b04d099f2e65" />

`poly conversations get-audio`
<img width="928" height="36" alt="Screenshot 2026-05-27 at 16 37 28" src="https://github.com/user-attachments/assets/6f729da0-4c2d-4902-9f69-2b0a9d7319cb" />