### PR TITLE
fix: Allow disabled non-standard adjectives in personality settings

### DIFF
--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -78,9 +78,11 @@ class SettingsPersonality(YamlResource):
             raise ValueError("Other adjective can only be set if no other adjectives are selected.")
 
         # Adjectives must be from the allowed set
-        if not set(self.adjectives.keys()).issubset(ALLOWED_ADJECTIVES):
+        if any(
+            enabled and adj not in ALLOWED_ADJECTIVES for adj, enabled in self.adjectives.items()
+        ):
             raise ValueError(
-                f"Adjectives must be from the allowed set: {', '.join(ALLOWED_ADJECTIVES)}"
+                f"Enabled adjectives must be from the allowed set: {', '.join(ALLOWED_ADJECTIVES)}"
             )
 
         references = utils.get_references_from_prompt(
@@ -95,7 +97,11 @@ class SettingsPersonality(YamlResource):
 
         return Personality_UpdatePersonality(
             adjectives={
-                "values": self.adjectives,
+                "values": {
+                    adj: enabled
+                    for adj, enabled in self.adjectives.items()
+                    if adj in ALLOWED_ADJECTIVES
+                },
             },
             custom=self.custom,
         )

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1709,7 +1709,16 @@ class SettingsPersonalityTests(unittest.TestCase):
         )
         with self.assertRaises(ValueError) as cm:
             invalid_personality.validate()
-        self.assertIn("Adjectives must be from the allowed set:", str(cm.exception))
+        self.assertIn("Enabled adjectives must be from the allowed set:", str(cm.exception))
+
+        # Test with disabled invalid adjective (valid — only enabled adjectives are checked)
+        personality_with_disabled_invalid = SettingsPersonality(
+            resource_id="personality_123",
+            name="personality",
+            adjectives={"Polite": True, "InvalidAdjective": False},
+            custom="",
+        )
+        self.assertIsNone(personality_with_disabled_invalid.validate())
 
         # Test with custom and 'Other' selected (valid case)
         valid_personality = SettingsPersonality(
@@ -1733,6 +1742,19 @@ class SettingsPersonalityTests(unittest.TestCase):
             "Invalid reference type: global_functions is not a valid reference type for this resource. Valid references are: ['attributes', 'variables']",
             str(cm.exception),
         )
+
+    def test_build_update_proto_filters_invalid_adjectives(self):
+        """Test that build_update_proto excludes non-allowed adjectives from the payload."""
+        personality = SettingsPersonality(
+            resource_id="personality_123",
+            name="personality",
+            adjectives={"Polite": True, "InvalidAdjective": False, "Calm": True},
+            custom="",
+        )
+        proto = personality.build_update_proto()
+        adjective_values = proto.adjectives.values
+        self.assertEqual(adjective_values, {"Polite": True, "Calm": True})
+        self.assertNotIn("InvalidAdjective", adjective_values)
 
     def test_read_local_resource(self):
         """Test reading a personality from a YAML file."""


### PR DESCRIPTION
## Summary

Fixes personality validation to only reject *enabled* invalid adjectives, and filters out non-allowed adjectives from the update proto payload.

## Motivation

The platform can return adjectives not in the local allowed set (e.g. deprecated or new adjectives). Previously, having any such adjective in the local YAML — even disabled — would block pushes. Now disabled non-standard adjectives pass validation and are silently excluded from the update.

## Changes

- `validate()` now only raises on invalid adjectives that are enabled (`True`)
- `build_update_proto()` filters the adjectives dict to only include allowed keys
- Updated error message to clarify "Enabled adjectives"
- Added tests for disabled invalid adjective validation and proto filtering

## Test plan

- [x] Added/updated unit tests (`SettingsPersonalityTests`)
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project

Replicates https://github.com/PolyAI-LDN/local_agent_studio/pull/141

Made with [Cursor](https://cursor.com)