### PR TITLE
fix: Defer API key lookup until first SourcererSDK HTTP request

### DIFF
--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -46,6 +46,24 @@ class SourcererSDK:
         "studio": "https://api.studio.poly.ai/adk/v1",
     }
 
+    _session: requests.Session = None
+
+    @property
+    def session(self) -> requests.Session:
+        if self._session is None:
+            session = requests.Session()
+            correlation_id = f"adk-{uuid.uuid4()}"
+            headers = {
+                "Content-Type": "application/json",
+                "X-API-KEY": retrieve_api_key(self.region),
+                "X-PolyAI-Correlation-Id": correlation_id,
+            }
+            if self.email:
+                headers["X-PolyAI-Email"] = self.email
+            session.headers.update(headers)
+            self._session = session
+        return self._session
+
     def __init__(
         self,
         region: str,
@@ -79,17 +97,7 @@ class SourcererSDK:
             self.base_url = self.ENVIRONMENT_URLS[region]
 
         # Initialize session with auth headers
-        correlation_id = f"adk-{uuid.uuid4()}"
         self.email = os.environ.get("ADK_COMMAND_USER_OVERRIDE")
-        self.session = requests.Session()
-        headers = {
-            "Content-Type": "application/json",
-            "X-API-KEY": retrieve_api_key(self.region),
-            "X-PolyAI-Correlation-Id": correlation_id,
-        }
-        if self.email:
-            headers["X-PolyAI-Email"] = self.email
-        self.session.headers.update(headers)
 
         # Cache for projection and sequence number
         self._projection_cache: Optional[dict[str, Any]] = None


### PR DESCRIPTION
## Summary

Lazy-initialize the `SourcererSDK` HTTP session so `retrieve_api_key()` runs on the first API request, not during `__init__`.

## Motivation

Offline CLI workflows (`poly pull --from-projection`, `poly push --dry-run --output-json-commands`) still construct `SyncClientHandler` / `SourcererSDK` even when no HTTP calls are made. Resolving credentials in `__init__` caused those flows to fail when `POLY_ADK_KEY` was unset.

## Changes

- Add a lazy `session` property on `SourcererSDK` that builds the `requests.Session` and auth headers on first use
- Remove eager session creation and `retrieve_api_key()` from `SourcererSDK.__init__`

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

Manual checks:

- [x] `poly push --from-projection - < proj.json --json --dry-run --output-json-commands` works without `POLY_ADK_KEY` when `branch_id` is set in `project.yaml`
- [x] `poly push` still authenticates and sends when API key is configured
- [x] `poly pull` / branch operations still work with a valid API key

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass (pre-commit on commit)
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

N/A