### PR TITLE
fix: default language mapping name + projection key for translations

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -938,7 +938,7 @@ class SyncClientHandler:
         if not language_data:
             return {DefaultLanguage: {}, AdditionalLanguage: {}}
 
-        default_code = language_data.get("defaultLanguage")
+        default_code = language_data.get("defaultLanguageCode")
         default_languages = {}
         if default_code:
             default_languages[default_code] = DefaultLanguage(

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2146,15 +2146,34 @@ class AgentStudioProject:
                     if not resource_info:
                         raise ValueError(f"Resource info not found for {file_path}")
 
+                    resource_name = resource_info["resource_name"]
+                    flow_name = flow_paths_to_names.get(
+                        resource_utils.get_flow_name_from_path(file_path),
+                    )
+
+                    if resource_type == DefaultLanguage:
+                        resource = self.read_local_resource(
+                            ResourceMapping(
+                                resource_id=resource_info["resource_id"],
+                                resource_type=resource_type,
+                                resource_name=resource_name,
+                                file_path=file_path,
+                                flow_name=flow_name,
+                                resource_prefix=resource_type.get_resource_prefix(
+                                    file_path=file_path
+                                ),
+                            ),
+                            resource_mappings=[],
+                        )
+                        resource_name = resource.name
+
                     kept_resource_mappings.append(
                         ResourceMapping(
                             resource_id=resource_info["resource_id"],
                             resource_type=resource_type,
-                            resource_name=resource_info["resource_name"],
+                            resource_name=resource_name,
                             file_path=file_path,
-                            flow_name=flow_paths_to_names.get(
-                                resource_utils.get_flow_name_from_path(file_path),
-                            ),
+                            flow_name=flow_name,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
                         )
                     )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2151,6 +2151,8 @@ class AgentStudioProject:
                         resource_utils.get_flow_name_from_path(file_path),
                     )
 
+                    # Default Language will only be modified, but name must
+                    # be read from file
                     if resource_type == DefaultLanguage:
                         resource = self.read_local_resource(
                             ResourceMapping(


### PR DESCRIPTION
## Summary

Fixes two bugs that broke translation validation when the default language is changed locally.

## Motivation

Translation validation cross-references configured languages via ResourceMappings. When the default language was changed locally, the ResourceMapping still had the old language code (cached from pull), so translations appeared to be missing entries for the new language. Separately, the projection reader used the wrong key to extract the default language code from the API response.

## Changes

- Re-read default language name from disk for kept resources so the ResourceMapping reflects the current value
- Fix projection key `defaultLanguage` → `defaultLanguageCode` in `SyncClientHandler._read_languages_from_projection`

## Test strategy

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (662 tests)
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)