### PR TITLE
feat: webchat config validation and push support

### DIFF
--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -288,6 +288,17 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
+    def queue_command(self, command: Message) -> None:
+        """Queue a single command for the specific project.
+
+        Args:
+            command (Message): The Command protobuf message to queue
+        """
+        try:
+            self.sync_client.queue_command(command)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
     def send_queued_commands(self) -> bool:
         """Send all queued commands as a batch and clear the queue.
 

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -1101,6 +1101,20 @@ class SyncClientHandler:
         logger.debug(f"Commands: {commands!r}")
         return commands
 
+    def queue_command(self, command: Command) -> None:
+        """Add a single command to the queue.
+        Sets the command ID and metadata before adding to the queue.
+
+        Args:
+            command (Command): The Command protobuf message to add to the queue.
+        """
+        command.metadata.CopyFrom(self.sdk.create_metadata())
+        command.command_id = str(uuid.uuid4())
+        self.sdk.add_command_to_queue(command)
+        logger.info("Queued command")
+        logger.debug(f"Command: {command!r}")
+        return command
+
     def send_queued_commands(self) -> bool:
         """Send all queued commands as a batch and clear the queue.
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1377,6 +1377,23 @@ class AgentStudioProject:
         post_push_updated_resources: ResourceMap = {}
         post_push_deleted_resources: ResourceMap = {}
 
+        # If we are creating any Webchat config, instead enable Webchat and set
+        # the configs as update
+        if (
+            ChatGreeting in new_resources
+            or ChatSafetyFilters in new_resources
+            or ChatStylePrompt in new_resources
+        ):
+            self.api_handler.queue_command(
+                utils.create_command_webchat_channel_update_status(enabled=True)
+            )
+            # Move any Webchat config in new resources to updated resources
+            for resource_type in [ChatGreeting, ChatSafetyFilters, ChatStylePrompt]:
+                for resource_id, resource in new_resources.get(resource_type, {}).items():
+                    pre_push_updated_resources.setdefault(resource_type, {})[resource_id] = resource
+                if resource_type in new_resources:
+                    new_resources.pop(resource_type)
+
         # When a function is deleted the backend prunes that function ID from all
         # variable references. If the deleted function was the variable's only reference,
         # the backend auto-deletes the variable, which causes an explicit delete command

--- a/src/poly/resources/channel_settings.py
+++ b/src/poly/resources/channel_settings.py
@@ -253,6 +253,11 @@ class ChatGreeting(ChannelGreeting):
     channel_type: ClassVar[ChannelType] = ChannelType.WEB_CHAT
     channel_subpath: ClassVar[str] = "chat"
 
+    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
+        """Validate the chat greeting resource."""
+        super().validate(resource_mappings=resource_mappings, **kwargs)
+        utils.validate_webchat_siblings(type(self), resource_mappings)
+
 
 @dataclass
 class ChannelStylePrompt(MultiResourceYamlResource):
@@ -343,3 +348,8 @@ class ChatStylePrompt(ChannelStylePrompt):
 
     channel_type: ClassVar[ChannelType] = ChannelType.WEB_CHAT
     channel_subpath: ClassVar[str] = "chat"
+
+    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
+        """Validate the chat style prompt resource."""
+        super().validate(resource_mappings=resource_mappings, **kwargs)
+        utils.validate_webchat_siblings(type(self), resource_mappings)

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -749,3 +749,25 @@ def assign_flow_node_position(
             "y": y_start,
         }
         return node.position["x"]
+
+
+_WEBCHAT_CONFIG_TYPES: list[str] = [
+    "ChatGreeting",
+    "ChatSafetyFilters",
+    "ChatStylePrompt",
+]
+
+
+def validate_webchat_siblings(
+    self_type: type, resource_mappings: list["ResourceMapping"] | None
+) -> None:
+    """Raise if some but not all webchat config resources are present."""
+    if not resource_mappings:
+        return
+    sibling_names = [n for n in _WEBCHAT_CONFIG_TYPES if n != self_type.__name__]
+    present_types = {rm.resource_type.__name__ for rm in resource_mappings}
+    missing = [n for n in sibling_names if n not in present_types]
+    if missing:
+        raise ValueError(
+            f"Webchat config resources must all be present together. Missing: {', '.join(missing)}."
+        )

--- a/src/poly/resources/safety_filters.py
+++ b/src/poly/resources/safety_filters.py
@@ -15,6 +15,7 @@ from poly.handlers.protobuf.content_filter_settings_pb2 import (
     AzureContentFilterCategory,
     ContentFilterSettings_UpdateContentFilterSettings,
 )
+import poly.resources.resource_utils as utils
 from poly.resources.resource import ResourceMapping, YamlResource
 
 PRECISION_MAPPING = {"LOOSE": "lenient", "MEDIUM": "medium", "STRICT": "strict"}
@@ -327,3 +328,8 @@ class ChatSafetyFilters(ChannelSafetyFilters):
 
     channel_type: ClassVar[ChannelType] = ChannelType.WEB_CHAT
     channel_subpath: ClassVar[str] = "chat"
+
+    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
+        """Validate the chat safety filters resource."""
+        super().validate(resource_mappings=resource_mappings, **kwargs)
+        utils.validate_webchat_siblings(type(self), resource_mappings)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -16,6 +16,7 @@ from poly.project import AgentStudioProject
 from poly.resources import (
     AsrSettings,
     ChatGreeting,
+    ChatSafetyFilters,
     ChatStylePrompt,
     Entity,
     ExperimentalConfig,
@@ -1664,6 +1665,49 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertIn("CONDITION-cond-1", cleaned_new.get(Condition, {}))
         # And removed from updated
         self.assertNotIn("CONDITION-cond-1", cleaned_updated.get(Condition, {}))
+
+    def test_clean_resources_before_push_webchat_enables_channel_and_moves_to_updates(self):
+        """New webchat configs should enable the channel and be moved to pre-push updates."""
+        greeting = ChatGreeting(
+            resource_id="chat-greeting-1",
+            name="greeting",
+            welcome_message="Hello",
+            language_code="en-GB",
+        )
+        safety = ChatSafetyFilters(
+            resource_id="chat-safety-1",
+            name="safety_filters",
+            enabled=True,
+            categories={
+                "violence": {"enabled": True, "precision": "MEDIUM"},
+                "hate": {"enabled": True, "precision": "MEDIUM"},
+                "sexual": {"enabled": True, "precision": "MEDIUM"},
+                "self_harm": {"enabled": True, "precision": "MEDIUM"},
+            },
+        )
+        style = ChatStylePrompt(
+            resource_id="chat-style-1",
+            name="style_prompt",
+            prompt="Be helpful",
+        )
+        new_resources = {
+            ChatGreeting: {"chat-greeting-1": greeting},
+            ChatSafetyFilters: {"chat-safety-1": safety},
+            ChatStylePrompt: {"chat-style-1": style},
+        }
+
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            push_changes = self.project._clean_resources_before_push(
+                {}, new_resources, {}, {}
+            )
+            mock_api.queue_command.assert_called_once()
+
+        self.assertNotIn(ChatGreeting, push_changes.main.new)
+        self.assertNotIn(ChatSafetyFilters, push_changes.main.new)
+        self.assertNotIn(ChatStylePrompt, push_changes.main.new)
+        self.assertIn(ChatGreeting, push_changes.pre.updated)
+        self.assertIn(ChatSafetyFilters, push_changes.pre.updated)
+        self.assertIn(ChatStylePrompt, push_changes.pre.updated)
 
 
 class PushProjectTest(unittest.TestCase):

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -7,6 +7,8 @@ import os
 import unittest
 
 import yaml
+
+import poly.resources.resource_utils as resource_utils
 from jsonschema import ValidationError
 
 from poly.handlers.sync_client import SyncClientHandler
@@ -3756,13 +3758,7 @@ class ExperimentalConfigTests(unittest.TestCase):
         experimental_config = ExperimentalConfig(
             resource_id="experimental-config-123",
             name="experimental_config",
-            config={
-                "asr": {
-                    "provider": "fakegram",
-                    "model": "nova-2",
-                    "language": "en"
-                }
-            }
+            config={"asr": {"provider": "fakegram", "model": "nova-2", "language": "en"}},
         )
         with self.assertRaises(ValidationError) as cm:
             experimental_config.validate()
@@ -7578,6 +7574,85 @@ class AdditionalLanguageTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             lang.validate(resource_mappings=mappings)
         self.assertIn("Duplicate language code", str(cm.exception))
+
+
+class ValidateWebchatSiblingsTests(unittest.TestCase):
+    """Tests for validate_webchat_siblings in resource_utils."""
+
+    def _make_mapping(self, resource_type: type) -> ResourceMapping:
+        """Create a minimal ResourceMapping with the given resource_type."""
+        return ResourceMapping(
+            resource_id="fake-id",
+            resource_type=resource_type,
+            resource_name="fake",
+            file_path=None,
+            flow_name=None,
+            resource_prefix=None,
+        )
+
+    def test_all_three_present_no_error(self):
+        """No error when all webchat config types are present."""
+        mappings = [
+            self._make_mapping(ChatGreeting),
+            self._make_mapping(ChatSafetyFilters),
+            self._make_mapping(ChatStylePrompt),
+        ]
+        # Should not raise
+        resource_utils.validate_webchat_siblings(ChatGreeting, mappings)
+
+    def test_none_present_no_error(self):
+        """No error when resource_mappings is empty."""
+        resource_utils.validate_webchat_siblings(ChatGreeting, [])
+
+    def test_resource_mappings_none_no_error(self):
+        """No error when resource_mappings is None."""
+        resource_utils.validate_webchat_siblings(ChatGreeting, None)
+
+    def test_only_chat_greeting_raises(self):
+        """ValueError when only ChatGreeting is present, missing the other two."""
+        mappings = [self._make_mapping(ChatGreeting)]
+        with self.assertRaises(ValueError) as cm:
+            resource_utils.validate_webchat_siblings(ChatGreeting, mappings)
+        self.assertIn("ChatSafetyFilters", str(cm.exception))
+        self.assertIn("ChatStylePrompt", str(cm.exception))
+
+    def test_only_chat_safety_filters_raises(self):
+        """ValueError when only ChatSafetyFilters is present."""
+        mappings = [self._make_mapping(ChatSafetyFilters)]
+        with self.assertRaises(ValueError) as cm:
+            resource_utils.validate_webchat_siblings(ChatSafetyFilters, mappings)
+        self.assertIn("ChatGreeting", str(cm.exception))
+        self.assertIn("ChatStylePrompt", str(cm.exception))
+
+    def test_only_chat_style_prompt_raises(self):
+        """ValueError when only ChatStylePrompt is present."""
+        mappings = [self._make_mapping(ChatStylePrompt)]
+        with self.assertRaises(ValueError) as cm:
+            resource_utils.validate_webchat_siblings(ChatStylePrompt, mappings)
+        self.assertIn("ChatGreeting", str(cm.exception))
+        self.assertIn("ChatSafetyFilters", str(cm.exception))
+
+    def test_two_of_three_raises_listing_missing_one(self):
+        """ValueError listing only the single missing type when two are present."""
+        mappings = [
+            self._make_mapping(ChatGreeting),
+            self._make_mapping(ChatSafetyFilters),
+        ]
+        with self.assertRaises(ValueError) as cm:
+            resource_utils.validate_webchat_siblings(ChatGreeting, mappings)
+        msg = str(cm.exception)
+        self.assertIn("ChatStylePrompt", msg)
+        # The two present types should not appear in the missing list
+        self.assertNotIn("ChatGreeting", msg.split("Missing:")[1])
+        self.assertNotIn("ChatSafetyFilters", msg.split("Missing:")[1])
+
+    def test_unrelated_mappings_only_raises(self):
+        """ValueError when only unrelated types are in mappings (siblings missing)."""
+        mappings = [self._make_mapping(Entity)]
+        with self.assertRaises(ValueError) as cm:
+            resource_utils.validate_webchat_siblings(ChatGreeting, mappings)
+        self.assertIn("ChatSafetyFilters", str(cm.exception))
+        self.assertIn("ChatStylePrompt", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -15,6 +15,13 @@ from typing import Callable, Optional
 
 from poly.resources import Function, FunctionStep, Resource, ResourceMapping
 
+from poly.handlers.protobuf.commands_pb2 import Command
+from poly.handlers.protobuf.channels_pb2 import (
+    Channel_UpdateStatus,
+    WebChatChannel_UpdateStatus,
+    ChannelStatus,
+)
+
 logger = logging.getLogger(__name__)
 
 _TYPES_PACKAGE = "poly.types"
@@ -509,3 +516,17 @@ def compute_variable_references(
         for var_id in variable_references:
             var_refs.setdefault(var_id, {}).setdefault(field_name, {})[fn_id] = True
     return var_refs
+
+
+def create_command_webchat_channel_update_status(enabled: bool) -> Command:
+    """Create a Channel_UpdateStatus command with the given status."""
+    if enabled:
+        status = ChannelStatus.CREATED
+    else:
+        status = ChannelStatus.NOT_CREATED
+    return Command(
+        type="channel_update_status",
+        channel_update_status=Channel_UpdateStatus(
+            webchat=WebChatChannel_UpdateStatus(status=status),
+        ),
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.21.1"
+version = "0.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

- Add all-or-nothing validation for webchat config resources (ChatGreeting, ChatSafetyFilters, ChatStylePrompt)
- On push, new webchat configs enable the webchat channel and are sent as updates instead of creates
- Add `queue_command` to SyncClientHandler and AgentStudioInterface for queuing individual commands

## Motivation

Previously, to enable webchat you had to do it manually on the platform — it couldn't be done through ADK. This change allows ADK to enable the webchat channel automatically when webchat configs are pushed, and validates that all three config types are present together.

## Changes

- `resource_utils.validate_webchat_siblings()` — validates all three webchat types are present when any one is
- `ChatGreeting`, `ChatSafetyFilters`, `ChatStylePrompt` — override `validate()` to call sibling check
- `SyncClientHandler.queue_command()` / `AgentStudioInterface.queue_command()` — queue a single command
- `utils.create_command_webchat_channel_update_status()` — create enable/disable channel command
- `project._clean_resources_before_push()` — move new webchat configs to pre-push updates and queue enable command

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)