### PR TITLE
fix: skip interactive project_id prompt when --output-json is set

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1722,7 +1722,7 @@ class AgentStudioCLI:
                 return
             project_name = project_name.strip()
 
-        if not project_id and region != "studio":
+        if not project_id and region != "studio" and not output_json:
             project_id = questionary.text(
                 "Enter project ID (leave empty to let the platform generate one):",
                 validate=lambda val: (


### PR DESCRIPTION
## Summary

Skip the interactive `project_id` prompt during `poly create` when `--json` is passed, since JSON output mode is non-interactive.

## Motivation

When using `poly create --json`, the CLI shouldn't prompt for interactive input — it should let the platform generate the project ID automatically.

## Changes

- Added `and not output_json` guard to the `project_id` prompt condition in `cli.py`

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly create --json`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)