### PR TITLE
fix: simplify pronunciation position assignment

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -782,10 +782,6 @@ class SyncClientHandler:
             .get("entities", {})
             .items()
         ):
-            # FIXME: Sourcerer SDK bug
-            # Sometimes, even if the dict has multiple elements
-            # They are all at position 0.
-            position = pronunciation_data.get("position") or index
             pronunciations[pronunciation_id] = Pronunciation(
                 resource_id=pronunciation_id,
                 name=pronunciation_data.get("name", ""),
@@ -794,7 +790,7 @@ class SyncClientHandler:
                 case_sensitive=pronunciation_data.get("caseSensitive", False),
                 language_code=pronunciation_data.get("languageCode", ""),
                 description=pronunciation_data.get("description", ""),
-                position=position if position == index else index + 1,
+                position=index,  # Positions returned by API are not reliable, so we set them based on the order they are returned in
             )
             index += 1
         return pronunciations


### PR DESCRIPTION
## Summary

Simplifies pronunciation position assignment by removing the workaround for unreliable API position data and using the iteration index directly.

## Motivation

The previous code had a `FIXME` noting a Sourcerer SDK bug where multiple entities could share position 0. The workaround logic (`position if position == index else index + 1`) was brittle and unnecessary — since API positions are unreliable, we should just use the order items are returned in.

## Changes

- Removed the `FIXME` comment and position workaround in `_read_pronunciations_from_projection`
- Position is now set directly from the iteration `index`

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)