### PR TITLE
fix(test_suite): reject test cases with no assertions at validation time

### DIFF
--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -406,6 +406,14 @@ class TestCase(YamlResource):
                         f"Invalid value type for function call assertion argument: {argument.value_type}"
                     )
 
+        # A case with no assertions cannot be evaluated — the runner silently skips it.
+        has_prompt_assertions = any(p and p.strip() for p in self.assertions.prompts)
+        if not has_prompt_assertions and not self.assertions.function_calls:
+            raise ValueError(
+                "Test case must have at least one assertion: add `prompt_assertions` "
+                "(or `function_call_assertions`) describing the expected behaviour"
+            )
+
     def get_new_updated_deleted_subresources(
         self, old_resource: Optional["TestCase"] = None
     ) -> tuple[list[SubResource], list[SubResource], list[SubResource]]:

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -7272,6 +7272,40 @@ class TestCaseTests(unittest.TestCase):
             ]
         )
 
+    def _case_with_assertions(self, prompts, function_calls=None) -> TestCase:
+        return TestCase(
+            resource_id="TEST-assertions",
+            name="Assertion presence",
+            scenario="Test scenario",
+            channel="chat.polyai",
+            language="en-GB",
+            assertions=TestCaseAssertion(
+                resource_id="TEST-assertions",
+                name="assertions",
+                prompts=prompts,
+                function_calls=function_calls or [],
+            ),
+            tags=TestCaseTags(resource_id="TEST-assertions", name="tags", tags=[]),
+        )
+
+    def test_validate_requires_at_least_one_assertion(self):
+        with self.assertRaises(ValueError) as cm:
+            self._case_with_assertions(prompts=[]).validate()
+        self.assertIn("at least one assertion", str(cm.exception))
+
+        # Whitespace-only prompt assertions do not count.
+        with self.assertRaises(ValueError) as cm:
+            self._case_with_assertions(prompts=["   ", ""]).validate()
+        self.assertIn("at least one assertion", str(cm.exception))
+
+        self._case_with_assertions(prompts=["The agent offers to help"]).validate()
+
+        # Function-call assertions alone are sufficient.
+        self._case_with_assertions(
+            prompts=[],
+            function_calls=[FunctionCallAssertion(name="test_function", arguments=[])],
+        ).validate()
+
     def test_get_new_updated_deleted_subresources(self):
         test_case = self._sample_test_case()
         new, updated, deleted = test_case.get_new_updated_deleted_subresources()


### PR DESCRIPTION
## Summary

`TestCase.validate()` now rejects a test case that has no assertions — previously such a case passed validation but could never be evaluated: the runner has nothing to judge and silently skips it, so the authored "test" verifies nothing.

## Motivation

Hit in Glot (the Agent Studio assistant): LLM-authored cases occasionally omitted assertions, and the gap only surfaced a full build/apply/run cycle later, with no signal pointing at the malformed case. Currently guarded client-side ([platform_ui#7609](https://github.com/PolyAI-LDN/platform_ui/pull/7609) review discussion) — ADK owning the rule gives every authoring surface the same protection.

## Changes

- `validate()` raises unless the case has at least one non-empty `prompt_assertions` entry or a `function_call_assertions` entry (whitespace-only prompts don't count; function-call-only cases remain valid)
- Check runs last in `validate()`, so existing error precedence is unchanged
- If any checked-in projects have intentionally assertion-less cases, their next push will fail validation — happy to soften to a warning if that's a migration concern

## Test strategy

- [x] Added/updated unit tests (`test_validate_requires_at_least_one_assertion`)
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` passes; `ruff format` (pinned 0.14.2): added lines are clean — note `format --check` already fails on `main` for pre-existing drift in `resources_test.py`, left untouched here to keep the diff scoped
- [x] `pytest` passes (683 passed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
