### PR TITLE
fix: correct GitHub Issues link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ poly docs --output doc_file.md
 
 ## Bugs & Feature Requests
 
-Please report bugs or request features via the [GitHub Issues](https://github.com/PolyAI-LDN/adk/issues) page.
+Please report bugs or request features via the [GitHub Issues](https://github.com/PolyAI/adk/issues) page.
 
 ## Contributing
 


### PR DESCRIPTION
## Summary
- The GitHub Issues link in README.md pointed to `PolyAI-LDN/adk` which is inaccessible to public users
- Updated to `PolyAI/adk` to match the actual public repository

## Test plan
- [x] Verify the new link resolves to the correct repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)