### PR TITLE
fix: preserve unicode characters in JSON output

### DIFF
--- a/src/poly/resources/experimental_config.py
+++ b/src/poly/resources/experimental_config.py
@@ -26,7 +26,7 @@ class ExperimentalConfig(Resource):
 
     @property
     def raw(self) -> str:
-        return json.dumps(self.config, indent=2, sort_keys=True)
+        return json.dumps(self.config, indent=2, sort_keys=True, ensure_ascii=False)
 
     @staticmethod
     def format_resource(content: str, file_name: str = None, **kwargs) -> str:

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -515,7 +515,7 @@ def format_json(json_content: str) -> str:
     """
     try:
         data = json.loads(json_content)
-        return json.dumps(data, indent=2, sort_keys=True) + "\n"
+        return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
     except Exception:
         return json_content
 


### PR DESCRIPTION
## Summary

Prevents `json.dumps` from escaping Unicode characters (e.g. `'` → `’`) in experimental config and formatted JSON output.

## Motivation

When pulling agent configs containing Unicode characters like smart quotes (`'`), the JSON serializer escapes them to `\uXXXX` sequences. This makes config files harder to read and creates noisy diffs.

## Changes

- Set `ensure_ascii=False` in `ExperimentalConfig.raw` property
- Set `ensure_ascii=False` in `format_json()` utility

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

```diff
-    "step_footer": "If the user asks a follow-up question while you are waiting for an answer, answer the user’s question first..."
+    "step_footer": "If the user asks a follow-up question while you are waiting for an answer, answer the user's question first..."
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)