### PR TITLE
fix: add global DTMF config to experimental_config schema

### DIFF
--- a/src/poly/resources/experimental_config_schema.yaml
+++ b/src/poly/resources/experimental_config_schema.yaml
@@ -499,6 +499,24 @@ components:
       description: Configure DTMF behavior, including disabling speech recognition for DTMF-only steps
       additionalProperties: false
       properties:
+        global:
+          type: object
+          description: Global DTMF config applied to every turn. Step-level DTMF takes precedence when enabled.
+          additionalProperties: false
+          properties:
+            is_enabled:
+              type: boolean
+              description: Whether global DTMF collection is enabled
+            max_digits:
+              type: integer
+              description: Maximum number of DTMF digits to collect
+              minimum: 0
+            end_key:
+              type: string
+              description: Key that signals the end of DTMF input (e.g. "#")
+            collect_while_agent_speaking:
+              type: boolean
+              description: Whether to collect DTMF digits while the agent is speaking
         flow_overrides:
           type: object
           description: Flow-specific DTMF configuration overrides. Each key should be a flow name.


### PR DESCRIPTION
## Summary

- Adds `dtmf.global` section to `experimental_config_schema.yaml`, syncing with [poly_core#42747](https://github.com/PolyAI-LDN/poly_core/pull/42747)
- Global DTMF enables digit collection on every turn; step-level DTMF takes precedence when enabled
- New properties: `is_enabled`, `max_digits`, `end_key`, `collect_while_agent_speaking`

**Jira:** [FDX-3768](https://poly-ai.atlassian.net/browse/FDX-3768)

## Test plan

- [x] Existing `ExperimentalConfigTests` pass (schema validation + invalid config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)