### PR TITLE
fix: use relative imports in type stubs and add integrations stubs

### DIFF
--- a/scripts/sync_runtime_stubs.py
+++ b/scripts/sync_runtime_stubs.py
@@ -324,21 +324,55 @@ def _collect_import_stmts(stmts: list[ast.stmt]) -> list[ast.stmt]:
     return result
 
 
+def _expand_module_import(module: str, alias: str, body_text: str) -> str | None:
+    """Convert ``import runtime.X as Y`` to ``from .X import A, B, C``.
+
+    Scans *body_text* for ``Y.name`` references and emits a relative
+    ``from`` import for each attribute used.  Also rewrites those
+    ``Y.name`` references in body_text to just ``name``.
+    Returns (import_line, new_body_text) or None if no attributes are found.
+    """
+    import re as _re
+
+    pattern = _re.compile(r"(?<![a-zA-Z0-9_.])" + _re.escape(alias) + r"\.(\w+)")
+    names = sorted(set(m.group(1) for m in pattern.finditer(body_text)))
+    if not names:
+        return None, body_text
+    # Relativize: runtime.foo -> .foo
+    rel_module = "." + module.split(".", 1)[1] if "." in module else module
+    import_line = f"from {rel_module} import {', '.join(names)}"
+    # Rewrite body: extraction_types.EntityConfig -> EntityConfig
+    new_body = pattern.sub(r"\1", body_text)
+    return import_line, new_body
+
+
+def _relativize_module(module: str) -> str:
+    """Convert ``runtime.X`` or ``utils.X`` to ``.X`` for relative imports."""
+    if module.startswith(("runtime.", "utils.")):
+        return "." + module.split(".", 1)[1]
+    return module
+
+
 def _extract_imports(tree: ast.Module, source_path: Path) -> list[str]:
     """Extract imports needed for the stub.
 
     Includes:
     - typing imports
-    - runtime.* imports (excluding internal modules and private names)
-    - stdlib/pydantic imports used in type annotations (enum, datetime, etc.)
+    - runtime.* imports (relativized to .X)
+    - stdlib/pydantic imports used in type annotations
     - imports from ``if TYPE_CHECKING:`` blocks (promoted to unconditional)
+
+    ``import runtime.X as Y`` forms are tagged for deferred expansion
+    (needs body_text to resolve which attributes are used).
     """
     imports = []
     for stmt in _collect_import_stmts(tree.body):
         if isinstance(stmt, ast.Import):
             for alias in stmt.names:
                 if alias.name.startswith("runtime"):
-                    imports.append(ast.unparse(stmt))
+                    imports.append(
+                        ("module_alias", alias.name, alias.asname or alias.name.rsplit(".", 1)[-1])
+                    )
                 elif alias.name in _ALLOWED_STDLIB_MODULES:
                     imports.append(ast.unparse(stmt))
         elif isinstance(stmt, ast.ImportFrom):
@@ -357,10 +391,11 @@ def _extract_imports(tree: ast.Module, source_path: Path) -> list[str]:
                 public_names = _filter_import_names(stmt.names)
                 if not public_names:
                     continue
+                rel_module = _relativize_module(stmt.module)
                 filtered = ast.ImportFrom(
-                    module=stmt.module,
+                    module=rel_module,
                     names=public_names,
-                    level=stmt.level,
+                    level=0 if rel_module.startswith(".") else stmt.level,
                 )
                 imports.append(ast.unparse(filtered))
     return imports
@@ -476,7 +511,22 @@ def generate_stub(source_path: Path) -> str:
         body_parts.append("\n".join(assignments_after))
     body_text = "\n".join(body_parts)
 
-    imports = _prune_imports(candidate_imports, body_text)
+    # Resolve deferred module-alias imports and rewrite body references.
+    resolved_imports = []
+    for item in candidate_imports:
+        if isinstance(item, tuple) and item[0] == "module_alias":
+            _, module, alias = item
+            import_line, body_text = _expand_module_import(module, alias, body_text)
+            if import_line:
+                resolved_imports.append(import_line)
+        else:
+            resolved_imports.append(item)
+
+    imports = _prune_imports(resolved_imports, body_text)
+
+    # Rebuild body_parts from (possibly rewritten) body_text
+    # Split back into sections for assembly
+    all_body_lines = body_text.split("\n") if body_text.strip() else []
 
     # Assemble final stub
     parts = [STUB_HEADER]
@@ -488,14 +538,8 @@ def generate_stub(source_path: Path) -> str:
         items = ", ".join(f'"{name}"' for name in all_list)
         parts.append(f"\n__all__ = [{items}]")
 
-    if assignments_before:
-        parts.append("\n".join(assignments_before))
-
-    if classes:
-        parts.append("\n\n".join(classes))
-
-    if assignments_after:
-        parts.append("\n".join(assignments_after))
+    if all_body_lines:
+        parts.append("\n".join(all_body_lines))
 
     return "\n\n".join(parts) + "\n"
 

--- a/src/poly/types/conv_utils.py
+++ b/src/poly/types/conv_utils.py
@@ -5,9 +5,9 @@
 
 
 from typing import Literal
-import runtime.value_extraction_types as extraction_types
-from runtime.history import AgentResponse, UserInput
-from runtime.value_extraction import Address
+from .value_extraction_types import EntityConfig
+from .history import AgentResponse, UserInput
+from .value_extraction import Address
 
 
 __all__ = ["Utils"]
@@ -62,9 +62,7 @@ class Utils:
     ) -> str | dict:
         """[Opt-in Feature] 🚧"""
 
-    def validate_entity(
-        self, value: str, entity_config: extraction_types.EntityConfig
-    ) -> _EntityValidationResponse:
+    def validate_entity(self, value: str, entity_config: EntityConfig) -> _EntityValidationResponse:
         """Validate an entity value against its configuration."""
 
     def get_secret(self, secret_name: str) -> str | dict:

--- a/src/poly/types/conversation.py
+++ b/src/poly/types/conversation.py
@@ -5,15 +5,15 @@
 
 
 from typing import Any, Literal, NewType
-import runtime.external_events as external_events
-from runtime.agentic_dial import AgenticDialData
-from runtime.entity_validator import EntityValidationResult
-from runtime.history import AgentResponse, UserInput
-from runtime.integrations.integrations import Integrations
-from runtime.memory import Memory
-from runtime.sms import OutgoingSMS, OutgoingSMSTemplate, SMSTemplate
-from runtime.webchat import WebchatInterface
-from runtime.attachment import Attachment
+from .external_events import GenericExternalEvent, SMSReceived
+from .agentic_dial import AgenticDialData
+from .entity_validator import EntityValidationResult
+from .history import AgentResponse, UserInput
+from .integrations.integrations import Integrations
+from .memory import Memory
+from .sms import OutgoingSMS, OutgoingSMSTemplate, SMSTemplate
+from .webchat import WebchatInterface
+from .attachment import Attachment
 
 
 __all__ = [
@@ -538,11 +538,11 @@ class Conversation:
         integration_attributes: dict[str, Any] | None = ...,
         memory: Memory | None = ...,
         metric_events: list[MetricEvent] | None = ...,
-        sms_received: list[external_events.SMSReceived] | None = ...,
+        sms_received: list[SMSReceived] | None = ...,
         realtime_config: dict[str, Any] | None = ...,
         functions: dict[str, Any] | None = ...,
         vpc_enabled: bool | None = ...,
-        generic_external_events: list[external_events.GenericExternalEvent] | None = ...,
+        generic_external_events: list[GenericExternalEvent] | None = ...,
         channel_type: Literal["sms", "VOICE", "sip.polyai"] | None = ...,
         entities: dict[str, EntityValidationResult] | None = ...,
         apis: list[ApiIntegrationData] | None = ...,

--- a/src/poly/types/entity_validator.py
+++ b/src/poly/types/entity_validator.py
@@ -4,7 +4,7 @@
 # type: ignore
 
 
-from runtime.value_extraction_types import EntityType
+from .value_extraction_types import EntityType
 
 
 __all__ = ["EntityValidationResult"]

--- a/src/poly/types/flow.py
+++ b/src/poly/types/flow.py
@@ -5,7 +5,7 @@
 
 
 from typing import Any
-from runtime.conversation import Conversation
+from .conversation import Conversation
 
 
 __all__ = ["Transition", "StepTransition", "FlowFunctionExecutor", "Flow"]

--- a/src/poly/types/integrations/__init__.py
+++ b/src/poly/types/integrations/__init__.py
@@ -1,0 +1,1 @@
+# Copyright PolyAI Limited

--- a/src/poly/types/integrations/available_integrations/__init__.py
+++ b/src/poly/types/integrations/available_integrations/__init__.py
@@ -1,0 +1,1 @@
+# Copyright PolyAI Limited

--- a/src/poly/types/integrations/available_integrations/opentable.py
+++ b/src/poly/types/integrations/available_integrations/opentable.py
@@ -1,0 +1,28 @@
+# Copyright PolyAI Limited
+# flake8: noqa
+# ruff: noqa
+# type: ignore
+from typing import Any
+
+from ..integration import Integration
+
+__all__ = ["OpenTable"]
+
+
+class OpenTable(Integration):
+    """OpenTable integration class for proxying requests to the OpenTable API"""
+
+    integration_id: str
+    integration_name: str
+
+    def proxy_request(
+        self,
+        endpoint: str,
+        http_method: str,
+        base_url: str | None = ...,
+        headers: dict[str, str] | None = ...,
+        params: dict[str, str] | None = ...,
+        body: dict[str, Any] | None = ...,
+        timeout: int = ...,
+    ) -> Any:
+        """Proxy a request to the OpenTable API using the integration's authentication."""

--- a/src/poly/types/integrations/available_integrations/tripleseat.py
+++ b/src/poly/types/integrations/available_integrations/tripleseat.py
@@ -1,0 +1,31 @@
+# Copyright PolyAI Limited
+# flake8: noqa
+# ruff: noqa
+# type: ignore
+from typing import Any
+
+from ..integration import Integration
+
+__all__ = ["Tripleseat"]
+
+
+class Tripleseat(Integration):
+    """Tripleseat integration class for proxying requests to the Tripleseat API"""
+
+    integration_id: str
+    integration_name: str
+
+    def get_bookings(self) -> Any:
+        """Get bookings from Tripleseat."""
+
+    def create_lead(
+        self,
+        public_key: str,
+        first_name: str | None = ...,
+        last_name: str | None = ...,
+        email_address: str | None = ...,
+        phone_number: str | None = ...,
+        location_id: str | None = ...,
+        additional_fields: dict | None = ...,
+    ) -> Any:
+        """Create a lead in Tripleseat."""

--- a/src/poly/types/integrations/integration.py
+++ b/src/poly/types/integrations/integration.py
@@ -1,0 +1,27 @@
+# Copyright PolyAI Limited
+# flake8: noqa
+# ruff: noqa
+# type: ignore
+from typing import Any
+
+from ..log_utils import ConversationLogger
+
+__all__ = ["Integration"]
+
+
+class Integration:
+    """Base class for all integrations"""
+
+    integration_id: str
+    integration_name: str
+
+    def __init__(self, log: ConversationLogger, proxy_request: Any): ...
+    def proxy_request(
+        self,
+        endpoint: str,
+        http_method: str,
+        headers: dict[str, str] | None = ...,
+        params: dict[str, str] | None = ...,
+        body: dict[str, Any] | None = ...,
+    ) -> Any:
+        """Proxy a request to the integration's API using the integration's authentication."""

--- a/src/poly/types/integrations/integrations.py
+++ b/src/poly/types/integrations/integrations.py
@@ -1,0 +1,35 @@
+# Copyright PolyAI Limited
+# flake8: noqa
+# ruff: noqa
+# type: ignore
+from typing import Any
+
+from .available_integrations.opentable import OpenTable
+from .available_integrations.tripleseat import Tripleseat
+
+__all__ = ["Integrations"]
+
+
+class Integrations:
+    """Integrations interface"""
+
+    opentable: OpenTable
+    tripleseat: Tripleseat
+
+    def __init__(
+        self,
+        log: Any,
+        paragon_connection_ids: dict[str, str] | None = ...,
+        paragon_project_id: str | None = ...,
+        integration_token: str | None = ...,
+    ): ...
+    def proxy_request(
+        self,
+        integration_id: str,
+        endpoint: str,
+        http_method: str,
+        headers: dict[str, str] | None = ...,
+        params: dict[str, str] | None = ...,
+        body: dict[str, Any] | None = ...,
+    ) -> Any:
+        """General method to proxy request through Paragon."""


### PR DESCRIPTION
## Summary

Fix type stubs to use relative imports and add integrations stubs.

## Motivation

The stubs updated in #184 used absolute `runtime.` imports. When copied into `_gen/`, the rewriter regex didn't catch all forms, causing import errors. Also missing stubs for the integrations subpackage.

## Changes

- Replace `from runtime.X import` → `from .X import` in all stubs
- Expand `import runtime.X as Y` into direct name imports (`from .X import A, B`)
- Add integrations stubs: `Integration` base class, `Integrations` facade, `OpenTable`, `Tripleseat`

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)