### PR TITLE
fix(languages): correct update command field for default_language

### DIFF
--- a/src/poly/resources/languages.py
+++ b/src/poly/resources/languages.py
@@ -76,6 +76,10 @@ class DefaultLanguage(MultiResourceYamlResource):
     def command_type(self) -> str:
         return "languages_update_default_language"
 
+    @property
+    def update_command_type(self) -> str:
+        return "languages_update_default_language"
+
     def build_update_proto(self) -> Languages_UpdateDefaultLanguage:
         return Languages_UpdateDefaultLanguage(language_code=self.name)
 

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -7677,6 +7677,16 @@ class DefaultLanguageTests(unittest.TestCase):
         proto = lang.build_update_proto()
         self.assertEqual(proto.language_code, "en-GB")
 
+    def test_update_command_type_is_a_real_command_field(self):
+        """update_command_type names a real Command field, not the double-prefixed one."""
+        from poly.handlers.protobuf.commands_pb2 import Command
+
+        lang = DefaultLanguage(resource_id="en-US", name="en-US")
+        self.assertEqual(
+            lang.update_command_type, "languages_update_default_language"
+        )
+        Command(**{lang.update_command_type: lang.build_update_proto()})
+
     def test_validate_duplicate_with_additional_raises(self):
         """validate raises when default language code also appears in additional languages."""
         lang = DefaultLanguage(resource_id="en-GB", name="en-GB")


### PR DESCRIPTION
## Summary

Fixes a bug where changing a project's `default_language` via `push` always returned `422 — Protocol message Command has no "update_languages_update_default_language" field`. `DefaultLanguage` now emits the correct `languages_update_default_language` Command field.

## Motivation

Tracking: https://linear.app/poly-ai/issue/ORCH-309

Surfaced from Glot eval runs (lead-qualification, restaurant-booking, multilingual-payment-reminder): authoring an agent in a primary language other than the template default (`en-GB`) sent every build into a `languages.yaml` rewrite loop, because the default-language update could never push. Adding a locale to `additional_languages` worked; changing the default did not.

Root cause: `DefaultLanguage.command_type` already returns the full Command field name `languages_update_default_language`, but the base `update_command_type` derives the field as `f"update_{command_type}"`, producing the nonexistent `update_languages_update_default_language`. `sync_client` then builds `Command(**{update_type: build_update_proto()})` with that bad name and the proto rejects it. The payload (`Languages_UpdateDefaultLanguage`) was always correct — only the field name was wrong. `AdditionalLanguage` already overrides `create_/delete_command_type` for the same reason; `DefaultLanguage` was missing the matching `update_command_type` override.

## Changes

- `DefaultLanguage`: override `update_command_type` to return `languages_update_default_language` (no `update_` prefix), mirroring `AdditionalLanguage`.
- Add `test_update_command_type_is_a_real_command_field`: asserts the field name and constructs the `Command` the way `sync_client` does, so a future regression fails loudly.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

New test verified to **fail** without the fix (`update_languages_update_default_language != languages_update_default_language`) and **pass** with it.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (683 passed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/) (`fix:` → patch)

## Screenshots / Logs

Without the fix:
```
FAILED ...::DefaultLanguageTests::test_update_command_type_is_a_real_command_field
AssertionError: 'update_languages_update_default_language' != 'languages_update_default_language'
```

With the fix:
```
683 passed, 22 warnings, 30 subtests passed in 9.28s
ruff check .  ->  All checks passed!
```