### PR TITLE
fix(project): hint at unquoted-YAML cause on resource-read TypeError

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2104,18 +2104,6 @@ class AgentStudioProject:
             raise FileNotFoundError(
                 f"File not found for resource {resource.resource_name} at {resource.file_path}"
             ) from e
-        except TypeError as e:
-            # A TypeError here almost always means a YAML value parsed as the
-            # wrong type: an unquoted string with a mid-sentence colon parses as a
-            # mapping, a leading [ { * & ? as a sequence/anchor/alias. The raw
-            # CPython message (e.g. "bad argument type for built-in operation")
-            # names no field, so add the likely cause.
-            raise ValueError(
-                f"Error reading resource {resource.resource_name} at "
-                f"{resource.file_path}: {str(e)}. A YAML value is likely unquoted "
-                f"and parsed as the wrong type — check for an unquoted mid-sentence "
-                f"colon or a leading [ {{ * & ? and quote the value."
-            ) from e
         except Exception as e:
             raise ValueError(
                 f"Error reading resource {resource.resource_name} at {resource.file_path}: {str(e)}"

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2104,6 +2104,18 @@ class AgentStudioProject:
             raise FileNotFoundError(
                 f"File not found for resource {resource.resource_name} at {resource.file_path}"
             ) from e
+        except TypeError as e:
+            # A TypeError here almost always means a YAML value parsed as the
+            # wrong type: an unquoted string with a mid-sentence colon parses as a
+            # mapping, a leading [ { * & ? as a sequence/anchor/alias. The raw
+            # CPython message (e.g. "bad argument type for built-in operation")
+            # names no field, so add the likely cause.
+            raise ValueError(
+                f"Error reading resource {resource.resource_name} at "
+                f"{resource.file_path}: {str(e)}. A YAML value is likely unquoted "
+                f"and parsed as the wrong type — check for an unquoted mid-sentence "
+                f"colon or a leading [ {{ * & ? and quote the value."
+            ) from e
         except Exception as e:
             raise ValueError(
                 f"Error reading resource {resource.resource_name} at {resource.file_path}: {str(e)}"

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -355,7 +355,7 @@ class YamlResource(Resource, ABC):
         try:
             yaml_dict = utils.load_yaml(contents) or {}
         except Exception as e:
-            raise ValueError(f"Error loading YAML file: {file_path}") from e
+            raise ValueError(f"Error loading YAML file {file_path}: {e}") from e
         yaml_dict = cls.from_pretty_dict(
             yaml_dict,
             resource_mappings=resource_mappings,

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -132,7 +132,17 @@ def load_yaml(content):
     Returns:
         Parsed YAML data.
     """
-    return _yaml_loader.load(content)
+    try:
+        return _yaml_loader.load(content)
+    except (yaml.YAMLError, TypeError) as e:
+        # An unquoted scalar parsed as the wrong type: a mid-sentence colon reads
+        # as a mapping, a leading [ { * & ? as a sequence/anchor/alias. The raw
+        # message names no field, so point at the likely cause.
+        raise ValueError(
+            f"{e}. A YAML value is likely unquoted and parsed as the wrong type "
+            f"— check for an unquoted mid-sentence colon or a leading [ {{ * & ? "
+            f"and quote the value."
+        ) from e
 
 
 def get_diff(original: str, updated: str) -> str:

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -7,6 +7,7 @@ Copyright PolyAI Limited
 
 import json
 import os
+import tempfile
 import unittest
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
@@ -3279,7 +3280,7 @@ class GetUpdatedSubresourcesTest(unittest.TestCase):
 class ReadLocalResourceErrorTest(unittest.TestCase):
     """read_local_resource should attach file + cause context to read errors."""
 
-    def _mapping(self):
+    def _function_mapping(self):
         return ResourceMapping(
             resource_id="FUNCTION-broken",
             resource_type=Function,
@@ -3289,27 +3290,33 @@ class ReadLocalResourceErrorTest(unittest.TestCase):
             resource_prefix="fn",
         )
 
-    def test_typeerror_adds_yaml_scalar_hint(self):
-        """A TypeError (the unquoted-scalar footgun) is wrapped with the cause."""
+    def test_malformed_yaml_adds_scalar_hint(self):
+        """A real unquoted-scalar YAML file surfaces the cause through the read path."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-        mapping = self._mapping()
-        with patch.object(
-            Function,
-            "read_local_resource",
-            side_effect=TypeError("bad argument type for built-in operation"),
-        ):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            file_path = os.path.join(tmp_dir, "broken.yaml")
+            with open(file_path, "w", encoding="utf-8") as f:
+                # An unquoted mid-sentence colon — ruamel reads it as a mapping.
+                f.write("name: broken\nactions: do this: then that\n")
+            mapping = ResourceMapping(
+                resource_id="TOPIC-broken",
+                resource_type=Topic,
+                resource_name="broken",
+                file_path=file_path,
+                flow_name=None,
+                resource_prefix="topic",
+            )
             with self.assertRaises(ValueError) as ctx:
                 project.read_local_resource(resource=mapping, resource_mappings=[mapping])
         message = str(ctx.exception)
-        self.assertIn(mapping.file_path, message)
-        self.assertIn("bad argument type for built-in operation", message)
+        self.assertIn(file_path, message)
         self.assertIn("unquoted", message)
         self.assertIn("quote the value", message)
 
-    def test_non_typeerror_keeps_plain_wrapping(self):
+    def test_non_yaml_error_keeps_plain_wrapping(self):
         """Other errors keep the plain message — no spurious YAML hint."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-        mapping = self._mapping()
+        mapping = self._function_mapping()
         with patch.object(
             Function,
             "read_local_resource",

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -243,7 +243,9 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
                 os.path.join(TEST_DIR, "config", "entities.yaml", "entities", "phone_number"),
                 os.path.join(TEST_DIR, "config", "entities.yaml", "entities", "date"),
                 os.path.join(TEST_DIR, "config", "entities.yaml", "entities", "party_size"),
-                os.path.join(TEST_DIR, "config", "entities.yaml", "entities", "confirmation_status"),
+                os.path.join(
+                    TEST_DIR, "config", "entities.yaml", "entities", "confirmation_status"
+                ),
                 os.path.join(TEST_DIR, "config", "entities.yaml", "entities", "email"),
             ],
         )
@@ -304,8 +306,12 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertCountEqual(
             local_resources[SMSTemplate],
             [
-                os.path.join(TEST_DIR, "config", "sms_templates.yaml", "sms_templates", "test_template_1"),
-                os.path.join(TEST_DIR, "config", "sms_templates.yaml", "sms_templates", "test_template_2"),
+                os.path.join(
+                    TEST_DIR, "config", "sms_templates.yaml", "sms_templates", "test_template_1"
+                ),
+                os.path.join(
+                    TEST_DIR, "config", "sms_templates.yaml", "sms_templates", "test_template_2"
+                ),
             ],
         )
 
@@ -316,7 +322,7 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
             [
                 os.path.join(TEST_DIR, "variables", "customer_name"),
                 os.path.join(TEST_DIR, "variables", "payment_success"),
-                os.path.join(TEST_DIR, "variables", "data_processed")
+                os.path.join(TEST_DIR, "variables", "data_processed"),
             ],
         )
 
@@ -326,9 +332,27 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertCountEqual(
             local_resources[KeyphraseBoosting],
             [
-                os.path.join(TEST_DIR, speech_recognition_path, "keyphrase_boosting.yaml", "keyphrases", "PolyAI"),
-                os.path.join(TEST_DIR, speech_recognition_path, "keyphrase_boosting.yaml", "keyphrases", "reservation"),
-                os.path.join(TEST_DIR, speech_recognition_path, "keyphrase_boosting.yaml", "keyphrases", "check_in"),
+                os.path.join(
+                    TEST_DIR,
+                    speech_recognition_path,
+                    "keyphrase_boosting.yaml",
+                    "keyphrases",
+                    "PolyAI",
+                ),
+                os.path.join(
+                    TEST_DIR,
+                    speech_recognition_path,
+                    "keyphrase_boosting.yaml",
+                    "keyphrases",
+                    "reservation",
+                ),
+                os.path.join(
+                    TEST_DIR,
+                    speech_recognition_path,
+                    "keyphrase_boosting.yaml",
+                    "keyphrases",
+                    "check_in",
+                ),
             ],
         )
 
@@ -337,8 +361,20 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertCountEqual(
             local_resources[TranscriptCorrection],
             [
-                os.path.join(TEST_DIR, speech_recognition_path, "transcript_corrections.yaml", "corrections", "Email_domain_fix"),
-                os.path.join(TEST_DIR, speech_recognition_path, "transcript_corrections.yaml", "corrections", "Number_normalization"),
+                os.path.join(
+                    TEST_DIR,
+                    speech_recognition_path,
+                    "transcript_corrections.yaml",
+                    "corrections",
+                    "Email_domain_fix",
+                ),
+                os.path.join(
+                    TEST_DIR,
+                    speech_recognition_path,
+                    "transcript_corrections.yaml",
+                    "corrections",
+                    "Number_normalization",
+                ),
             ],
         )
 
@@ -356,7 +392,7 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
             [
                 os.path.join(TEST_DIR, "test_suite", "greeting_flow_test.yaml"),
                 os.path.join(TEST_DIR, "test_suite", "webchat_smoke_test.yaml"),
-            ]
+            ],
         )
 
         # Find Translations
@@ -364,12 +400,8 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertCountEqual(
             local_resources[Translation],
             [
-                os.path.join(
-                    TEST_DIR, "config", "translations.yaml", "translations", "greeting"
-                ),
-                os.path.join(
-                    TEST_DIR, "config", "translations.yaml", "translations", "farewell"
-                ),
+                os.path.join(TEST_DIR, "config", "translations.yaml", "translations", "greeting"),
+                os.path.join(TEST_DIR, "config", "translations.yaml", "translations", "farewell"),
             ],
         )
 
@@ -755,9 +787,7 @@ class GetDiffsTest(unittest.TestCase):
         """Reordering extracted_entities should not produce a diff."""
         project_data = deepcopy(PROJECT_DATA)
         # Reverse the extracted_entities order so it differs from local YAML
-        step = project_data["resources"]["flow_steps"][
-            "test_flow_with_punctuation!_welcome_step"
-        ]
+        step = project_data["resources"]["flow_steps"]["test_flow_with_punctuation!_welcome_step"]
         step["extracted_entities"] = list(reversed(step["extracted_entities"]))
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         diffs = project.get_diffs(all_files=True)
@@ -928,7 +958,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         # The original step should be in deleted_resources
         self.assertIn(FlowStep, cleaned_deleted)
         self.assertIn("flow-123_step-1", cleaned_deleted[FlowStep])
-        self.assertEqual(cleaned_deleted[FlowStep]["flow-123_step-1"].step_type, StepType.ADVANCED_STEP)
+        self.assertEqual(
+            cleaned_deleted[FlowStep]["flow-123_step-1"].step_type, StepType.ADVANCED_STEP
+        )
 
         # The updated step should be in new_resources
         self.assertIn(FlowStep, cleaned_new)
@@ -999,9 +1031,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertEqual(dummy.extracted_entities, [])
 
         self.assertIn(FlowConfig, pre_push_updated)
-        self.assertEqual(
-            pre_push_updated[FlowConfig]["flow-123"].start_step, "step-1_temp"
-        )
+        self.assertEqual(pre_push_updated[FlowConfig]["flow-123"].start_step, "step-1_temp")
 
         # Post-push: delete dummy
         self.assertIn(FlowStep, post_push_deleted)
@@ -1021,9 +1051,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             StepType.DEFAULT_STEP,
         )
         self.assertIn(FlowConfig, cleaned_updated)
-        self.assertEqual(
-            cleaned_updated[FlowConfig]["flow-123"].start_step, "step-1"
-        )
+        self.assertEqual(cleaned_updated[FlowConfig]["flow-123"].start_step, "step-1")
 
     def test_clean_resources_before_push_deletes_start_step_after_switching_to_different_step(
         self,
@@ -1142,9 +1170,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-1",
         )
 
-        self.project.resources.setdefault(FlowStep, {})[
-            "Test Flow_step-abc123"
-        ] = old_start_step
+        self.project.resources.setdefault(FlowStep, {})["Test Flow_step-abc123"] = old_start_step
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
         new_resources = {FlowStep: {"Test Flow_step-1": new_start_step}}
@@ -1172,9 +1198,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertEqual(dummy.step_id, "step-abc123_temp")
 
         self.assertIn(FlowConfig, pre_push_updated)
-        self.assertEqual(
-            pre_push_updated[FlowConfig]["flow-123"].start_step, "step-abc123_temp"
-        )
+        self.assertEqual(pre_push_updated[FlowConfig]["flow-123"].start_step, "step-abc123_temp")
 
         # Post-push: delete dummy (not old step - old stays in main push deleted)
         self.assertIn(FlowStep, post_push_deleted)
@@ -1225,9 +1249,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-2",
         )
 
-        self.project.resources.setdefault(FunctionStep, {})[
-            "Test Flow_func_step"
-        ] = old_function_step
+        self.project.resources.setdefault(FunctionStep, {})["Test Flow_func_step"] = (
+            old_function_step
+        )
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
         new_resources = {FlowStep: {"Test Flow_step-2": new_flow_step}}
@@ -1290,16 +1314,14 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="func_step",
         )
 
-        self.project.resources.setdefault(FunctionStep, {})[
-            "Test Flow_func_step_old"
-        ] = old_function_step
+        self.project.resources.setdefault(FunctionStep, {})["Test Flow_func_step_old"] = (
+            old_function_step
+        )
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
         new_resources = {FunctionStep: {"Test Flow_func_step": new_function_step}}
         updated_resources = {FlowConfig: {"flow-123": updated_flow_config}}
-        deleted_resources = {
-            FunctionStep: {"Test Flow_func_step_old": old_function_step}
-        }
+        deleted_resources = {FunctionStep: {"Test Flow_func_step_old": old_function_step}}
 
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1373,7 +1395,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertEqual(created_flow.start_step, "entry_func_start_step_temp")
         step_ids = [s.step_id for s in created_flow.steps]
         self.assertIn("entry_func_start_step_temp", step_ids)
-        dummy_step = next(s for s in created_flow.steps if s.step_id == "entry_func_start_step_temp")
+        dummy_step = next(
+            s for s in created_flow.steps if s.step_id == "entry_func_start_step_temp"
+        )
         self.assertEqual(dummy_step.step_type, StepType.DEFAULT_STEP)
 
         # Flow config update is scheduled to reset start to the function step
@@ -1623,7 +1647,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         # But the condition belonging to that step should NOT be deleted
         self.assertNotIn("CONDITION-cond-1", cleaned_deleted.get(Condition, {}))
 
-    def test_clean_resources_before_push_condition_update_becomes_create_when_original_target_step_deleted(self):
+    def test_clean_resources_before_push_condition_update_becomes_create_when_original_target_step_deleted(
+        self,
+    ):
         """When a condition is updated but its original child_step is being deleted,
         move it from updated to new (the platform auto-deletes the condition on step delete,
         so an update would fail)."""
@@ -1710,9 +1736,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         }
 
         with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            push_changes = self.project._clean_resources_before_push(
-                {}, new_resources, {}, {}
-            )
+            push_changes = self.project._clean_resources_before_push({}, new_resources, {}, {})
             mock_api.queue_command.assert_called_once()
 
         self.assertNotIn(ChatGreeting, push_changes.main.new)
@@ -1951,7 +1975,6 @@ class PushProjectTest(unittest.TestCase):
         deleted_resources = call_args.kwargs["deleted_resources"]
         self.assertIn(Condition, deleted_resources)
 
-
     def test_push_project_updated_sub_resource_asr_biasing(self):
         """Test pushing an updated ASRBiasing sub-resource"""
         project_data = deepcopy(PROJECT_DATA)
@@ -2041,7 +2064,9 @@ class PushProjectTest(unittest.TestCase):
 
     def test_push_project_modified_keyphrase_boosting(self):
         project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["keyphrase_boosting"]["KEYPHRASE_BOOSTING-polyai"]["level"] = "default"
+        project_data["resources"]["keyphrase_boosting"]["KEYPHRASE_BOOSTING-polyai"]["level"] = (
+            "default"
+        )
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
 
         success, message, commands = project.push_project(force=True)
@@ -2055,7 +2080,9 @@ class PushProjectTest(unittest.TestCase):
 
     def test_push_project_new_transcript_correction(self):
         project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["transcript_corrections"].pop("TRANSCRIPT_CORRECTIONS-email_domain")
+        project_data["resources"]["transcript_corrections"].pop(
+            "TRANSCRIPT_CORRECTIONS-email_domain"
+        )
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
 
         success, message, commands = project.push_project(force=True)
@@ -2106,7 +2133,9 @@ class PushProjectTest(unittest.TestCase):
     def test_push_project_validation_error(self):
         project_data = deepcopy(PROJECT_DATA)
         # Create invalid resource (empty description)
-        project_data["resources"]["flow_config"]["FLOW_CONFIG-test_flow"]["description"] = "description"
+        project_data["resources"]["flow_config"]["FLOW_CONFIG-test_flow"]["description"] = (
+            "description"
+        )
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         # Modify the local file to match
         flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
@@ -2121,7 +2150,9 @@ class PushProjectTest(unittest.TestCase):
     def test_push_project_validation_error_skip(self):
         project_data = deepcopy(PROJECT_DATA)
         # Create invalid resource (empty description)
-        project_data["resources"]["flow_config"]["FLOW_CONFIG-test_flow"]["description"] = "description"
+        project_data["resources"]["flow_config"]["FLOW_CONFIG-test_flow"]["description"] = (
+            "description"
+        )
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         # Modify the local file to match
         flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
@@ -2181,7 +2212,9 @@ class ValidateProjectTest(unittest.TestCase):
         ):
             errors = project.validate_project()
         self.assertEqual(len(errors), 2)
-        self.assertIn("Invalid references: ['global_functions: FUNCTION-missing_function']", errors[0])
+        self.assertIn(
+            "Invalid references: ['global_functions: FUNCTION-missing_function']", errors[0]
+        )
         self.assertIn("Start step 'missing_step' not found.", errors[1])
 
 
@@ -2244,11 +2277,7 @@ class PullProjectTest(unittest.TestCase):
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
         with mock_read_from_file(
-            {
-                os.path.join(
-                    TEST_DIR, "config", "variant_attributes.yaml"
-                ): "{}\n"
-            }
+            {os.path.join(TEST_DIR, "config", "variant_attributes.yaml"): "{}\n"}
         ):
             files_with_conflicts, _ = project.pull_project(force=False)
 
@@ -2371,9 +2400,7 @@ class PullProjectTest(unittest.TestCase):
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
         # Mock local file with different changes
-        flow_config_path = os.path.join(
-            TEST_DIR, "flows", "test_flow", "flow_config.yaml"
-        )
+        flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
         with mock_read_from_file(
             {
                 flow_config_path: "name: test_flow\ndescription: Modified locally - different description\nstart_step: start_step\n"
@@ -2392,7 +2419,9 @@ class PullProjectTest(unittest.TestCase):
             if len(call[0]) >= 2 and call[0][1] == flow_config_path
         ]
         # Check that the saved content contains merge conflict
-        self.assertGreater(len(flow_config_calls), 0, "save_to_file should be called for flow_config.yaml")
+        self.assertGreater(
+            len(flow_config_calls), 0, "save_to_file should be called for flow_config.yaml"
+        )
         saved_content = flow_config_calls[0][0][0] if flow_config_calls else ""
         # Verify merge conflict markers are present
         self.assertIn("<<<<<<<", saved_content)
@@ -2537,7 +2566,9 @@ class PullProjectTest(unittest.TestCase):
 
         full_project_resources = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR).resources
         incoming_resources = deepcopy(full_project_resources)
-        incoming_resources[Function]["FUNCTION-test_function_with_parameters"].code = 'def test_function_with_parameters(conv: Conversation):\n    """Test function with parameters."""\n    return "Test function with parameters"\n'
+        incoming_resources[Function][
+            "FUNCTION-test_function_with_parameters"
+        ].code = 'def test_function_with_parameters(conv: Conversation):\n    """Test function with parameters."""\n    return "Test function with parameters"\n'
 
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
         files_with_conflicts, _ = project.pull_project(force=False)
@@ -2546,7 +2577,7 @@ class PullProjectTest(unittest.TestCase):
     def test_pull_project_deleted_locally(self):
         """Test pulling when a resource was deleted locally and exists remotely"""
         project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["topics"]['TOPIC-new-topic'] = {
+        project_data["resources"]["topics"]["TOPIC-new-topic"] = {
             "resource_id": "TOPIC-new-topic",
             "name": "new-topic",
             "actions": "Use {{fn:test_function}}",
@@ -2570,7 +2601,6 @@ class PullProjectTest(unittest.TestCase):
         ]
         self.assertEqual(test_topic_calls, [])
 
-
     def test_pull_project_resource_moved(self):
         """Test pulling when a resource's file path has changed (e.g., renamed)"""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
@@ -2580,8 +2610,8 @@ class PullProjectTest(unittest.TestCase):
         # Store original path before renaming
         original_path = renamed_topic.get_path(TEST_DIR)
         # Clear cached property so it recalculates with new name
-        if hasattr(renamed_topic, '__dict__'):
-            renamed_topic.__dict__.pop('file_path', None)
+        if hasattr(renamed_topic, "__dict__"):
+            renamed_topic.__dict__.pop("file_path", None)
 
         # Rename the topic (this changes the file path)
         renamed_topic.name = "renamed_topic"
@@ -2646,9 +2676,7 @@ class PullProjectTest(unittest.TestCase):
         cache rebuild) and local_kp_content on the third call (post-loop local-file read).
         All other file paths fall through to the real file on disk.
         """
-        kp_path = os.path.join(
-            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
-        )
+        kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         kp_call_count = [0]
 
         def side_effect(path, **kwargs):
@@ -2673,9 +2701,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
-        kp_path = os.path.join(
-            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
-        )
+        kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         # dump_yaml format produced by MultiResourceYamlResource.save(save_to_cache=True)
         original_kp_content = (
             "keyphrases:\n"
@@ -2720,9 +2746,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
-        kp_path = os.path.join(
-            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
-        )
+        kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         original_kp_content = (
             "keyphrases:\n"
             "- keyphrase: PolyAI\n"
@@ -2779,9 +2803,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
-        kp_path = os.path.join(
-            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
-        )
+        kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         original_kp_content = (
             "keyphrases:\n"
             "- keyphrase: PolyAI\n"
@@ -2816,7 +2838,9 @@ class PullProjectTest(unittest.TestCase):
             for call in self.mock_save_to_file.call_args_list
             if len(call[0]) >= 2 and kp_path in str(call[0][1])
         ]
-        self.assertGreater(len(kp_calls), 0, "save_to_file should be called for keyphrase_boosting.yaml")
+        self.assertGreater(
+            len(kp_calls), 0, "save_to_file should be called for keyphrase_boosting.yaml"
+        )
         saved_content = kp_calls[-1][0][0]
         self.assertIn("<<<<<<<", saved_content)
         self.assertIn("=======", saved_content)
@@ -2832,9 +2856,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
         self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
 
-        kp_path = os.path.join(
-            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
-        )
+        kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
 
         MultiResourceYamlResource._file_cache.clear()
         files_with_conflicts, _ = project.pull_project(force=True)
@@ -2964,9 +2986,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         func_id = "FUNCTION-test_function"
         modified_func = deepcopy(incoming_resources[Function][func_id])
-        modified_func.code = (
-            'def test_function(conv: Conversation):\n    """Modified in live."""\n    return "Live"\n'
-        )
+        modified_func.code = 'def test_function(conv: Conversation):\n    """Modified in live."""\n    return "Live"\n'
         incoming_resources[Function][func_id] = modified_func
         self.mock_get_remote.return_value = incoming_resources
 
@@ -3004,9 +3024,9 @@ class PullProjectFromEnvTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         incoming_resources = deepcopy(project.resources)
         func_id = "FUNCTION-test_function"
-        incoming_resources[Function][func_id].code = (
-            'def test_function(conv: Conversation):\n    return "From live"\n'
-        )
+        incoming_resources[Function][
+            func_id
+        ].code = 'def test_function(conv: Conversation):\n    return "From live"\n'
         self.mock_get_remote.return_value = incoming_resources
 
         with mock_read_from_file(
@@ -3254,6 +3274,53 @@ class GetUpdatedSubresourcesTest(unittest.TestCase):
             change_set.updated[TestCaseTags][test_case.resource_id].tags,
             ["booking"],
         )
+
+
+class ReadLocalResourceErrorTest(unittest.TestCase):
+    """read_local_resource should attach file + cause context to read errors."""
+
+    def _mapping(self):
+        return ResourceMapping(
+            resource_id="FUNCTION-broken",
+            resource_type=Function,
+            resource_name="broken",
+            file_path=os.path.join(TEST_DIR, "functions", "broken.py"),
+            flow_name=None,
+            resource_prefix="fn",
+        )
+
+    def test_typeerror_adds_yaml_scalar_hint(self):
+        """A TypeError (the unquoted-scalar footgun) is wrapped with the cause."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        mapping = self._mapping()
+        with patch.object(
+            Function,
+            "read_local_resource",
+            side_effect=TypeError("bad argument type for built-in operation"),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                project.read_local_resource(resource=mapping, resource_mappings=[mapping])
+        message = str(ctx.exception)
+        self.assertIn(mapping.file_path, message)
+        self.assertIn("bad argument type for built-in operation", message)
+        self.assertIn("unquoted", message)
+        self.assertIn("quote the value", message)
+
+    def test_non_typeerror_keeps_plain_wrapping(self):
+        """Other errors keep the plain message — no spurious YAML hint."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        mapping = self._mapping()
+        with patch.object(
+            Function,
+            "read_local_resource",
+            side_effect=ValueError("some other problem"),
+        ):
+            with self.assertRaises(ValueError) as ctx:
+                project.read_local_resource(resource=mapping, resource_mappings=[mapping])
+        message = str(ctx.exception)
+        self.assertIn(mapping.file_path, message)
+        self.assertIn("some other problem", message)
+        self.assertNotIn("unquoted", message)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -137,15 +137,17 @@ class MergeUtilsTests(unittest.TestCase):
         updated = "keep\nversion A\nkeep"
         incoming = "keep\nversion B\nkeep"
         result = utils.merge_strings(original, updated, incoming)
-        expected = "\n".join([
-            "keep",
-            "<<<<<<<",
-            "version A",
-            "=======",
-            "version B",
-            ">>>>>>>",
-            "keep",
-        ])
+        expected = "\n".join(
+            [
+                "keep",
+                "<<<<<<<",
+                "version A",
+                "=======",
+                "version B",
+                ">>>>>>>",
+                "keep",
+            ]
+        )
         self.assertEqual(result, expected)
 
     def test_merge_strings_with_trailing_newlines(self):
@@ -289,7 +291,6 @@ def test_code(
             restored_code,
         )
 
-
         with_docstring_code = """import random
 def test_code(
     conv: Conversation,
@@ -371,16 +372,8 @@ def test_code(
 
     def test_restore_function_def_line_comment_with_hash_in_body(self):
         """Test that a # inside the comment text is not double-spaced."""
-        code = (
-            "def test_code(\n"
-            "    conv: Conversation\n"
-            "):  # see issue #123\n"
-            "    pass\n"
-        )
-        expected = (
-            "def test_code(conv: Conversation):  # see issue #123\n"
-            "    pass\n"
-        )
+        code = "def test_code(\n    conv: Conversation\n):  # see issue #123\n    pass\n"
+        expected = "def test_code(conv: Conversation):  # see issue #123\n    pass\n"
         restored = resource_utils.restore_function_def_line(code, "test_code")
         self.assertEqual(restored, expected)
 
@@ -407,10 +400,14 @@ class StringUtilsTests(unittest.TestCase):
         self.assertEqual(cleaned_name, "this_is_a_test_name_with_special_chars")
 
         allow_uppercase = "ThisIsATestName"
-        self.assertEqual(resource_utils.clean_name(allow_uppercase, lowercase=False), "ThisIsATestName")
+        self.assertEqual(
+            resource_utils.clean_name(allow_uppercase, lowercase=False), "ThisIsATestName"
+        )
 
         allow_non_english = "こんにちは"
-        self.assertEqual(resource_utils.clean_name(allow_non_english, lowercase=False), "こんにちは")
+        self.assertEqual(
+            resource_utils.clean_name(allow_non_english, lowercase=False), "こんにちは"
+        )
 
     def test_to_snake_case(self):
         camel_case = "ThisIsATestName"
@@ -547,9 +544,7 @@ class ValidateReferencesTests(unittest.TestCase):
         self.assertTrue(valid)
         self.assertEqual(invalid, [])
 
-        valid, invalid = resource_utils.validate_references(
-            {"attributes": {}, "variables": {}}, []
-        )
+        valid, invalid = resource_utils.validate_references({"attributes": {}, "variables": {}}, [])
         self.assertTrue(valid)
         self.assertEqual(invalid, [])
 
@@ -918,6 +913,35 @@ class FlowUtilsTests(unittest.TestCase):
         self.assertIsNone(flow_name_none)
 
     # TODO: Test assigning positions to flow steps
+
+
+class LoadYamlErrorTests(unittest.TestCase):
+    """load_yaml should turn opaque parse failures into an actionable hint."""
+
+    def assert_scalar_hint(self, content):
+        with self.assertRaises(ValueError) as ctx:
+            resource_utils.load_yaml(content)
+        message = str(ctx.exception)
+        self.assertIn("unquoted", message)
+        self.assertIn("quote the value", message)
+
+    def test_unquoted_mid_sentence_colon(self):
+        # Reads as `mapping values are not allowed here`.
+        self.assert_scalar_hint("name: foo\noutcome: either press 1: or press 2")
+
+    def test_leading_open_bracket(self):
+        # Reads as an unterminated flow sequence.
+        self.assert_scalar_hint("outcome: [press 1 or press 2")
+
+    def test_unknown_alias(self):
+        # A leading * reads as an alias to an undefined anchor.
+        self.assert_scalar_hint("outcome: *press")
+
+    def test_valid_yaml_still_parses(self):
+        self.assertEqual(
+            resource_utils.load_yaml("name: foo\noutcome: press 1 or press 2"),
+            {"name": "foo", "outcome": "press 1 or press 2"},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Make the opaque `/push` failure on malformed resource YAML actionable: `read_local_resource` now catches `TypeError` specifically and re-raises with the file path it already reports **plus** the likely cause (an unquoted YAML scalar parsed as the wrong type).

## Motivation

When a pushed resource YAML has an unquoted scalar that parses as the wrong type — a string with a mid-sentence colon (`outcome: either ...`) read as a mapping, or a leading `[ { * & ?` read as a sequence/anchor — `push_project` raises a bare CPython `TypeError` ("bad argument type for built-in operation"). The `/push` HTTP service surfaces that verbatim as a 422, so consumers (e.g. Glot, the Agent Studio assistant) get an error that names no file or field and bisect blindly to find the offending value.

Linear: DEVP-331

## Changes

- `read_local_resource` (`src/poly/project.py`): add a `TypeError` branch that re-raises a `ValueError` keeping the file path + original message and appending the likely cause (unquoted YAML value parsed as the wrong type — quote it). Non-`TypeError` failures keep the existing plain wrapping, so no spurious hint is added to unrelated errors.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

`ReadLocalResourceErrorTest` in `src/poly/tests/project_test.py`: a `TypeError` from the resource read is wrapped with the file path + YAML hint; a non-`TypeError` keeps the plain message with no hint.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (new tests + nearby read/discover/find suites)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Before: `ADK /push returned status 422: {"detail":"bad argument type for built-in operation"}`
After: `Error reading resource <name> at <file>: bad argument type for built-in operation. A YAML value is likely unquoted and parsed as the wrong type — check for an unquoted mid-sentence colon or a leading [ { * & ? and quote the value.`