### PR TITLE
fix: [docs] bottom-panel loop-backs across docs

### DIFF
--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -7,25 +7,25 @@ Small, focused examples that can be copied and adapted when building with the **
 
 <div class="grid cards" markdown>
 
--   **Concepts**
+-   **Confirm caller ID before SMS**
 
     ---
 
-    Learn how a feature or workflow works before applying it.
-    [Open core concepts](../concepts/working-locally.md)
+    Validate the caller's identity before sending an SMS confirmation.
+    [Open example](./confirm-caller-id-before-sms.md)
 
--   **Reference**
-
-    ---
-
-    Look up exact fields, structures, and command behavior.
-    [Open CLI reference](../reference/cli.md)
-
--   **Tutorials**
+-   **Venue-specific goodbye**
 
     ---
 
-    Follow a complete workflow from start to finish.
-    [Open tutorials](../tutorials/build-an-agent.md)
+    Customize the agent's closing message based on variant attributes.
+    [Open example](./venue-specific-goodbye.md)
+
+-   **SMS link with transfer fallback**
+
+    ---
+
+    Send an SMS with a link and fall back to a live transfer if it fails.
+    [Open example](./sms-or-transfer-fallback.md)
 
 </div>

--- a/docs/docs/get-started/prerequisites.md
+++ b/docs/docs/get-started/prerequisites.md
@@ -51,11 +51,11 @@ Before continuing, confirm:
 
 <div class="grid cards" markdown>
 
--   **Getting started**
+-   **First commands**
 
     ---
 
-    Install the ADK, sign in, and create your first project.
-    [Open getting started](./get-started.md)
+    Initialize a project, pull configuration, and push your first change.
+    [Open first commands](./first-commands.md)
 
 </div>

--- a/docs/docs/get-started/what-is-the-adk.md
+++ b/docs/docs/get-started/what-is-the-adk.md
@@ -45,25 +45,25 @@ It preserves the same guardrails as Agent Studio, so developers cannot push chan
 
 <div class="grid cards" markdown>
 
--   **Not sure where to start?**
-
-    ---
-
-    Build a working agent from your website in minutes, then pull it into the ADK.
-    [Open getting started guide](./get-started.md)
-
--   **Install the ADK**
-
-    ---
-
-    Install the ADK and get your first project running.
-    [Open getting started](./get-started.md)
-
 -   **Watch the walkthrough**
 
     ---
 
     See a practical demonstration of the ADK in use.
     [Open the walkthrough video](./walkthrough-video.md)
+
+-   **Install prerequisites**
+
+    ---
+
+    Set up uv, Git, and your API key before running your first commands.
+    [Open prerequisites](./prerequisites.md)
+
+-   **Run your first commands**
+
+    ---
+
+    Initialize a project, pull configuration, and push your first change.
+    [Open first commands](./first-commands.md)
 
 </div>

--- a/docs/docs/reference/branch_merge.md
+++ b/docs/docs/reference/branch_merge.md
@@ -143,19 +143,19 @@ The web UI surfaces the same conflicts as the CLI and lets you resolve them in t
 
 <div class="grid cards" markdown>
 
--   **CLI reference**
+-   **Tests**
 
     ---
 
-    Full surface of every `poly` command, including `poly branch` and its sibling subcommands.
-    [Open CLI reference](./cli.md)
+    Validate agent behavior with conversation tests before merging.
+    [Open tests reference](./tests.md)
 
--   **Working locally**
+-   **Tooling**
 
     ---
 
-    Where branching fits into the daily edit/push/test loop.
-    [Open working locally](../concepts/working-locally.md)
+    IDE extensions and AI coding tools that integrate with the ADK workflow.
+    [Open tooling](./tooling.md)
 
 -   **Multi-user workflows and guardrails**
 
@@ -163,12 +163,5 @@ The web UI surfaces the same conflicts as the CLI and lets you resolve them in t
 
     How branches, merges, and validation interact across a team.
     [Open multi-user workflows](../concepts/multi-user-and-guardrails.md)
-
--   **Build an agent tutorial**
-
-    ---
-
-    Walks through a feature-branch workflow end-to-end.
-    [Open the tutorial](../tutorials/build-an-agent.md)
 
 </div>

--- a/docs/docs/reference/tooling.md
+++ b/docs/docs/reference/tooling.md
@@ -103,22 +103,29 @@ Tooling slots into the standard [CLI workflow](./cli.md#working-pattern): pull o
 
     Faster editing and generation are valuable, but project review, validation, and testing still matter.
 
-## Related pages
+## Next steps
 
 <div class="grid cards" markdown>
 
--   **Getting started**
+-   **Agent settings reference**
 
     ---
 
-    Install the ADK and set up your environment.
-    [Open getting started](../get-started/get-started.md)
+    Configure personality, role, and rules that define agent behavior.
+    [Open agent settings](./agent_settings.md)
 
--   **CLI reference**
+-   **Flows reference**
 
     ---
 
-    Review the commands that drive the local workflow.
-    [Open CLI reference](./cli.md)
+    Build conversation flows with prompts, transitions, and entities.
+    [Open flows reference](./flows.md)
+
+-   **Functions reference**
+
+    ---
+
+    Write Python functions the agent calls at runtime.
+    [Open functions reference](./functions.md)
 
 </div>

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -471,6 +471,22 @@ At that point, the agent is live.
 
 <div class="grid cards" markdown>
 
+-   **Restaurant booking agent**
+
+    ---
+
+    Apply the workflow to a real-world example with flows, functions, and variants.
+
+    [Open restaurant booking tutorial](./restaurant-booking-agent.md)
+
+-   **Core concepts**
+
+    ---
+
+    Understand resource architecture, local development patterns, and team workflows.
+
+    [Open core concepts](../concepts/working-locally.md)
+
 -   **CLI reference**
 
     ---
@@ -478,13 +494,5 @@ At that point, the agent is live.
     Explore the available ADK commands and options.
 
     [Open CLI reference](../reference/cli.md)
-
--   **Walkthrough video**
-
-    ---
-
-    See the workflow demonstrated in video form.
-
-    [Open the walkthrough video](../get-started/walkthrough-video.md)
 
 </div>


### PR DESCRIPTION
## Summary

- Replace backward-pointing "Related" / "Next steps" card links with forward-pointing ones across 6 pages so every bottom panel guides readers deeper into the docs
- Fix `examples/index.md` which listed no actual examples — now links to all 3 example pages
- Fix `reference/branch_merge.md` which was a complete navigation dead-end (all 4 links backward)

## Pages changed

| Page | Problem | Fix |
|------|---------|-----|
| `get-started/what-is-the-adk` | 2 of 3 links loop back to `get-started` | Points forward to walkthrough, prerequisites, first-commands |
| `get-started/prerequisites` | Only link goes back to `get-started` | Points forward to `first-commands` |
| `tutorials/build-an-agent` | Links back to walkthrough video | Points forward to restaurant-booking tutorial + core concepts |
| `examples/index` | No example links; 2 of 3 links backward | Lists all 3 example pages |
| `reference/tooling` | Both links backward | Points forward to agent_settings, flows, functions |
| `reference/branch_merge` | All 4 links backward (dead end) | Points forward to tests, tooling + keeps multi-user cross-ref |

## Test plan

- [ ] Run `mkdocs serve` locally and verify bottom-panel "Previous/Next" navigation follows sidebar order
- [ ] Click through all changed card links and confirm they resolve correctly
- [ ] Verify no broken links introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)