### PR TITLE
fix: send X-Poly-Source header on all API requests

### DIFF
--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -103,6 +103,7 @@ class PlatformAPIHandler:
                 "X-API-KEY": retrieve_api_key(region),
                 "X-PolyAI-Correlation-Id": correlation_id,
                 "Content-Type": "application/json",
+                "X-Poly-Source": "adk",
             }
 
         logger.info(f"Making {method} request to {url}")
@@ -572,6 +573,7 @@ class PlatformAPIHandler:
             "Authorization": f"Bearer {jwt_token}",
             "Content-Type": "application/json",
             "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
         }
 
         return PlatformAPIHandler.make_request(
@@ -594,6 +596,7 @@ class PlatformAPIHandler:
             "Authorization": f"Bearer {jwt_token}",
             "Content-Type": "application/json",
             "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
         }
 
         return PlatformAPIHandler.make_request(
@@ -617,6 +620,7 @@ class PlatformAPIHandler:
             "Authorization": f"Bearer {jwt_token}",
             "Content-Type": "application/json",
             "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
         }
 
         response = PlatformAPIHandler.make_request(
@@ -699,6 +703,7 @@ class PlatformAPIHandler:
         headers = {
             "X-API-KEY": retrieve_api_key(region),
             "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
         }
         params = {"direction": direction, "redacted": str(redacted).lower()}
 

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -57,6 +57,7 @@ class SourcererSDK:
                 "Content-Type": "application/json",
                 "X-API-KEY": retrieve_api_key(self.region),
                 "X-PolyAI-Correlation-Id": correlation_id,
+                "X-Poly-Source": "adk",
             }
             if self.email:
                 headers["X-PolyAI-Email"] = self.email


### PR DESCRIPTION
## Summary

Adds the `X-Poly-Source: adk` header to all outbound API requests so the platform can identify traffic originating from the ADK CLI.

## Motivation

Enables the platform team to distinguish ADK-originated requests from other API consumers for analytics, debugging, and rate-limiting purposes.

## Changes

- Added `X-Poly-Source: adk` header to `PlatformAPIHandler.make_request` (API-key auth path)
- Added `X-Poly-Source: adk` header to JWT-authenticated endpoints (`push_resource`, `push_function`, `publish_agent`)
- Added `X-Poly-Source: adk` header to `get_conversation_logs`
- Added `X-Poly-Source: adk` header to `SourcererSDK` request headers

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)