### PR TITLE
feat: add `integrations` command and support cxone-chat

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -62,6 +62,7 @@ from poly.output.console import (
 from poly.output.json_output import json_print, commands_to_dicts
 from poly.handlers.github_api_handler import GitHubAPIHandler
 from poly.handlers.auth0_handler import Auth0Handler
+from poly.handlers.platform_api import PlatformAPIHandler
 from poly.handlers.interface import (
     REGIONS,
     AgentStudioInterface,
@@ -1255,6 +1256,85 @@ class AgentStudioCLI:
             help="Output file path. Defaults to <conversation_id>.wav.",
         )
 
+        # --- integrations get/apply ---
+        integrations_parser = subparsers.add_parser(
+            "integrations",
+            help="Manage integrations for the project.",
+            description=(
+                "Manage messaging handoff integrations (non-versioned, updates live).\n\n"
+                "Examples:\n"
+                "  poly integrations get cxone-chat\n"
+                "  poly integrations apply cxone-chat -f integrations/cxone-chat.yaml\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        integrations_sub = integrations_parser.add_subparsers(
+            dest="integrations_subcommand", required=True
+        )
+
+        integrations_sub.add_parser(
+            "list",
+            parents=[json_parent, verbose_parent],
+            help="List available integration types.",
+        )
+
+        integrations_get_parser = integrations_sub.add_parser(
+            "get",
+            parents=[json_parent, verbose_parent],
+            help="Fetch a messaging handoff integration.",
+        )
+        integrations_get_parser.add_argument(
+            "integration_name",
+            type=str,
+            help="Integration name (e.g. cxone-chat)",
+        )
+        integrations_get_parser.add_argument(
+            "-p",
+            "--path",
+            type=str,
+            default=".",
+            help="Path to the project directory (default: current directory)",
+        )
+        integrations_get_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            choices=["table", "yaml"],
+            default="table",
+            help="Output format (default: table)",
+        )
+
+        integrations_apply_parser = integrations_sub.add_parser(
+            "apply",
+            parents=[json_parent, verbose_parent],
+            help="Apply a messaging handoff integration (LIVE).",
+        )
+        integrations_apply_parser.add_argument(
+            "integration_name",
+            type=str,
+            help="Integration name (e.g. cxone-chat)",
+        )
+        integrations_apply_parser.add_argument(
+            "-f",
+            "--file",
+            type=str,
+            required=True,
+            help="Path to the YAML file to apply",
+        )
+        integrations_apply_parser.add_argument(
+            "-p",
+            "--path",
+            type=str,
+            default=".",
+            help="Path to the project directory (default: current directory)",
+        )
+        integrations_apply_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            default=False,
+            help="Show diff without applying changes",
+        )
+
         return parser
 
     @classmethod
@@ -1500,6 +1580,22 @@ class AgentStudioCLI:
                         output_json=args.json,
                     )
 
+            elif args.command == "integrations":
+                if args.integrations_subcommand == "list":
+                    cls.list_integrations(args.json)
+                elif args.integrations_subcommand == "get":
+                    cls.get_integration(
+                        args.path, args.integration_name, args.json, output=args.output
+                    )
+                elif args.integrations_subcommand == "apply":
+                    cls.apply_integration(
+                        args.path,
+                        args.integration_name,
+                        args.file,
+                        args.json,
+                        dry_run=args.dry_run,
+                    )
+
             elif args.command == "start":
                 cls.start(base_path=args.base_path)
 
@@ -1522,6 +1618,232 @@ class AgentStudioCLI:
         """
         script = argcomplete.shellcode(["poly", "adk"], shell=shell)
         print(script)
+
+    @classmethod
+    def _get_variant_mappings(
+        cls, project: AgentStudioProject
+    ) -> tuple[dict[str, str], dict[str, str]]:
+        """Get variant ID/name mappings from the project's projection.
+
+        Args:
+            project: The loaded project
+
+        Returns:
+            (variant_id_to_name, variant_name_to_id)
+        """
+        from poly.resources.variant_attributes import Variant
+
+        resources, _ = project.api_handler.pull_resources()
+        variant_id_to_name: dict[str, str] = {}
+        variant_name_to_id: dict[str, str] = {}
+        for resource in resources.get(Variant, {}).values():
+            variant_id_to_name[resource.resource_id] = resource.name
+            variant_name_to_id[resource.name] = resource.resource_id
+        return variant_id_to_name, variant_name_to_id
+
+    @classmethod
+    def list_integrations(cls, output_json: bool = False) -> None:
+        """List available integration types."""
+        from poly.resources.messaging_integration import INTEGRATION_TYPES
+
+        if output_json:
+            json_print(list(INTEGRATION_TYPES.keys()))
+            return
+
+        for slug, meta in INTEGRATION_TYPES.items():
+            console.print(f"  [bold]{slug}[/bold]  {meta['description']}")
+
+    @classmethod
+    def get_integration(
+        cls,
+        base_path: str,
+        integration_name: str,
+        output_json: bool = False,
+        output: str = "table",
+    ) -> None:
+        """Fetch a messaging handoff integration.
+
+        Args:
+            base_path: Path to the project directory
+            integration_name: The local integration name (e.g. "cxone-chat")
+            output_json: If True, output raw JSON instead of YAML
+            output: Output format — "table" or "yaml"
+        """
+        from poly.resources.messaging_integration import (
+            LOCAL_NAME_TO_API_TYPE,
+            api_response_to_yaml,
+        )
+
+        api_type = LOCAL_NAME_TO_API_TYPE.get(integration_name)
+        if not api_type:
+            error(
+                f"Unknown integration '{integration_name}'. "
+                f"Known integrations: {', '.join(LOCAL_NAME_TO_API_TYPE)}"
+            )
+            sys.exit(1)
+
+        project = cls.read_project_config(base_path)
+        if not project:
+            error("No project found. Run from within a project directory.")
+            sys.exit(1)
+
+        if output != "yaml":
+            info(f"Fetching {integration_name} from {project.account_id}/{project.project_id}...")
+        response = PlatformAPIHandler.get_messaging_integration(
+            region=project.region,
+            account_id=project.account_id,
+            project_id=project.project_id,
+            integration_type=api_type,
+        )
+        if response is None:
+            error(f"No {integration_name} integration found for this project.")
+            sys.exit(1)
+
+        if output_json:
+            json_print(response)
+            return
+
+        variant_id_to_name, _ = cls._get_variant_mappings(project)
+        yaml_data = api_response_to_yaml(response, variant_id_to_name)
+
+        if output == "yaml":
+            print(yaml_data, end="")
+            return
+
+        import yaml as _yaml
+        from rich.table import Table
+
+        data = _yaml.safe_load(yaml_data)
+        credential_sets = data.get("credential_sets", {})
+
+        all_fields: list[str] = []
+        for cred_values in credential_sets.values():
+            for k in cred_values:
+                if k not in all_fields:
+                    all_fields.append(k)
+
+        table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+        table.add_column("Variant", style="bold yellow", no_wrap=True)
+        table.add_column("Credential Set", no_wrap=True)
+        table.add_column("Default", no_wrap=True, justify="center")
+        for field in all_fields:
+            table.add_column(field, no_wrap=True)
+
+        for v in data.get("variants", []):
+            default = "[green]✓[/green]" if v.get("is_default") else ""
+            cred_name = v["credential_set"]
+            cred = credential_sets.get(cred_name, {})
+            table.add_row(
+                v["name"],
+                cred_name,
+                default,
+                *[str(cred.get(f, "")) for f in all_fields],
+            )
+
+        console.print()
+        console.print(table)
+
+    @classmethod
+    def apply_integration(
+        cls,
+        base_path: str,
+        integration_name: str,
+        file_path: str,
+        output_json: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        """Apply a messaging handoff integration YAML file to the platform.
+
+        Args:
+            base_path: Path to the project directory
+            integration_name: The local integration name (e.g. "cxone-chat")
+            file_path: Path to the YAML file to apply
+            output_json: If True, output JSON result
+            dry_run: If True, show diff only without applying
+        """
+        from poly.resources.messaging_integration import (
+            LOCAL_NAME_TO_API_TYPE,
+            api_response_to_yaml,
+            yaml_to_api_payload,
+        )
+        from poly.resources.resource_utils import get_diff
+
+        api_type = LOCAL_NAME_TO_API_TYPE.get(integration_name)
+        if not api_type:
+            error(
+                f"Unknown integration '{integration_name}'. "
+                f"Known integrations: {', '.join(LOCAL_NAME_TO_API_TYPE)}"
+            )
+            sys.exit(1)
+
+        if not os.path.exists(file_path):
+            error(f"File not found: {file_path}")
+            sys.exit(1)
+
+        project = cls.read_project_config(base_path)
+        if not project:
+            error("No project found. Run from within a project directory.")
+            sys.exit(1)
+
+        with open(file_path, encoding="utf-8") as f:
+            yaml_content = f.read()
+
+        variant_id_to_name, variant_name_to_id = cls._get_variant_mappings(project)
+
+        try:
+            payload = yaml_to_api_payload(yaml_content, variant_name_to_id)
+        except (ValueError, KeyError) as e:
+            error(f"Invalid YAML: {e}")
+            sys.exit(1)
+
+        # Fetch current config and show diff
+        current_response = PlatformAPIHandler.get_messaging_integration(
+            region=project.region,
+            account_id=project.account_id,
+            project_id=project.project_id,
+            integration_type=api_type,
+        )
+        current_yaml = (
+            api_response_to_yaml(current_response, variant_id_to_name) if current_response else ""
+        )
+        new_yaml = api_response_to_yaml(payload, variant_id_to_name)
+        diff = get_diff(current_yaml, new_yaml)
+
+        if not diff:
+            info("No changes detected.")
+            return
+
+        print_diff(diff)
+
+        if dry_run:
+            return
+
+        warning(
+            f"This will update the LIVE {integration_name} integration "
+            f"for {project.account_id}/{project.project_id} ({project.region})."
+        )
+        confirm = input("Continue? [y/N]: ").strip().lower()
+        if confirm != "y":
+            info("Aborted.")
+            return
+
+        info(f"Applying {integration_name}...")
+        try:
+            result = PlatformAPIHandler.put_messaging_integration(
+                region=project.region,
+                account_id=project.account_id,
+                project_id=project.project_id,
+                integration_type=api_type,
+                data=payload,
+            )
+        except requests.HTTPError as e:
+            error(f"Failed to apply: {e}")
+            sys.exit(1)
+
+        if output_json:
+            json_print({"success": True, "response": result})
+        else:
+            success(f"Successfully applied {integration_name}.")
 
     @classmethod
     def main(cls, sys_args=None):

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -557,6 +557,19 @@ class PlatformAPIHandler:
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
 
     @staticmethod
+    def _jupiter_headers(region: str) -> dict[str, str]:
+        """Build auth headers for Jupiter API using a polyctx OAuth token."""
+        from poly.utils import load_polyctx_token
+
+        token = load_polyctx_token(region)
+        correlation_id = f"adk-{uuid.uuid4()}"
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+            "X-PolyAI-Correlation-Id": correlation_id,
+        }
+
+    @staticmethod
     def authorise(region: str, jwt_token: str) -> dict:
         """Authorise the user via JWT, creating their account if needed.
 
@@ -628,6 +641,67 @@ class PlatformAPIHandler:
             use_jupiter_api=True,
         )
         return response.get("key")
+
+    @staticmethod
+    def get_messaging_integration(
+        region: str,
+        account_id: str,
+        project_id: str,
+        integration_type: str,
+    ) -> ty.Optional[dict]:
+        """Fetch a messaging handoff integration config from the Jupiter API.
+
+        Args:
+            region: The region name
+            account_id: The account ID
+            project_id: The project ID
+            integration_type: The API integration type (e.g. "nice")
+
+        Returns:
+            dict | None: The integration config, or None if not found
+        """
+        endpoint = (
+            f"/jupiter/v2/accounts/{account_id}/projects/{project_id}"
+            f"/messaging-handoff-integrations/{integration_type}"
+        )
+        headers = PlatformAPIHandler._jupiter_headers(region)
+        try:
+            return PlatformAPIHandler.make_request(
+                region, endpoint, "GET", headers=headers, use_jupiter_api=True
+            )
+        except requests.HTTPError as e:
+            if hasattr(e, "response") and e.response is not None and e.response.status_code == 404:
+                return None
+            raise
+
+    @staticmethod
+    def put_messaging_integration(
+        region: str,
+        account_id: str,
+        project_id: str,
+        integration_type: str,
+        data: dict,
+    ) -> dict:
+        """Update a messaging handoff integration config via the Jupiter API.
+
+        Args:
+            region: The region name
+            account_id: The account ID
+            project_id: The project ID
+            integration_type: The API integration type (e.g. "nice")
+            data: The full integration payload
+
+        Returns:
+            dict: The API response
+        """
+        endpoint = (
+            f"/jupiter/v2/accounts/{account_id}/projects/{project_id}"
+            f"/messaging-handoff-integrations/{integration_type}"
+        )
+        headers = PlatformAPIHandler._jupiter_headers(region)
+        return PlatformAPIHandler.make_request(
+            region, endpoint, "PUT", data=data, headers=headers, use_jupiter_api=True
+        )
 
     @staticmethod
     def list_conversations(

--- a/src/poly/resources/messaging_integration.py
+++ b/src/poly/resources/messaging_integration.py
@@ -1,0 +1,119 @@
+"""Messaging handoff integration transforms.
+
+Converts between the Jupiter API format and the local YAML format.
+Handles variant ID/name resolution and per-env credential flattening.
+
+Copyright PolyAI Limited
+"""
+
+from typing import Any
+
+import yaml
+
+# Maps API integration type to local CLI name.
+INTEGRATION_TYPES: dict[str, dict[str, str]] = {
+    "cxone-chat": {
+        "api_type": "nice",
+        "name": "NICE CXone Messaging",
+        "description": "Hand off chat conversations to NICE CXone agents via the Chat SDK.",
+    },
+}
+API_TYPE_TO_LOCAL_NAME: dict[str, str] = {v["api_type"]: k for k, v in INTEGRATION_TYPES.items()}
+LOCAL_NAME_TO_API_TYPE: dict[str, str] = {v: k for k, v in API_TYPE_TO_LOCAL_NAME.items()}
+
+
+def api_response_to_yaml(
+    api_response: dict,
+    variant_id_to_name: dict[str, str],
+) -> str:
+    """Convert a Jupiter API response to the local YAML format.
+
+    Args:
+        api_response: Raw JSON from the messaging-handoff-integrations endpoint
+        variant_id_to_name: Mapping of variant IDs to human-readable names
+
+    Returns:
+        YAML string for the local file
+    """
+    raw_assignments = dict(api_response.get("_assignments", {}))
+    default_cred_set = raw_assignments.pop("__default__", "")
+
+    raw_cred_sets = api_response.get("_credential_sets", {})
+    credential_sets: dict[str, dict[str, Any]] = {}
+    for cred_name, envs in raw_cred_sets.items():
+        first_env = next(iter(envs.values()), {})
+        credential_sets[cred_name] = {
+            k: v.strip() if isinstance(v, str) else v for k, v in first_env.items()
+        }
+
+    variants: list[dict[str, Any]] = []
+    for variant_id, cred_set in raw_assignments.items():
+        entry: dict[str, Any] = {
+            "name": variant_id_to_name.get(variant_id, variant_id),
+            "credential_set": cred_set,
+        }
+        if cred_set == default_cred_set:
+            entry["is_default"] = True
+        variants.append(entry)
+
+    data = {
+        "variants": variants,
+        "credential_sets": credential_sets,
+    }
+    return yaml.dump(data, default_flow_style=False, sort_keys=False, allow_unicode=True)
+
+
+def yaml_to_api_payload(
+    yaml_content: str,
+    variant_name_to_id: dict[str, str],
+) -> dict:
+    """Convert a local YAML file to the Jupiter API payload format.
+
+    Args:
+        yaml_content: The raw YAML string from the local file
+        variant_name_to_id: Mapping of variant names to IDs
+
+    Returns:
+        dict suitable for PUT to the messaging-handoff-integrations endpoint
+
+    Raises:
+        ValueError: If the YAML is invalid or missing required fields
+    """
+    data = yaml.safe_load(yaml_content)
+    if not data:
+        raise ValueError("YAML file is empty")
+
+    assignments: dict[str, str] = {}
+    default_cred_set = ""
+
+    for v in data.get("variants", []):
+        name = v.get("name", "")
+        variant_id = variant_name_to_id.get(name, name)
+        cred_set = v["credential_set"]
+        assignments[variant_id] = cred_set
+        if v.get("is_default"):
+            default_cred_set = cred_set
+
+    if not default_cred_set:
+        raise ValueError("No variant has is_default: true")
+
+    assignments["__default__"] = default_cred_set
+
+    envs = ("sandbox", "pre-release", "live")
+    credential_sets = data.get("credential_sets", {})
+    expanded: dict[str, dict[str, dict[str, Any]]] = {}
+    for cred_name, config in credential_sets.items():
+        expanded[cred_name] = {env: dict(config) for env in envs}
+
+    for v in data.get("variants", []):
+        cred_set = v["credential_set"]
+        if cred_set not in credential_sets:
+            raise ValueError(
+                f"Variant '{v.get('name')}' references unknown credential set '{cred_set}'"
+            )
+
+    return {
+        "_assignments": assignments,
+        "_credential_sets": expanded,
+        "_version": 2,
+    }

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -84,6 +84,13 @@ from poly.resources.topic import (
     Topic,
 )
 from poly.resources.transcript_correction import RegularExpressionRule, TranscriptCorrection
+from poly.resources.messaging_integration import (
+    API_TYPE_TO_LOCAL_NAME,
+    INTEGRATION_TYPES,
+    LOCAL_NAME_TO_API_TYPE,
+    api_response_to_yaml,
+    yaml_to_api_payload,
+)
 from poly.resources.translations import Translation
 from poly.resources.variable import Variable
 from poly.resources.variant_attributes import Variant, VariantAttribute
@@ -8108,6 +8115,228 @@ class CheckYamlFieldTypesTest(unittest.TestCase):
             variant=None,
         )
         resource_utils.check_yaml_field_types(test_case)
+
+
+class MessagingIntegrationTests(unittest.TestCase):
+    """Tests for messaging_integration transform functions."""
+
+    SAMPLE_API_RESPONSE = {
+        "_assignments": {
+            "VARIANT-AC274AAB": "breakers",
+            "VARIANT-FC763DBD": "bayview",
+            "__default__": "breakers",
+        },
+        "_credential_sets": {
+            "bayview": {
+                "live": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_abc ",
+                },
+                "pre-release": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_abc ",
+                },
+                "sandbox": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_abc ",
+                },
+            },
+            "breakers": {
+                "live": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_def",
+                },
+                "pre-release": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_def",
+                },
+                "sandbox": {
+                    "environment": "NA1",
+                    "ws_brand_id": "5724",
+                    "ws_channel_id": "chat_def",
+                },
+            },
+        },
+        "_version": 2,
+    }
+
+    VARIANT_ID_TO_NAME = {
+        "VARIANT-AC274AAB": "breakers-variant",
+        "VARIANT-FC763DBD": "bayview-variant",
+    }
+
+    VARIANT_NAME_TO_ID = {v: k for k, v in VARIANT_ID_TO_NAME.items()}
+
+    # -- INTEGRATION_TYPES mappings --
+
+    def test_integration_types_api_type_round_trip(self):
+        """API_TYPE_TO_LOCAL_NAME and LOCAL_NAME_TO_API_TYPE are consistent inverses."""
+        for local_name, info in INTEGRATION_TYPES.items():
+            api_type = info["api_type"]
+            self.assertEqual(API_TYPE_TO_LOCAL_NAME[api_type], local_name)
+            self.assertEqual(LOCAL_NAME_TO_API_TYPE[local_name], api_type)
+
+    def test_api_type_to_local_name_has_all_entries(self):
+        """API_TYPE_TO_LOCAL_NAME has one entry per INTEGRATION_TYPES entry."""
+        self.assertEqual(len(API_TYPE_TO_LOCAL_NAME), len(INTEGRATION_TYPES))
+
+    # -- api_response_to_yaml --
+
+    def test_api_response_to_yaml_resolves_variant_ids_to_names(self):
+        """Variant IDs in assignments are resolved to human-readable names."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        data = yaml.safe_load(yaml_str)
+        variant_names = {v["name"] for v in data["variants"]}
+        self.assertEqual(variant_names, {"breakers-variant", "bayview-variant"})
+
+    def test_api_response_to_yaml_flattens_credential_sets(self):
+        """Per-env credentials are collapsed to a single flat dict per credential set."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        data = yaml.safe_load(yaml_str)
+        # Credential sets should be flat dicts, not nested by env
+        for cred_name, cred_values in data["credential_sets"].items():
+            self.assertIsInstance(cred_values, dict)
+            for key, val in cred_values.items():
+                self.assertNotIn(key, ("sandbox", "pre-release", "live"))
+
+    def test_api_response_to_yaml_strips_whitespace_from_credentials(self):
+        """Trailing whitespace on credential values is stripped."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        data = yaml.safe_load(yaml_str)
+        # The bayview credential set had trailing space on ws_channel_id
+        bayview_creds = data["credential_sets"]["bayview"]
+        self.assertEqual(bayview_creds["ws_channel_id"], "chat_abc")
+
+    def test_api_response_to_yaml_sets_is_default(self):
+        """The variant whose credential_set matches __default__ gets is_default: true."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        data = yaml.safe_load(yaml_str)
+        defaults = [v for v in data["variants"] if v.get("is_default")]
+        self.assertEqual(len(defaults), 1)
+        self.assertEqual(defaults[0]["credential_set"], "breakers")
+
+    def test_api_response_to_yaml_unmapped_variant_id_passes_through(self):
+        """Variant IDs not in the mapping are used as-is."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, {})
+        data = yaml.safe_load(yaml_str)
+        variant_names = {v["name"] for v in data["variants"]}
+        self.assertIn("VARIANT-AC274AAB", variant_names)
+        self.assertIn("VARIANT-FC763DBD", variant_names)
+
+    def test_api_response_to_yaml_empty_assignments(self):
+        """An API response with no assignments produces empty variants list."""
+        api = {"_assignments": {"__default__": "x"}, "_credential_sets": {}}
+        yaml_str = api_response_to_yaml(api, {})
+        data = yaml.safe_load(yaml_str)
+        self.assertEqual(data["variants"], [])
+
+    # -- yaml_to_api_payload --
+
+    def test_yaml_to_api_payload_expands_to_three_envs(self):
+        """Flat credentials are expanded to sandbox, pre-release, and live."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        payload = yaml_to_api_payload(yaml_str, self.VARIANT_NAME_TO_ID)
+        for cred_name, envs in payload["_credential_sets"].items():
+            self.assertEqual(set(envs.keys()), {"sandbox", "pre-release", "live"})
+
+    def test_yaml_to_api_payload_resolves_names_to_ids(self):
+        """Variant names in YAML are resolved back to IDs in the payload."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        payload = yaml_to_api_payload(yaml_str, self.VARIANT_NAME_TO_ID)
+        assignment_keys = set(payload["_assignments"].keys())
+        self.assertIn("VARIANT-AC274AAB", assignment_keys)
+        self.assertIn("VARIANT-FC763DBD", assignment_keys)
+
+    def test_yaml_to_api_payload_sets_default_from_is_default(self):
+        """The __default__ assignment is set from the variant with is_default: true."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        payload = yaml_to_api_payload(yaml_str, self.VARIANT_NAME_TO_ID)
+        self.assertEqual(payload["_assignments"]["__default__"], "breakers")
+
+    def test_yaml_to_api_payload_unmapped_name_passes_through(self):
+        """Variant names not in the mapping are used as-is for the ID."""
+        yaml_content = yaml.dump(
+            {
+                "variants": [
+                    {"name": "unknown-variant", "credential_set": "creds", "is_default": True},
+                ],
+                "credential_sets": {"creds": {"key": "value"}},
+            }
+        )
+        payload = yaml_to_api_payload(yaml_content, {})
+        self.assertIn("unknown-variant", payload["_assignments"])
+
+    def test_yaml_to_api_payload_version_is_2(self):
+        """The payload always includes _version: 2."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        payload = yaml_to_api_payload(yaml_str, self.VARIANT_NAME_TO_ID)
+        self.assertEqual(payload["_version"], 2)
+
+    # -- Error cases --
+
+    def test_yaml_to_api_payload_empty_yaml_raises(self):
+        """Empty YAML content raises ValueError."""
+        with self.assertRaises(ValueError) as cm:
+            yaml_to_api_payload("", {})
+        self.assertIn("empty", str(cm.exception).lower())
+
+    def test_yaml_to_api_payload_no_is_default_raises(self):
+        """YAML with no is_default variant raises ValueError."""
+        yaml_content = yaml.dump(
+            {
+                "variants": [
+                    {"name": "v1", "credential_set": "creds"},
+                ],
+                "credential_sets": {"creds": {"key": "value"}},
+            }
+        )
+        with self.assertRaises(ValueError) as cm:
+            yaml_to_api_payload(yaml_content, {})
+        self.assertIn("is_default", str(cm.exception))
+
+    def test_yaml_to_api_payload_unknown_credential_set_raises(self):
+        """Variant referencing a non-existent credential set raises ValueError."""
+        yaml_content = yaml.dump(
+            {
+                "variants": [
+                    {"name": "v1", "credential_set": "nonexistent", "is_default": True},
+                ],
+                "credential_sets": {"real_creds": {"key": "value"}},
+            }
+        )
+        with self.assertRaises(ValueError) as cm:
+            yaml_to_api_payload(yaml_content, {})
+        self.assertIn("nonexistent", str(cm.exception))
+
+    # -- Roundtrip --
+
+    def test_roundtrip_api_to_yaml_to_api(self):
+        """API response -> YAML -> API payload reproduces the original structure."""
+        yaml_str = api_response_to_yaml(self.SAMPLE_API_RESPONSE, self.VARIANT_ID_TO_NAME)
+        payload = yaml_to_api_payload(yaml_str, self.VARIANT_NAME_TO_ID)
+
+        # Assignments should match (values are credential set names, keys are variant IDs)
+        original_assignments = dict(self.SAMPLE_API_RESPONSE["_assignments"])
+        self.assertEqual(payload["_assignments"], original_assignments)
+
+        # Credential sets: the roundtrip should produce identical expanded creds
+        # (stripped whitespace is the only expected difference)
+        for cred_name in self.SAMPLE_API_RESPONSE["_credential_sets"]:
+            for env in ("sandbox", "pre-release", "live"):
+                original = self.SAMPLE_API_RESPONSE["_credential_sets"][cred_name][env]
+                result = payload["_credential_sets"][cred_name][env]
+                for key in original:
+                    expected = (
+                        original[key].strip() if isinstance(original[key], str) else original[key]
+                    )
+                    self.assertEqual(result[key], expected)
+
+        self.assertEqual(payload["_version"], 2)
 
 
 if __name__ == "__main__":

--- a/src/poly/utils.py
+++ b/src/poly/utils.py
@@ -105,6 +105,60 @@ def retrieve_api_key(region: str) -> str:
     return api_key
 
 
+def load_polyctx_token(region: str) -> str:
+    """Load a polyctx OAuth token for the given region.
+
+    Reads from ~/.polyctx/token-platform-{region}. If the token is expired
+    or missing, runs ``polyctx profile {region}`` to refresh it.
+
+    Args:
+        region: The region name (e.g. "us-1", "euw-1")
+
+    Returns:
+        The access token string
+
+    Raises:
+        ValueError: If the token cannot be loaded
+    """
+    import subprocess
+    from datetime import UTC, datetime, timedelta
+
+    polyctx_region = "us-1-staging" if region == "staging" else region
+    token_path = os.path.expanduser(f"~/.polyctx/token-platform-{region}")
+
+    if not os.path.exists(token_path):
+        subprocess.run(
+            ["/bin/zsh", "-i", "-c", f"polyctx profile {polyctx_region}"],
+            check=True,
+            timeout=60,
+        )
+
+    def _read_token() -> dict:
+        with open(token_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    token_data = _read_token()
+
+    if "expires_at" not in token_data:
+        raise ValueError("expires_at not found in polyctx token file")
+
+    from dateutil.parser import isoparse
+
+    expires_at = isoparse(token_data["expires_at"])
+    if expires_at <= datetime.now(UTC) + timedelta(minutes=1):
+        subprocess.run(
+            ["/bin/zsh", "-i", "-c", f"polyctx profile {polyctx_region}"],
+            check=True,
+            timeout=60,
+        )
+        token_data = _read_token()
+
+    if "access_token" not in token_data:
+        raise ValueError("access_token not found in polyctx token file")
+
+    return token_data["access_token"]
+
+
 def any_credentials_exist() -> bool:
     """Check if any API key credentials are available via environment variables or credential file."""
     if os.getenv(_API_KEY_ENV_VAR):


### PR DESCRIPTION
## Summary

Add `adk integrations` commands to fetch and apply integration configs (e.g. NICE CXone Messaging) directly from the Jupiter API.

## Motivation

There was no CLI support for managing integrations; users had to use the Agent Studio UI to configure integrations. Some integrations support multiple channels, and manually adding all channels could be time-consuming.

Messaging handoff integrations (e.g. NICE CXone Messaging) are not in the project projection. They have no versioning or deployment pipeline — changes take effect immediately. 

## Changes

- Add `adk integrations list` — lists supported integration types
- Add `adk integrations get <name>` — fetches config from Jupiter API, displays as table or YAML (-o yaml)
- Add `adk integrations apply <name> -f <file>` — applies a YAML file to the live integration with diff preview and confirmation prompt; supports --dry-run
- Add `get_messaging_integration` / `put_messaging_integration` to `PlatformAPIHandler` using polyctx OAuth auth
- Add `load_polyctx_token` utility for Jupiter API authentication
- Add `messaging_integration.py` transform module (API response ↔ YAML with variant ID/name resolution and per-env credential flattening)

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [x] Added/updated unit tests
- [X] Manual CLI testing (`poly <command>`)
- [X] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [X] `ruff check .` and `ruff format --check .` pass
- [X] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

```
% adk integrations list                                                      
  cxone-chat  Hand off chat conversations to NICE CXone agents via the Chat SDK.
  


% adk integrations get cxone-chat                                            
Fetching cxone-chat from brittain-us/brittain-usp...

 Variant          Credential Set  Default  environment  ws_brand_id  ws_channel_id                             
 Breakers Resort  breakers           ✓     NA1          5724         chat_6a80240b-f07d-4069-8581-a6cf69a094ba 
 Bay View Resort  bayview                  NA1          5724         chat_3465a6ac-815d-40ed-8362-4548cb275fa7 
 


 % adk integrations apply cxone-chat -f integrations/cxone-chat.yaml --dry-run
--- original
+++ updated
@@ -4,6 +4,68 @@
   is_default: true
 - name: Bay View Resort
   credential_set: bayview
+- name: Caribbean
+  credential_set: caribbean
+- name: Compass Cove
+  credential_set: compass_cove
 credential_sets:
   bayview:
     environment: NA1
@@ -13,3 +75,127 @@
     environment: NA1
     ws_brand_id: '5724'
     ws_channel_id: chat_6a80240b-f07d-4069-8581-a6cf69a094ba
+  caribbean:
+    environment: NA1
+    ws_brand_id: '5724'
+    ws_channel_id: chat_094dfe10-5665-4bb7-9d0c-7c29bcc8ad6d
+  compass_cove:
+    environment: NA1
+    ws_brand_id: '5724'
+    ws_channel_id: chat_61e34ae4-6ca2-4c62-b357-88b56beaf963
```