### PR TITLE
feat: open agent studio from cli

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -246,6 +246,23 @@ class AgentStudioCLI:
             help="Base path to initialize the project. Defaults to current working directory.",
         )
 
+        # STUDIO (open project in Agent Studio web UI)
+        studio_parser = subparsers.add_parser(
+            "studio",
+            parents=[verbose_parent, json_parent],
+            help="Open the current project in Agent Studio (web).",
+            description=(
+                "Open the project in the Agent Studio web application using the default browser."
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        studio_parser.add_argument(
+            "--path",
+            type=str,
+            default=os.getcwd(),
+            help="Base path to the project. Defaults to current working directory.",
+        )
+
         # Login (existing enterprise users)
         login_parser = subparsers.add_parser(
             "login",
@@ -1634,6 +1651,9 @@ class AgentStudioCLI:
                         output_json=args.json,
                     )
 
+            elif args.command == "studio":
+                cls.open_agent_studio(base_path=args.path, output_json=args.json)
+
             elif args.command == "start":
                 cls.start(base_path=args.base_path)
 
@@ -1763,6 +1783,17 @@ class AgentStudioCLI:
             return None
         # Recurse into parent directory
         return cls.read_project_config(parent_path)
+
+    @classmethod
+    def open_agent_studio(cls, base_path: str = "", output_json: bool = False) -> None:
+        """Open the current project in the Agent Studio web UI."""
+        project = cls._load_project(base_path or os.getcwd(), output_json=output_json)
+        url = project.studio_base_url
+        if output_json:
+            json_print({"url": url})
+        else:
+            info(f"Opening {url}")
+            webbrowser.open(url)
 
     @classmethod
     def create_project(

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2546,6 +2546,14 @@ class AgentStudioProject:
             environment=environment,
         )
 
+    @property
+    def studio_base_url(self) -> str:
+        """Base Agent Studio URL for this project's region."""
+        region_link_map = {"uk-1": "uk", "euw-1": "eu", "us-1": "us", "studio": ""}
+        short = region_link_map.get(self.region, self.region)
+        domain = f"studio.{short}.poly.ai" if short else "studio.poly.ai"
+        return f"https://{domain}/{self.account_id}/{self.project_id}"
+
     def get_conversation_url(self, conversation_id: str) -> str:
         """Build the Studio URL for a conversation.
 
@@ -2555,13 +2563,7 @@ class AgentStudioProject:
         Returns:
             str: The URL of the conversation.
         """
-        region_link_map = {"uk-1": "uk", "euw-1": "eu", "us-1": "us"}
-        short = region_link_map.get(self.region, self.region)
-        return (
-            f"https://studio.{short}.poly.ai"
-            f"/{self.account_id}/{self.project_id}"
-            f"/conversations/{conversation_id}"
-        )
+        return f"{self.studio_base_url}/conversations/{conversation_id}"
 
     def _make_resource_mappings(self, resources: ResourceMap) -> list[ResourceMapping]:
         resource_mappings: list[ResourceMapping] = []


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->
Adds a new command in the cli "poly studio" to open agent studio in the web browser and takes the user to the specific workspace and project.
## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->
To make it easier for users to access agent studio. 
Closes #<!-- issue number -->[DEVP-326](https://linear.app/poly-ai/issue/DEVP-326)

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

- added new command "poly studio"
- created new function to build studio base url

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

  - [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->
https://www.loom.com/share/6804c76d2f554a97af38254167f91d10