### PR TITLE
fix: Bump experimental config schema with Raven ASR

### DIFF
--- a/src/poly/resources/experimental_config_schema.yaml
+++ b/src/poly/resources/experimental_config_schema.yaml
@@ -29,6 +29,7 @@ components:
         - fano
         - nemo
         - deepgram
+        - raven
 
     asr_common_config_properties:
       type: object
@@ -43,6 +44,7 @@ components:
             - riva: Riva in-house speech recognition engine
             - openai: OpenAI realtime API
             - deepgram: Deepgram cloud speech recognition
+            - raven: PolyAI Raven Omni speech recognition
         model:
           type: string
           minLength: 1
@@ -55,6 +57,7 @@ components:
               architecture, size, decoder type, and latency characteristics
             - openai: "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"
             - deepgram: "nova-3", "nova-2"
+            - raven: "raven-omni"
         language:
           type: string
           minLength: 2


### PR DESCRIPTION
## Summary

Adds `raven` as a supported ASR engine in the experimental config schema.

## Motivation

The Raven Omni speech recognition engine needs to be a valid option in the experimental config schema so projects using it pass validation.

## Changes

- Added `raven` to the ASR engine enum list
- Added `raven: PolyAI Raven Omni speech recognition` to the engine description enum
- Added `raven: "raven-omni"` to the model documentation

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)