### PR TITLE
feat: Update help info text and poly status

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1728,12 +1728,12 @@ class AgentStudioCLI:
                 json_print(
                     {
                         "success": False,
-                        "error": "No project configuration found. Run poly init to initialize a project.",
+                        "error": "No project configuration found. Run poly init to initialize a project, or change your directory to an existing workspace/project.",
                     }
                 )
                 sys.exit(1)
             error(
-                "No project configuration found. Run [bold]poly init[/bold] to initialize a project."
+                "No project configuration found. Run [bold]poly init[/bold] to initialize a project, or change your directory to an existing workspace/project."
             )
             sys.exit(1)
         return project
@@ -2370,6 +2370,7 @@ class AgentStudioCLI:
             else:
                 region = questionary.select("Select Region", choices=regions).ask()
 
+        account_name = None
         if not account_id:
             accounts = api_handler.get_accounts(region)
             if not accounts:
@@ -2410,6 +2411,9 @@ class AgentStudioCLI:
                     warning("No account selected. Exiting.")
                     return
                 account_name = accounts[account_id]
+        else:
+            accounts = api_handler.get_accounts(region)
+            account_name = accounts.get(account_id)
 
         if not project_id:
             projects = api_handler.get_projects(region, account_id)
@@ -2491,6 +2495,7 @@ class AgentStudioCLI:
                 account_id=account_id,
                 project_id=project_id,
                 project_name=project_name,
+                account_name=account_name,
                 format=format,
                 projection_json=projection_json,
                 on_save=on_save,
@@ -2513,6 +2518,9 @@ class AgentStudioCLI:
             json_print(json_output)
         else:
             success(f"Project initialized at {project.root_path}")
+            info(
+                f'Change your working directory to your project\'s directory to continue. "cd {project.root_path}"'
+            )
 
     @classmethod
     def pull(
@@ -2642,10 +2650,22 @@ class AgentStudioCLI:
         """Check the changed files of the project."""
         project = cls._load_project(base_path, output_json=output_json)
 
+        if not project.account_name:
+            try:
+                api_handler = AgentStudioInterface()
+                accounts = api_handler.get_accounts(project.region)
+                project.account_name = accounts.get(project.account_id)
+                if project.account_name:
+                    project.save_config()
+            except Exception:
+                logger.debug("Failed to fetch account name for status display", exc_info=True)
+
         files_with_conflicts, modified_files, new_files, deleted_files = project.project_status()
 
         if output_json:
             json_output = {
+                "account_name": project.account_name,
+                "project_name": project.project_name,
                 "files_with_conflicts": files_with_conflicts,
                 "modified_files": modified_files,
                 "new_files": new_files,
@@ -2662,6 +2682,8 @@ class AgentStudioCLI:
             project_id=project.project_id,
             last_updated=project.last_updated.isoformat(),
             branch=branch_info,
+            account_name=project.account_name,
+            project_name=project.project_name,
         )
 
         print_file_list("Files with merge conflicts", files_with_conflicts, "filename.conflict")

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -81,14 +81,16 @@ def print_status(
     project_id: str,
     last_updated: str,
     branch: str,
+    account_name: str = None,
+    project_name: str = None,
 ) -> None:
     """Print project status in a styled panel."""
     table = Table(show_header=False, box=None, padding=(0, 1))
     table.add_column("Key", style="label", no_wrap=True)
     table.add_column("Value")
     table.add_row("Region", region)
-    table.add_row("Account ID", account_id)
-    table.add_row("Project ID", project_id)
+    table.add_row("Workspace", f"{account_name} ({account_id})" if account_name else account_id)
+    table.add_row("Project", f"{project_name} ({project_id})" if project_name else project_id)
     table.add_row("Last Pulled", last_updated)
     table.add_row("Current Branch", branch)
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -164,6 +164,7 @@ class AgentStudioProject:
     last_updated: datetime
     branch_id: str = None
     project_name: Optional[str] = None
+    account_name: Optional[str] = None
     _api_handler: AgentStudioInterface = None
     file_structure_info: dict[str, dict[str, str]] = None
     _migration_flags: set[MigrationFlag] = None
@@ -205,6 +206,8 @@ class AgentStudioProject:
         }
         if self.project_name:
             config["project_name"] = self.project_name
+        if self.account_name:
+            config["account_name"] = self.account_name
         return config
 
     @classmethod
@@ -278,6 +281,7 @@ class AgentStudioProject:
             file_structure_info={},
             branch_id=status_dict.get("branch_id", "main"),
             project_name=config_dict.get("project_name") or status_dict.get("project_name"),
+            account_name=config_dict.get("account_name") or status_dict.get("account_name"),
             _not_loaded_resources=not_loaded_resources,
             _migration_flags=migration_flags,
         )
@@ -298,6 +302,7 @@ class AgentStudioProject:
             "file_structure_info": self.file_structure_info,
             "branch_id": self.branch_id,
             "project_name": self.project_name,
+            "account_name": self.account_name,
             "migration_flags": [flag.value for flag in self._migration_flags]
             if self._migration_flags
             else [],
@@ -323,6 +328,7 @@ class AgentStudioProject:
             file_structure_info=file_structure_info,
             branch_id=data.get("branch_id", "main"),
             project_name=data.get("project_name"),
+            account_name=data.get("account_name"),
             _migration_flags=migration_flags,
             _not_loaded_resources=not_loaded_resources,
         )
@@ -362,6 +368,7 @@ class AgentStudioProject:
         account_id: str,
         project_id: str,
         project_name: str = None,
+        account_name: str = None,
         format: bool = False,
         projection_json: Optional[dict[str, Any]] = None,
         on_save: Callable[[int, int], None] | None = None,
@@ -374,6 +381,7 @@ class AgentStudioProject:
             account_id (str): The account ID of the project
             project_id (str): The project ID
             project_name (str): The human-readable project name
+            account_name (str): The human-readable account/workspace name
             format (bool): If True, format resources after pulling
             projection_json (dict[str, Any]): A dictionary containing the projection
                 If provided, the projection will be used instead of fetching it from the API.
@@ -397,6 +405,7 @@ class AgentStudioProject:
             last_updated=datetime.now(),
             branch_id="main",
             project_name=project_name,
+            account_name=account_name,
             _migration_flags=get_all_migration_flags(),
         )
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->
Updates the info text to remind the user that they need to change directories to a project folder to continue. Also adds workspace and project names to display during the poly status command.
## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #[DEVP-344](https://linear.app/poly-ai/issue/DEVP-344/update-help-text-and-poly-status)

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

- Updates help info text when no project configuration is found
- Adds workspace and project names to display when "poly status" command is used

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
https://www.loom.com/share/749c074bb76649d6ae6b6fe45abdeb10
<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->