### PR TITLE
feat: add CLI test commands (run, list, show)

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -40,6 +40,8 @@ from poly.output.console import (
     info,
     plain,
     poll_test_run_live,
+    print_test_run_summary,
+    print_test_detail,
     print_agents,
     print_branches,
     print_conversations,
@@ -1430,6 +1432,31 @@ class AgentStudioCLI:
             help="List the tests that would be run without triggering them.",
         )
 
+        test_get_parser = testing_subparsers.add_parser(
+            "get",
+            parents=[testing_path_parent, json_parent, verbose_parent, debug_parent],
+            help="Get test run results.",
+            description=(
+                "Get test run results.\n\n"
+                "Examples:\n"
+                "  poly test get <run_id>\n"
+                "  poly test get <run_id> <test_case_id>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        test_get_parser.add_argument(
+            "run_id",
+            type=str,
+            help="The test run ID.",
+        )
+        test_get_parser.add_argument(
+            "test_case_id",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Optional test case ID for detailed view.",
+        )
+
         return parser
 
     @classmethod
@@ -1715,6 +1742,13 @@ class AgentStudioCLI:
                         push=args.push,
                         output_json=args.json,
                         dry_run=args.dry_run,
+                    )
+                elif args.test_subcommand == "get":
+                    cls.testing_get(
+                        args.path,
+                        run_id=args.run_id,
+                        test_case_id=args.test_case_id,
+                        output_json=args.json,
                     )
 
         except Exception as e:
@@ -4864,6 +4898,46 @@ class AgentStudioCLI:
             return
 
         poll_test_run_live(project.get_test_run, test_run_id, matched)
+
+    @classmethod
+    def testing_get(
+        cls,
+        base_path: str,
+        run_id: str,
+        test_case_id: str = None,
+        output_json: bool = False,
+    ) -> None:
+        """Get test run results, optionally for a specific test case."""
+        project = cls._load_project(base_path)
+        result = project.get_test_run(run_id)
+
+        if output_json:
+            if test_case_id:
+                test_history = result.get("testHistory") or []
+                entry = next(
+                    (e for e in test_history if e.get("testCaseId") == test_case_id),
+                    None,
+                )
+                if not entry:
+                    json_print({"success": False, "error": f"Test case {test_case_id} not found"})
+                    sys.exit(1)
+                json_print({"success": True, "test": entry})
+            else:
+                json_print({"success": True, "test_run": result})
+            return
+
+        if test_case_id:
+            test_history = result.get("testHistory") or []
+            entry = next(
+                (e for e in test_history if e.get("testCaseId") == test_case_id),
+                None,
+            )
+            if not entry:
+                error(f"Test case {test_case_id} not found in run {run_id}")
+                sys.exit(1)
+            print_test_detail(entry)
+        else:
+            print_test_run_summary(result)
 
     @classmethod
     def start(cls, base_path: str) -> None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2321,7 +2321,7 @@ class AgentStudioCLI:
                     "success": True,
                     "agents": [
                         {
-                            "agent_id": a.get("agentId"),
+                            "project_id": a.get("project_id"),
                             "agent_name": a.get("agentName"),
                             "updated_at": a.get("updatedAt"),
                             "branch_count": a.get("branchCount"),
@@ -2479,7 +2479,7 @@ class AgentStudioCLI:
                 sys.exit(1)
 
         if output_json:
-            json_print({"success": True, "agent_id": project_id})
+            json_print({"success": True, "project_id": project_id})
         else:
             success(f"Deleted project [bold]{display_name}[/bold].")
 
@@ -2643,7 +2643,7 @@ class AgentStudioCLI:
         new_display = result.get("name", new_name)
 
         if output_json:
-            json_print({"success": True, "agent_id": new_id, "agent_name": new_display})
+            json_print({"success": True, "project_id": new_id, "agent_name": new_display})
         else:
             success(
                 f"Duplicated [bold]{display_name}[/bold] → [bold]{new_display}[/bold] ({new_id})"

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -4889,8 +4889,7 @@ class AgentStudioCLI:
                     success("Project pushed successfully.")
                 else:
                     json_output["push"] = {"success": True, "message": output}
-
-            if not push_success:
+            else:
                 if output_json:
                     json_output["push"] = {
                         "success": False,

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -4928,7 +4928,7 @@ class AgentStudioCLI:
 
         if dont_poll:
             info(
-                f"Use [bold]poly test get {test_run_id}[/bold] to check the status of the test run."
+                f"Use [bold]poly test show {test_run_id}[/bold] to check the status of the test run."
             )
             return
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -39,6 +39,7 @@ from poly.output.console import (
     handle_exception,
     info,
     plain,
+    poll_test_run_live,
     print_agents,
     print_branches,
     print_conversations,
@@ -4842,20 +4843,27 @@ class AgentStudioCLI:
             info(f"Running tests for {project.account_id}/{project.project_id}...")
 
         test_info = project.trigger_tests(test_ids)
+        test_run_id = test_info.get("id")
 
-        if not output_json:
-            test_run_id = test_info.get("id")
-            test_count = test_info.get("test_case_count", "?")
-            success(
-                f"Triggered test run [bold]{test_run_id}[/bold] "
-                f"({test_count} test{'s' if test_count != 1 else ''})"
-            )
+        if output_json:
+            json_output["test_run"] = test_info
+            json_output["success"] = True
+            json_print(json_output)
+            return
+
+        test_count = test_info.get("test_case_count", "?")
+        success(
+            f"Triggered test run [bold]{test_run_id}[/bold] "
+            f"({test_count} test{'s' if test_count != 1 else ''})"
+        )
+
+        if dont_poll:
             info(
                 f"Use [bold]poly test get {test_run_id}[/bold] to check the status of the test run."
             )
-        else:
-            json_output["test_run"] = test_info
-            json_output["success"] = True
+            return
+
+        poll_test_run_live(project.get_test_run, test_run_id, matched)
 
     @classmethod
     def start(cls, base_path: str) -> None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -40,6 +40,7 @@ from poly.output.console import (
     info,
     plain,
     poll_test_run_live,
+    print_test_run_list,
     print_test_run_summary,
     print_test_detail,
     print_agents,
@@ -1457,6 +1458,33 @@ class AgentStudioCLI:
             help="Optional test case ID for detailed view.",
         )
 
+        test_list_parser = testing_subparsers.add_parser(
+            "list",
+            parents=[testing_path_parent, json_parent, verbose_parent, debug_parent],
+            help="List test runs.",
+            description=(
+                "List test runs.\n\n"
+                "Examples:\n"
+                "  poly test list\n"
+                "  poly test list --limit 10 --offset 5\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        test_list_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of test runs to list. Defaults to 10.",
+        )
+
+        test_list_parser.add_argument(
+            "--offset",
+            type=int,
+            default=0,
+            help="Number of test runs to skip. Defaults to 0.",
+        )
+
         return parser
 
     @classmethod
@@ -1748,6 +1776,13 @@ class AgentStudioCLI:
                         args.path,
                         run_id=args.run_id,
                         test_case_id=args.test_case_id,
+                        output_json=args.json,
+                    )
+                elif args.test_subcommand == "list":
+                    cls.testing_list(
+                        args.path,
+                        limit=args.limit,
+                        offset=args.offset,
                         output_json=args.json,
                     )
 
@@ -4898,6 +4933,24 @@ class AgentStudioCLI:
             return
 
         poll_test_run_live(project.get_test_run, test_run_id, matched)
+
+    @classmethod
+    def testing_list(
+        cls,
+        base_path: str,
+        limit: int = 10,
+        offset: int = 0,
+        output_json: bool = False,
+    ) -> None:
+        """List test runs."""
+        project = cls._load_project(base_path)
+        result = project.list_test_runs(limit=limit, offset=offset)
+
+        if output_json:
+            json_print({"success": True, "test_runs": result})
+            return
+
+        print_test_run_list(result)
 
     @classmethod
     def testing_get(

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1393,11 +1393,13 @@ class AgentStudioCLI:
             parents=[testing_path_parent, json_parent, verbose_parent, debug_parent],
             help="Run tests for the project.",
             description=(
-                "Run tests for the project.\n\n"
+                "Run tests for the project. Runs all tests by default.\n"
+                "Use --files or --tag to filter.\n\n"
                 "Examples:\n"
                 "  poly test run\n"
                 "  poly test run --path /path/to/project\n"
                 "  poly test run --files test1.yaml test2.yaml\n"
+                "  poly test run --tag smoke\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -1411,11 +1413,6 @@ class AgentStudioCLI:
             type=str,
             nargs="*",
             help="Run tests with the specified tag(s).",
-        )
-        test_run_parser.add_argument(
-            "--all",
-            action="store_true",
-            help="Run all tests.",
         )
         test_run_parser.add_argument(
             "--dont-poll",
@@ -1765,7 +1762,6 @@ class AgentStudioCLI:
                         args.path,
                         files=args.files,
                         tags=args.tag,
-                        run_all=args.all,
                         dont_poll=args.dont_poll,
                         push=args.push,
                         output_json=args.json,
@@ -4846,7 +4842,6 @@ class AgentStudioCLI:
         base_path: str,
         files: list[str],
         tags: list[str] = None,
-        run_all: bool = False,
         dont_poll: bool = False,
         push: bool = False,
         output_json: bool = False,
@@ -4857,7 +4852,7 @@ class AgentStudioCLI:
         json_output = {}
 
         if dry_run:
-            matched = project.resolve_tests(all=run_all, files=files, tags=tags)
+            matched = project.resolve_tests(files=files, tags=tags)
             if output_json:
                 json_print(
                     {
@@ -4904,7 +4899,7 @@ class AgentStudioCLI:
                     plain(output)
                 sys.exit(1)
 
-        matched = project.resolve_tests(all=run_all, files=files, tags=tags)
+        matched = project.resolve_tests(files=files, tags=tags)
         test_ids = [t.resource_id for t in matched]
 
         if not output_json:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1434,14 +1434,14 @@ class AgentStudioCLI:
         )
 
         test_get_parser = testing_subparsers.add_parser(
-            "get",
+            "show",
             parents=[testing_path_parent, json_parent, verbose_parent, debug_parent],
-            help="Get test run results.",
+            help="View test run results.",
             description=(
                 "Get test run results.\n\n"
                 "Examples:\n"
-                "  poly test get <run_id>\n"
-                "  poly test get <run_id> <test_case_id>\n"
+                "  poly test show <run_id>\n"
+                "  poly test show <run_id> <test_case_id>\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -1771,8 +1771,8 @@ class AgentStudioCLI:
                         output_json=args.json,
                         dry_run=args.dry_run,
                     )
-                elif args.test_subcommand == "get":
-                    cls.testing_get(
+                elif args.test_subcommand == "show":
+                    cls.testing_show(
                         args.path,
                         run_id=args.run_id,
                         test_case_id=args.test_case_id,
@@ -4953,14 +4953,14 @@ class AgentStudioCLI:
         print_test_run_list(result)
 
     @classmethod
-    def testing_get(
+    def testing_show(
         cls,
         base_path: str,
         run_id: str,
         test_case_id: str = None,
         output_json: bool = False,
     ) -> None:
-        """Get test run results, optionally for a specific test case."""
+        """Show test run results, optionally for a specific test case."""
         project = cls._load_project(base_path)
         result = project.get_test_run(run_id)
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1366,6 +1366,69 @@ class AgentStudioCLI:
             help="Output file path. Defaults to <conversation_id>.wav.",
         )
 
+        # TESTING
+        testing_path_parent = ArgumentParser(add_help=False)
+        testing_path_parent.add_argument(
+            "--path",
+            type=str,
+            default=os.getcwd(),
+            help="Base path to the project. Defaults to current working directory.",
+        )
+
+        test_parser = subparsers.add_parser(
+            "test",
+            parents=[verbose_parent, debug_parent],
+            help="Manage and run tests for the project.",
+            description="Manage and run tests for the project.\n\nExamples:\n  poly test\n",
+            formatter_class=RawTextHelpFormatter,
+        )
+        testing_subparsers = test_parser.add_subparsers(dest="test_subcommand", required=True)
+
+        test_run_parser = testing_subparsers.add_parser(
+            "run",
+            parents=[testing_path_parent, json_parent, verbose_parent, debug_parent],
+            help="Run tests for the project.",
+            description=(
+                "Run tests for the project.\n\n"
+                "Examples:\n"
+                "  poly test run\n"
+                "  poly test run --path /path/to/project\n"
+                "  poly test run --files test1.yaml test2.yaml\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        test_run_parser.add_argument(
+            "--files",
+            nargs="*",
+            help="List of test files to run.",
+        )
+        test_run_parser.add_argument(
+            "--tag",
+            type=str,
+            nargs="*",
+            help="Run tests with the specified tag(s).",
+        )
+        test_run_parser.add_argument(
+            "--all",
+            action="store_true",
+            help="Run all tests.",
+        )
+        test_run_parser.add_argument(
+            "--dont-poll",
+            action="store_true",
+            help="Do not poll for test results.",
+        )
+        test_run_parser.add_argument(
+            "--push",
+            action="store_true",
+            help="Push the project before running tests.",
+        )
+        test_run_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="List the tests that would be run without triggering them.",
+        )
+
         return parser
 
     @classmethod
@@ -1639,6 +1702,19 @@ class AgentStudioCLI:
 
             elif args.command == "login":
                 cls.login(region=args.region)
+
+            elif args.command == "test":
+                if args.test_subcommand == "run":
+                    cls.testing_run(
+                        args.path,
+                        files=args.files,
+                        tags=args.tag,
+                        run_all=args.all,
+                        dont_poll=args.dont_poll,
+                        push=args.push,
+                        output_json=args.json,
+                        dry_run=args.dry_run,
+                    )
 
         except Exception as e:
             if hasattr(args, "json") and args.json:
@@ -4693,6 +4769,93 @@ class AgentStudioCLI:
         else:
             size_mb = size_bytes / 1_000_000
             success(f"Audio saved to {output_path} ({size_mb:.1f} MB)")
+
+    @classmethod
+    def testing_run(
+        cls,
+        base_path: str,
+        files: list[str],
+        tags: list[str] = None,
+        run_all: bool = False,
+        dont_poll: bool = False,
+        push: bool = False,
+        output_json: bool = False,
+        dry_run: bool = False,
+    ) -> None:
+        project = cls._load_project(base_path)
+
+        json_output = {}
+
+        if dry_run:
+            matched = project.resolve_tests(all=run_all, files=files, tags=tags)
+            if output_json:
+                json_print(
+                    {
+                        "success": True,
+                        "test_count": len(matched),
+                        "tests": [{"resource_id": t.resource_id, "name": t.name} for t in matched],
+                    }
+                )
+            else:
+                info(f"Would run {len(matched)} test{'s' if len(matched) != 1 else ''}:")
+                for test in matched:
+                    plain(f"  - {test.name} ({test.resource_id})")
+            return
+
+        if push:
+            if not output_json:
+                info("Pushing project before running tests...")
+            push_success, output, _ = project.push_project(
+                force=False,
+                skip_validation=False,
+                dry_run=False,
+                format=False,
+            )
+            if output == "No changes detected":
+                push_success = True  # Not an error if there are no changes to push
+
+            if push_success:
+                if not output_json:
+                    success("Project pushed successfully.")
+                else:
+                    json_output["push"] = {"success": True, "message": output}
+
+            if not push_success:
+                if output_json:
+                    json_output["push"] = {
+                        "success": False,
+                        "message": "Failed to push project before running tests.",
+                        "error": output,
+                    }
+                    json_print(json_output)
+                else:
+                    error(
+                        f"Failed to push {project.account_id}/{project.project_id} to Agent Studio."
+                    )
+                    plain(output)
+                sys.exit(1)
+
+        matched = project.resolve_tests(all=run_all, files=files, tags=tags)
+        test_ids = [t.resource_id for t in matched]
+
+        if not output_json:
+            info(f"Running tests for {project.account_id}/{project.project_id}...")
+
+        test_info = project.trigger_tests(test_ids)
+
+        if not output_json:
+            test_run_id = test_info.get("id")
+            test_count = test_info.get("test_case_count", "?")
+            success(
+                f"Triggered test run [bold]{test_run_id}[/bold] "
+                f"({test_count} test{'s' if test_count != 1 else ''})"
+            )
+            info(
+                f"Use [bold]poly test get {test_run_id}[/bold] to check the status of the test run."
+            )
+        else:
+            json_output["test_run"] = test_info
+            json_output["success"] = True
 
     @classmethod
     def start(cls, base_path: str) -> None:

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -2762,7 +2762,7 @@ class AgentStudioCLI:
         # If relative paths are provided, convert them to absolute paths
         files = [os.path.abspath(os.path.join(os.getcwd(), file)) for file in files or []]
 
-        files_reverted = project.revert_changes(files=files)
+        files_reverted = project.revert_changes(file_paths=files)
         if output_json:
             json_print(
                 {
@@ -2795,7 +2795,7 @@ class AgentStudioCLI:
         project = cls._load_project(base_path, output_json=output_json)
         files = [os.path.abspath(os.path.join(os.getcwd(), file)) for file in files or []]
         if not (before or after):
-            return project.get_diffs(all_files=not files, files=files)
+            return project.get_diffs(file_paths=files)
 
         if not before:
             client_env = "sandbox"
@@ -3140,7 +3140,7 @@ class AgentStudioCLI:
 
         if env in ["pre-release", "live"]:
             # Checks for any local changes on main before creating env branch.
-            if diffs := project.get_diffs(all_files=True):
+            if diffs := project.get_diffs():
                 if not force:
                     raise ValueError(
                         f"Uncommitted changes on main branch, diffs: {list(diffs.keys())}"

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -184,19 +184,19 @@ class AgentStudioInterface:
         return PlatformAPIHandler.list_agents(region, account_id)
 
     @staticmethod
-    def delete_project(region: str, agent_id: str) -> None:
+    def delete_project(region: str, project_id: str) -> None:
         """Delete a project (agent).
 
         Args:
             region (str): The region name
-            agent_id (str): The agent ID (slug) to delete
+            project_id (str): The project ID (slug) to delete
         """
-        PlatformAPIHandler.delete_project(region, agent_id)
+        PlatformAPIHandler.delete_project(region, project_id)
 
     @staticmethod
     def duplicate_project(
         region: str,
-        agent_id: str,
+        project_id: str,
         new_name: str,
         new_id: str | None = None,
     ) -> dict[str, str]:
@@ -204,7 +204,7 @@ class AgentStudioInterface:
 
         Args:
             region (str): The region name
-            agent_id (str): The agent ID (slug) to duplicate
+            project_id (str): The project ID (slug) to duplicate
             new_name (str): The display name for the new project
             new_id (str | None): Optional slug/ID for the new project.
                 When omitted the platform generates one automatically.
@@ -212,7 +212,7 @@ class AgentStudioInterface:
         Returns:
             dict[str, str]: A dictionary with the new project's 'id' and 'name'
         """
-        return PlatformAPIHandler.duplicate_project(region, agent_id, new_name, new_id)
+        return PlatformAPIHandler.duplicate_project(region, project_id, new_name, new_id)
 
     @staticmethod
     def get_deployments(

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -781,3 +781,93 @@ class AgentStudioInterface:
         return PlatformAPIHandler.get_conversation_audio(
             region, project_id, conversation_id, direction, redacted
         )
+
+    @staticmethod
+    def list_test_runs(
+        region: str,
+        project_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        test_set_id: Optional[str] = None,
+        branch_id: Optional[str] = None,
+    ) -> dict:
+        """List test runs for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of test runs to return.
+            offset: Number of test runs to skip.
+            test_set_id: Optional filter by test set ID.
+            branch_id: Optional filter by branch ID.
+
+        Returns:
+            dict: The API response with test runs.
+        """
+        return PlatformAPIHandler.list_test_runs(
+            region, project_id, limit, offset, test_set_id, branch_id
+        )
+
+    @staticmethod
+    def get_test_run(
+        region: str,
+        project_id: str,
+        test_run_id: str,
+    ) -> dict:
+        """Get a single test run by ID, including nested test history.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            test_run_id: The test run ID.
+
+        Returns:
+            dict: The test run detail response.
+        """
+        return PlatformAPIHandler.get_test_run(region, project_id, test_run_id)
+
+    @staticmethod
+    def list_test_history(
+        region: str,
+        project_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        test_case_id: Optional[str] = None,
+        branch_id: Optional[str] = None,
+    ) -> dict:
+        """List test execution history for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of history entries to return.
+            offset: Number of history entries to skip.
+            test_case_id: Optional filter by test case ID.
+            branch_id: Optional filter by branch ID.
+
+        Returns:
+            dict: The API response with test history.
+        """
+        return PlatformAPIHandler.list_test_history(
+            region, project_id, limit, offset, test_case_id, branch_id
+        )
+
+    @staticmethod
+    def trigger_test_run(
+        region: str,
+        project_id: str,
+        test_case_ids: list[str],
+        branch_id: str,
+    ) -> dict:
+        """Trigger a test run for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            test_case_ids: List of test case IDs to run.
+            branch_id: The branch ID to run tests against.
+
+        Returns:
+            dict: The created test run response.
+        """
+        return PlatformAPIHandler.trigger_test_run(region, project_id, test_case_ids, branch_id)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -36,8 +36,8 @@ CONVERSATIONS_URL = "/v1/agents/{project_id}/conversations"
 CONVERSATION_URL = "/v1/agents/{project_id}/conversations/{conversation_id}"
 CONVERSATION_AUDIO_URL = "/v1/agents/{project_id}/conversations/{conversation_id}/audio"
 LIST_AGENTS_URL = "/v1/accounts/{account_id}/agents"
-DELETE_AGENT_URL = "/v1/agents/{agent_id}"
-DUPLICATE_AGENT_URL = "/v1/agents/{agent_id}/duplicate"
+DELETE_AGENT_URL = "/v1/agents/{project_id}"
+DUPLICATE_AGENT_URL = "/v1/agents/{project_id}/duplicate"
 TEST_RUNS_URL = "/v1/agents/{project_id}/testing/test-runs"
 TEST_RUN_URL = "/v1/agents/{project_id}/testing/test-runs/{test_run_id}"
 TEST_HISTORY_URL = "/v1/agents/{project_id}/testing/test-history"
@@ -328,20 +328,20 @@ class PlatformAPIHandler:
         return agents
 
     @staticmethod
-    def delete_project(region: str, agent_id: str) -> None:
+    def delete_project(region: str, project_id: str) -> None:
         """Delete a project (agent) via the Agents API.
 
         Args:
             region (str): The region name
-            agent_id (str): The agent ID (slug) to delete
+            project_id (str): The project ID (slug) to delete
         """
-        endpoint = DELETE_AGENT_URL.format(agent_id=agent_id)
+        endpoint = DELETE_AGENT_URL.format(project_id=project_id)
         PlatformAPIHandler.make_request(region, endpoint, "DELETE")
 
     @staticmethod
     def duplicate_project(
         region: str,
-        agent_id: str,
+        project_id: str,
         new_name: str,
         new_id: str | None = None,
     ) -> dict[str, str]:
@@ -349,7 +349,7 @@ class PlatformAPIHandler:
 
         Args:
             region (str): The region name
-            agent_id (str): The agent ID (slug) to duplicate
+            project_id (str): The project ID (slug) to duplicate
             new_name (str): The display name for the new project
             new_id (str | None): Optional slug/ID for the new project.
                 When omitted the platform generates one automatically.
@@ -357,7 +357,7 @@ class PlatformAPIHandler:
         Returns:
             dict[str, str]: A dictionary with the new project's 'id' and 'name'
         """
-        endpoint = DUPLICATE_AGENT_URL.format(agent_id=agent_id)
+        endpoint = DUPLICATE_AGENT_URL.format(project_id=project_id)
         data: dict[str, str] = {"newAgentName": new_name}
         if new_id:
             data["newAgentId"] = new_id

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -35,6 +35,10 @@ CONVERSATION_AUDIO_URL = "/v1/agents/{project_id}/conversations/{conversation_id
 LIST_AGENTS_URL = "/v1/accounts/{account_id}/agents"
 DELETE_AGENT_URL = "/v1/agents/{agent_id}"
 DUPLICATE_AGENT_URL = "/v1/agents/{agent_id}/duplicate"
+TEST_RUNS_URL = "/v1/agents/{project_id}/testing/test-runs"
+TEST_RUN_URL = "/v1/agents/{project_id}/testing/test-runs/{test_run_id}"
+TEST_HISTORY_URL = "/v1/agents/{project_id}/testing/test-history"
+TRIGGER_TEST_RUN_URL = "/v1/agents/{project_id}/testing/test-runs/trigger"
 
 
 class PlatformAPIHandler:
@@ -808,3 +812,107 @@ class PlatformAPIHandler:
             raise
 
         return response.content
+
+    @staticmethod
+    def list_test_runs(
+        region: str,
+        project_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        test_set_id: ty.Optional[str] = None,
+        branch_id: ty.Optional[str] = None,
+    ) -> dict:
+        """List test runs for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of test runs to return.
+            offset: Number of test runs to skip.
+            test_set_id: Optional filter by test set ID.
+            branch_id: Optional filter by branch ID.
+
+        Returns:
+            dict: The API response with test runs.
+        """
+        endpoint = TEST_RUNS_URL.format(project_id=project_id)
+        params: dict[str, ty.Any] = {"limit": limit, "offset": offset}
+        if test_set_id:
+            params["testSetId"] = test_set_id
+        if branch_id:
+            params["branchId"] = branch_id
+        return PlatformAPIHandler.make_request(region, endpoint, "GET", params=params)
+
+    @staticmethod
+    def get_test_run(
+        region: str,
+        project_id: str,
+        test_run_id: str,
+    ) -> dict:
+        """Get a single test run by ID, including nested test history.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            test_run_id: The test run ID.
+
+        Returns:
+            dict: The test run detail response.
+        """
+        endpoint = TEST_RUN_URL.format(project_id=project_id, test_run_id=test_run_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
+
+    @staticmethod
+    def list_test_history(
+        region: str,
+        project_id: str,
+        limit: int = 100,
+        offset: int = 0,
+        test_case_id: ty.Optional[str] = None,
+        branch_id: ty.Optional[str] = None,
+    ) -> dict:
+        """List test execution history for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max number of history entries to return.
+            offset: Number of history entries to skip.
+            test_case_id: Optional filter by test case ID.
+            branch_id: Optional filter by branch ID.
+
+        Returns:
+            dict: The API response with test history.
+        """
+        endpoint = TEST_HISTORY_URL.format(project_id=project_id)
+        params: dict[str, ty.Any] = {"limit": limit, "offset": offset}
+        if test_case_id:
+            params["testCaseId"] = test_case_id
+        if branch_id:
+            params["branchId"] = branch_id
+        return PlatformAPIHandler.make_request(region, endpoint, "GET", params=params)
+
+    @staticmethod
+    def trigger_test_run(
+        region: str,
+        project_id: str,
+        test_case_ids: list[str],
+        branch_id: str,
+    ) -> dict:
+        """Trigger a test run for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            test_case_ids: List of test case IDs to run.
+            branch_id: The branch ID to run tests against.
+
+        Returns:
+            dict: The created test run response.
+        """
+        endpoint = TRIGGER_TEST_RUN_URL.format(project_id=project_id)
+        data = {
+            "testCaseIds": test_case_ids,
+            "branchId": branch_id,
+        }
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -880,11 +880,23 @@ def handle_exception(exc: Exception) -> None:
     sys.exit(1)
 
 
+# TESTING
+
+
+_COMPACT_THRESHOLD = 20
+_RECENT_COUNT = 10
+
 _TEST_STATUS_STYLES = {
     "passed": ("Passed", "green"),
     "failed": ("Failed", "red"),
     "error": ("Error", "red"),
+    "errored": ("Error", "red"),
+    "timed_out": ("Timed Out", "red"),
 }
+
+_PENDING_STATUSES = {"pending", "running", "in_progress"}
+_FAILURE_STATUSES = {"failed", "error", "errored", "timed_out"}
+_ERROR_STATUSES = {"error", "errored", "timed_out"}
 
 
 def _build_test_table(
@@ -892,7 +904,7 @@ def _build_test_table(
     test_names: dict[str, str],
     finished: bool = False,
 ) -> Table:
-    """Build a Rich table for test run results."""
+    """Build a Rich table for test run results (full mode, ≤ 20 tests)."""
     table = Table(show_header=False, show_edge=False, pad_edge=False)
     table.add_column("test", no_wrap=True)
     table.add_column("status", no_wrap=True)
@@ -900,19 +912,116 @@ def _build_test_table(
         case_id = entry.get("testCaseId", "")
         name = test_names.get(case_id, case_id)
         status = entry.get("status", "pending")
-        if finished and status in ("pending", "running", "in_progress"):
+        if finished and status in _PENDING_STATUSES:
             status = "error"
-        label, style = _TEST_STATUS_STYLES.get(status, ("Pending...", "yellow"))
-        if status in ("pending", "running", "in_progress"):
+        label, style = _TEST_STATUS_STYLES.get(status, ("Pending", "yellow"))
+        if status in _PENDING_STATUSES:
             status_cell = Spinner(
                 "dots",
-                text=f"[{style}][{label}][/{style}]",
+                text=f"[{style}]{label}[/{style}]",
                 style=style,
             )
         else:
-            status_cell = Text(f"[{label}]", style=style)
+            status_cell = Text(f"{label}", style=style)
         table.add_row(name, status_cell)
     return table
+
+
+def _build_compact_display(
+    completed: list[dict],
+    total: int,
+    test_names: dict[str, str],
+) -> Group:
+    """Build the compact rolling display (> 20 tests)."""
+    done = len(completed)
+    passed = sum(1 for e in completed if e.get("status") not in _FAILURE_STATUSES)
+    failed = sum(1 for e in completed if e.get("status") in _FAILURE_STATUSES)
+    pending = total - done
+    header = Spinner(
+        "dots",
+        text=(
+            "Running tests: "
+            f"Passed: [green]{passed}[/green]  "
+            f"Failed: [red]{failed}[/red]  "
+            f"Pending: [yellow]{pending}[/yellow]"
+        ),
+        style="info",
+    )
+    recent = completed[-_RECENT_COUNT:]
+    lines: list[Text] = []
+    if len(completed) > _RECENT_COUNT:
+        lines.append(Text("  ...", style="dim"))
+    for entry in recent:
+        case_id = entry.get("testCaseId", "")
+        name = test_names.get(case_id, case_id)
+        status = entry.get("status", "")
+        if status in _FAILURE_STATUSES:
+            lines.append(Text(f"  ✗ {name}", style="red"))
+        else:
+            lines.append(Text(f"  ✓ {name}", style="green"))
+    return Group(header, *lines)
+
+
+def _print_test_failures(
+    merged: list[dict],
+    test_names: dict[str, str],
+) -> None:
+    """Print failed test details with assertion reasons."""
+    failures = [e for e in merged if e.get("status") == "failed"]
+    errors = [e for e in merged if e.get("status") in _ERROR_STATUSES]
+    if not failures and not errors:
+        return
+
+    if errors:
+        console.print()
+        console.print("[error]Errors:[/error]")
+        for entry in errors:
+            case_id = entry.get("testCaseId", "")
+            name = test_names.get(case_id, case_id)
+            console.print(f"  [red]✗ {name}[/red] - [muted]{entry.get('status')}[/muted]")
+            test_run_id = entry.get("testRunId", "")
+            conv_id = entry.get("rawConversation", {}).get("id", "")
+            console.print(f"    [muted]Test run ID: {test_run_id}[/muted]")
+            console.print(f"    [muted]Conversation ID: {conv_id}[/muted]")
+
+    if not failures:
+        return
+
+    console.print()
+    console.print("[error]Failed:[/error]")
+    for entry in failures:
+        case_id = entry.get("testCaseId", "")
+        name = test_names.get(case_id, case_id)
+        console.print(f"  [red]✗ {name}[/red]")
+
+        results = entry.get("results") or {}
+        prompt_assertions = results.get("prompt_assertion_results") or []
+        for assertion in prompt_assertions:
+            if assertion.get("is_pass"):
+                continue
+            prompt = assertion.get("prompt", "")
+            reason = assertion.get("reason", "")
+            console.print(f"    {prompt}")
+            console.print(f"    [muted]→ {reason}[/muted]")
+
+        function_assertions = results.get("function_call_failures") or []
+        for assertion in function_assertions:
+            if assertion.get("is_pass"):
+                continue
+            function_name = assertion.get("name", "")
+            failure_reason = assertion.get("failure_reason", "")
+            function_error = assertion.get("error", "")
+            console.print(f"    {function_name}()")
+            console.print(f"    [muted]→ {failure_reason}[/muted]")
+            if function_error:
+                console.print(f"    [muted]→ {function_error}[/muted]")
+
+        test_run_id = entry.get("testRunId", "")
+        conv_id = entry.get("rawConversation", {}).get("id", "")
+        console.print(f"    [muted]Test run ID: {test_run_id}[/muted]")
+        console.print(f"    [muted]Conversation ID: {conv_id}[/muted]")
+
+        console.print()
 
 
 def poll_test_run_live(
@@ -934,15 +1043,21 @@ def poll_test_run_live(
     """
     import time
 
+    total = len(matched_tests)
     test_names = {t.resource_id: t.name for t in matched_tests}
     pending_results = [{"testCaseId": t.resource_id, "status": "pending"} for t in matched_tests]
+    compact = total > _COMPACT_THRESHOLD
+
+    seen_done: set[str] = set()
+    completed_ordered: list[dict] = []
 
     merged = pending_results
-    with Live(
-        _build_test_table(merged, test_names),
-        console=console,
-        refresh_per_second=10,
-    ) as live:
+    initial = (
+        _build_compact_display([], total, test_names)
+        if compact
+        else _build_test_table(merged, test_names)
+    )
+    with Live(initial, console=console, refresh_per_second=10) as live:
         while True:
             time.sleep(poll_interval)
             result = get_test_run(test_run_id)
@@ -950,25 +1065,39 @@ def poll_test_run_live(
 
             actual_by_id = {r.get("testCaseId"): r for r in test_results}
             merged = [actual_by_id.get(p.get("testCaseId"), p) for p in pending_results]
-            live.update(_build_test_table(merged, test_names))
+
+            for entry in merged:
+                cid = entry.get("testCaseId", "")
+                st = entry.get("status", "pending")
+                if st not in _PENDING_STATUSES and cid not in seen_done:
+                    seen_done.add(cid)
+                    completed_ordered.append(entry)
+
+            if compact:
+                live.update(_build_compact_display(completed_ordered, total, test_names))
+            else:
+                live.update(_build_test_table(merged, test_names))
 
             status = result.get("status", "")
-            if status not in ("pending", "running", "in_progress"):
-                live.update(_build_test_table(merged, test_names, finished=True))
+            if status not in _PENDING_STATUSES:
+                if not compact:
+                    live.update(_build_test_table(merged, test_names, finished=True))
                 break
+
+    _print_test_failures(merged, test_names)
 
     passed = result.get("passedCount", 0)
     failed = result.get("failedCount", 0)
     error_count = result.get("errorCount", 0)
-    total = result.get("testCaseCount", len(matched_tests))
+    total_count = result.get("testCaseCount", total)
 
     if failed or error_count:
         error(
             f"Test run {result.get('status', 'unknown')}: "
-            f"{passed}/{total} passed, "
+            f"{passed}/{total_count} passed, "
             f"{failed} failed, {error_count} errors"
         )
     else:
-        success(f"Test run {result.get('status', 'unknown')}: {passed}/{total} passed")
+        success(f"Test run {result.get('status', 'unknown')}: {passed}/{total_count} passed")
 
     return result

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -978,10 +978,11 @@ def _print_test_failures(
         for entry in errors:
             case_id = entry.get("testCaseId", "")
             name = test_names.get(case_id, case_id)
-            console.print(f"  [red]✗ {name}[/red] - [muted]{entry.get('status')}[/muted]")
-            test_run_id = entry.get("testRunId", "")
+            console.print(
+                f"  [red]✗ {name}[/red] [muted]({case_id})[/muted]"
+                f" - [muted]{entry.get('status')}[/muted]"
+            )
             conv_id = entry.get("rawConversation", {}).get("id", "")
-            console.print(f"    [muted]Test run ID: {test_run_id}[/muted]")
             console.print(f"    [muted]Conversation ID: {conv_id}[/muted]")
 
     if not failures:
@@ -992,7 +993,7 @@ def _print_test_failures(
     for entry in failures:
         case_id = entry.get("testCaseId", "")
         name = test_names.get(case_id, case_id)
-        console.print(f"  [red]✗ {name}[/red]")
+        console.print(f"  [red]✗ {name}[/red] [muted]({case_id})[/muted]")
 
         results = entry.get("results") or {}
         prompt_assertions = results.get("prompt_assertion_results") or []
@@ -1016,12 +1017,107 @@ def _print_test_failures(
             if function_error:
                 console.print(f"    [muted]→ {function_error}[/muted]")
 
-        test_run_id = entry.get("testRunId", "")
         conv_id = entry.get("rawConversation", {}).get("id", "")
-        console.print(f"    [muted]Test run ID: {test_run_id}[/muted]")
         console.print(f"    [muted]Conversation ID: {conv_id}[/muted]")
 
         console.print()
+
+
+def print_test_run_summary(result: dict) -> None:
+    """Print a summary of a test run."""
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("key", style="label", no_wrap=True)
+    table.add_column("value")
+    table.add_row("Run ID", result.get("id", "—"))
+    table.add_row("Status", result.get("status", "—"))
+    table.add_row("Tests", str(result.get("testCaseCount", "—")))
+    table.add_row(
+        "Results",
+        f"[green]{result.get('passedCount', 0)} passed[/green], "
+        f"[red]{result.get('failedCount', 0)} failed[/red], "
+        f"[red]{result.get('errorCount', 0)} errors[/red]",
+    )
+    table.add_row("Started", result.get("startedAt", "—"))
+    table.add_row("Started By", result.get("startedBy", "—"))
+    console.print(table)
+
+    test_history = result.get("testHistory") or []
+    if not test_history:
+        return
+
+    console.print()
+    results_table = Table(
+        show_header=True,
+        header_style="bold",
+        box=None,
+        padding=(0, 1),
+    )
+    results_table.add_column("Test", no_wrap=True)
+    results_table.add_column("Status", no_wrap=True)
+    results_table.add_column("Test Case ID", style="muted", no_wrap=True)
+    for entry in test_history:
+        case_id = entry.get("testCaseId", "")
+        snapshot = entry.get("testCaseSnapshot") or {}
+        name = snapshot.get("name", case_id)
+        status = entry.get("status", "unknown")
+        _, style = _TEST_STATUS_STYLES.get(status, ("", "yellow"))
+        results_table.add_row(name, Text(status, style=style), case_id)
+    console.print(results_table)
+
+
+def print_test_detail(entry: dict) -> None:
+    """Print detailed results for a single test."""
+    snapshot = entry.get("testCaseSnapshot") or {}
+    name = snapshot.get("name", entry.get("testCaseId", "—"))
+    status = entry.get("status", "unknown")
+    _, style = _TEST_STATUS_STYLES.get(status, ("", "yellow"))
+
+    console.print(f"[bold]{name}[/bold] [{style}]{status}[/{style}]")
+    console.print()
+
+    results = entry.get("results") or {}
+
+    prompt_assertions = results.get("prompt_assertion_results") or []
+    if prompt_assertions:
+        console.print("[label]Assertions:[/label]")
+        for a in prompt_assertions:
+            passed = a.get("is_pass", False)
+            mark = "[green]✓[/green]" if passed else "[red]✗[/red]"
+            console.print(f"  {mark} {a.get('prompt', '')}")
+            reason = a.get("reason", "")
+            if reason:
+                console.print(f"    [muted]→ {reason}[/muted]")
+        console.print()
+
+    fn_failures = results.get("function_call_failures") or []
+    if fn_failures:
+        console.print("[label]Function Call Failures:[/label]")
+        for f in fn_failures:
+            console.print(f"  [red]✗ {f.get('name', '')}()[/red]")
+            if f.get("failure_reason"):
+                console.print(f"    [muted]→ {f['failure_reason']}[/muted]")
+            if f.get("error"):
+                console.print(f"    [muted]→ {f['error']}[/muted]")
+        console.print()
+
+    raw_conv = entry.get("rawConversation") or {}
+    turns = raw_conv.get("turns") or []
+    if turns:
+        console.print("[label]Conversation:[/label]")
+        for turn in turns:
+            user_input = turn.get("user_input", "")
+            agent_response = turn.get("agent_response", "")
+            if user_input:
+                console.print(f"  [cyan]User:[/cyan] {user_input}")
+            if agent_response:
+                console.print(f"  [yellow]Agent:[/yellow] {agent_response}")
+            fns = turn.get("function_calls") or []
+            for fn in fns:
+                fn_name = fn.get("name", "")
+                fn_args = fn.get("arguments") or {}
+                args_str = ", ".join(f"{k}={v}" for k, v in fn_args.items() if v)
+                console.print(f"  [muted]→ {fn_name}({args_str})[/muted]")
+            console.print()
 
 
 def poll_test_run_live(

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -1230,7 +1230,17 @@ def poll_test_run_live(
 
             status = result.get("status", "")
             if status not in _PENDING_STATUSES:
-                if not compact:
+                for entry in merged:
+                    if entry.get("status") in _PENDING_STATUSES:
+                        entry["status"] = "error"
+                if compact:
+                    for entry in merged:
+                        cid = entry.get("testCaseId", "")
+                        if cid not in seen_done:
+                            seen_done.add(cid)
+                            completed_ordered.append(entry)
+                    live.update(_build_compact_display(completed_ordered, total, test_names))
+                else:
                     live.update(_build_test_table(merged, test_names, finished=True))
                 break
 

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -15,7 +15,9 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from rich import box
 from rich.console import Console, Group
+from rich.live import Live
 from rich.panel import Panel
+from rich.spinner import Spinner
 from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
@@ -876,3 +878,97 @@ def handle_exception(exc: Exception) -> None:
         err_console.print("[muted]Run with --verbose for the full traceback.[/muted]")
 
     sys.exit(1)
+
+
+_TEST_STATUS_STYLES = {
+    "passed": ("Passed", "green"),
+    "failed": ("Failed", "red"),
+    "error": ("Error", "red"),
+}
+
+
+def _build_test_table(
+    test_results: list[dict],
+    test_names: dict[str, str],
+    finished: bool = False,
+) -> Table:
+    """Build a Rich table for test run results."""
+    table = Table(show_header=False, show_edge=False, pad_edge=False)
+    table.add_column("test", no_wrap=True)
+    table.add_column("status", no_wrap=True)
+    for entry in test_results:
+        case_id = entry.get("testCaseId", "")
+        name = test_names.get(case_id, case_id)
+        status = entry.get("status", "pending")
+        if finished and status in ("pending", "running", "in_progress"):
+            status = "error"
+        label, style = _TEST_STATUS_STYLES.get(status, ("Pending...", "yellow"))
+        if status in ("pending", "running", "in_progress"):
+            status_cell = Spinner(
+                "dots",
+                text=f"[{style}][{label}][/{style}]",
+                style=style,
+            )
+        else:
+            status_cell = Text(f"[{label}]", style=style)
+        table.add_row(name, status_cell)
+    return table
+
+
+def poll_test_run_live(
+    get_test_run: Callable[[str], dict],
+    test_run_id: str,
+    matched_tests: list,
+    poll_interval: int = 5,
+) -> dict:
+    """Poll a test run with a live-updating display.
+
+    Args:
+        get_test_run: Callable that takes a test run ID and returns the run dict.
+        test_run_id: The test run ID to poll.
+        matched_tests: List of TestCase objects (must have resource_id and name).
+        poll_interval: Seconds between polls.
+
+    Returns:
+        dict: The final test run response.
+    """
+    import time
+
+    test_names = {t.resource_id: t.name for t in matched_tests}
+    pending_results = [{"testCaseId": t.resource_id, "status": "pending"} for t in matched_tests]
+
+    merged = pending_results
+    with Live(
+        _build_test_table(merged, test_names),
+        console=console,
+        refresh_per_second=10,
+    ) as live:
+        while True:
+            time.sleep(poll_interval)
+            result = get_test_run(test_run_id)
+            test_results = result.get("testHistory", [])
+
+            actual_by_id = {r.get("testCaseId"): r for r in test_results}
+            merged = [actual_by_id.get(p.get("testCaseId"), p) for p in pending_results]
+            live.update(_build_test_table(merged, test_names))
+
+            status = result.get("status", "")
+            if status not in ("pending", "running", "in_progress"):
+                live.update(_build_test_table(merged, test_names, finished=True))
+                break
+
+    passed = result.get("passedCount", 0)
+    failed = result.get("failedCount", 0)
+    error_count = result.get("errorCount", 0)
+    total = result.get("testCaseCount", len(matched_tests))
+
+    if failed or error_count:
+        error(
+            f"Test run {result.get('status', 'unknown')}: "
+            f"{passed}/{total} passed, "
+            f"{failed} failed, {error_count} errors"
+        )
+    else:
+        success(f"Test run {result.get('status', 'unknown')}: {passed}/{total} passed")
+
+    return result

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -1023,6 +1023,60 @@ def _print_test_failures(
         console.print()
 
 
+def print_test_run_list(result: dict) -> None:
+    """Print a table of test runs.
+
+    Args:
+        result: API response dict with a 'testRuns' key.
+    """
+    runs = result.get("testRuns") or []
+    if not runs:
+        warning("No test runs found.")
+        return
+
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("Run ID", style="bold yellow", no_wrap=True)
+    table.add_column("Started", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Total", no_wrap=True, justify="right")
+    table.add_column("Passed", no_wrap=True, justify="right")
+    table.add_column("Failed", no_wrap=True, justify="right")
+    table.add_column("Errors", no_wrap=True, justify="right")
+    table.add_column("Run", no_wrap=True)
+
+    for run in runs:
+        status = run.get("status", "unknown")
+        passed = run.get("passedCount", 0)
+        failed = run.get("failedCount", 0)
+        errors = run.get("errorCount", 0)
+
+        if status == "completed" and failed == 0 and errors == 0:
+            status_display = "[green]completed[/green]"
+        elif status == "completed":
+            status_display = "[yellow]completed[/yellow]"
+        elif status in _PENDING_STATUSES:
+            status_display = f"[cyan]{status}[/cyan]"
+        else:
+            status_display = status
+
+        started = run.get("startedAt") or "—"
+        if started != "—":
+            started = _format_iso_timestamp(started)
+
+        table.add_row(
+            run.get("id", "—"),
+            started,
+            status_display,
+            str(run.get("testCaseCount", "—")),
+            f"[green]{passed}[/green]",
+            f"[red]{failed}[/red]" if failed else str(failed),
+            f"[red]{errors}[/red]" if errors else str(errors),
+            run.get("startedBy") or "—",
+        )
+
+    console.print(table)
+
+
 def print_test_run_summary(result: dict) -> None:
     """Print a summary of a test run."""
     table = Table(show_header=False, box=None, padding=(0, 1))

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2984,13 +2984,13 @@ class AgentStudioProject:
         Returns:
             list[TestCase]: The matched test cases.
         """
-        tests = self.resources.get(TestCase, {})
+        tests: dict[str, TestCase] = self.resources.get(TestCase, {})
         matched: list[TestCase] = []
         if all:
             matched = list(tests.values())
         elif tags:
             for test in tests.values():
-                if any(tag in test.tags for tag in tags):
+                if any(tag in test.tags.tags for tag in tags):
                     matched.append(test)
         elif files:
             for test in tests.values():

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2972,13 +2972,13 @@ class AgentStudioProject:
         return True
 
     def resolve_tests(
-        self, all: bool = False, files: list[str] = None, tags: list[str] = None
+        self, all_tests: bool = False, files: list[str] = None, tags: list[str] = None
     ) -> list["TestCase"]:
         """Resolve which tests match the given criteria.
 
         Args:
-            all: If True, select all tests.
-            tags: List of tags to filter by. Ignored if `all` is True.
+            all_tests: If True, select all tests.
+            tags: List of tags to filter by. Ignored if `all_tests` is True.
             files: List of specific test resource IDs to select.
 
         Returns:
@@ -2986,7 +2986,7 @@ class AgentStudioProject:
         """
         tests: dict[str, TestCase] = self.resources.get(TestCase, {})
         matched: list[TestCase] = []
-        if all:
+        if all_tests:
             matched = list(tests.values())
         elif tags:
             for test in tests.values():

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3020,3 +3020,14 @@ class AgentStudioProject:
             test_ids,
             self.branch_id,
         )
+
+    def get_test_run(self, test_run_id: str) -> dict:
+        """Get a test run by ID, including individual test results.
+
+        Args:
+            test_run_id: The test run ID.
+
+        Returns:
+            dict: The test run detail response.
+        """
+        return self.api_handler.get_test_run(self.region, self.project_id, test_run_id)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3031,3 +3031,17 @@ class AgentStudioProject:
             dict: The test run detail response.
         """
         return self.api_handler.get_test_run(self.region, self.project_id, test_run_id)
+
+    def list_test_runs(self, limit: int = 10, offset: int = 0) -> dict:
+        """List test runs for the project.
+
+        Args:
+            limit: The maximum number of test runs to return.
+            offset: The number of test runs to skip before starting to collect the result set.
+
+        Returns:
+            dict: The list of test runs.
+        """
+        return self.api_handler.list_test_runs(
+            self.region, self.project_id, limit, offset, branch_id=self.branch_id
+        )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1753,17 +1753,17 @@ class AgentStudioProject:
 
         return files_with_conflicts, modified_files, new_files, deleted_files
 
-    def revert_changes(self, files: list[str] = None) -> list[str]:
+    def revert_changes(self, file_paths: list[str] = None) -> list[str]:
         """Revert changes in the project.
 
         Args:
-            files (list[str]): List of specific files to revert. If None, revert all changes.
+            file_paths (list[str]): List of specific files to revert. If None, revert all changes.
         """
         reverted_files = []
         resource_mappings = self._make_resource_mappings(self.resources)
-        all_files = not files
+        all_files = not file_paths
         for resource in self.all_resources:
-            if not all_files and resource.get_path(self.root_path) not in files:
+            if not all_files and resource.get_path(self.root_path) not in file_paths:
                 continue
 
             resource.save(self.root_path, resource_mappings=resource_mappings)
@@ -1771,24 +1771,24 @@ class AgentStudioProject:
 
         return reverted_files
 
-    def get_diffs(self, all_files: bool = False, files: list[str] = None) -> dict[str, str]:
+    def get_diffs(self, file_paths: list[str] = None) -> dict[str, str]:
         """Get the diffs of all resources in the project.
 
         Args:
-            all_files (bool): If True, get diffs for all files.
-            files (list[str]): List of specific files to get diffs for.
+            file_paths (list[str]): List of specific files to get diffs for. If None, diff all.
 
         Returns:
             dict[str, str]: A dictionary mapping resource file names to their diffs.
         """
         diffs = {}
+        all_files = not file_paths
         new_resources_mappings, kept_resources_mappings, deleted_resources_mappings = (
             self.find_new_kept_deleted(self.discover_local_resources())
         )
         local_resources_mappings = new_resources_mappings + kept_resources_mappings
 
         for local_resource_mapping in kept_resources_mappings:
-            if not all_files and files and local_resource_mapping.file_path not in files:
+            if not all_files and file_paths and local_resource_mapping.file_path not in file_paths:
                 continue
 
             original_hash = self.file_structure_info.get(
@@ -1840,7 +1840,7 @@ class AgentStudioProject:
             )
 
         for resource_mapping in deleted_resources_mappings:
-            if not all_files and files and resource_mapping.file_path not in files:
+            if not all_files and file_paths and resource_mapping.file_path not in file_paths:
                 continue
 
             original_resource = self.resources.get(resource_mapping.resource_type, {}).get(
@@ -2365,7 +2365,7 @@ class AgentStudioProject:
             bool: True if the switch was successful, False otherwise
             dict[str, Any]: The projection data
         """
-        if self.get_diffs(all_files=True) and not force:
+        if self.get_diffs() and not force:
             raise ValueError(
                 "Cannot switch branches with uncommitted changes. Use --force to switch and discard changes."
             )
@@ -2773,7 +2773,7 @@ class AgentStudioProject:
         if self.branch_id == "main":
             raise ValueError("Merging from 'main' branch is not supported.")
 
-        if diffs := self.get_diffs(all_files=True):
+        if diffs := self.get_diffs():
             raise ValueError(
                 f"Cannot merge branch with uncommitted changes, diffs: {list(diffs.keys())}"
             )
@@ -2826,7 +2826,7 @@ class AgentStudioProject:
         if self.branch_id == "main":
             raise ValueError("Cannot sync ids while on main branch.")
 
-        if self.get_diffs(all_files=True):
+        if self.get_diffs():
             raise ValueError("Cannot sync ids due to uncommitted changes.")
 
         sandbox_resources = self.get_remote_resources_by_name("main")
@@ -2994,7 +2994,7 @@ class AgentStudioProject:
                     matched.append(test)
         elif files:
             for test in tests.values():
-                if test.resource_id in files:
+                if test.file_path in files:
                     matched.append(test)
 
         if not matched:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2970,3 +2970,53 @@ class AgentStudioProject:
             message=message,
         )
         return True
+
+    def resolve_tests(
+        self, all: bool = False, files: list[str] = None, tags: list[str] = None
+    ) -> list["TestCase"]:
+        """Resolve which tests match the given criteria.
+
+        Args:
+            all: If True, select all tests.
+            tags: List of tags to filter by. Ignored if `all` is True.
+            files: List of specific test resource IDs to select.
+
+        Returns:
+            list[TestCase]: The matched test cases.
+        """
+        tests = self.resources.get(TestCase, {})
+        matched: list[TestCase] = []
+        if all:
+            matched = list(tests.values())
+        elif tags:
+            for test in tests.values():
+                if any(tag in test.tags for tag in tags):
+                    matched.append(test)
+        elif files:
+            for test in tests.values():
+                if test.resource_id in files:
+                    matched.append(test)
+
+        if not matched:
+            raise ValueError("No tests found to run based on the provided criteria.")
+
+        return matched
+
+    def trigger_tests(self, test_ids: list[str]) -> dict:
+        """Trigger tests for the project.
+
+        Args:
+            test_ids: List of test case resource IDs to run.
+
+        Returns:
+            dict: API response with test run details.
+        """
+        if not test_ids:
+            raise ValueError("No test IDs provided.")
+
+        return self.api_handler.trigger_test_run(
+            self.region,
+            self.project_id,
+            test_ids,
+            self.branch_id,
+        )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2971,24 +2971,21 @@ class AgentStudioProject:
         )
         return True
 
-    def resolve_tests(
-        self, all_tests: bool = False, files: list[str] = None, tags: list[str] = None
-    ) -> list["TestCase"]:
+    def resolve_tests(self, files: list[str] = None, tags: list[str] = None) -> list["TestCase"]:
         """Resolve which tests match the given criteria.
 
+        Runs all tests by default. Use files or tags to filter.
+
         Args:
-            all_tests: If True, select all tests.
-            tags: List of tags to filter by. Ignored if `all_tests` is True.
-            files: List of specific test resource IDs to select.
+            files: List of specific test file paths to select.
+            tags: List of tags to filter by.
 
         Returns:
             list[TestCase]: The matched test cases.
         """
         tests: dict[str, TestCase] = self.resources.get(TestCase, {})
         matched: list[TestCase] = []
-        if all_tests:
-            matched = list(tests.values())
-        elif tags:
+        if tags:
             for test in tests.values():
                 if any(tag in test.tags.tags for tag in tags):
                     matched.append(test)
@@ -2996,6 +2993,8 @@ class AgentStudioProject:
             for test in tests.values():
                 if test.file_path in files:
                     matched.append(test)
+        else:
+            matched = list(tests.values())
 
         if not matched:
             raise ValueError("No tests found to run based on the provided criteria.")

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2494,7 +2494,7 @@ class DeleteProjectTest(unittest.TestCase):
     @patch("poly.cli.json_print")
     @patch("poly.cli.AgentStudioInterface")
     def test_json_mode_outputs_success_payload(self, mock_iface_cls, mock_json_print):
-        """delete project --json outputs success JSON with agent_id."""
+        """delete project --json outputs success JSON with project_id."""
         mock_iface = mock_iface_cls.return_value
         mock_iface.get_agents.return_value = {"proj-123": "My Project"}
 
@@ -2507,7 +2507,7 @@ class DeleteProjectTest(unittest.TestCase):
         )
 
         mock_iface.delete_project.assert_called_once_with("us-1", "proj-123")
-        mock_json_print.assert_called_with({"success": True, "agent_id": "proj-123"})
+        mock_json_print.assert_called_with({"success": True, "project_id": "proj-123"})
 
 
 class DuplicateProjectTest(unittest.TestCase):
@@ -2595,7 +2595,7 @@ class DuplicateProjectTest(unittest.TestCase):
     @patch("poly.cli.json_print")
     @patch("poly.cli.AgentStudioInterface")
     def test_json_mode_outputs_success_payload(self, mock_iface_cls, mock_json_print):
-        """duplicate project --json outputs success JSON with agent_id and agent_name."""
+        """duplicate project --json outputs success JSON with project_id and agent_name."""
         mock_iface = mock_iface_cls.return_value
         mock_iface.get_agents.return_value = {"proj-123": "My Project"}
         mock_iface.duplicate_project.return_value = {"id": "proj-dup", "name": "Dup Name"}
@@ -2613,7 +2613,7 @@ class DuplicateProjectTest(unittest.TestCase):
             "us-1", "proj-123", "Dup Name", "proj-dup"
         )
         mock_json_print.assert_called_with(
-            {"success": True, "agent_id": "proj-dup", "agent_name": "Dup Name"}
+            {"success": True, "project_id": "proj-dup", "agent_name": "Dup Name"}
         )
 
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1067,17 +1067,17 @@ class ComputeDiffTest(unittest.TestCase):
         patch.stopall()
 
     def test_no_before_no_after_returns_local_diffs(self):
-        """Without before/after, calls get_diffs with all_files=True."""
+        """Without before/after, calls get_diffs with empty file_paths."""
         expected = {"file.py": "some diff"}
         self.proj.get_diffs.return_value = expected
 
         result = AgentStudioCLI._compute_diff(TEST_DIR)
 
-        self.proj.get_diffs.assert_called_once_with(all_files=True, files=[])
+        self.proj.get_diffs.assert_called_once_with(file_paths=[])
         self.assertEqual(result, expected)
 
     def test_no_before_no_after_with_files(self):
-        """Without before/after but with files, calls get_diffs with all_files=False."""
+        """Without before/after but with files, calls get_diffs with file_paths."""
         expected = {"file.py": "diff"}
         self.proj.get_diffs.return_value = expected
 
@@ -1085,8 +1085,7 @@ class ComputeDiffTest(unittest.TestCase):
 
         self.proj.get_diffs.assert_called_once()
         call_kwargs = self.proj.get_diffs.call_args[1]
-        self.assertFalse(call_kwargs["all_files"])
-        self.assertEqual(len(call_kwargs["files"]), 1)
+        self.assertEqual(len(call_kwargs["file_paths"]), 1)
 
     def test_only_after_finds_previous_version(self):
         """With only after, resolves to previous version and diffs remote versions."""
@@ -1203,7 +1202,7 @@ class RevertTest(unittest.TestCase):
 
         AgentStudioCLI.revert(TEST_DIR, files=[])
 
-        self.proj.revert_changes.assert_called_once_with(files=[])
+        self.proj.revert_changes.assert_called_once_with(file_paths=[])
 
 
 class PrintDeploymentsTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3256,5 +3256,62 @@ class GetUpdatedSubresourcesTest(unittest.TestCase):
         )
 
 
+class ResolveTestsTest(unittest.TestCase):
+    """Tests for AgentStudioProject.resolve_tests."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_all_returns_every_test(self):
+        """all_tests=True returns all test cases."""
+        result = self.project.resolve_tests(all_tests=True)
+        self.assertEqual(len(result), 2)
+        names = {t.name for t in result}
+        self.assertEqual(names, {"Greeting flow test", "Webchat smoke test"})
+
+    def test_filter_by_single_tag(self):
+        """Filtering by a tag only present on one test returns that test."""
+        result = self.project.resolve_tests(tags=["booking"])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "Greeting flow test")
+
+    def test_filter_by_shared_tag(self):
+        """Filtering by a tag shared across tests returns all matching tests."""
+        result = self.project.resolve_tests(tags=["smoke"])
+        self.assertEqual(len(result), 2)
+
+    def test_filter_by_multiple_tags_is_or(self):
+        """Passing multiple tags matches tests that have any of them."""
+        result = self.project.resolve_tests(tags=["booking", "smoke"])
+        self.assertEqual(len(result), 2)
+
+    def test_filter_by_file_path(self):
+        """Filtering by file_path matches the test with that path."""
+        target = self.project.resolve_tests(all_tests=True)[0]
+        result = self.project.resolve_tests(files=[target.file_path])
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].resource_id, target.resource_id)
+
+    def test_no_criteria_raises(self):
+        """Passing no filters raises ValueError."""
+        with self.assertRaises(ValueError, msg="No tests found"):
+            self.project.resolve_tests()
+
+    def test_unmatched_tag_raises(self):
+        """A tag that matches nothing raises ValueError."""
+        with self.assertRaises(ValueError, msg="No tests found"):
+            self.project.resolve_tests(tags=["nonexistent"])
+
+    def test_unmatched_file_raises(self):
+        """A file path that matches nothing raises ValueError."""
+        with self.assertRaises(ValueError, msg="No tests found"):
+            self.project.resolve_tests(files=["no_such_test.yaml"])
+
+    def test_all_takes_precedence_over_tags(self):
+        """When all_tests=True, tags are ignored and all tests are returned."""
+        result = self.project.resolve_tests(all_tests=True, tags=["booking"])
+        self.assertEqual(len(result), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -628,7 +628,7 @@ class GetDiffsTest(unittest.TestCase):
 
     def test_get_diffs_no_changes(self):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
         self.assertEqual(diffs, {})
 
     def test_get_diffs_new_resource(self):
@@ -636,7 +636,7 @@ class GetDiffsTest(unittest.TestCase):
         # Remove a topic so it seems there's a new one
         project_data["resources"]["topics"].pop("TOPIC-Topic 1")
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
 
         topic_path = os.path.join("topics", "topic_1.yaml")
         self.assertIn(topic_path, diffs)
@@ -661,7 +661,7 @@ class GetDiffsTest(unittest.TestCase):
             "function_type": "global",
         }
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
 
         func_path = os.path.join(TEST_DIR, "functions", "extra_function.py")
         self.assertIn(func_path, diffs)
@@ -678,7 +678,7 @@ class GetDiffsTest(unittest.TestCase):
             'from _gen import *  # <AUTO GENERATED>\n\n@func_description(\'A test function for global use.\')\ndef test_function(conv: Conversation):\n    """A modified test function."""\n    return "Modified return value"\n'
         )
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
 
         func_path = os.path.join("functions", "test_function.py")
         self.assertIn(func_path, diffs)
@@ -705,7 +705,7 @@ class GetDiffsTest(unittest.TestCase):
             "function_type": "global",
         }
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
 
         topic_path = os.path.join("topics", "topic_1.yaml")
         func_path = os.path.join(TEST_DIR, "functions", "extra_function.py")
@@ -738,7 +738,7 @@ class GetDiffsTest(unittest.TestCase):
         }
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         requested_file = os.path.join(TEST_DIR, "topics", "topic_1.yaml")
-        diffs = project.get_diffs(files=[requested_file])
+        diffs = project.get_diffs(file_paths=[requested_file])
 
         # Topic diff
         topic_path = os.path.join("topics", "topic_1.yaml")
@@ -760,7 +760,7 @@ class GetDiffsTest(unittest.TestCase):
         ]
         step["extracted_entities"] = list(reversed(step["extracted_entities"]))
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-        diffs = project.get_diffs(all_files=True)
+        diffs = project.get_diffs()
 
         step_path = os.path.join(
             "flows", "test_flow_with_punctuation!", "steps", "welcome_step.yaml"
@@ -3145,7 +3145,7 @@ class RevertChangesTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         target = project.all_resources[0].get_path(project.root_path)
 
-        reverted = project.revert_changes(files=[target])
+        reverted = project.revert_changes(file_paths=[target])
 
         self.assertEqual(reverted, [target])
 
@@ -3153,7 +3153,7 @@ class RevertChangesTest(unittest.TestCase):
         """revert_changes with a path that matches no resource returns an empty list."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
-        reverted = project.revert_changes(files=["/nonexistent/path/file.yaml"])
+        reverted = project.revert_changes(file_paths=["/nonexistent/path/file.yaml"])
 
         self.assertEqual(reverted, [])
 

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3262,9 +3262,9 @@ class ResolveTestsTest(unittest.TestCase):
     def setUp(self):
         self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
-    def test_all_returns_every_test(self):
-        """all_tests=True returns all test cases."""
-        result = self.project.resolve_tests(all_tests=True)
+    def test_default_returns_all_tests(self):
+        """No filters returns all test cases."""
+        result = self.project.resolve_tests()
         self.assertEqual(len(result), 2)
         names = {t.name for t in result}
         self.assertEqual(names, {"Greeting flow test", "Webchat smoke test"})
@@ -3287,15 +3287,10 @@ class ResolveTestsTest(unittest.TestCase):
 
     def test_filter_by_file_path(self):
         """Filtering by file_path matches the test with that path."""
-        target = self.project.resolve_tests(all_tests=True)[0]
+        target = self.project.resolve_tests()[0]
         result = self.project.resolve_tests(files=[target.file_path])
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0].resource_id, target.resource_id)
-
-    def test_no_criteria_raises(self):
-        """Passing no filters raises ValueError."""
-        with self.assertRaises(ValueError, msg="No tests found"):
-            self.project.resolve_tests()
 
     def test_unmatched_tag_raises(self):
         """A tag that matches nothing raises ValueError."""
@@ -3306,11 +3301,6 @@ class ResolveTestsTest(unittest.TestCase):
         """A file path that matches nothing raises ValueError."""
         with self.assertRaises(ValueError, msg="No tests found"):
             self.project.resolve_tests(files=["no_such_test.yaml"])
-
-    def test_all_takes_precedence_over_tags(self):
-        """When all_tests=True, tags are ignored and all tests are returned."""
-        result = self.project.resolve_tests(all_tests=True, tags=["booking"])
-        self.assertEqual(len(result), 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds a complete testing workflow to the CLI: trigger tests, watch results live, list past runs, and inspect failures — all without leaving the terminal.

## Motivation

Running tests previously required switching to Agent Studio to see results. This brings the full test lifecycle into the CLI: trigger, poll, list, and review results.

## Changes

- **`poly test run`**: trigger tests with live polling UI (every 5s), adaptive display (full table for ≤20 tests, compact rolling view for >20), `--dry-run` to preview, `--dont-poll` to trigger and exit, `--push` to push before running, `--files`/`--tag` for filtering (runs all tests by default)
- **`poly test list`**: list past test runs with status, pass/fail/error counts, branch, and timestamps
- **`poly test show <run_id>`**: inspect a completed test run with all results
- **`poly test show <run_id> <test_case_id>`**: drill into a single test — assertions, function call failures, and conversation transcript
- All commands support `--json` for machine-readable output
- Handle all API statuses: `pending`, `in_progress`, `passed`, `failed`, `errored`, `timed_out`
- Extract `resolve_tests()`, `get_test_run()`, `list_test_runs()`, and `trigger_tests()` on `AgentStudioProject`
- Add `print_test_run_list`, `print_test_run_summary`, `print_test_detail`, and `poll_test_run_live` console helpers
- Simplify `get_diffs()` and `revert_changes()` signatures — replace `all_files`/`files` with a single `file_paths` param (defaults to all)

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (12 pre-existing failures unrelated to this change)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

### Running tests:
With <20 tests (by tag)
<img width="446" height="78" alt="Screenshot 2026-06-29 at 17 48 21" src="https://github.com/user-attachments/assets/c3e71fa7-b6fa-4a94-b51c-27de07f14b49" />
With >20 tests (all tests)
<img width="753" height="576" alt="Screenshot 2026-06-30 at 18 18 54" src="https://github.com/user-attachments/assets/f2450674-1a68-4069-b6f9-a3823e740981" />


### View previous runs
<img width="741" height="148" alt="Screenshot 2026-06-29 at 17 47 55" src="https://github.com/user-attachments/assets/811abffb-b876-4945-95e5-37bc70c7f3b7" />

### View test run
<img width="786" height="360" alt="Screenshot 2026-06-29 at 17 47 50" src="https://github.com/user-attachments/assets/b79dbbb3-2abc-44b8-a30c-f7c96befc0ed" />

### View specific test in a run
<img width="1268" height="310" alt="Screenshot 2026-06-29 at 17 47 41" src="https://github.com/user-attachments/assets/a2449f03-5b10-4d8b-8f22-f97d7460b165" />