### PR TITLE
feat: add A/B test management to deployments CLI

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -57,6 +57,8 @@ from poly.output.console import (
     print_deployments,
     prompt_typed_edit,
     print_deployment_show,
+    print_ab_tests,
+    print_ab_test_detail,
     print_welcome_message,
     mask_api_key,
 )
@@ -1277,6 +1279,126 @@ class AgentStudioCLI:
             help="Show what would be rolled back without actually rolling back. Displays the target deployment and reverted deployments.",
         )
 
+        # A/B TESTS
+        ab_test_parser = deployments_subparsers.add_parser(
+            "ab-test",
+            parents=[verbose_parent],
+            help="Manage A/B tests for live deployments.",
+            description=(
+                "Manage A/B tests for live deployments.\n\n"
+                "Examples:\n"
+                "  poly deployments ab-test start --name 'v2 test'"
+                " --variant <deployment_id> --traffic 50\n"
+                "  poly deployments ab-test list\n"
+                "  poly deployments ab-test active\n"
+                "  poly deployments ab-test update --traffic 30\n"
+                "  poly deployments ab-test end\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        ab_test_subparsers = ab_test_parser.add_subparsers(dest="ab_test_subcommand", required=True)
+
+        ab_test_start_parser = ab_test_subparsers.add_parser(
+            "start",
+            parents=[deployments_path_parent, json_parent, verbose_parent],
+            help="Start a new A/B test.",
+            description=(
+                "Start a new A/B test against the current live deployment.\n\n"
+                "The variant must be a pre-release deployment. Traffic percentage\n"
+                "controls what fraction of calls route to the variant (0-100).\n\n"
+                "Examples:\n"
+                "  poly deployments ab-test start"
+                " --name 'v2 test' --variant <dep_id> --traffic 50\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        ab_test_start_parser.add_argument(
+            "--name",
+            "-n",
+            type=str,
+            default=None,
+            help="Name/label for the A/B test. If omitted, prompts interactively.",
+        )
+        ab_test_start_parser.add_argument(
+            "--variant",
+            type=str,
+            default=None,
+            help="Deployment ID of the variant (must be pre-release). If omitted, prompts interactively.",
+        )
+        ab_test_start_parser.add_argument(
+            "--traffic",
+            type=int,
+            default=None,
+            help="Percentage of traffic to route to the variant (0-100). Defaults to 50 interactively.",
+        )
+
+        ab_test_list_parser = ab_test_subparsers.add_parser(
+            "list",
+            parents=[deployments_path_parent, json_parent, verbose_parent],
+            help="List A/B tests for the project.",
+            description=(
+                "List A/B tests for the project.\n\n"
+                "Examples:\n"
+                "  poly deployments ab-test list\n"
+                "  poly deployments ab-test list --limit 20\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        ab_test_list_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of A/B tests to show. Defaults to 10.",
+        )
+
+        ab_test_subparsers.add_parser(
+            "active",
+            parents=[deployments_path_parent, json_parent, verbose_parent],
+            help="Show the currently active A/B test.",
+            description="Show the currently active A/B test, if any.",
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        ab_test_update_parser = ab_test_subparsers.add_parser(
+            "update",
+            parents=[deployments_path_parent, json_parent, verbose_parent],
+            help="Update traffic percentage for an active A/B test.",
+            description=(
+                "Update the traffic split for the active A/B test.\n\n"
+                "Examples:\n"
+                "  poly deployments ab-test update --traffic 30\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        ab_test_update_parser.add_argument(
+            "--traffic",
+            type=int,
+            default=None,
+            help="New percentage of traffic to route to the variant (0-100). Prompts if omitted.",
+        )
+
+        ab_test_end_parser = ab_test_subparsers.add_parser(
+            "end",
+            parents=[deployments_path_parent, json_parent, verbose_parent],
+            help="End an active A/B test and choose a winner.",
+            description=(
+                "End the active A/B test and choose which deployment wins.\n\n"
+                "If --chosen-deployment-id is omitted, an interactive prompt\n"
+                "shows the control and variant deployments for selection.\n\n"
+                "Examples:\n"
+                "  poly deployments ab-test end"
+                " --chosen-deployment-id <dep_id>\n"
+                "  poly deployments ab-test end   # interactive\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        ab_test_end_parser.add_argument(
+            "--chosen-deployment-id",
+            type=str,
+            default=None,
+            help="Deployment ID to keep as the winner. If omitted, prompts interactively.",
+        )
+
         # CONVERSATIONS
         conversations_path_parent = ArgumentParser(add_help=False)
         conversations_path_parent.add_argument(
@@ -1626,6 +1748,35 @@ class AgentStudioCLI:
                         output_json=args.json,
                         dry_run=args.dry_run,
                     )
+                elif args.deployments_subcommand == "ab-test":
+                    if args.ab_test_subcommand == "start":
+                        cls.ab_test_start(
+                            args.path,
+                            args.name,
+                            args.variant,
+                            args.traffic,
+                            output_json=args.json,
+                        )
+                    elif args.ab_test_subcommand == "list":
+                        cls.ab_test_list(
+                            args.path,
+                            args.limit,
+                            output_json=args.json,
+                        )
+                    elif args.ab_test_subcommand == "active":
+                        cls.ab_test_active(args.path, output_json=args.json)
+                    elif args.ab_test_subcommand == "update":
+                        cls.ab_test_update(
+                            args.path,
+                            args.traffic,
+                            output_json=args.json,
+                        )
+                    elif args.ab_test_subcommand == "end":
+                        cls.ab_test_end(
+                            args.path,
+                            chosen_deployment_id=args.chosen_deployment_id,
+                            output_json=args.json,
+                        )
 
             elif args.command == "conversations":
                 if args.conversations_subcommand == "list":
@@ -4611,6 +4762,425 @@ class AgentStudioCLI:
             else:
                 error(f"Failed to rollback deployment: {e}")
             sys.exit(1)
+
+    # ── A/B tests ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _default_ab_test_name() -> str:
+        """Generate a default A/B test name matching the Agent Studio UI format."""
+        from datetime import datetime
+
+        now = datetime.now()
+        day = now.day
+        if 11 <= day <= 13:
+            suffix = "th"
+        else:
+            suffix = {1: "st", 2: "nd", 3: "rd"}.get(day % 10, "th")
+        return f"{day}{suffix} {now.strftime('%B %Y')} Test {now.strftime('%H:%M')}"
+
+    @staticmethod
+    def _fetch_deployment_map(project: AgentStudioProject) -> dict[str, dict]:
+        """Build a deployment ID → deployment dict map for display enrichment."""
+        dep_map: dict[str, dict] = {}
+        try:
+            for env in ("live", "pre-release"):
+                deps, _ = project.get_deployments(client_env=env)
+                for dep in deps:
+                    if dep.get("id"):
+                        dep_map[dep["id"]] = dep
+        except Exception as e:
+            logger.debug("Failed to fetch deployments for A/B test display: %s", e)
+        return dep_map
+
+    @classmethod
+    def ab_test_start(
+        cls,
+        base_path: str,
+        name: str | None,
+        variant_deployment_id: str | None,
+        traffic_percentage: int | None,
+        output_json: bool = False,
+    ) -> None:
+        """Start a new A/B test."""
+        project = cls._load_project(base_path, output_json=output_json)
+
+        # -- name --
+        if name is None:
+            if output_json:
+                msg = "--name is required when using --json."
+                json_print({"success": False, "error": msg})
+                sys.exit(1)
+            default_name = cls._default_ab_test_name()
+            name = questionary.text("A/B test name:", default=default_name).ask()
+            if name is None:
+                warning("Aborted.")
+                sys.exit(0)
+
+        if not name.strip():
+            msg = "A/B test name is required and cannot be empty."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        # -- variant --
+        try:
+            pr_deployments, active_hashes = project.get_deployments(client_env="pre-release")
+        except Exception as e:
+            msg = f"Failed to fetch pre-release deployments: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        live_version = active_hashes.get("live")
+
+        if variant_deployment_id is None:
+            if output_json:
+                msg = "--variant is required when using --json."
+                json_print({"success": False, "error": msg})
+                sys.exit(1)
+            eligible = [dep for dep in pr_deployments if dep.get("version_hash") != live_version]
+            if not eligible:
+                error(
+                    "No eligible pre-release deployments found."
+                    " All pre-release versions match the current live version."
+                )
+                sys.exit(1)
+            dep_choices = []
+            for dep in eligible:
+                dep_id = dep.get("id", "")
+                dep_hash = (dep.get("version_hash") or "")[:9]
+                dep_msg = (dep.get("deployment_metadata") or {}).get("deployment_message", "") or ""
+                label = f"{dep_hash}  {dep_msg}" if dep_msg else dep_hash
+                dep_choices.append(questionary.Choice(title=label, value=dep_id))
+            variant_deployment_id = questionary.select(
+                "Select pre-release deployment (variant):", choices=dep_choices
+            ).ask()
+            if not variant_deployment_id:
+                warning("Aborted.")
+                sys.exit(0)
+        elif live_version:
+            variant_version = None
+            for dep in pr_deployments:
+                if dep.get("id") == variant_deployment_id:
+                    variant_version = dep.get("version_hash")
+                    break
+            if variant_version and variant_version == live_version:
+                msg = (
+                    "Variant deployment has the same version as the current live deployment."
+                    " An A/B test requires different versions."
+                )
+                if output_json:
+                    json_print({"success": False, "error": msg})
+                else:
+                    error(msg)
+                sys.exit(1)
+
+        # -- traffic --
+        if traffic_percentage is None:
+            if output_json:
+                msg = "--traffic is required when using --json."
+                json_print({"success": False, "error": msg})
+                sys.exit(1)
+            traffic_input = questionary.text(
+                "Traffic percentage for variant (0-100):", default="50"
+            ).ask()
+            if traffic_input is None:
+                warning("Aborted.")
+                sys.exit(0)
+            try:
+                traffic_percentage = int(traffic_input)
+            except ValueError:
+                error("Traffic percentage must be an integer.")
+                sys.exit(1)
+
+        if not 0 <= traffic_percentage <= 100:
+            msg = "Traffic percentage must be an integer between 0 and 100."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        try:
+            result = project.create_ab_test(name.strip(), variant_deployment_id, traffic_percentage)
+            if output_json:
+                json_print({"success": True, "ab_test": result})
+            else:
+                success("A/B test started.")
+                dep_map = cls._fetch_deployment_map(project)
+                print_ab_test_detail(result, deployments=dep_map)
+        except requests.HTTPError as e:
+            body = {}
+            try:
+                body = e.response.json()
+            except Exception:
+                pass
+            msg = body.get("error") or f"Failed to start A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+    @classmethod
+    def ab_test_list(
+        cls,
+        base_path: str,
+        limit: int = 10,
+        output_json: bool = False,
+    ) -> None:
+        """List A/B tests for the project."""
+        project = cls._load_project(base_path, output_json=output_json)
+        try:
+            ab_tests = project.list_ab_tests(limit=limit)
+            if output_json:
+                json_print({"success": True, "ab_tests": ab_tests})
+            else:
+                print_ab_tests(ab_tests)
+        except requests.HTTPError as e:
+            msg = f"Failed to list A/B tests: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+    @classmethod
+    def ab_test_active(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+    ) -> None:
+        """Show the currently active A/B test."""
+        project = cls._load_project(base_path, output_json=output_json)
+        try:
+            ab_test = project.get_active_ab_test()
+            if output_json:
+                json_print({"success": True, "ab_test": ab_test})
+            else:
+                dep_map = cls._fetch_deployment_map(project) if ab_test else {}
+                print_ab_test_detail(ab_test, deployments=dep_map)
+        except requests.HTTPError as e:
+            msg = f"Failed to get active A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+    @classmethod
+    def ab_test_update(
+        cls,
+        base_path: str,
+        traffic_percentage: int | None,
+        output_json: bool = False,
+    ) -> None:
+        """Update traffic percentage for the active A/B test."""
+        project = cls._load_project(base_path, output_json=output_json)
+
+        try:
+            ab_test = project.get_active_ab_test()
+        except requests.HTTPError as e:
+            msg = f"Failed to fetch active A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if not ab_test:
+            msg = "No active A/B test found for this project."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if traffic_percentage is None:
+            if output_json:
+                msg = "--traffic is required when using --json."
+                json_print({"success": False, "error": msg})
+                sys.exit(1)
+            current = str(ab_test.get("traffic_percentage", 50))
+            traffic_input = questionary.text(
+                "Traffic percentage for variant (0-100):", default=current
+            ).ask()
+            if traffic_input is None:
+                warning("Aborted.")
+                sys.exit(0)
+            try:
+                traffic_percentage = int(traffic_input)
+            except ValueError:
+                error("Traffic percentage must be an integer.")
+                sys.exit(1)
+
+        if not 0 <= traffic_percentage <= 100:
+            msg = "Traffic percentage must be an integer between 0 and 100."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        ab_test_id = ab_test["id"]
+        if traffic_percentage == ab_test.get("traffic_percentage"):
+            if output_json:
+                json_print({"success": True, "ab_test": ab_test, "unchanged": True})
+            else:
+                info(f"Traffic is already at {traffic_percentage}%. No update needed.")
+            return
+
+        try:
+            result = project.update_ab_test(ab_test_id, traffic_percentage)
+            if output_json:
+                json_print({"success": True, "ab_test": result})
+            else:
+                success(f"Traffic updated to {traffic_percentage}%.")
+                dep_map = cls._fetch_deployment_map(project)
+                print_ab_test_detail(result, deployments=dep_map)
+        except requests.HTTPError as e:
+            body = {}
+            try:
+                body = e.response.json()
+            except Exception:
+                pass
+            msg = body.get("error") or f"Failed to update A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+    @classmethod
+    def ab_test_end(
+        cls,
+        base_path: str,
+        chosen_deployment_id: str | None = None,
+        output_json: bool = False,
+    ) -> None:
+        """End the active A/B test and choose the winning deployment."""
+        project = cls._load_project(base_path, output_json=output_json)
+
+        try:
+            ab_test = project.get_active_ab_test()
+        except requests.HTTPError as e:
+            msg = f"Failed to fetch active A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if not ab_test:
+            msg = "No active A/B test found for this project."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        ab_test_id = ab_test["id"]
+        ab_test_name = ab_test.get("name") or ab_test_id
+        control_id = ab_test.get("control_deployment_id", "unknown")
+        variant_id = ab_test.get("variant_deployment_id", "unknown")
+
+        dep_map = cls._fetch_deployment_map(project)
+
+        def _label(did: str) -> str:
+            dep = dep_map.get(did)
+            if not dep:
+                return did
+            h = (dep.get("version_hash") or "")[:9]
+            m = (dep.get("deployment_metadata") or {}).get("deployment_message", "") or ""
+            return f"{h}  {m}".strip() if h else did
+
+        control_label = _label(control_id)
+        variant_label = _label(variant_id)
+
+        if not output_json:
+            info(f"Active A/B test: [bold]{ab_test_name}[/bold]")
+
+        if not chosen_deployment_id:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "--chosen-deployment-id is required when using --json.",
+                    }
+                )
+                sys.exit(1)
+
+            choices = [
+                questionary.Choice(title=f"Control — {control_label}", value=control_id),
+                questionary.Choice(title=f"Variant — {variant_label}", value=variant_id),
+            ]
+            chosen_deployment_id = questionary.select(
+                "Choose the winning deployment:", choices=choices
+            ).ask()
+            if not chosen_deployment_id:
+                warning("Aborted.")
+                sys.exit(0)
+
+        winner_label = _label(chosen_deployment_id)
+        promote_variant = chosen_deployment_id == variant_id
+
+        try:
+            result = project.end_ab_test(ab_test_id, chosen_deployment_id)
+        except requests.HTTPError as e:
+            body = {}
+            try:
+                body = e.response.json()
+            except Exception:
+                pass
+            msg = body.get("error") or f"Failed to end A/B test: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if not output_json:
+            success(f"A/B test '{ab_test_name}' ended. Winner: {winner_label}")
+
+        promoted = False
+        if promote_variant:
+            if not output_json:
+                info("Promoting variant to live...")
+            try:
+                variant_dep = dep_map.get(variant_id, {})
+                variant_msg = (variant_dep.get("deployment_metadata") or {}).get(
+                    "deployment_message", ""
+                ) or ""
+                project.promote_deployment(variant_id, "live", message=variant_msg)
+                promoted = True
+                if not output_json:
+                    success("Variant promoted to live.")
+            except Exception as e:
+                if output_json:
+                    json_print(
+                        {
+                            "success": True,
+                            "ab_test": result,
+                            "promoted": False,
+                            "promote_error": str(e),
+                        }
+                    )
+                else:
+                    warning(f"A/B test ended but failed to promote variant to live: {e}")
+                return
+
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "ab_test": result,
+                    "promoted": promoted,
+                }
+            )
 
     # ── conversations ────────────────────────────────────────────────
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -4956,26 +4956,13 @@ class AgentStudioCLI:
                 error(msg)
             sys.exit(1)
 
-        try:
-            result = project.create_ab_test(name.strip(), variant_deployment_id, traffic_percentage)
-            if output_json:
-                json_print({"success": True, "ab_test": result})
-            else:
-                success("A/B test started.")
-                dep_map = cls._fetch_deployment_map(project)
-                print_ab_test_detail(result, deployments=dep_map)
-        except requests.HTTPError as e:
-            body = {}
-            try:
-                body = e.response.json()
-            except Exception:
-                pass
-            msg = body.get("error") or f"Failed to start A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+        result = project.create_ab_test(name.strip(), variant_deployment_id, traffic_percentage)
+        if output_json:
+            json_print({"success": True, "ab_test": result})
+        else:
+            success("A/B test started.")
+            dep_map = cls._fetch_deployment_map(project)
+            print_ab_test_detail(result, deployments=dep_map)
 
     @classmethod
     def ab_test_list(
@@ -4986,20 +4973,12 @@ class AgentStudioCLI:
     ) -> None:
         """List A/B tests for the project."""
         project = cls._load_project(base_path, output_json=output_json)
-        try:
-            ab_tests = project.list_ab_tests(limit=limit)
-            if output_json:
-                json_print({"success": True, "ab_tests": ab_tests})
-            else:
-                dep_map = cls._fetch_deployment_map(project) if ab_tests else {}
-                print_ab_tests(ab_tests, deployments=dep_map)
-        except requests.HTTPError as e:
-            msg = f"Failed to list A/B tests: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+        ab_tests = project.list_ab_tests(limit=limit)
+        if output_json:
+            json_print({"success": True, "ab_tests": ab_tests})
+        else:
+            dep_map = cls._fetch_deployment_map(project) if ab_tests else {}
+            print_ab_tests(ab_tests, deployments=dep_map)
 
     @classmethod
     def ab_test_active(
@@ -5009,20 +4988,12 @@ class AgentStudioCLI:
     ) -> None:
         """Show the currently active A/B test."""
         project = cls._load_project(base_path, output_json=output_json)
-        try:
-            ab_test = project.get_active_ab_test()
-            if output_json:
-                json_print({"success": True, "ab_test": ab_test})
-            else:
-                dep_map = cls._fetch_deployment_map(project) if ab_test else {}
-                print_ab_test_detail(ab_test, deployments=dep_map)
-        except requests.HTTPError as e:
-            msg = f"Failed to get active A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+        ab_test = project.get_active_ab_test()
+        if output_json:
+            json_print({"success": True, "ab_test": ab_test})
+        else:
+            dep_map = cls._fetch_deployment_map(project) if ab_test else {}
+            print_ab_test_detail(ab_test, deployments=dep_map)
 
     @classmethod
     def ab_test_update(
@@ -5034,16 +5005,7 @@ class AgentStudioCLI:
         """Update traffic percentage for the active A/B test."""
         project = cls._load_project(base_path, output_json=output_json)
 
-        try:
-            ab_test = project.get_active_ab_test()
-        except requests.HTTPError as e:
-            msg = f"Failed to fetch active A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
-
+        ab_test = project.get_active_ab_test()
         if not ab_test:
             msg = "No active A/B test found for this project."
             if output_json:
@@ -5086,26 +5048,13 @@ class AgentStudioCLI:
                 info(f"Traffic is already at {traffic_percentage}%. No update needed.")
             return
 
-        try:
-            result = project.update_ab_test(ab_test_id, traffic_percentage)
-            if output_json:
-                json_print({"success": True, "ab_test": result})
-            else:
-                success(f"Traffic updated to {traffic_percentage}%.")
-                dep_map = cls._fetch_deployment_map(project)
-                print_ab_test_detail(result, deployments=dep_map)
-        except requests.HTTPError as e:
-            body = {}
-            try:
-                body = e.response.json()
-            except Exception:
-                pass
-            msg = body.get("error") or f"Failed to update A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+        result = project.update_ab_test(ab_test_id, traffic_percentage)
+        if output_json:
+            json_print({"success": True, "ab_test": result})
+        else:
+            success(f"Traffic updated to {traffic_percentage}%.")
+            dep_map = cls._fetch_deployment_map(project)
+            print_ab_test_detail(result, deployments=dep_map)
 
     @classmethod
     def ab_test_end(
@@ -5117,16 +5066,7 @@ class AgentStudioCLI:
         """End the active A/B test and choose the winning deployment."""
         project = cls._load_project(base_path, output_json=output_json)
 
-        try:
-            ab_test = project.get_active_ab_test()
-        except requests.HTTPError as e:
-            msg = f"Failed to fetch active A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
-
+        ab_test = project.get_active_ab_test()
         if not ab_test:
             msg = "No active A/B test found for this project."
             if output_json:
@@ -5191,20 +5131,7 @@ class AgentStudioCLI:
         winner_label = _label(chosen_deployment_id)
         promote_variant = chosen_deployment_id == variant_id
 
-        try:
-            result = project.end_ab_test(ab_test_id, chosen_deployment_id)
-        except requests.HTTPError as e:
-            body = {}
-            try:
-                body = e.response.json()
-            except Exception:
-                pass
-            msg = body.get("error") or f"Failed to end A/B test: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+        result = project.end_ab_test(ab_test_id, chosen_deployment_id)
 
         if not output_json:
             success(f"A/B test '{ab_test_name}' ended. Winner: {winner_label}")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1288,7 +1288,7 @@ class AgentStudioCLI:
                 "Manage A/B tests for live deployments.\n\n"
                 "Examples:\n"
                 "  poly deployments ab-test start --name 'v2 test'"
-                " --variant <deployment_id> --traffic 50\n"
+                " --variant-version <hash> --traffic 50\n"
                 "  poly deployments ab-test list\n"
                 "  poly deployments ab-test active\n"
                 "  poly deployments ab-test update --traffic 30\n"

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -5149,7 +5149,8 @@ class AgentStudioCLI:
                 questionary.Choice(title=f"Variant — {variant_label}", value=variant_id),
             ]
             chosen_deployment_id = questionary.select(
-                "Choose the winning deployment:", choices=choices
+                "Choose the winning deployment (this version will receive all live traffic):",
+                choices=choices,
             ).ask()
             if not chosen_deployment_id:
                 warning("Aborted.")

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -1308,7 +1308,7 @@ class AgentStudioCLI:
                 "controls what fraction of calls route to the variant (0-100).\n\n"
                 "Examples:\n"
                 "  poly deployments ab-test start"
-                " --name 'v2 test' --variant <dep_id> --traffic 50\n"
+                " --name 'v2 test' --variant-version <hash> --traffic 50\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -1320,10 +1320,10 @@ class AgentStudioCLI:
             help="Name/label for the A/B test. If omitted, prompts interactively.",
         )
         ab_test_start_parser.add_argument(
-            "--variant",
+            "--variant-version",
             type=str,
             default=None,
-            help="Deployment ID of the variant (must be pre-release). If omitted, prompts interactively.",
+            help="Version hash of the pre-release variant. If omitted, prompts interactively.",
         )
         ab_test_start_parser.add_argument(
             "--traffic",
@@ -1383,20 +1383,20 @@ class AgentStudioCLI:
             help="End an active A/B test and choose a winner.",
             description=(
                 "End the active A/B test and choose which deployment wins.\n\n"
-                "If --chosen-deployment-id is omitted, an interactive prompt\n"
+                "If --chosen-version is omitted, an interactive prompt\n"
                 "shows the control and variant deployments for selection.\n\n"
                 "Examples:\n"
                 "  poly deployments ab-test end"
-                " --chosen-deployment-id <dep_id>\n"
+                " --chosen-version <hash>\n"
                 "  poly deployments ab-test end   # interactive\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
         ab_test_end_parser.add_argument(
-            "--chosen-deployment-id",
+            "--chosen-version",
             type=str,
             default=None,
-            help="Deployment ID to keep as the winner. If omitted, prompts interactively.",
+            help="Version hash of the deployment to keep as winner. If omitted, prompts interactively.",
         )
 
         # CONVERSATIONS
@@ -1753,7 +1753,7 @@ class AgentStudioCLI:
                         cls.ab_test_start(
                             args.path,
                             args.name,
-                            args.variant,
+                            args.variant_version,
                             args.traffic,
                             output_json=args.json,
                         )
@@ -1774,7 +1774,7 @@ class AgentStudioCLI:
                     elif args.ab_test_subcommand == "end":
                         cls.ab_test_end(
                             args.path,
-                            chosen_deployment_id=args.chosen_deployment_id,
+                            chosen_version=args.chosen_version,
                             output_json=args.json,
                         )
 
@@ -4792,12 +4792,32 @@ class AgentStudioCLI:
             logger.debug("Failed to fetch deployments for A/B test display: %s", e)
         return dep_map
 
+    @staticmethod
+    def _resolve_version_to_deployment_id(
+        version_hash: str,
+        deployments: list[dict],
+    ) -> str | None:
+        """Resolve a version hash (or prefix) to a deployment ID.
+
+        Args:
+            version_hash: Full or 9-char prefix of a version hash.
+            deployments: List of deployment dicts with 'id' and 'version_hash' keys.
+
+        Returns:
+            The deployment ID if exactly one match is found, else None.
+        """
+        prefix = version_hash[:9]
+        matches = [dep for dep in deployments if (dep.get("version_hash") or "")[:9] == prefix]
+        if len(matches) == 1:
+            return matches[0].get("id")
+        return None
+
     @classmethod
     def ab_test_start(
         cls,
         base_path: str,
         name: str | None,
-        variant_deployment_id: str | None,
+        variant_version: str | None,
         traffic_percentage: int | None,
         output_json: bool = False,
     ) -> None:
@@ -4837,9 +4857,9 @@ class AgentStudioCLI:
 
         live_version = active_hashes.get("live")
 
-        if variant_deployment_id is None:
+        if variant_version is None:
             if output_json:
-                msg = "--variant is required when using --json."
+                msg = "--variant-version is required when using --json."
                 json_print({"success": False, "error": msg})
                 sys.exit(1)
             eligible = [dep for dep in pr_deployments if dep.get("version_hash") != live_version]
@@ -4862,13 +4882,22 @@ class AgentStudioCLI:
             if not variant_deployment_id:
                 warning("Aborted.")
                 sys.exit(0)
-        elif live_version:
-            variant_version = None
-            for dep in pr_deployments:
-                if dep.get("id") == variant_deployment_id:
-                    variant_version = dep.get("version_hash")
-                    break
-            if variant_version and variant_version == live_version:
+        else:
+            variant_deployment_id = cls._resolve_version_to_deployment_id(
+                variant_version, pr_deployments
+            )
+            if not variant_deployment_id:
+                msg = f"No pre-release deployment found matching version '{variant_version}'."
+                if output_json:
+                    json_print({"success": False, "error": msg})
+                else:
+                    error(msg)
+                sys.exit(1)
+            matched_dep = next(
+                (d for d in pr_deployments if d.get("id") == variant_deployment_id), None
+            )
+            matched_version = matched_dep.get("version_hash") if matched_dep else None
+            if live_version and matched_version and matched_version == live_version:
                 msg = (
                     "Variant deployment has the same version as the current live deployment."
                     " An A/B test requires different versions."
@@ -4940,7 +4969,8 @@ class AgentStudioCLI:
             if output_json:
                 json_print({"success": True, "ab_tests": ab_tests})
             else:
-                print_ab_tests(ab_tests)
+                dep_map = cls._fetch_deployment_map(project) if ab_tests else {}
+                print_ab_tests(ab_tests, deployments=dep_map)
         except requests.HTTPError as e:
             msg = f"Failed to list A/B tests: {e}"
             if output_json:
@@ -5059,7 +5089,7 @@ class AgentStudioCLI:
     def ab_test_end(
         cls,
         base_path: str,
-        chosen_deployment_id: str | None = None,
+        chosen_version: str | None = None,
         output_json: bool = False,
     ) -> None:
         """End the active A/B test and choose the winning deployment."""
@@ -5104,12 +5134,12 @@ class AgentStudioCLI:
         if not output_json:
             info(f"Active A/B test: [bold]{ab_test_name}[/bold]")
 
-        if not chosen_deployment_id:
+        if not chosen_version:
             if output_json:
                 json_print(
                     {
                         "success": False,
-                        "error": "--chosen-deployment-id is required when using --json.",
+                        "error": "--chosen-version is required when using --json.",
                     }
                 )
                 sys.exit(1)
@@ -5124,6 +5154,16 @@ class AgentStudioCLI:
             if not chosen_deployment_id:
                 warning("Aborted.")
                 sys.exit(0)
+        else:
+            all_deps = list(dep_map.values())
+            chosen_deployment_id = cls._resolve_version_to_deployment_id(chosen_version, all_deps)
+            if not chosen_deployment_id:
+                msg = f"No deployment found matching version '{chosen_version}'."
+                if output_json:
+                    json_print({"success": False, "error": msg})
+                else:
+                    error(msg)
+                sys.exit(1)
 
         winner_label = _label(chosen_deployment_id)
         promote_variant = chosen_deployment_id == variant_id

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -681,6 +681,118 @@ class AgentStudioInterface:
         return PlatformAPIHandler.rollback_deployment(region, project_id, deployment_id, message)
 
     @staticmethod
+    def create_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        name: str,
+        variant_deployment_id: str,
+        traffic_percentage: int,
+    ) -> dict:
+        """Create a new A/B test.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            name: Display name for the A/B test.
+            variant_deployment_id: ID of the pre-release variant deployment.
+            traffic_percentage: Percentage of traffic routed to variant (0-100).
+
+        Returns:
+            dict: The created A/B test record.
+        """
+        return PlatformAPIHandler.create_ab_test(
+            region, account_id, project_id, name, variant_deployment_id, traffic_percentage
+        )
+
+    @staticmethod
+    def list_ab_tests(
+        region: str,
+        account_id: str,
+        project_id: str,
+        limit: Optional[int] = None,
+    ) -> dict:
+        """List A/B tests for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            limit: Maximum number of tests to return.
+
+        Returns:
+            dict: Response containing an ``ab_tests`` list.
+        """
+        return PlatformAPIHandler.list_ab_tests(region, account_id, project_id, limit)
+
+    @staticmethod
+    def get_active_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+    ) -> dict:
+        """Get the active A/B test for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            dict: The active A/B test record, or empty dict if none.
+        """
+        return PlatformAPIHandler.get_active_ab_test(region, account_id, project_id)
+
+    @staticmethod
+    def end_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        ab_test_id: str,
+        chosen_deployment_id: str,
+    ) -> dict:
+        """End an A/B test and choose a winner.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            ab_test_id: The A/B test ID.
+            chosen_deployment_id: Deployment ID to keep (control or variant).
+
+        Returns:
+            dict: The ended A/B test record.
+        """
+        return PlatformAPIHandler.end_ab_test(
+            region, account_id, project_id, ab_test_id, chosen_deployment_id
+        )
+
+    @staticmethod
+    def update_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        ab_test_id: str,
+        traffic_percentage: int,
+    ) -> dict:
+        """Update traffic percentage for an A/B test.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            ab_test_id: The A/B test ID.
+            traffic_percentage: New traffic percentage (0-100).
+
+        Returns:
+            dict: The updated A/B test record.
+        """
+        return PlatformAPIHandler.update_ab_test(
+            region, account_id, project_id, ab_test_id, traffic_percentage
+        )
+
+    @staticmethod
     def authorise(region: str, jwt_token: str) -> dict:
         """Authorise the user via JWT, creating their account if needed.
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -26,6 +26,9 @@ DRAFT_CHAT_CONVERSATION_URL = (
     "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
 )
 CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+AB_TESTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests"
+AB_TEST_ACTIVE_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/active"
+AB_TEST_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/{ab_test_id}"
 # These use public APIs not /adk endpoints
 PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/promote"
 ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/rollback"
@@ -640,6 +643,131 @@ class PlatformAPIHandler:
         endpoint = ROLLBACK_URL.format(project_id=project_id, deployment_id=deployment_id)
         body = {"deploymentMessage": message}
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=body)
+
+    @staticmethod
+    def create_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        name: str,
+        variant_deployment_id: str,
+        traffic_percentage: int,
+    ) -> dict:
+        """Create a new A/B test.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            name: Display name for the A/B test.
+            variant_deployment_id: ID of the pre-release variant deployment.
+            traffic_percentage: Percentage of traffic routed to variant (0-100).
+
+        Returns:
+            dict: The created A/B test record.
+        """
+        endpoint = AB_TESTS_URL.format(account_id=account_id, project_id=project_id)
+        data = {
+            "name": name,
+            "variant_deployment_id": variant_deployment_id,
+            "traffic_percentage": traffic_percentage,
+        }
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def list_ab_tests(
+        region: str,
+        account_id: str,
+        project_id: str,
+        limit: ty.Optional[int] = None,
+    ) -> dict:
+        """List A/B tests for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            limit: Maximum number of tests to return.
+
+        Returns:
+            dict: Response containing an ``ab_tests`` list.
+        """
+        endpoint = AB_TESTS_URL.format(account_id=account_id, project_id=project_id)
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        return PlatformAPIHandler.make_request(region, endpoint, "GET", params=params)
+
+    @staticmethod
+    def get_active_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+    ) -> dict:
+        """Get the active A/B test for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            dict: The active A/B test record, or empty dict if none.
+        """
+        endpoint = AB_TEST_ACTIVE_URL.format(account_id=account_id, project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
+
+    @staticmethod
+    def end_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        ab_test_id: str,
+        chosen_deployment_id: str,
+    ) -> dict:
+        """End an A/B test and choose a winner.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            ab_test_id: The A/B test ID.
+            chosen_deployment_id: Deployment ID to keep (control or variant).
+
+        Returns:
+            dict: The ended A/B test record.
+        """
+        endpoint = AB_TEST_URL.format(
+            account_id=account_id, project_id=project_id, ab_test_id=ab_test_id
+        )
+        data = {"chosen_deployment_id": chosen_deployment_id}
+        return PlatformAPIHandler.make_request(region, endpoint, "DELETE", data=data)
+
+    @staticmethod
+    def update_ab_test(
+        region: str,
+        account_id: str,
+        project_id: str,
+        ab_test_id: str,
+        traffic_percentage: int,
+    ) -> dict:
+        """Update traffic percentage for an A/B test.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            ab_test_id: The A/B test ID.
+            traffic_percentage: New traffic percentage (0-100).
+
+        Returns:
+            dict: The updated A/B test record.
+        """
+        endpoint = AB_TEST_URL.format(
+            account_id=account_id, project_id=project_id, ab_test_id=ab_test_id
+        )
+        data = {"traffic_percentage": traffic_percentage}
+        return PlatformAPIHandler.make_request(region, endpoint, "PATCH", data=data)
 
     @staticmethod
     def authorise(region: str, jwt_token: str) -> dict:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -644,15 +644,21 @@ def _ab_test_status(ab_test: dict[str, Any]) -> str:
     return "[bold green]active[/bold green]"
 
 
-def print_ab_tests(ab_tests: list[dict[str, Any]]) -> None:
+def print_ab_tests(
+    ab_tests: list[dict[str, Any]],
+    deployments: dict[str, dict[str, Any]] | None = None,
+) -> None:
     """Print a table of A/B tests.
 
     Args:
         ab_tests: List of A/B test records.
+        deployments: Optional mapping of deployment ID to deployment dict
+            for enriched display (version hash, message).
     """
     if not ab_tests:
         info("No A/B tests found.")
         return
+    deps = deployments or {}
     table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
     table.add_column("ID", style="bold yellow", no_wrap=True)
     table.add_column("Name", overflow="fold")
@@ -662,13 +668,15 @@ def print_ab_tests(ab_tests: list[dict[str, Any]]) -> None:
     table.add_column("Variant", no_wrap=True)
     table.add_column("Created", no_wrap=True)
     for t in ab_tests:
+        control_id = t.get("control_deployment_id") or "—"
+        variant_id = t.get("variant_deployment_id") or "—"
         table.add_row(
             t.get("id", "—"),
             t.get("name", "—"),
             _ab_test_status(t),
             str(t.get("traffic_percentage", "—")),
-            t.get("control_deployment_id") or "—",
-            t.get("variant_deployment_id") or "—",
+            _format_dep_label(deps.get(control_id), control_id),
+            _format_dep_label(deps.get(variant_id), variant_id),
             _format_iso_timestamp(t.get("created_at", "")),
         )
     console.print(table)

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -634,6 +634,112 @@ def print_deployment_show(
         print_deployments(included_deployments, {})
 
 
+# ── A/B Tests ────────────────────────────────────────────────────────
+
+
+def _ab_test_status(ab_test: dict[str, Any]) -> str:
+    """Derive a styled status string from an A/B test record."""
+    if ab_test.get("ended_at"):
+        return "[dim]ended[/dim]"
+    return "[bold green]active[/bold green]"
+
+
+def print_ab_tests(ab_tests: list[dict[str, Any]]) -> None:
+    """Print a table of A/B tests.
+
+    Args:
+        ab_tests: List of A/B test records.
+    """
+    if not ab_tests:
+        info("No A/B tests found.")
+        return
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("ID", style="bold yellow", no_wrap=True)
+    table.add_column("Name", overflow="fold")
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Traffic %", justify="right", no_wrap=True)
+    table.add_column("Control", no_wrap=True)
+    table.add_column("Variant", no_wrap=True)
+    table.add_column("Created", no_wrap=True)
+    for t in ab_tests:
+        table.add_row(
+            t.get("id", "—"),
+            t.get("name", "—"),
+            _ab_test_status(t),
+            str(t.get("traffic_percentage", "—")),
+            t.get("control_deployment_id") or "—",
+            t.get("variant_deployment_id") or "—",
+            _format_iso_timestamp(t.get("created_at", "")),
+        )
+    console.print(table)
+
+
+def _format_dep_label(dep: dict[str, Any] | None, dep_id: str) -> str:
+    """Build a human-readable label for a deployment."""
+    if not dep:
+        return dep_id
+    version = (dep.get("version_hash") or "")[:9]
+    msg = (dep.get("deployment_metadata") or {}).get("deployment_message", "") or ""
+    if version and msg:
+        return f"{version}  [bold]{msg}[/bold]"
+    if version:
+        return version
+    return dep_id
+
+
+def print_ab_test_detail(
+    ab_test: dict[str, Any] | None,
+    deployments: dict[str, dict[str, Any]] | None = None,
+) -> None:
+    """Print detailed information for a single A/B test.
+
+    Args:
+        ab_test: A single A/B test record, or None.
+        deployments: Optional mapping of deployment ID to deployment dict
+            for enriched display (version hash, message).
+    """
+    if not ab_test:
+        info("No active A/B test.")
+        return
+
+    deps = deployments or {}
+    traffic = ab_test.get("traffic_percentage", "—")
+    control_id = ab_test.get("control_deployment_id", "—")
+    variant_id = ab_test.get("variant_deployment_id", "—")
+    control_label = _format_dep_label(deps.get(control_id), control_id)
+    variant_label = _format_dep_label(deps.get(variant_id), variant_id)
+
+    if isinstance(traffic, int):
+        control_traffic = f"{100 - traffic}%"
+        variant_traffic = f"{traffic}%"
+    else:
+        control_traffic = "—"
+        variant_traffic = "—"
+
+    table = Table(show_header=False, box=None, padding=(0, 1))
+    table.add_column("Key", style="cyan", no_wrap=True)
+    table.add_column("Value")
+    table.add_row("Name", ab_test.get("name", "—"))
+    table.add_row("Status", _ab_test_status(ab_test))
+    table.add_row(
+        "Control",
+        f"[dim]({control_traffic} traffic)[/dim]  {control_label}",
+    )
+    table.add_row(
+        "Variant",
+        f"[dim]({variant_traffic} traffic)[/dim]  {variant_label}",
+    )
+    table.add_row("Created By", ab_test.get("created_by", "—"))
+    table.add_row("Created", _format_iso_timestamp(ab_test.get("created_at", "")))
+    if ab_test.get("ended_at"):
+        table.add_row("Ended", _format_iso_timestamp(ab_test["ended_at"]))
+    if ab_test.get("chosen_deployment_id"):
+        winner_id = ab_test["chosen_deployment_id"]
+        winner_label = _format_dep_label(deps.get(winner_id), winner_id)
+        table.add_row("Winner", winner_label)
+    console.print(Panel(table, title="[bold]A/B Test[/bold]", border_style="cyan"))
+
+
 # ── Conversations ────────────────────────────────────────────────────
 
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2972,3 +2972,92 @@ class AgentStudioProject:
             message=message,
         )
         return True
+
+    # ── A/B tests ───────────────────────────────────────────────────
+
+    def create_ab_test(
+        self, name: str, variant_deployment_id: str, traffic_percentage: int
+    ) -> dict:
+        """Create a new A/B test for the project.
+
+        Args:
+            name: Display name for the test.
+            variant_deployment_id: ID of the pre-release variant deployment.
+            traffic_percentage: Percentage of traffic routed to variant (0-100).
+
+        Returns:
+            dict: The created A/B test record.
+        """
+        return self.api_handler.create_ab_test(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+            name=name,
+            variant_deployment_id=variant_deployment_id,
+            traffic_percentage=traffic_percentage,
+        )
+
+    def list_ab_tests(self, limit: int | None = None) -> list[dict]:
+        """List A/B tests for the project.
+
+        Args:
+            limit: Maximum number of tests to return.
+
+        Returns:
+            list[dict]: A list of A/B test records.
+        """
+        result = self.api_handler.list_ab_tests(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+            limit=limit,
+        )
+        return result.get("ab_tests", [])
+
+    def get_active_ab_test(self) -> dict:
+        """Get the active A/B test for the project.
+
+        Returns:
+            dict: The active A/B test record, or empty dict if none.
+        """
+        return self.api_handler.get_active_ab_test(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+        )
+
+    def end_ab_test(self, ab_test_id: str, chosen_deployment_id: str) -> dict:
+        """End an A/B test and choose a winner.
+
+        Args:
+            ab_test_id: The A/B test ID.
+            chosen_deployment_id: Deployment ID to keep (control or variant).
+
+        Returns:
+            dict: The ended A/B test record.
+        """
+        return self.api_handler.end_ab_test(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+            ab_test_id=ab_test_id,
+            chosen_deployment_id=chosen_deployment_id,
+        )
+
+    def update_ab_test(self, ab_test_id: str, traffic_percentage: int) -> dict:
+        """Update traffic percentage for an A/B test.
+
+        Args:
+            ab_test_id: The A/B test ID.
+            traffic_percentage: New traffic percentage (0-100).
+
+        Returns:
+            dict: The updated A/B test record.
+        """
+        return self.api_handler.update_ab_test(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+            ab_test_id=ab_test_id,
+            traffic_percentage=traffic_percentage,
+        )

--- a/src/poly/tests/ab_test_test.py
+++ b/src/poly/tests/ab_test_test.py
@@ -1,0 +1,906 @@
+"""Tests for the A/B test CLI commands (poly deployments ab-test ...).
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from poly.cli import AgentStudioCLI
+from poly.tests.project_test import TEST_DIR
+
+
+def _make_http_error(status_code: int, body: dict | None = None) -> requests.HTTPError:
+    """Build a requests.HTTPError with a mock response carrying JSON body."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = body or {}
+    err = requests.HTTPError(f"{status_code} Error", response=response)
+    err.response = response
+    return err
+
+
+SAMPLE_AB_TEST = {
+    "id": "ab-001",
+    "name": "v2 test",
+    "control_deployment_id": "dep-live",
+    "variant_deployment_id": "dep-variant",
+    "traffic_percentage": 50,
+    "status": "active",
+}
+
+
+class ABTestStartTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.ab_test_start."""
+
+    def setUp(self):
+        patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = patcher.start()
+        self.proj = MagicMock()
+        self.proj.create_ab_test.return_value = dict(SAMPLE_AB_TEST)
+        self.proj.get_deployments.return_value = (
+            [
+                {
+                    "id": "dep-v",
+                    "version_hash": "variant111",
+                    "deployment_metadata": {"deployment_message": "v2"},
+                }
+            ],
+            {"live": "live000000"},
+        )
+        self.mock_load.return_value = self.proj
+        self.addCleanup(patch.stopall)
+
+    # -- Happy path --
+
+    @patch("poly.cli.success")
+    @patch("poly.cli.print_ab_test_detail")
+    def test_start__success_rich_output(self, mock_detail, mock_success):
+        """Successful start prints success and detail in rich mode."""
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR, name="v2 test", variant_deployment_id="dep-v", traffic_percentage=50
+        )
+
+        self.proj.create_ab_test.assert_called_once_with("v2 test", "dep-v", 50)
+        mock_success.assert_called_once()
+        mock_detail.assert_called_once()
+
+    @patch("poly.cli.json_print")
+    def test_start__success_json_output(self, mock_json):
+        """Successful start emits JSON with success=True and the ab_test payload."""
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR,
+            name="v2 test",
+            variant_deployment_id="dep-v",
+            traffic_percentage=50,
+            output_json=True,
+        )
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["ab_test"]["id"], "ab-001")
+
+    @patch("poly.cli.json_print")
+    def test_start__name_is_stripped(self, mock_json):
+        """Leading/trailing whitespace in name is stripped before calling the API."""
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR,
+            name="  v2 test  ",
+            variant_deployment_id="dep-v",
+            traffic_percentage=50,
+            output_json=True,
+        )
+
+        self.proj.create_ab_test.assert_called_once_with("v2 test", "dep-v", 50)
+
+    # -- Interactive prompts --
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.success")
+    @patch("poly.cli.print_ab_test_detail")
+    def test_start__interactive_name_and_traffic(self, mock_detail, mock_success, mock_q):
+        """When name and traffic are None, prompts interactively with defaults."""
+        mock_q.text.return_value.ask.side_effect = ["my test", "50"]
+
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR, name=None, variant_deployment_id="dep-v", traffic_percentage=None
+        )
+
+        self.assertEqual(mock_q.text.call_count, 2)
+        name_call = mock_q.text.call_args_list[0]
+        self.assertIn("name", name_call[0][0].lower())
+        traffic_call = mock_q.text.call_args_list[1]
+        self.assertEqual(traffic_call[1]["default"], "50")
+        self.proj.create_ab_test.assert_called_once_with("my test", "dep-v", 50)
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.success")
+    @patch("poly.cli.print_ab_test_detail")
+    def test_start__interactive_variant_picker(self, mock_detail, mock_success, mock_q):
+        """When variant is None, fetches pre-release deployments and prompts."""
+        self.proj.get_deployments.return_value = (
+            [
+                {
+                    "id": "dep-pr-1",
+                    "version_hash": "abc123456",
+                    "deployment_metadata": {"deployment_message": "v2 candidate"},
+                }
+            ],
+            {"live": "live000000"},
+        )
+        mock_q.text.return_value.ask.return_value = "50"
+        mock_q.Choice = MagicMock(side_effect=lambda **kw: kw)
+        mock_q.select.return_value.ask.return_value = "dep-pr-1"
+
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR, name="test", variant_deployment_id=None, traffic_percentage=None
+        )
+
+        self.proj.get_deployments.assert_any_call(client_env="pre-release")
+        mock_q.select.assert_called_once()
+        self.proj.create_ab_test.assert_called_once_with("test", "dep-pr-1", 50)
+
+    # -- Version validation --
+
+    @patch("poly.cli.error")
+    def test_start__variant_same_version_as_live_exits(self, mock_error):
+        """Explicit variant with same version_hash as live exits with error."""
+        self.proj.get_deployments.return_value = (
+            [{"id": "dep-v", "version_hash": "same_hash"}],
+            {"live": "same_hash"},
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=50
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("same version", mock_error.call_args[0][0])
+        self.proj.create_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_start__variant_same_version_as_live_json(self, mock_json):
+        """Explicit variant with same version as live exits with error JSON."""
+        self.proj.get_deployments.return_value = (
+            [{"id": "dep-v", "version_hash": "same_hash"}],
+            {"live": "same_hash"},
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("same version", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_start__interactive_filters_same_version_deployments(self, mock_error):
+        """Interactive picker excludes pre-release deployments matching live version."""
+        self.proj.get_deployments.return_value = (
+            [{"id": "dep-1", "version_hash": "live_hash"}],
+            {"live": "live_hash"},
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="test", variant_deployment_id=None, traffic_percentage=50
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("match the current live version", mock_error.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_start__json_mode_requires_name(self, mock_json):
+        """JSON mode with name=None exits with error."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name=None,
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("--name", payload["error"])
+
+    @patch("poly.cli.json_print")
+    def test_start__json_mode_requires_variant(self, mock_json):
+        """JSON mode with variant=None exits with error."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id=None,
+                traffic_percentage=50,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("--variant", payload["error"])
+
+    @patch("poly.cli.json_print")
+    def test_start__json_mode_requires_traffic(self, mock_json):
+        """JSON mode with traffic=None exits with error."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=None,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("--traffic", payload["error"])
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.error")
+    def test_start__interactive_traffic_not_a_number(self, mock_error, mock_q):
+        """Non-numeric interactive traffic input exits with error."""
+        mock_q.text.return_value.ask.side_effect = ["my test", "abc"]
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name=None, variant_deployment_id="dep-v", traffic_percentage=None
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("integer", mock_error.call_args[0][0])
+
+    # -- Validation: name --
+
+    @patch("poly.cli.error")
+    def test_start__empty_name_exits_with_error(self, mock_error):
+        """Empty string name triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="", variant_deployment_id="dep-v", traffic_percentage=50
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+        self.assertIn("required", mock_error.call_args[0][0])
+        self.proj.create_ab_test.assert_not_called()
+
+    @patch("poly.cli.error")
+    def test_start__whitespace_only_name_exits_with_error(self, mock_error):
+        """Whitespace-only name triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="   ", variant_deployment_id="dep-v", traffic_percentage=50
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.create_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_start__empty_name_json_mode_exits_with_error(self, mock_json):
+        """Empty name in JSON mode emits error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="",
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("required", payload["error"])
+
+    # -- Validation: traffic_percentage --
+
+    @patch("poly.cli.error")
+    def test_start__negative_traffic_exits_with_error(self, mock_error):
+        """Negative traffic percentage triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=-1
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("0 and 100", mock_error.call_args[0][0])
+        self.proj.create_ab_test.assert_not_called()
+
+    @patch("poly.cli.error")
+    def test_start__traffic_above_100_exits_with_error(self, mock_error):
+        """Traffic percentage > 100 triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=101
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.create_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_start__traffic_above_100_json_mode(self, mock_json):
+        """Traffic > 100 in JSON mode emits error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=101,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+
+    # -- Boundary: traffic at 0 and 100 --
+
+    @patch("poly.cli.json_print")
+    def test_start__traffic_zero_is_valid(self, mock_json):
+        """Traffic percentage of 0 is accepted."""
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR,
+            name="test",
+            variant_deployment_id="dep-v",
+            traffic_percentage=0,
+            output_json=True,
+        )
+
+        self.proj.create_ab_test.assert_called_once_with("test", "dep-v", 0)
+
+    @patch("poly.cli.json_print")
+    def test_start__traffic_100_is_valid(self, mock_json):
+        """Traffic percentage of 100 is accepted."""
+        AgentStudioCLI.ab_test_start(
+            TEST_DIR,
+            name="test",
+            variant_deployment_id="dep-v",
+            traffic_percentage=100,
+            output_json=True,
+        )
+
+        self.proj.create_ab_test.assert_called_once_with("test", "dep-v", 100)
+
+    # -- HTTP errors --
+
+    @patch("poly.cli.json_print")
+    def test_start__http_409_json_extracts_error_message(self, mock_json):
+        """409 Conflict extracts error from response body in JSON mode."""
+        self.proj.create_ab_test.side_effect = _make_http_error(
+            409, {"error": "An A/B test is already active."}
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["error"], "An A/B test is already active.")
+
+    @patch("poly.cli.error")
+    def test_start__http_404_rich_extracts_error_message(self, mock_error):
+        """404 Not Found shows error from response body in rich mode."""
+        self.proj.create_ab_test.side_effect = _make_http_error(
+            404, {"error": "Deployment not found."}
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once_with("Deployment not found.")
+
+    @patch("poly.cli.error")
+    def test_start__http_error_without_body_uses_fallback_message(self, mock_error):
+        """HTTPError with no JSON body uses the fallback message."""
+        response = MagicMock()
+        response.json.side_effect = ValueError("no json")
+        err = requests.HTTPError("500 Server Error", response=response)
+        err.response = response
+        self.proj.create_ab_test.side_effect = err
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.ab_test_start(
+                TEST_DIR,
+                name="test",
+                variant_deployment_id="dep-v",
+                traffic_percentage=50,
+            )
+
+        msg = mock_error.call_args[0][0]
+        self.assertIn("Failed to start A/B test", msg)
+
+
+class ABTestListTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.ab_test_list."""
+
+    def setUp(self):
+        patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+        self.addCleanup(patch.stopall)
+
+    @patch("poly.cli.print_ab_tests")
+    def test_list__success_rich_output(self, mock_print):
+        """Successful list calls print_ab_tests with results."""
+        self.proj.list_ab_tests.return_value = [SAMPLE_AB_TEST]
+
+        AgentStudioCLI.ab_test_list(TEST_DIR, limit=10)
+
+        self.proj.list_ab_tests.assert_called_once_with(limit=10)
+        mock_print.assert_called_once_with([SAMPLE_AB_TEST])
+
+    @patch("poly.cli.json_print")
+    def test_list__success_json_output(self, mock_json):
+        """Successful list emits JSON with success=True and the ab_tests array."""
+        self.proj.list_ab_tests.return_value = [SAMPLE_AB_TEST]
+
+        AgentStudioCLI.ab_test_list(TEST_DIR, limit=5, output_json=True)
+
+        self.proj.list_ab_tests.assert_called_once_with(limit=5)
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(len(payload["ab_tests"]), 1)
+
+    @patch("poly.cli.print_ab_tests")
+    def test_list__empty_results(self, mock_print):
+        """Empty list result still calls print_ab_tests with empty list."""
+        self.proj.list_ab_tests.return_value = []
+
+        AgentStudioCLI.ab_test_list(TEST_DIR)
+
+        mock_print.assert_called_once_with([])
+
+    @patch("poly.cli.json_print")
+    def test_list__limit_parameter_forwarded(self, mock_json):
+        """Custom limit is forwarded to project.list_ab_tests."""
+        self.proj.list_ab_tests.return_value = []
+
+        AgentStudioCLI.ab_test_list(TEST_DIR, limit=25, output_json=True)
+
+        self.proj.list_ab_tests.assert_called_once_with(limit=25)
+
+    @patch("poly.cli.error")
+    def test_list__http_error_rich(self, mock_error):
+        """HTTPError in rich mode prints error and exits."""
+        self.proj.list_ab_tests.side_effect = _make_http_error(500)
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_list(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+
+    @patch("poly.cli.json_print")
+    def test_list__http_error_json(self, mock_json):
+        """HTTPError in JSON mode emits error JSON and exits."""
+        self.proj.list_ab_tests.side_effect = _make_http_error(500)
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_list(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+
+
+class ABTestActiveTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.ab_test_active."""
+
+    def setUp(self):
+        patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+        self.addCleanup(patch.stopall)
+
+    @patch("poly.cli.print_ab_test_detail")
+    def test_active__found_rich_output(self, mock_detail):
+        """Active test found prints detail in rich mode."""
+        self.proj.get_active_ab_test.return_value = SAMPLE_AB_TEST
+
+        AgentStudioCLI.ab_test_active(TEST_DIR)
+
+        mock_detail.assert_called_once()
+        self.assertEqual(mock_detail.call_args[0][0], SAMPLE_AB_TEST)
+
+    @patch("poly.cli.json_print")
+    def test_active__found_json_output(self, mock_json):
+        """Active test found emits JSON with the ab_test."""
+        self.proj.get_active_ab_test.return_value = SAMPLE_AB_TEST
+
+        AgentStudioCLI.ab_test_active(TEST_DIR, output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["ab_test"]["id"], "ab-001")
+
+    @patch("poly.cli.print_ab_test_detail")
+    def test_active__none_returned_rich(self, mock_detail):
+        """No active test passes None to print_ab_test_detail."""
+        self.proj.get_active_ab_test.return_value = None
+
+        AgentStudioCLI.ab_test_active(TEST_DIR)
+
+        mock_detail.assert_called_once()
+        self.assertIsNone(mock_detail.call_args[0][0])
+
+    @patch("poly.cli.json_print")
+    def test_active__none_returned_json(self, mock_json):
+        """No active test emits JSON with ab_test: None."""
+        self.proj.get_active_ab_test.return_value = None
+
+        AgentStudioCLI.ab_test_active(TEST_DIR, output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertIsNone(payload["ab_test"])
+
+    @patch("poly.cli.error")
+    def test_active__http_error_rich(self, mock_error):
+        """HTTPError in rich mode prints error and exits."""
+        self.proj.get_active_ab_test.side_effect = _make_http_error(500)
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_active(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+
+    @patch("poly.cli.json_print")
+    def test_active__http_error_json(self, mock_json):
+        """HTTPError in JSON mode emits error JSON and exits."""
+        self.proj.get_active_ab_test.side_effect = _make_http_error(500)
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_active(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+
+
+class ABTestUpdateTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.ab_test_update."""
+
+    def setUp(self):
+        patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = patcher.start()
+        self.proj = MagicMock()
+        updated = dict(SAMPLE_AB_TEST, traffic_percentage=30)
+        self.proj.update_ab_test.return_value = updated
+        self.proj.get_active_ab_test.return_value = dict(SAMPLE_AB_TEST)
+        self.mock_load.return_value = self.proj
+        self.addCleanup(patch.stopall)
+
+    # -- Happy path --
+
+    @patch("poly.cli.success")
+    @patch("poly.cli.print_ab_test_detail")
+    def test_update__success_rich_output(self, mock_detail, mock_success):
+        """Successful update prints success message with new percentage."""
+        AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30)
+
+        self.proj.update_ab_test.assert_called_once_with("ab-001", 30)
+        mock_success.assert_called_once()
+        self.assertIn("30%", mock_success.call_args[0][0])
+        mock_detail.assert_called_once()
+
+    @patch("poly.cli.json_print")
+    def test_update__success_json_output(self, mock_json):
+        """Successful update emits JSON with updated ab_test."""
+        AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30, output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["ab_test"]["traffic_percentage"], 30)
+
+    # -- No active test --
+
+    @patch("poly.cli.error")
+    def test_update__no_active_test_exits(self, mock_error):
+        """No active test exits with error."""
+        self.proj.get_active_ab_test.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("No active", mock_error.call_args[0][0])
+        self.proj.update_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_update__no_active_test_json_exits(self, mock_json):
+        """No active test in JSON mode exits with error JSON."""
+        self.proj.get_active_ab_test.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("No active", payload["error"])
+
+    # -- Validation: traffic_percentage --
+
+    @patch("poly.cli.error")
+    def test_update__negative_traffic_exits_with_error(self, mock_error):
+        """Negative traffic percentage triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=-5)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("0 and 100", mock_error.call_args[0][0])
+        self.proj.update_ab_test.assert_not_called()
+
+    @patch("poly.cli.error")
+    def test_update__traffic_above_100_exits_with_error(self, mock_error):
+        """Traffic > 100 triggers error and sys.exit(1)."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=150)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+        self.proj.update_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_update__traffic_above_100_json_mode(self, mock_json):
+        """Traffic > 100 in JSON mode emits error JSON and exits."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=200, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+
+    # -- HTTP errors --
+
+    @patch("poly.cli.json_print")
+    def test_update__http_error_json_extracts_error(self, mock_json):
+        """HTTP error extracts error message from response body."""
+        self.proj.update_ab_test.side_effect = _make_http_error(
+            400, {"error": "Traffic percentage must be between 0 and 100"}
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("Traffic percentage", payload["error"])
+
+    @patch("poly.cli.error")
+    def test_update__http_error_without_body_uses_fallback(self, mock_error):
+        """HTTPError with no JSON body uses fallback message."""
+        response = MagicMock()
+        response.json.side_effect = ValueError("no json")
+        err = requests.HTTPError("500 Server Error", response=response)
+        err.response = response
+        self.proj.update_ab_test.side_effect = err
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30)
+
+        msg = mock_error.call_args[0][0]
+        self.assertIn("Failed to update A/B test", msg)
+
+
+class ABTestEndTest(unittest.TestCase):
+    """Tests for AgentStudioCLI.ab_test_end."""
+
+    def setUp(self):
+        patcher = patch("poly.cli.AgentStudioCLI._load_project")
+        self.mock_load = patcher.start()
+        self.proj = MagicMock()
+        self.proj.end_ab_test.return_value = dict(SAMPLE_AB_TEST, status="ended")
+        self.proj.get_active_ab_test.return_value = dict(SAMPLE_AB_TEST)
+        self.proj.get_deployments.return_value = (
+            [
+                {
+                    "id": "dep-variant",
+                    "version_hash": "variant111",
+                    "deployment_metadata": {"deployment_message": "v2 candidate"},
+                }
+            ],
+            {},
+        )
+        self.mock_load.return_value = self.proj
+        self.addCleanup(patch.stopall)
+
+    # -- Happy path: control wins (no promotion) --
+
+    @patch("poly.cli.success")
+    @patch("poly.cli.info")
+    def test_end__explicit_winner_rich_output(self, mock_info, mock_success):
+        """Ending with control as winner prints success, no promotion."""
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live")
+
+        self.proj.end_ab_test.assert_called_once_with("ab-001", "dep-live")
+        mock_success.assert_called_once()
+        self.proj.promote_deployment.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_end__explicit_winner_json_output(self, mock_json):
+        """Ending with control as winner emits JSON with promoted=False."""
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertFalse(payload["promoted"])
+
+    # -- Happy path: variant wins (triggers promotion) --
+
+    @patch("poly.cli.success")
+    @patch("poly.cli.info")
+    def test_end__variant_wins_promotes_to_live(self, mock_info, mock_success):
+        """Choosing the variant promotes it to live."""
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant")
+
+        self.proj.end_ab_test.assert_called_once_with("ab-001", "dep-variant")
+        self.proj.promote_deployment.assert_called_once_with(
+            "dep-variant", "live", message="v2 candidate"
+        )
+        self.assertEqual(mock_success.call_count, 2)
+
+    @patch("poly.cli.json_print")
+    def test_end__variant_wins_json_includes_promoted(self, mock_json):
+        """Variant win in JSON mode includes promoted=True."""
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertTrue(payload["promoted"])
+
+    @patch("poly.cli.warning")
+    @patch("poly.cli.success")
+    @patch("poly.cli.info")
+    def test_end__variant_wins_promote_fails_warns(self, mock_info, mock_success, mock_warning):
+        """If promotion fails after ending, warns but doesn't exit with error."""
+        self.proj.promote_deployment.side_effect = Exception("promote failed")
+
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant")
+
+        self.proj.end_ab_test.assert_called_once()
+        mock_warning.assert_called_once()
+        self.assertIn("failed to promote", mock_warning.call_args[0][0])
+
+    # -- JSON mode without chosen_deployment_id --
+
+    @patch("poly.cli.json_print")
+    def test_end__json_mode_without_chosen_id_exits_with_error(self, mock_json):
+        """JSON mode requires --chosen-deployment-id; omitting it exits with error."""
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("--chosen-deployment-id", payload["error"])
+        self.proj.end_ab_test.assert_not_called()
+
+    # -- Interactive prompt flow --
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.success")
+    @patch("poly.cli.info")
+    def test_end__interactive_prompt_selects_winner(self, mock_info, mock_success, mock_q):
+        """Interactive mode fetches active test, prompts, ends test and promotes variant."""
+        mock_q.Choice = MagicMock(side_effect=lambda **kw: kw)
+        mock_q.select.return_value.ask.return_value = "dep-variant"
+
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+
+        self.proj.get_active_ab_test.assert_called_once()
+        mock_q.select.assert_called_once()
+        self.proj.end_ab_test.assert_called_once_with("ab-001", "dep-variant")
+        self.proj.promote_deployment.assert_called_once()
+        self.assertEqual(mock_success.call_count, 2)
+
+    @patch("poly.cli.questionary")
+    @patch("poly.cli.warning")
+    @patch("poly.cli.info")
+    def test_end__interactive_user_aborts(self, mock_info, mock_warning, mock_q):
+        """User aborting the interactive prompt exits with 0."""
+        mock_q.Choice = MagicMock(side_effect=lambda **kw: kw)
+        mock_q.select.return_value.ask.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+
+        self.assertEqual(ctx.exception.code, 0)
+        mock_warning.assert_called_once()
+        self.proj.end_ab_test.assert_not_called()
+
+    # -- No active test --
+
+    @patch("poly.cli.error")
+    def test_end__no_active_test_exits(self, mock_error):
+        """If no active test exists, exits with error."""
+        self.proj.get_active_ab_test.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("No active", mock_error.call_args[0][0])
+        self.proj.end_ab_test.assert_not_called()
+
+    @patch("poly.cli.json_print")
+    def test_end__no_active_test_json_exits(self, mock_json):
+        """If no active test exists in JSON mode, exits with error JSON."""
+        self.proj.get_active_ab_test.return_value = None
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertIn("No active", payload["error"])
+
+    # -- HTTPError fetching active test --
+
+    @patch("poly.cli.error")
+    def test_end__http_error_fetching_active_exits(self, mock_error):
+        """HTTPError when fetching active test exits."""
+        self.proj.get_active_ab_test.side_effect = _make_http_error(500)
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("Failed to fetch", mock_error.call_args[0][0])
+
+    # -- HTTP errors on end_ab_test --
+
+    @patch("poly.cli.json_print")
+    def test_end__http_409_json(self, mock_json):
+        """409 Conflict (already ended) extracts error from body."""
+        self.proj.end_ab_test.side_effect = _make_http_error(
+            409, {"error": "A/B test already ended."}
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["error"], "A/B test already ended.")
+
+    @patch("poly.cli.error")
+    @patch("poly.cli.info")
+    def test_end__http_404_rich(self, mock_info, mock_error):
+        """404 Not Found shows error from response body."""
+        self.proj.end_ab_test.side_effect = _make_http_error(404, {"error": "A/B test not found."})
+
+        with self.assertRaises(SystemExit) as ctx:
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live")
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once_with("A/B test not found.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/ab_test_test.py
+++ b/src/poly/tests/ab_test_test.py
@@ -372,65 +372,21 @@ class ABTestStartTest(unittest.TestCase):
 
         self.proj.create_ab_test.assert_called_once_with("test", "dep-v", 100)
 
-    # -- HTTP errors --
+    # -- HTTP errors (propagated to top-level handler) --
 
-    @patch("poly.cli.json_print")
-    def test_start__http_409_json_extracts_error_message(self, mock_json):
-        """409 Conflict extracts error from response body in JSON mode."""
+    def test_start__http_error_propagates(self):
+        """HTTPError from create_ab_test propagates to the top-level handler."""
         self.proj.create_ab_test.side_effect = _make_http_error(
             409, {"error": "An A/B test is already active."}
         )
 
-        with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_start(
-                TEST_DIR,
-                name="test",
-                variant_version="variant111",
-                traffic_percentage=50,
-                output_json=True,
-            )
-
-        self.assertEqual(ctx.exception.code, 1)
-        payload = mock_json.call_args[0][0]
-        self.assertEqual(payload["error"], "An A/B test is already active.")
-
-    @patch("poly.cli.error")
-    def test_start__http_404_rich_extracts_error_message(self, mock_error):
-        """404 Not Found shows error from response body in rich mode."""
-        self.proj.create_ab_test.side_effect = _make_http_error(
-            404, {"error": "Deployment not found."}
-        )
-
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
                 variant_version="variant111",
                 traffic_percentage=50,
             )
-
-        self.assertEqual(ctx.exception.code, 1)
-        mock_error.assert_called_once_with("Deployment not found.")
-
-    @patch("poly.cli.error")
-    def test_start__http_error_without_body_uses_fallback_message(self, mock_error):
-        """HTTPError with no JSON body uses the fallback message."""
-        response = MagicMock()
-        response.json.side_effect = ValueError("no json")
-        err = requests.HTTPError("500 Server Error", response=response)
-        err.response = response
-        self.proj.create_ab_test.side_effect = err
-
-        with self.assertRaises(SystemExit):
-            AgentStudioCLI.ab_test_start(
-                TEST_DIR,
-                name="test",
-                variant_version="variant111",
-                traffic_percentage=50,
-            )
-
-        msg = mock_error.call_args[0][0]
-        self.assertIn("Failed to start A/B test", msg)
 
 
 class ABTestListTest(unittest.TestCase):
@@ -487,28 +443,12 @@ class ABTestListTest(unittest.TestCase):
 
         self.proj.list_ab_tests.assert_called_once_with(limit=25)
 
-    @patch("poly.cli.error")
-    def test_list__http_error_rich(self, mock_error):
-        """HTTPError in rich mode prints error and exits."""
+    def test_list__http_error_propagates(self):
+        """HTTPError from list_ab_tests propagates to the top-level handler."""
         self.proj.list_ab_tests.side_effect = _make_http_error(500)
 
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_list(TEST_DIR)
-
-        self.assertEqual(ctx.exception.code, 1)
-        mock_error.assert_called_once()
-
-    @patch("poly.cli.json_print")
-    def test_list__http_error_json(self, mock_json):
-        """HTTPError in JSON mode emits error JSON and exits."""
-        self.proj.list_ab_tests.side_effect = _make_http_error(500)
-
-        with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_list(TEST_DIR, output_json=True)
-
-        self.assertEqual(ctx.exception.code, 1)
-        payload = mock_json.call_args[0][0]
-        self.assertFalse(payload["success"])
 
 
 class ABTestActiveTest(unittest.TestCase):
@@ -563,28 +503,12 @@ class ABTestActiveTest(unittest.TestCase):
         self.assertTrue(payload["success"])
         self.assertIsNone(payload["ab_test"])
 
-    @patch("poly.cli.error")
-    def test_active__http_error_rich(self, mock_error):
-        """HTTPError in rich mode prints error and exits."""
+    def test_active__http_error_propagates(self):
+        """HTTPError from get_active_ab_test propagates to the top-level handler."""
         self.proj.get_active_ab_test.side_effect = _make_http_error(500)
 
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_active(TEST_DIR)
-
-        self.assertEqual(ctx.exception.code, 1)
-        mock_error.assert_called_once()
-
-    @patch("poly.cli.json_print")
-    def test_active__http_error_json(self, mock_json):
-        """HTTPError in JSON mode emits error JSON and exits."""
-        self.proj.get_active_ab_test.side_effect = _make_http_error(500)
-
-        with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_active(TEST_DIR, output_json=True)
-
-        self.assertEqual(ctx.exception.code, 1)
-        payload = mock_json.call_args[0][0]
-        self.assertFalse(payload["success"])
 
 
 class ABTestUpdateTest(unittest.TestCase):
@@ -682,34 +606,14 @@ class ABTestUpdateTest(unittest.TestCase):
 
     # -- HTTP errors --
 
-    @patch("poly.cli.json_print")
-    def test_update__http_error_json_extracts_error(self, mock_json):
-        """HTTP error extracts error message from response body."""
+    def test_update__http_error_propagates(self):
+        """HTTPError from update_ab_test propagates to the top-level handler."""
         self.proj.update_ab_test.side_effect = _make_http_error(
             400, {"error": "Traffic percentage must be between 0 and 100"}
         )
 
-        with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30, output_json=True)
-
-        self.assertEqual(ctx.exception.code, 1)
-        payload = mock_json.call_args[0][0]
-        self.assertIn("Traffic percentage", payload["error"])
-
-    @patch("poly.cli.error")
-    def test_update__http_error_without_body_uses_fallback(self, mock_error):
-        """HTTPError with no JSON body uses fallback message."""
-        response = MagicMock()
-        response.json.side_effect = ValueError("no json")
-        err = requests.HTTPError("500 Server Error", response=response)
-        err.response = response
-        self.proj.update_ab_test.side_effect = err
-
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_update(TEST_DIR, traffic_percentage=30)
-
-        msg = mock_error.call_args[0][0]
-        self.assertIn("Failed to update A/B test", msg)
 
 
 class ABTestEndTest(unittest.TestCase):
@@ -871,48 +775,23 @@ class ABTestEndTest(unittest.TestCase):
         payload = mock_json.call_args[0][0]
         self.assertIn("No active", payload["error"])
 
-    # -- HTTPError fetching active test --
+    # -- HTTP errors (propagated to top-level handler) --
 
-    @patch("poly.cli.error")
-    def test_end__http_error_fetching_active_exits(self, mock_error):
-        """HTTPError when fetching active test exits."""
+    def test_end__http_error_fetching_active_propagates(self):
+        """HTTPError when fetching active test propagates to the top-level handler."""
         self.proj.get_active_ab_test.side_effect = _make_http_error(500)
 
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None)
 
-        self.assertEqual(ctx.exception.code, 1)
-        self.assertIn("Failed to fetch", mock_error.call_args[0][0])
-
-    # -- HTTP errors on end_ab_test --
-
-    @patch("poly.cli.json_print")
-    def test_end__http_409_json(self, mock_json):
-        """409 Conflict (already ended) extracts error from body."""
+    def test_end__http_error_ending_test_propagates(self):
+        """HTTPError from end_ab_test propagates to the top-level handler."""
         self.proj.end_ab_test.side_effect = _make_http_error(
             409, {"error": "A/B test already ended."}
         )
 
-        with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(
-                TEST_DIR, chosen_version="live00000", output_json=True
-            )
-
-        self.assertEqual(ctx.exception.code, 1)
-        payload = mock_json.call_args[0][0]
-        self.assertEqual(payload["error"], "A/B test already ended.")
-
-    @patch("poly.cli.error")
-    @patch("poly.cli.info")
-    def test_end__http_404_rich(self, mock_info, mock_error):
-        """404 Not Found shows error from response body."""
-        self.proj.end_ab_test.side_effect = _make_http_error(404, {"error": "A/B test not found."})
-
-        with self.assertRaises(SystemExit) as ctx:
+        with self.assertRaises(requests.HTTPError):
             AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="live00000")
-
-        self.assertEqual(ctx.exception.code, 1)
-        mock_error.assert_called_once_with("A/B test not found.")
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/ab_test_test.py
+++ b/src/poly/tests/ab_test_test.py
@@ -60,7 +60,7 @@ class ABTestStartTest(unittest.TestCase):
     def test_start__success_rich_output(self, mock_detail, mock_success):
         """Successful start prints success and detail in rich mode."""
         AgentStudioCLI.ab_test_start(
-            TEST_DIR, name="v2 test", variant_deployment_id="dep-v", traffic_percentage=50
+            TEST_DIR, name="v2 test", variant_version="variant111", traffic_percentage=50
         )
 
         self.proj.create_ab_test.assert_called_once_with("v2 test", "dep-v", 50)
@@ -73,7 +73,7 @@ class ABTestStartTest(unittest.TestCase):
         AgentStudioCLI.ab_test_start(
             TEST_DIR,
             name="v2 test",
-            variant_deployment_id="dep-v",
+            variant_version="variant111",
             traffic_percentage=50,
             output_json=True,
         )
@@ -88,7 +88,7 @@ class ABTestStartTest(unittest.TestCase):
         AgentStudioCLI.ab_test_start(
             TEST_DIR,
             name="  v2 test  ",
-            variant_deployment_id="dep-v",
+            variant_version="variant111",
             traffic_percentage=50,
             output_json=True,
         )
@@ -105,7 +105,7 @@ class ABTestStartTest(unittest.TestCase):
         mock_q.text.return_value.ask.side_effect = ["my test", "50"]
 
         AgentStudioCLI.ab_test_start(
-            TEST_DIR, name=None, variant_deployment_id="dep-v", traffic_percentage=None
+            TEST_DIR, name=None, variant_version="variant111", traffic_percentage=None
         )
 
         self.assertEqual(mock_q.text.call_count, 2)
@@ -135,7 +135,7 @@ class ABTestStartTest(unittest.TestCase):
         mock_q.select.return_value.ask.return_value = "dep-pr-1"
 
         AgentStudioCLI.ab_test_start(
-            TEST_DIR, name="test", variant_deployment_id=None, traffic_percentage=None
+            TEST_DIR, name="test", variant_version=None, traffic_percentage=None
         )
 
         self.proj.get_deployments.assert_any_call(client_env="pre-release")
@@ -154,7 +154,7 @@ class ABTestStartTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=50
+                TEST_DIR, name="test", variant_version="same_hash", traffic_percentage=50
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -173,7 +173,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="same_hash",
                 traffic_percentage=50,
                 output_json=True,
             )
@@ -192,7 +192,7 @@ class ABTestStartTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="test", variant_deployment_id=None, traffic_percentage=50
+                TEST_DIR, name="test", variant_version=None, traffic_percentage=50
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -205,7 +205,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name=None,
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=50,
                 output_json=True,
             )
@@ -215,20 +215,20 @@ class ABTestStartTest(unittest.TestCase):
         self.assertIn("--name", payload["error"])
 
     @patch("poly.cli.json_print")
-    def test_start__json_mode_requires_variant(self, mock_json):
-        """JSON mode with variant=None exits with error."""
+    def test_start__json_mode_requires_variant_version(self, mock_json):
+        """JSON mode with variant_version=None exits with error."""
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id=None,
+                variant_version=None,
                 traffic_percentage=50,
                 output_json=True,
             )
 
         self.assertEqual(ctx.exception.code, 1)
         payload = mock_json.call_args[0][0]
-        self.assertIn("--variant", payload["error"])
+        self.assertIn("--variant-version", payload["error"])
 
     @patch("poly.cli.json_print")
     def test_start__json_mode_requires_traffic(self, mock_json):
@@ -237,7 +237,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=None,
                 output_json=True,
             )
@@ -254,7 +254,7 @@ class ABTestStartTest(unittest.TestCase):
 
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name=None, variant_deployment_id="dep-v", traffic_percentage=None
+                TEST_DIR, name=None, variant_version="variant111", traffic_percentage=None
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -267,7 +267,7 @@ class ABTestStartTest(unittest.TestCase):
         """Empty string name triggers error and sys.exit(1)."""
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="", variant_deployment_id="dep-v", traffic_percentage=50
+                TEST_DIR, name="", variant_version="variant111", traffic_percentage=50
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -280,7 +280,7 @@ class ABTestStartTest(unittest.TestCase):
         """Whitespace-only name triggers error and sys.exit(1)."""
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="   ", variant_deployment_id="dep-v", traffic_percentage=50
+                TEST_DIR, name="   ", variant_version="variant111", traffic_percentage=50
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -293,7 +293,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=50,
                 output_json=True,
             )
@@ -310,7 +310,7 @@ class ABTestStartTest(unittest.TestCase):
         """Negative traffic percentage triggers error and sys.exit(1)."""
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=-1
+                TEST_DIR, name="test", variant_version="variant111", traffic_percentage=-1
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -322,7 +322,7 @@ class ABTestStartTest(unittest.TestCase):
         """Traffic percentage > 100 triggers error and sys.exit(1)."""
         with self.assertRaises(SystemExit) as ctx:
             AgentStudioCLI.ab_test_start(
-                TEST_DIR, name="test", variant_deployment_id="dep-v", traffic_percentage=101
+                TEST_DIR, name="test", variant_version="variant111", traffic_percentage=101
             )
 
         self.assertEqual(ctx.exception.code, 1)
@@ -335,7 +335,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=101,
                 output_json=True,
             )
@@ -352,7 +352,7 @@ class ABTestStartTest(unittest.TestCase):
         AgentStudioCLI.ab_test_start(
             TEST_DIR,
             name="test",
-            variant_deployment_id="dep-v",
+            variant_version="variant111",
             traffic_percentage=0,
             output_json=True,
         )
@@ -365,7 +365,7 @@ class ABTestStartTest(unittest.TestCase):
         AgentStudioCLI.ab_test_start(
             TEST_DIR,
             name="test",
-            variant_deployment_id="dep-v",
+            variant_version="variant111",
             traffic_percentage=100,
             output_json=True,
         )
@@ -385,7 +385,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=50,
                 output_json=True,
             )
@@ -405,7 +405,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=50,
             )
 
@@ -425,7 +425,7 @@ class ABTestStartTest(unittest.TestCase):
             AgentStudioCLI.ab_test_start(
                 TEST_DIR,
                 name="test",
-                variant_deployment_id="dep-v",
+                variant_version="variant111",
                 traffic_percentage=50,
             )
 
@@ -443,15 +443,19 @@ class ABTestListTest(unittest.TestCase):
         self.mock_load.return_value = self.proj
         self.addCleanup(patch.stopall)
 
+    @patch("poly.cli.AgentStudioCLI._fetch_deployment_map")
     @patch("poly.cli.print_ab_tests")
-    def test_list__success_rich_output(self, mock_print):
-        """Successful list calls print_ab_tests with results."""
+    def test_list__success_rich_output(self, mock_print, mock_dep_map):
+        """Successful list calls print_ab_tests with results and deployment map."""
         self.proj.list_ab_tests.return_value = [SAMPLE_AB_TEST]
+        mock_dep_map.return_value = {"dep-live": {"id": "dep-live"}}
 
         AgentStudioCLI.ab_test_list(TEST_DIR, limit=10)
 
         self.proj.list_ab_tests.assert_called_once_with(limit=10)
-        mock_print.assert_called_once_with([SAMPLE_AB_TEST])
+        mock_print.assert_called_once_with(
+            [SAMPLE_AB_TEST], deployments={"dep-live": {"id": "dep-live"}}
+        )
 
     @patch("poly.cli.json_print")
     def test_list__success_json_output(self, mock_json):
@@ -472,7 +476,7 @@ class ABTestListTest(unittest.TestCase):
 
         AgentStudioCLI.ab_test_list(TEST_DIR)
 
-        mock_print.assert_called_once_with([])
+        mock_print.assert_called_once_with([], deployments={})
 
     @patch("poly.cli.json_print")
     def test_list__limit_parameter_forwarded(self, mock_json):
@@ -720,10 +724,15 @@ class ABTestEndTest(unittest.TestCase):
         self.proj.get_deployments.return_value = (
             [
                 {
+                    "id": "dep-live",
+                    "version_hash": "live00000",
+                    "deployment_metadata": {"deployment_message": "v1 stable"},
+                },
+                {
                     "id": "dep-variant",
                     "version_hash": "variant111",
                     "deployment_metadata": {"deployment_message": "v2 candidate"},
-                }
+                },
             ],
             {},
         )
@@ -736,7 +745,7 @@ class ABTestEndTest(unittest.TestCase):
     @patch("poly.cli.info")
     def test_end__explicit_winner_rich_output(self, mock_info, mock_success):
         """Ending with control as winner prints success, no promotion."""
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live")
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="live00000")
 
         self.proj.end_ab_test.assert_called_once_with("ab-001", "dep-live")
         mock_success.assert_called_once()
@@ -745,7 +754,7 @@ class ABTestEndTest(unittest.TestCase):
     @patch("poly.cli.json_print")
     def test_end__explicit_winner_json_output(self, mock_json):
         """Ending with control as winner emits JSON with promoted=False."""
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="live00000", output_json=True)
 
         payload = mock_json.call_args[0][0]
         self.assertTrue(payload["success"])
@@ -757,7 +766,7 @@ class ABTestEndTest(unittest.TestCase):
     @patch("poly.cli.info")
     def test_end__variant_wins_promotes_to_live(self, mock_info, mock_success):
         """Choosing the variant promotes it to live."""
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant")
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="variant111")
 
         self.proj.end_ab_test.assert_called_once_with("ab-001", "dep-variant")
         self.proj.promote_deployment.assert_called_once_with(
@@ -768,7 +777,7 @@ class ABTestEndTest(unittest.TestCase):
     @patch("poly.cli.json_print")
     def test_end__variant_wins_json_includes_promoted(self, mock_json):
         """Variant win in JSON mode includes promoted=True."""
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant", output_json=True)
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="variant111", output_json=True)
 
         payload = mock_json.call_args[0][0]
         self.assertTrue(payload["success"])
@@ -781,24 +790,24 @@ class ABTestEndTest(unittest.TestCase):
         """If promotion fails after ending, warns but doesn't exit with error."""
         self.proj.promote_deployment.side_effect = Exception("promote failed")
 
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-variant")
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="variant111")
 
         self.proj.end_ab_test.assert_called_once()
         mock_warning.assert_called_once()
         self.assertIn("failed to promote", mock_warning.call_args[0][0])
 
-    # -- JSON mode without chosen_deployment_id --
+    # -- JSON mode without chosen_version --
 
     @patch("poly.cli.json_print")
-    def test_end__json_mode_without_chosen_id_exits_with_error(self, mock_json):
-        """JSON mode requires --chosen-deployment-id; omitting it exits with error."""
+    def test_end__json_mode_without_chosen_version_exits_with_error(self, mock_json):
+        """JSON mode requires --chosen-version; omitting it exits with error."""
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None, output_json=True)
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None, output_json=True)
 
         self.assertEqual(ctx.exception.code, 1)
         payload = mock_json.call_args[0][0]
         self.assertFalse(payload["success"])
-        self.assertIn("--chosen-deployment-id", payload["error"])
+        self.assertIn("--chosen-version", payload["error"])
         self.proj.end_ab_test.assert_not_called()
 
     # -- Interactive prompt flow --
@@ -811,7 +820,7 @@ class ABTestEndTest(unittest.TestCase):
         mock_q.Choice = MagicMock(side_effect=lambda **kw: kw)
         mock_q.select.return_value.ask.return_value = "dep-variant"
 
-        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+        AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None)
 
         self.proj.get_active_ab_test.assert_called_once()
         mock_q.select.assert_called_once()
@@ -828,7 +837,7 @@ class ABTestEndTest(unittest.TestCase):
         mock_q.select.return_value.ask.return_value = None
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None)
 
         self.assertEqual(ctx.exception.code, 0)
         mock_warning.assert_called_once()
@@ -842,7 +851,7 @@ class ABTestEndTest(unittest.TestCase):
         self.proj.get_active_ab_test.return_value = None
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None)
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("No active", mock_error.call_args[0][0])
@@ -854,7 +863,9 @@ class ABTestEndTest(unittest.TestCase):
         self.proj.get_active_ab_test.return_value = None
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+            AgentStudioCLI.ab_test_end(
+                TEST_DIR, chosen_version="live00000", output_json=True
+            )
 
         self.assertEqual(ctx.exception.code, 1)
         payload = mock_json.call_args[0][0]
@@ -868,7 +879,7 @@ class ABTestEndTest(unittest.TestCase):
         self.proj.get_active_ab_test.side_effect = _make_http_error(500)
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id=None)
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version=None)
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertIn("Failed to fetch", mock_error.call_args[0][0])
@@ -883,7 +894,9 @@ class ABTestEndTest(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live", output_json=True)
+            AgentStudioCLI.ab_test_end(
+                TEST_DIR, chosen_version="live00000", output_json=True
+            )
 
         self.assertEqual(ctx.exception.code, 1)
         payload = mock_json.call_args[0][0]
@@ -896,7 +909,7 @@ class ABTestEndTest(unittest.TestCase):
         self.proj.end_ab_test.side_effect = _make_http_error(404, {"error": "A/B test not found."})
 
         with self.assertRaises(SystemExit) as ctx:
-            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_deployment_id="dep-live")
+            AgentStudioCLI.ab_test_end(TEST_DIR, chosen_version="live00000")
 
         self.assertEqual(ctx.exception.code, 1)
         mock_error.assert_called_once_with("A/B test not found.")


### PR DESCRIPTION
## Summary

Adds `poly deployments ab-test {start|list|active|update|end}` subcommands for managing A/B tests between live and pre-release deployments from the CLI.

## Motivation

A/B tests could previously only be managed through the Agent Studio UI. This adds full CLI support so operators can start, monitor, adjust, and end A/B tests from the terminal or scripts.

## Changes

- API client (`platform_api.py`, `interface.py`): 5 new endpoints — create, list, get active, update traffic, end test
- Project model (`project.py`): convenience methods forwarding to the API layer
- CLI parser (`cli.py`): `ab-test` sub-subparser under `deployments` with `start`, `list`, `active`, `update`, `end`
- All flags (`--name`, `--variant`, `--traffic`) are optional interactively and required with `--json`
- `start` prompts for name (defaulting to UI datetime format), pre-release variant picker, and traffic split
- `start` validates the variant version differs from the current live version
- `update` and `end` auto-resolve the active test (only one per project)
- `end` promotes the variant to live if chosen as the winner
- `end` shows human-readable deployment labels (hash + message) instead of raw UUIDs
- Console display (`console.py`): `print_ab_tests` table and `print_ab_test_detail` panel with traffic splits, version hashes, and deployment names
- Status derived from `ended_at` field (no `status` column in the backend model)
- 57 new tests covering validation, interactive prompts, HTTP error mapping, promotion flow

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs