### PR TITLE
fix: Exclude deleted attributes from new variant create commands

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1633,10 +1633,15 @@ class AgentStudioProject:
             updated_resources[FlowStep].pop(flow_step_id, None)
 
         # Add known attributes to any new variant to give it a default value
+        deleted_attribute_ids = set(deleted_resources.get(VariantAttribute, {}).keys())
         for variant in new_resources.get(Variant, {}).values():
             if not isinstance(variant, Variant):
                 raise TypeError(f"Variant is not a Variant: {variant}")
-            attribute_ids = list(self.resources.get(VariantAttribute, {}).keys())
+            attribute_ids = [
+                aid
+                for aid in self.resources.get(VariantAttribute, {}).keys()
+                if aid not in deleted_attribute_ids
+            ]
             variant.attribute_ids = attribute_ids
 
         # Only update the default variant if it's being enabled

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -38,6 +38,7 @@ from poly.resources import (
     Topic,
     TranscriptCorrection,
     Translation,
+    Variant,
     Variable,
     VariantAttribute,
     VoiceDisclaimerMessage,
@@ -1721,6 +1722,41 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertIn(ChatGreeting, push_changes.pre.updated)
         self.assertIn(ChatSafetyFilters, push_changes.pre.updated)
         self.assertIn(ChatStylePrompt, push_changes.pre.updated)
+
+    def test_new_variant_excludes_deleted_attribute_ids(self):
+        """New variants should not reference attributes that are being deleted."""
+        attr_keep = VariantAttribute(
+            resource_id="VARIANT_ATTRIBUTES-keep",
+            name="greeting_name",
+            mappings={"v1": "Hello"},
+        )
+        attr_delete = VariantAttribute(
+            resource_id="VARIANT_ATTRIBUTES-delete",
+            name="old_attribute",
+            mappings={"v1": "old_value"},
+        )
+        self.project.resources[VariantAttribute] = {
+            "VARIANT_ATTRIBUTES-keep": attr_keep,
+            "VARIANT_ATTRIBUTES-delete": attr_delete,
+        }
+
+        new_variant = Variant(
+            resource_id="VARIANTS-new",
+            name="New Variant",
+            is_default=False,
+        )
+
+        new_resources = {Variant: {"VARIANTS-new": new_variant}}
+        deleted_resources = {VariantAttribute: {"VARIANT_ATTRIBUTES-delete": attr_delete}}
+
+        self.project._clean_resources_before_push(
+            {},
+            new_resources,
+            {},
+            deleted_resources,
+        )
+
+        self.assertEqual(new_variant.attribute_ids, ["VARIANT_ATTRIBUTES-keep"])
 
 
 class PushProjectTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

When creating a new variant in the same push as deleting an attribute, the variant's create proto incorrectly included the deleted attribute ID with an empty value, causing the server to reject the batch.

## Motivation

`poly push` fails with `ZodValidationError: All attributes must have a value at "attributeValues"` when a variant is created in the same batch as an attribute deletion. The `variant_create_variant` command references the attribute being deleted because `attribute_ids` was populated from the full current state without filtering out deleted attributes.

## Changes

- Filter deleted attribute IDs from `attribute_ids` when building new variant create protos in `_clean_resources_before_push`
- Add test covering the scenario

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly push`)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Before fix:
```
ERROR:poly.handlers.sync_client:Failed to send commands: Error: {'name': 'ZodValidationError', 'message': '[command 2: variantCreateVariant "Variant 1" (VARIANTS-ac00f938)] Validation error: All attributes must have a value at "attributeValues"', 'details': [{'code': 'custom', 'message': 'All attributes must have a value', 'path': ['attributeValues']}]}
```