### PR TITLE
fix: Allow clearing variant_id on test case update

### DIFF
--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -453,7 +453,7 @@ class TestCase(YamlResource):
             id=self.resource_id,
             name=self.name,
             scenario=self.scenario,
-            variant_id=self.variant,
+            variant_id=self.variant or "",
             language=self.language,
             channel=self.channel,
         )


### PR DESCRIPTION
## Summary

Send empty string instead of omitting `variant_id` in the `Update_TestCase` proto when the variant is removed, so the platform can detect the field is being cleared.

## Motivation

When a user removes a variant from a test case and pushes, the `variant_id` field was omitted from the protobuf update command (proto3 optional fields with `None` are not serialized). The platform therefore didn't know to clear the variant, leaving stale data.

## Changes

- Changed `variant_id=self.variant` to `variant_id=self.variant or ""` in `TestCase.build_update_proto()` so the field is always present in the serialized proto

> **Note:** This requires a corresponding platform-side change to accept empty string for `variantId` in the `updateTestCase` Zod validation. Without that, the platform will reject the command with a min-length validation error.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Before (variant_id absent from command):
```
update_test_case {
  id: "TEST_CASES-d1a4ef69"
  name: "Greeting Test"
  scenario: "Hello, what can you help me with?"
  language: "en-US"
  channel: "chat.polyai"
}
```

After (variant_id explicitly set to empty):
```
update_test_case {
  id: "TEST_CASES-d1a4ef69"
  name: "Greeting Test"
  scenario: "Hello, what can you help me with?"
  variant_id: ""
  language: "en-US"
  channel: "chat.polyai"
}
```