### PR TITLE
fix: add missing X-Poly-Source header to send_command_batch

### DIFF
--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -564,6 +564,7 @@ class SourcererSDK:
             headers = {
                 "X-API-KEY": retrieve_api_key(self.region),
                 "X-PolyAI-Correlation-Id": correlation_id,
+                "X-Poly-Source": "adk",
                 "Content-Type": "application/octet-stream",
             }
             if self.email:


### PR DESCRIPTION
## Summary
- `send_command_batch` builds its own headers dict for the protobuf POST request but was missing the `X-Poly-Source: adk` header that every other request includes via the default session headers (line 60 of `sdk.py`).
- Adds the missing header to the dict at `sdk.py:567`.

## Test plan
- [x] Run `uv run pytest src/poly/tests/ -v` to confirm no regressions

## Linear: 
https://linear.app/poly-ai/issue/DEVP-424/fix-adk-metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)