### PR TITLE
feat: expose projection-to-projection diffing (diff_projections)

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -22,6 +22,7 @@ import poly.utils as utils
 from poly.handlers.interface import (
     AgentStudioInterface,
 )
+from poly.handlers.sync_client import SyncClientHandler
 from poly.migration_utils import (
     MigrationFlag,
     get_all_migration_flags,
@@ -1982,6 +1983,32 @@ class AgentStudioProject:
             )
             return None
 
+        diffs = self.diff_resource_maps(before_resources, after_resources)
+        if diffs is None:
+            logger.info(
+                f"No differences detected between names '{before_name}' and '{after_name}'."
+            )
+        return diffs
+
+    def diff_projections(
+        self, before_projection: dict[str, Any], after_projection: dict[str, Any]
+    ) -> Optional[dict[str, str]]:
+        """Compute diffs between two sourcerer projections without any API calls.
+
+        Empty projections are valid (e.g. diffing a branch against an empty main).
+        """
+        before_resources = SyncClientHandler.load_resources_from_projection(before_projection)
+        after_resources = SyncClientHandler.load_resources_from_projection(after_projection)
+        return self.diff_resource_maps(before_resources, after_resources)
+
+    def diff_resource_maps(
+        self, before_resources: ResourceMap, after_resources: ResourceMap
+    ) -> Optional[dict[str, str]]:
+        """Compute per-file diffs between two in-memory resource maps.
+
+        Returns a mapping of file path to unified diff, or None when the two
+        states render identically.
+        """
         before_resources_by_path: dict[tuple[ResourceType, str], Resource] = {}
         for resource_type, resources_dict in before_resources.items():
             for resource_id, resource in resources_dict.items():
@@ -2028,9 +2055,6 @@ class AgentStudioProject:
                 diffs[after_resource.file_path] = resource_utils.get_diff("", after_pretty)
 
         if not diffs:
-            logger.info(
-                f"No differences detected between names '{before_name}' and '{after_name}'."
-            )
             return None
 
         return diffs

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -624,6 +624,73 @@ class ProjectStatusTest(unittest.TestCase):
         self.assertEqual(deleted_files, [os.path.join(TEST_DIR, "functions", "extra_function.py")])
 
 
+class DiffProjectionsTest(unittest.TestCase):
+    """Tests for the diff_projections method"""
+
+    @staticmethod
+    def _projection(topics: dict[str, tuple[str, str]]) -> dict:
+        return {
+            "knowledgeBase": {
+                "topics": {
+                    "entities": {
+                        topic_id: {
+                            "name": name,
+                            "actions": "",
+                            "content": content,
+                            "exampleQueries": [],
+                            "isActive": True,
+                        }
+                        for topic_id, (name, content) in topics.items()
+                    }
+                }
+            }
+        }
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+
+    def test_identical_projections_return_none(self):
+        projection = self._projection({"TOPIC-1": ("Opening Hours", "We open at 9am")})
+        self.assertIsNone(self.project.diff_projections(projection, deepcopy(projection)))
+
+    def test_modified_resource(self):
+        before = self._projection({"TOPIC-1": ("Opening Hours", "We open at 9am")})
+        after = self._projection({"TOPIC-1": ("Opening Hours", "We open at 8am")})
+        diffs = self.project.diff_projections(before, after)
+
+        topic_path = os.path.join("topics", "opening_hours.yaml")
+        self.assertEqual(list(diffs.keys()), [topic_path])
+        self.assertIn("-content: We open at 9am", diffs[topic_path])
+        self.assertIn("+content: We open at 8am", diffs[topic_path])
+
+    def test_added_and_deleted_resources(self):
+        before = self._projection(
+            {
+                "TOPIC-1": ("Opening Hours", "We open at 9am"),
+                "TOPIC-2": ("Parking", "Free parking on site"),
+            }
+        )
+        after = self._projection(
+            {
+                "TOPIC-1": ("Opening Hours", "We open at 9am"),
+                "TOPIC-3": ("Refunds", "Refunds within 30 days"),
+            }
+        )
+        diffs = self.project.diff_projections(before, after)
+
+        parking_path = os.path.join("topics", "parking.yaml")
+        refunds_path = os.path.join("topics", "refunds.yaml")
+        self.assertEqual(sorted(diffs.keys()), [parking_path, refunds_path])
+        self.assertIn("-content: Free parking on site", diffs[parking_path])
+        self.assertIn("+content: Refunds within 30 days", diffs[refunds_path])
+
+    def test_empty_projections(self):
+        after = self._projection({"TOPIC-1": ("Opening Hours", "We open at 9am")})
+        diffs = self.project.diff_projections({}, after)
+        self.assertIn(os.path.join("topics", "opening_hours.yaml"), diffs)
+        self.assertIsNone(self.project.diff_projections({}, {}))
+
+
 class GetDiffsTest(unittest.TestCase):
     """Tests for the get_diffs method"""
 


### PR DESCRIPTION
## Summary

Adds `diff_projections(before_projection, after_projection)` — semantic per-file diffing of two sourcerer projections with no API calls — by extracting the diff core of `diff_remote_named_versions` into a reusable `diff_resource_maps`.

## Motivation

The deployed adk_service (poly_core) is stateless: callers (Glot) fetch projections from sourcerer with their own session auth and post them in the request body. To give Glot a branch-vs-main `branch_diff` tool with the same semantic, pretty-rendered diffs as `poly diff --before main --after <branch>`, adk_service needs a `/diff` endpoint following the `/pull`/`/push` pattern (PolyAI-LDN/poly_core#43520) — which needs this projection-based entry point.

## Changes

- `Project.diff_resource_maps(before, after)` — the by-path map building, combined resource mappings, `to_pretty` rendering and per-file `get_diff` previously inlined in `diff_remote_named_versions`.
- `Project.diff_projections(before_projection, after_projection)` — builds both resource maps via `SyncClientHandler.load_resources_from_projection` and delegates to `diff_resource_maps`. Empty projections are valid.
- `diff_remote_named_versions` delegates to the extracted core; behavior unchanged (same fetch, same error handling, same no-differences logging).

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

New `DiffProjectionsTest` covers modified / added+deleted / identical / empty-projection cases. Also verified end-to-end: installed this branch into a local adk_service and curled the new `/diff` endpoint — correct unified diffs for modified + added resources.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

```
$ curl -s -X POST localhost:8199/diff -d '{"before_projection": …, "after_projection": …}'
{
  "diffs": {
    "topics/opening_hours.yaml": "--- original\n+++ updated\n@@ -1,5 +1,5 @@\n name: Opening Hours\n ...\n-content: We open at 9am\n+content: We open at 8am\n ...",
    "topics/refunds.yaml": "--- original\n+++ updated\n@@ -0,0 +1,5 @@\n+name: Refunds\n+..."
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)