### PR TITLE
feat: add poly rtc pull/push commands

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,11 @@
       "mcp__GitHub__list_commits",
       "mcp__GitHub__get_commit",
       "mcp__GitHub__get_file_contents",
-      "mcp__GitHub__list_branches"
+      "mcp__GitHub__list_branches",
+      "Bash(ls /Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/real_time_configuration/)",
+      "Read(//Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/real_time_configuration/**)",
+      "Read(//Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/_gen/**)",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); print\\(json.dumps\\(d.get\\('rtc_metadata'\\), indent=2\\)\\)\")"
     ],
     "deny": [
       "Read(src/poly/handlers/protobuf/**)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,11 +40,7 @@
       "mcp__GitHub__list_commits",
       "mcp__GitHub__get_commit",
       "mcp__GitHub__get_file_contents",
-      "mcp__GitHub__list_branches",
-      "Bash(ls /Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/real_time_configuration/)",
-      "Read(//Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/real_time_configuration/**)",
-      "Read(//Users/miramilosavljevic/agent-deployments/agents/focaccia/firebirds-us/firebirds-usp/_gen/**)",
-      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); print\\(json.dumps\\(d.get\\('rtc_metadata'\\), indent=2\\)\\)\")"
+      "mcp__GitHub__list_branches"
     ],
     "deny": [
       "Read(src/poly/handlers/protobuf/**)",

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3,14 +3,17 @@
 Copyright PolyAI Limited
 """
 
+import json
 import logging
 import os
 import sys
 import traceback
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawTextHelpFormatter
 from importlib.metadata import version as get_package_version
 
 import argcomplete
+import questionary
+import requests
 
 from poly.cli_commands.auth import LoginCommand, StartCommand
 from poly.cli_commands.base import BaseCommand, Parents
@@ -20,6 +23,7 @@ from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand, StudioCommand
 from poly.cli_commands.review import ReviewCommand
+from poly.cli_commands.shared import load_project
 from poly.cli_commands.sync import (
     DiffCommand,
     FormatCommand,
@@ -31,6 +35,8 @@ from poly.cli_commands.sync import (
 )
 from poly.cli_commands.testing import TestingCommand
 from poly.cli_commands.utils import CompletionCommand, DocsCommand
+from poly.handlers.interface import AgentStudioInterface
+from poly.output.console import error, info, success
 from poly.output.json_output import json_print
 
 logger = logging.getLogger(__name__)
@@ -57,6 +63,14 @@ COMMANDS = [
     DocsCommand,
     CompletionCommand,
 ]
+
+# RTC environment name mapping
+RTC_ENV_TO_DIR = {
+    "sandbox": "draft_and_sandbox",
+    "pre-release": "pre_release",
+    "live": "live",
+}
+RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
 
 
 class AgentStudioCLI:
@@ -122,6 +136,78 @@ class AgentStudioCLI:
         for command in self.commands:
             command.add_arguments(subparsers, parents=parents)
 
+        # RTC
+        rtc_path_parent = ArgumentParser(add_help=False)
+        rtc_path_parent.add_argument(
+            "--path",
+            type=str,
+            default=os.getcwd(),
+            help="Base path to the project. Defaults to current working directory.",
+        )
+
+        rtc_parser = subparsers.add_parser(
+            "rtc",
+            parents=[verbose_parent],
+            help="Manage Real-Time Configuration.",
+            description=(
+                "Manage Real-Time Configuration (RTC) for the project.\n\n"
+                "Examples:\n"
+                "  poly rtc pull\n"
+                "  poly rtc pull --env sandbox\n"
+                "  poly rtc push --env sandbox\n"
+                "  poly rtc push --env live --force\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        rtc_subparsers = rtc_parser.add_subparsers(dest="rtc_subcommand", required=True)
+
+        rtc_pull_parser = rtc_subparsers.add_parser(
+            "pull",
+            parents=[rtc_path_parent, json_parent, verbose_parent],
+            help="Pull RTC from Agent Studio and write to local files.",
+            description=(
+                "Pull Real-Time Configuration from Agent Studio and write to local files.\n\n"
+                "Examples:\n"
+                "  poly rtc pull\n"
+                "  poly rtc pull --env sandbox\n"
+                "  poly rtc pull --env all\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_pull_parser.add_argument(
+            "--env",
+            type=str,
+            default="all",
+            choices=["sandbox", "pre-release", "live", "all"],
+            help="Environment to pull. Defaults to all.",
+        )
+
+        rtc_push_parser = rtc_subparsers.add_parser(
+            "push",
+            parents=[rtc_path_parent, json_parent, verbose_parent],
+            help="Push RTC from local files to Agent Studio.",
+            description=(
+                "Push Real-Time Configuration from local files to Agent Studio.\n\n"
+                "Examples:\n"
+                "  poly rtc push --env sandbox\n"
+                "  poly rtc push --env live --force\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_push_parser.add_argument(
+            "--env",
+            type=str,
+            required=True,
+            choices=["sandbox", "pre-release", "live"],
+            help="Environment to push to.",
+        )
+        rtc_push_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Skip confirmation prompt (required for live).",
+        )
+
         return parser
 
     def _run_command(self, args):
@@ -136,6 +222,15 @@ class AgentStudioCLI:
                 if args.command == command.command:
                     command.run(args)
                     return
+
+            if args.command == "rtc":
+                if args.rtc_subcommand == "pull":
+                    AgentStudioCLI.rtc_pull(args.path, args.env, args.json)
+                elif args.rtc_subcommand == "push":
+                    AgentStudioCLI.rtc_push(
+                        args.path, args.env, getattr(args, "force", False), args.json
+                    )
+                return
         except Exception as e:
             if hasattr(args, "json") and args.json:
                 json_print({"success": False, "error": str(e), "traceback": traceback.format_exc()})
@@ -172,6 +267,162 @@ class AgentStudioCLI:
             from poly.output.console import handle_exception
 
             handle_exception(e)
+
+    @staticmethod
+    def rtc_pull(
+        base_path: str,
+        env: str = "all",
+        output_json: bool = False,
+    ) -> None:
+        """Pull RTC from Agent Studio and write to local files.
+
+        Args:
+            base_path: Base path for the project.
+            env: Environment(s) to pull — sandbox, pre-release, live, or all.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = load_project(base_path, output_json=output_json)
+
+        if env == "all":
+            envs_to_fetch = ["sandbox", "pre-release", "live"]
+        else:
+            envs_to_fetch = [env]
+
+        rtc_root = os.path.join(base_path, "real_time_configuration")
+        results = []
+
+        try:
+            for client_env in envs_to_fetch:
+                config = AgentStudioInterface.get_rtc_config(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=client_env,
+                )
+
+                dir_name = RTC_ENV_TO_DIR[client_env]
+                env_dir = os.path.join(rtc_root, dir_name)
+                os.makedirs(env_dir, exist_ok=True)
+
+                schema = config.get("schema", {})
+                schema_path = os.path.join(env_dir, "schema.json")
+                with open(schema_path, "w", encoding="utf-8") as f:
+                    json.dump(schema, f, indent=2)
+
+                variables = config.get("variables", {})
+                data_path = os.path.join(env_dir, "data.json")
+                with open(data_path, "w", encoding="utf-8") as f:
+                    json.dump(variables, f, indent=2)
+
+                results.append(
+                    {
+                        "environment": client_env,
+                        "schema_file": schema_path,
+                        "data_file": data_path,
+                    }
+                )
+
+            if output_json:
+                json_print({"success": True, "files_written": results})
+            else:
+                for result in results:
+                    success(f"Pulled {result['environment']} — {result['schema_file']}")
+                    success(f"Pulled {result['environment']} — {result['data_file']}")
+
+        except requests.HTTPError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+                sys.exit(1)
+            else:
+                raise
+
+    @staticmethod
+    def rtc_push(
+        base_path: str,
+        env: str,
+        force: bool = False,
+        output_json: bool = False,
+    ) -> None:
+        """Push RTC from local files to Agent Studio.
+
+        Args:
+            base_path: Base path for the project.
+            env: Environment to push to — sandbox, pre-release, or live.
+            force: If True, skip confirmation for live environment.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = load_project(base_path, output_json=output_json)
+
+        dir_name = RTC_ENV_TO_DIR[env]
+        env_dir = os.path.join(base_path, "real_time_configuration", dir_name)
+
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        if not os.path.exists(schema_path):
+            msg = f"schema.json not found at {schema_path}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if not os.path.exists(data_path):
+            msg = f"data.json not found at {data_path}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        with open(schema_path, "r", encoding="utf-8") as f:
+            schema = json.load(f)
+
+        with open(data_path, "r", encoding="utf-8") as f:
+            variables = json.load(f)
+
+        if env == "live" and not force and not output_json:
+            confirm = questionary.confirm(
+                f"Push RTC to {env}? This will update live configuration.",
+                auto_enter=False,
+                default=False,
+            ).ask()
+            if not confirm:
+                info("Push cancelled.")
+                return
+
+        try:
+            AgentStudioInterface.put_rtc_schema(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+                schema=schema,
+            )
+
+            AgentStudioInterface.patch_rtc_variables(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+                variables=variables,
+            )
+
+            if output_json:
+                json_print(
+                    {
+                        "success": True,
+                        "environment": env,
+                        "schema_file": schema_path,
+                        "data_file": data_path,
+                    }
+                )
+            else:
+                success(f"Pushed RTC to {env}")
+
+        except requests.HTTPError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+                sys.exit(1)
+            else:
+                raise
 
 
 def main():

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -136,7 +136,8 @@ class AgentStudioCLI:
         for command in self.commands:
             command.add_arguments(subparsers, parents=parents)
 
-        # RTC
+        # RTC — inline rather than a BaseCommand subclass because RTC is
+        # environment-scoped (not branch-scoped) and bypasses Sourcerer.
         rtc_path_parent = ArgumentParser(add_help=False)
         rtc_path_parent.add_argument(
             "--path",
@@ -282,13 +283,14 @@ class AgentStudioCLI:
             output_json: If True, emit machine-readable JSON.
         """
         project = load_project(base_path, output_json=output_json)
+        project_root = project.root_path
 
         if env == "all":
             envs_to_fetch = ["sandbox", "pre-release", "live"]
         else:
             envs_to_fetch = [env]
 
-        rtc_root = os.path.join(base_path, "real_time_configuration")
+        rtc_root = os.path.join(project_root, "real_time_configuration")
         results = []
 
         try:
@@ -307,11 +309,13 @@ class AgentStudioCLI:
                 schema_path = os.path.join(env_dir, "schema.json")
                 with open(schema_path, "w", encoding="utf-8") as f:
                     json.dump(schema, f, indent=2)
+                    f.write("\n")
 
                 variables = config.get("variables", {})
                 data_path = os.path.join(env_dir, "data.json")
                 with open(data_path, "w", encoding="utf-8") as f:
                     json.dump(variables, f, indent=2)
+                    f.write("\n")
 
                 results.append(
                     {
@@ -351,9 +355,10 @@ class AgentStudioCLI:
             output_json: If True, emit machine-readable JSON.
         """
         project = load_project(base_path, output_json=output_json)
+        project_root = project.root_path
 
         dir_name = RTC_ENV_TO_DIR[env]
-        env_dir = os.path.join(base_path, "real_time_configuration", dir_name)
+        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
 
         schema_path = os.path.join(env_dir, "schema.json")
         data_path = os.path.join(env_dir, "data.json")
@@ -380,7 +385,12 @@ class AgentStudioCLI:
         with open(data_path, "r", encoding="utf-8") as f:
             variables = json.load(f)
 
-        if env == "live" and not force and not output_json:
+        if env == "live" and not force:
+            if output_json:
+                json_print(
+                    {"success": False, "error": "Refusing to push RTC to live without --force."}
+                )
+                sys.exit(1)
             confirm = questionary.confirm(
                 f"Push RTC to {env}? This will update live configuration.",
                 auto_enter=False,
@@ -397,32 +407,41 @@ class AgentStudioCLI:
                 client_env=env,
                 schema=schema,
             )
+        except requests.HTTPError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e), "step": "schema"})
+                sys.exit(1)
+            else:
+                raise
 
+        try:
             AgentStudioInterface.patch_rtc_variables(
                 region=project.region,
                 project_id=project.project_id,
                 client_env=env,
                 variables=variables,
             )
-
-            if output_json:
-                json_print(
-                    {
-                        "success": True,
-                        "environment": env,
-                        "schema_file": schema_path,
-                        "data_file": data_path,
-                    }
-                )
-            else:
-                success(f"Pushed RTC to {env}")
-
         except requests.HTTPError as e:
+            # Schema was already pushed — warn so the user knows the state is partial
+            msg = f"Schema pushed but variables failed: {e}"
             if output_json:
-                json_print({"success": False, "error": str(e)})
+                json_print({"success": False, "error": msg, "step": "variables"})
                 sys.exit(1)
             else:
+                error(f"Warning: schema was pushed to {env}, but variables update failed.")
                 raise
+
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "environment": env,
+                    "schema_file": schema_path,
+                    "data_file": data_path,
+                }
+            )
+        else:
+            success(f"Pushed RTC to {env}")
 
 
 def main():

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -165,7 +165,7 @@ class AgentStudioCLI:
 
         rtc_pull_parser = rtc_subparsers.add_parser(
             "pull",
-            parents=[rtc_path_parent, json_parent, verbose_parent],
+            parents=[rtc_path_parent, json_parent, verbose_parent, debug_parent],
             help="Pull RTC from Agent Studio and write to local files.",
             description=(
                 "Pull Real-Time Configuration from Agent Studio and write to local files.\n\n"
@@ -186,7 +186,7 @@ class AgentStudioCLI:
 
         rtc_push_parser = rtc_subparsers.add_parser(
             "push",
-            parents=[rtc_path_parent, json_parent, verbose_parent],
+            parents=[rtc_path_parent, json_parent, verbose_parent, debug_parent],
             help="Push RTC from local files to Agent Studio.",
             description=(
                 "Push Real-Time Configuration from local files to Agent Studio.\n\n"

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -3,17 +3,14 @@
 Copyright PolyAI Limited
 """
 
-import json
 import logging
 import os
 import sys
 import traceback
-from argparse import ArgumentParser, RawTextHelpFormatter
+from argparse import ArgumentParser
 from importlib.metadata import version as get_package_version
 
 import argcomplete
-import questionary
-import requests
 
 from poly.cli_commands.auth import LoginCommand, StartCommand
 from poly.cli_commands.base import BaseCommand, Parents
@@ -23,7 +20,7 @@ from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand, StudioCommand
 from poly.cli_commands.review import ReviewCommand
-from poly.cli_commands.shared import load_project
+from poly.cli_commands.rtc import RTCCommand
 from poly.cli_commands.sync import (
     DiffCommand,
     FormatCommand,
@@ -35,8 +32,6 @@ from poly.cli_commands.sync import (
 )
 from poly.cli_commands.testing import TestingCommand
 from poly.cli_commands.utils import CompletionCommand, DocsCommand
-from poly.handlers.interface import AgentStudioInterface
-from poly.output.console import error, info, success
 from poly.output.json_output import json_print
 
 logger = logging.getLogger(__name__)
@@ -59,18 +54,11 @@ COMMANDS = [
     DeploymentsCommand,
     ConversationsCommand,
     TestingCommand,
+    RTCCommand,
     ChatCommand,
     DocsCommand,
     CompletionCommand,
 ]
-
-# RTC environment name mapping
-RTC_ENV_TO_DIR = {
-    "sandbox": "draft_and_sandbox",
-    "pre-release": "pre_release",
-    "live": "live",
-}
-RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
 
 
 class AgentStudioCLI:
@@ -136,79 +124,6 @@ class AgentStudioCLI:
         for command in self.commands:
             command.add_arguments(subparsers, parents=parents)
 
-        # RTC — inline rather than a BaseCommand subclass because RTC is
-        # environment-scoped (not branch-scoped) and bypasses Sourcerer.
-        rtc_path_parent = ArgumentParser(add_help=False)
-        rtc_path_parent.add_argument(
-            "--path",
-            type=str,
-            default=os.getcwd(),
-            help="Base path to the project. Defaults to current working directory.",
-        )
-
-        rtc_parser = subparsers.add_parser(
-            "rtc",
-            parents=[verbose_parent],
-            help="Manage Real-Time Configuration.",
-            description=(
-                "Manage Real-Time Configuration (RTC) for the project.\n\n"
-                "Examples:\n"
-                "  poly rtc pull\n"
-                "  poly rtc pull --env sandbox\n"
-                "  poly rtc push --env sandbox\n"
-                "  poly rtc push --env live --force\n"
-            ),
-            formatter_class=RawTextHelpFormatter,
-        )
-
-        rtc_subparsers = rtc_parser.add_subparsers(dest="rtc_subcommand", required=True)
-
-        rtc_pull_parser = rtc_subparsers.add_parser(
-            "pull",
-            parents=[rtc_path_parent, json_parent, verbose_parent, debug_parent],
-            help="Pull RTC from Agent Studio and write to local files.",
-            description=(
-                "Pull Real-Time Configuration from Agent Studio and write to local files.\n\n"
-                "Examples:\n"
-                "  poly rtc pull\n"
-                "  poly rtc pull --env sandbox\n"
-                "  poly rtc pull --env all\n"
-            ),
-            formatter_class=RawTextHelpFormatter,
-        )
-        rtc_pull_parser.add_argument(
-            "--env",
-            type=str,
-            default="all",
-            choices=["sandbox", "pre-release", "live", "all"],
-            help="Environment to pull. Defaults to all.",
-        )
-
-        rtc_push_parser = rtc_subparsers.add_parser(
-            "push",
-            parents=[rtc_path_parent, json_parent, verbose_parent, debug_parent],
-            help="Push RTC from local files to Agent Studio.",
-            description=(
-                "Push Real-Time Configuration from local files to Agent Studio.\n\n"
-                "Examples:\n"
-                "  poly rtc push --env sandbox\n"
-                "  poly rtc push --env live --force\n"
-            ),
-            formatter_class=RawTextHelpFormatter,
-        )
-        rtc_push_parser.add_argument(
-            "--env",
-            type=str,
-            required=True,
-            choices=["sandbox", "pre-release", "live"],
-            help="Environment to push to.",
-        )
-        rtc_push_parser.add_argument(
-            "--force",
-            action="store_true",
-            help="Skip confirmation prompt (required for live).",
-        )
-
         return parser
 
     def _run_command(self, args):
@@ -223,15 +138,6 @@ class AgentStudioCLI:
                 if args.command == command.command:
                     command.run(args)
                     return
-
-            if args.command == "rtc":
-                if args.rtc_subcommand == "pull":
-                    AgentStudioCLI.rtc_pull(args.path, args.env, args.json)
-                elif args.rtc_subcommand == "push":
-                    AgentStudioCLI.rtc_push(
-                        args.path, args.env, getattr(args, "force", False), args.json
-                    )
-                return
         except Exception as e:
             if hasattr(args, "json") and args.json:
                 json_print({"success": False, "error": str(e), "traceback": traceback.format_exc()})
@@ -268,180 +174,6 @@ class AgentStudioCLI:
             from poly.output.console import handle_exception
 
             handle_exception(e)
-
-    @staticmethod
-    def rtc_pull(
-        base_path: str,
-        env: str = "all",
-        output_json: bool = False,
-    ) -> None:
-        """Pull RTC from Agent Studio and write to local files.
-
-        Args:
-            base_path: Base path for the project.
-            env: Environment(s) to pull — sandbox, pre-release, live, or all.
-            output_json: If True, emit machine-readable JSON.
-        """
-        project = load_project(base_path, output_json=output_json)
-        project_root = project.root_path
-
-        if env == "all":
-            envs_to_fetch = ["sandbox", "pre-release", "live"]
-        else:
-            envs_to_fetch = [env]
-
-        rtc_root = os.path.join(project_root, "real_time_configuration")
-        results = []
-
-        try:
-            for client_env in envs_to_fetch:
-                config = AgentStudioInterface.get_rtc_config(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=client_env,
-                )
-
-                dir_name = RTC_ENV_TO_DIR[client_env]
-                env_dir = os.path.join(rtc_root, dir_name)
-                os.makedirs(env_dir, exist_ok=True)
-
-                schema = config.get("schema", {})
-                schema_path = os.path.join(env_dir, "schema.json")
-                with open(schema_path, "w", encoding="utf-8") as f:
-                    json.dump(schema, f, indent=2)
-                    f.write("\n")
-
-                variables = config.get("variables", {})
-                data_path = os.path.join(env_dir, "data.json")
-                with open(data_path, "w", encoding="utf-8") as f:
-                    json.dump(variables, f, indent=2)
-                    f.write("\n")
-
-                results.append(
-                    {
-                        "environment": client_env,
-                        "schema_file": schema_path,
-                        "data_file": data_path,
-                    }
-                )
-
-            if output_json:
-                json_print({"success": True, "files_written": results})
-            else:
-                for result in results:
-                    success(f"Pulled {result['environment']} — {result['schema_file']}")
-                    success(f"Pulled {result['environment']} — {result['data_file']}")
-
-        except requests.HTTPError as e:
-            if output_json:
-                json_print({"success": False, "error": str(e)})
-                sys.exit(1)
-            else:
-                raise
-
-    @staticmethod
-    def rtc_push(
-        base_path: str,
-        env: str,
-        force: bool = False,
-        output_json: bool = False,
-    ) -> None:
-        """Push RTC from local files to Agent Studio.
-
-        Args:
-            base_path: Base path for the project.
-            env: Environment to push to — sandbox, pre-release, or live.
-            force: If True, skip confirmation for live environment.
-            output_json: If True, emit machine-readable JSON.
-        """
-        project = load_project(base_path, output_json=output_json)
-        project_root = project.root_path
-
-        dir_name = RTC_ENV_TO_DIR[env]
-        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
-
-        schema_path = os.path.join(env_dir, "schema.json")
-        data_path = os.path.join(env_dir, "data.json")
-
-        if not os.path.exists(schema_path):
-            msg = f"schema.json not found at {schema_path}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
-
-        if not os.path.exists(data_path):
-            msg = f"data.json not found at {data_path}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
-
-        with open(schema_path, "r", encoding="utf-8") as f:
-            schema = json.load(f)
-
-        with open(data_path, "r", encoding="utf-8") as f:
-            variables = json.load(f)
-
-        if env == "live" and not force:
-            if output_json:
-                json_print(
-                    {"success": False, "error": "Refusing to push RTC to live without --force."}
-                )
-                sys.exit(1)
-            confirm = questionary.confirm(
-                f"Push RTC to {env}? This will update live configuration.",
-                auto_enter=False,
-                default=False,
-            ).ask()
-            if not confirm:
-                info("Push cancelled.")
-                return
-
-        try:
-            AgentStudioInterface.put_rtc_schema(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-                schema=schema,
-            )
-        except requests.HTTPError as e:
-            if output_json:
-                json_print({"success": False, "error": str(e), "step": "schema"})
-                sys.exit(1)
-            else:
-                raise
-
-        try:
-            AgentStudioInterface.patch_rtc_variables(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-                variables=variables,
-            )
-        except requests.HTTPError as e:
-            # Schema was already pushed — warn so the user knows the state is partial
-            msg = f"Schema pushed but variables failed: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg, "step": "variables"})
-                sys.exit(1)
-            else:
-                error(f"Warning: schema was pushed to {env}, but variables update failed.")
-                raise
-
-        if output_json:
-            json_print(
-                {
-                    "success": True,
-                    "environment": env,
-                    "schema_file": schema_path,
-                    "data_file": data_path,
-                }
-            )
-        else:
-            success(f"Pushed RTC to {env}")
 
 
 def main():

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -40,8 +40,11 @@ def _save_rtc_base(env_dir: str, schema: dict, variables: dict) -> None:
 
 def _load_rtc_base(env_dir: str) -> tuple[Optional[dict], Optional[dict]]:
     """Load base copies, returning (schema, variables) or (None, None)."""
-    schema = read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
-    variables = read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
+    try:
+        schema = read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
+        variables = read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
+    except json.JSONDecodeError:
+        return None, None
     return schema, variables
 
 

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -7,6 +7,7 @@ import json
 import os
 import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+from datetime import datetime, timezone
 from typing import Optional
 
 import questionary
@@ -15,8 +16,10 @@ import requests
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project
 from poly.handlers.interface import AgentStudioInterface
-from poly.output.console import error, info, success
+from poly.project import AgentStudioProject
+from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
+from poly.resources.resource_utils import contains_merge_conflict
 
 RTC_ENV_TO_DIR = {
     "sandbox": "draft_and_sandbox",
@@ -24,6 +27,188 @@ RTC_ENV_TO_DIR = {
     "live": "live",
 }
 RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
+
+RTC_METADATA_FILE = ".rtc_metadata.json"
+RTC_BASE_SCHEMA_FILE = ".rtc_base_schema.json"
+RTC_BASE_DATA_FILE = ".rtc_base_data.json"
+
+
+def _write_json_file(path: str, data: dict) -> None:
+    """Write a dict as pretty-printed JSON with trailing newline."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _read_json_file(path: str) -> Optional[dict]:
+    """Read a JSON file, or None if it doesn't exist."""
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _save_rtc_metadata(env_dir: str, last_updated: Optional[str]) -> None:
+    """Write RTC metadata after a pull or successful push."""
+    metadata = {
+        "last_updated": last_updated,
+        "pulled_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _write_json_file(os.path.join(env_dir, RTC_METADATA_FILE), metadata)
+
+
+def _load_rtc_metadata(env_dir: str) -> Optional[dict]:
+    """Load RTC metadata from disk, or None if not present."""
+    return _read_json_file(os.path.join(env_dir, RTC_METADATA_FILE))
+
+
+def _save_rtc_base(env_dir: str, schema: dict, variables: dict) -> None:
+    """Save base copies of schema and data for 3-way merge on push."""
+    _write_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE), schema)
+    _write_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE), variables)
+
+
+def _load_rtc_base(env_dir: str) -> tuple[Optional[dict], Optional[dict]]:
+    """Load base copies, returning (schema, variables) or (None, None)."""
+    schema = _read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
+    variables = _read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
+    return schema, variables
+
+
+def _to_sorted_json(data: dict) -> str:
+    """Serialize a dict to deterministically ordered JSON for merging."""
+    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+
+
+def _merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
+    """3-way merge at the dict key level.
+
+    Returns:
+        (merged_dict, list_of_conflict_keys). If conflict_keys is empty, the
+        merge is clean.
+    """
+    all_keys = set(base) | set(local) | set(remote)
+    merged = {}
+    conflicts = []
+
+    for key in sorted(all_keys):
+        base_val = base.get(key)
+        local_val = local.get(key)
+        remote_val = remote.get(key)
+
+        if local_val == remote_val:
+            merged[key] = local_val
+        elif local_val == base_val:
+            merged[key] = remote_val
+        elif remote_val == base_val:
+            merged[key] = local_val
+        else:
+            conflicts.append(key)
+            merged[key] = local_val
+
+    return merged, conflicts
+
+
+def _merge_rtc_file(
+    filename: str,
+    base: dict,
+    local: dict,
+    remote: dict,
+    output_json: bool = False,
+) -> Optional[dict]:
+    """Attempt 3-way merge on a single RTC JSON file.
+
+    Args:
+        filename: Display name (e.g. "data.json").
+        base: The pulled version.
+        local: The user's local version.
+        remote: The current remote version.
+        output_json: If True, skip interactive resolution.
+
+    Returns:
+        Merged dict, or None if the user cancelled.
+    """
+    if local == remote:
+        return local
+    if local == base:
+        return remote
+    if remote == base:
+        return local
+
+    merged, conflict_keys = _merge_dicts(base, local, remote)
+
+    if not conflict_keys:
+        if not output_json:
+            info(f"  {filename}: clean merge")
+        return merged
+
+    if output_json:
+        return None
+
+    warning(f"  {filename}: {len(conflict_keys)} conflicting field(s): {', '.join(conflict_keys)}")
+
+    return _resolve_rtc_conflict_interactively(
+        filename,
+        _to_sorted_json(base),
+        _to_sorted_json(local),
+        _to_sorted_json(remote),
+        _to_sorted_json(merged),
+    )
+
+
+def _resolve_rtc_conflict_interactively(
+    filename: str,
+    base_str: str,
+    local_str: str,
+    remote_str: str,
+    merged_str: str,
+) -> Optional[dict]:
+    """Interactive conflict resolution for a single RTC file.
+
+    Returns:
+        Resolved dict, or None if the user cancelled.
+    """
+    while True:
+        choices = [
+            questionary.Choice("Use local version (yours)", value="local"),
+            questionary.Choice("Use remote version (theirs)", value="remote"),
+            questionary.Choice("Use base version (before both edits)", value="base"),
+            questionary.Choice("Edit merged result in $EDITOR", value="edit"),
+            questionary.Choice("Cancel push", value="cancel"),
+        ]
+
+        answer = questionary.select(
+            f"How do you want to resolve {filename}?",
+            choices=choices,
+        ).ask()
+
+        if answer is None or answer == "cancel":
+            info("Push cancelled.")
+            return None
+        elif answer == "local":
+            return json.loads(local_str)
+        elif answer == "remote":
+            return json.loads(remote_str)
+        elif answer == "base":
+            return json.loads(base_str)
+        elif answer == "edit":
+            try:
+                edited = edit_in_editor(merged_str, extension=".json", filename=filename)
+            except (ValueError, FileNotFoundError, OSError) as e:
+                error(f"Editor error: {e}")
+                continue
+
+            if contains_merge_conflict(edited):
+                warning("Conflict markers still present. Please resolve all conflicts.")
+                merged_str = edited
+                continue
+
+            try:
+                return json.loads(edited)
+            except json.JSONDecodeError as e:
+                error(f"Invalid JSON: {e}")
+                merged_str = edited
+                continue
 
 
 class RTCCommand(BaseCommand):
@@ -94,7 +279,12 @@ class RTCCommand(BaseCommand):
         rtc_push_parser.add_argument(
             "--force",
             action="store_true",
-            help="Skip confirmation prompt (required for live).",
+            help="Skip drift protection check and confirmation prompt.",
+        )
+        rtc_push_parser.add_argument(
+            "--no-merge",
+            action="store_true",
+            help="Disable automatic merge on drift; fail with error instead.",
         )
 
     @classmethod
@@ -112,7 +302,13 @@ class RTCCommand(BaseCommand):
                     success(f"Pulled {f['environment']} — {f['schema_file']}")
                     success(f"Pulled {f['environment']} — {f['data_file']}")
         elif args.rtc_subcommand == "push":
-            result = cls.rtc_push(args.path, args.env, getattr(args, "force", False), args.json)
+            result = cls.rtc_push(
+                args.path,
+                args.env,
+                force=getattr(args, "force", False),
+                output_json=args.json,
+                no_merge=getattr(args, "no_merge", False),
+            )
             if result is None:
                 return
             if args.json:
@@ -164,22 +360,18 @@ class RTCCommand(BaseCommand):
                 os.makedirs(env_dir, exist_ok=True)
 
                 schema = config.get("schema", {})
-                schema_path = os.path.join(env_dir, "schema.json")
-                with open(schema_path, "w", encoding="utf-8") as f:
-                    json.dump(schema, f, indent=2)
-                    f.write("\n")
-
                 variables = config.get("variables", {})
-                data_path = os.path.join(env_dir, "data.json")
-                with open(data_path, "w", encoding="utf-8") as f:
-                    json.dump(variables, f, indent=2)
-                    f.write("\n")
+
+                _write_json_file(os.path.join(env_dir, "schema.json"), schema)
+                _write_json_file(os.path.join(env_dir, "data.json"), variables)
+                _save_rtc_base(env_dir, schema, variables)
+                _save_rtc_metadata(env_dir, config.get("lastUpdated"))
 
                 results.append(
                     {
                         "environment": client_env,
-                        "schema_file": schema_path,
-                        "data_file": data_path,
+                        "schema_file": os.path.join(env_dir, "schema.json"),
+                        "data_file": os.path.join(env_dir, "data.json"),
                     }
                 )
 
@@ -195,14 +387,16 @@ class RTCCommand(BaseCommand):
         env: str,
         force: bool = False,
         output_json: bool = False,
+        no_merge: bool = False,
     ) -> Optional[dict]:
         """Push RTC from local files to Agent Studio.
 
         Args:
             base_path: Base path for the project.
             env: Environment to push to — sandbox, pre-release, or live.
-            force: If True, skip confirmation for live environment.
+            force: If True, skip drift check and confirmation prompt.
             output_json: If True, format errors as JSON on failure.
+            no_merge: If True, disable merge on drift; hard-fail instead.
 
         Returns:
             dict with success status, or None if the user cancelled interactively.
@@ -230,6 +424,47 @@ class RTCCommand(BaseCommand):
         except json.JSONDecodeError as e:
             return {"success": False, "error": f"Invalid JSON in local RTC file: {e}"}
 
+        # Drift protection
+        if not force:
+            metadata = _load_rtc_metadata(env_dir)
+            if metadata is None:
+                if not output_json:
+                    info(
+                        "No RTC metadata found; skipping drift check. "
+                        "Run 'poly rtc pull' to enable drift protection."
+                    )
+            else:
+                try:
+                    remote_config = AgentStudioInterface.get_rtc_config(
+                        region=project.region,
+                        project_id=project.project_id,
+                        client_env=env,
+                    )
+                    remote_last_updated = remote_config.get("lastUpdated")
+                    local_last_updated = metadata.get("last_updated")
+
+                    if remote_last_updated != local_last_updated:
+                        merge_result = cls._handle_drift(
+                            env_dir=env_dir,
+                            remote_config=remote_config,
+                            local_schema=schema,
+                            local_variables=variables,
+                            output_json=output_json,
+                            no_merge=no_merge,
+                            env=env,
+                            local_last_updated=local_last_updated,
+                            remote_last_updated=remote_last_updated,
+                        )
+                        if merge_result is None:
+                            return None
+                        if not merge_result["success"]:
+                            return merge_result
+                        schema = merge_result["schema"]
+                        variables = merge_result["variables"]
+
+                except requests.HTTPError as e:
+                    return {"success": False, "error": f"Drift check failed: {e}"}
+
         if env == "live" and not force:
             if output_json:
                 return {
@@ -245,6 +480,87 @@ class RTCCommand(BaseCommand):
                 info("Push cancelled.")
                 return None
 
+        return cls._do_push(project, env, env_dir, schema, variables, output_json)
+
+    @classmethod
+    def _handle_drift(
+        cls,
+        env_dir: str,
+        remote_config: dict,
+        local_schema: dict,
+        local_variables: dict,
+        output_json: bool,
+        no_merge: bool,
+        env: str,
+        local_last_updated: Optional[str],
+        remote_last_updated: Optional[str],
+    ) -> Optional[dict]:
+        """Handle drift between local and remote RTC config.
+
+        Returns:
+            dict with "success" and merged "schema"/"variables" on merge success,
+            dict with "success": False on error,
+            or None if the user cancelled.
+        """
+        drift_msg = (
+            f"Remote RTC config has changed since your last pull "
+            f"(local: {local_last_updated}, remote: {remote_last_updated}). "
+        )
+
+        if no_merge:
+            return {
+                "success": False,
+                "error": drift_msg + f"Run 'poly rtc pull --env {env}' first, "
+                "or use --force to override.",
+            }
+
+        base_schema, base_variables = _load_rtc_base(env_dir)
+        if base_schema is None or base_variables is None:
+            return {
+                "success": False,
+                "error": drift_msg + "Cannot merge: no base version available. "
+                f"Run 'poly rtc pull --env {env}' to enable merge on future pushes, "
+                "or use --force to overwrite.",
+            }
+
+        remote_schema = remote_config.get("schema", {})
+        remote_variables = remote_config.get("variables", {})
+
+        if not output_json:
+            info("Remote has changed since your last pull. Attempting merge...")
+
+        merged_schema = _merge_rtc_file(
+            "schema.json", base_schema, local_schema, remote_schema, output_json
+        )
+        if merged_schema is None and not output_json:
+            return None
+        if merged_schema is None:
+            return {"success": False, "error": drift_msg + "Schema conflicts.", "conflicts": True}
+
+        merged_variables = _merge_rtc_file(
+            "data.json", base_variables, local_variables, remote_variables, output_json
+        )
+        if merged_variables is None and not output_json:
+            return None
+        if merged_variables is None:
+            return {"success": False, "error": drift_msg + "Data conflicts.", "conflicts": True}
+
+        if not output_json:
+            info("Merge complete.")
+
+        return {"success": True, "schema": merged_schema, "variables": merged_variables}
+
+    @classmethod
+    def _do_push(
+        cls,
+        project: AgentStudioProject,
+        env: str,
+        env_dir: str,
+        schema: dict,
+        variables: dict,
+        output_json: bool,
+    ) -> dict:
+        """Execute the actual push to the API and update local state."""
         try:
             AgentStudioInterface.put_rtc_schema(
                 region=project.region,
@@ -256,7 +572,7 @@ class RTCCommand(BaseCommand):
             return {"success": False, "error": str(e), "step": "schema"}
 
         try:
-            AgentStudioInterface.patch_rtc_variables(
+            push_response = AgentStudioInterface.patch_rtc_variables(
                 region=project.region,
                 project_id=project.project_id,
                 client_env=env,
@@ -271,9 +587,15 @@ class RTCCommand(BaseCommand):
                 "step": "variables",
             }
 
+        new_last_updated = push_response.get("lastUpdated") if push_response else None
+        _save_rtc_metadata(env_dir, new_last_updated)
+        _save_rtc_base(env_dir, schema, variables)
+        _write_json_file(os.path.join(env_dir, "schema.json"), schema)
+        _write_json_file(os.path.join(env_dir, "data.json"), variables)
+
         return {
             "success": True,
             "environment": env,
-            "schema_file": schema_path,
-            "data_file": data_path,
+            "schema_file": os.path.join(env_dir, "schema.json"),
+            "data_file": os.path.join(env_dir, "data.json"),
         }

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -1,0 +1,284 @@
+"""RTC command family: pull and push Real-Time Configuration.
+
+Copyright PolyAI Limited
+"""
+
+import json
+import logging
+import os
+import sys
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+
+import questionary
+import requests
+
+from poly.cli_commands.base import BaseCommand, Parents
+from poly.cli_commands.shared import load_project
+from poly.handlers.interface import AgentStudioInterface
+from poly.output.console import error, info, success
+from poly.output.json_output import json_print
+
+logger = logging.getLogger(__name__)
+
+RTC_ENV_TO_DIR = {
+    "sandbox": "draft_and_sandbox",
+    "pre-release": "pre_release",
+    "live": "live",
+}
+RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
+
+
+class RTCCommand(BaseCommand):
+    """Manage Real-Time Configuration for the project."""
+
+    command = "rtc"
+
+    @classmethod
+    def add_arguments(cls, subparsers: _SubParsersAction[ArgumentParser], parents: Parents) -> None:
+        """Register the ``rtc`` subcommand tree."""
+        rtc_parser = subparsers.add_parser(
+            "rtc",
+            parents=[parents.verbose],
+            help="Manage Real-Time Configuration.",
+            description=(
+                "Manage Real-Time Configuration (RTC) for the project.\n\n"
+                "Examples:\n"
+                "  poly rtc pull\n"
+                "  poly rtc pull --env sandbox\n"
+                "  poly rtc push --env sandbox\n"
+                "  poly rtc push --env live --force\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        rtc_subparsers = rtc_parser.add_subparsers(dest="rtc_subcommand", required=True)
+
+        rtc_pull_parser = rtc_subparsers.add_parser(
+            "pull",
+            parents=[parents.path, parents.json, parents.verbose, parents.debug],
+            help="Pull RTC from Agent Studio and write to local files.",
+            description=(
+                "Pull Real-Time Configuration from Agent Studio and write to local files.\n\n"
+                "Examples:\n"
+                "  poly rtc pull\n"
+                "  poly rtc pull --env sandbox\n"
+                "  poly rtc pull --env all\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_pull_parser.add_argument(
+            "--env",
+            type=str,
+            default="all",
+            choices=["sandbox", "pre-release", "live", "all"],
+            help="Environment to pull. Defaults to all.",
+        )
+
+        rtc_push_parser = rtc_subparsers.add_parser(
+            "push",
+            parents=[parents.path, parents.json, parents.verbose, parents.debug],
+            help="Push RTC from local files to Agent Studio.",
+            description=(
+                "Push Real-Time Configuration from local files to Agent Studio.\n\n"
+                "Examples:\n"
+                "  poly rtc push --env sandbox\n"
+                "  poly rtc push --env live --force\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_push_parser.add_argument(
+            "--env",
+            type=str,
+            required=True,
+            choices=["sandbox", "pre-release", "live"],
+            help="Environment to push to.",
+        )
+        rtc_push_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Skip confirmation prompt (required for live).",
+        )
+
+    @classmethod
+    def run(cls, args: Namespace) -> None:
+        """Dispatch to the matching RTC sub-handler."""
+        if args.rtc_subcommand == "pull":
+            cls.rtc_pull(args.path, args.env, args.json)
+        elif args.rtc_subcommand == "push":
+            cls.rtc_push(args.path, args.env, getattr(args, "force", False), args.json)
+
+    @classmethod
+    def rtc_pull(
+        cls,
+        base_path: str,
+        env: str = "all",
+        output_json: bool = False,
+    ) -> None:
+        """Pull RTC from Agent Studio and write to local files.
+
+        Args:
+            base_path: Base path for the project.
+            env: Environment(s) to pull — sandbox, pre-release, live, or all.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = load_project(base_path, output_json=output_json)
+        project_root = project.root_path
+
+        if env == "all":
+            envs_to_fetch = ["sandbox", "pre-release", "live"]
+        else:
+            envs_to_fetch = [env]
+
+        rtc_root = os.path.join(project_root, "real_time_configuration")
+        results = []
+
+        try:
+            for client_env in envs_to_fetch:
+                config = AgentStudioInterface.get_rtc_config(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=client_env,
+                )
+
+                dir_name = RTC_ENV_TO_DIR[client_env]
+                env_dir = os.path.join(rtc_root, dir_name)
+                os.makedirs(env_dir, exist_ok=True)
+
+                schema = config.get("schema", {})
+                schema_path = os.path.join(env_dir, "schema.json")
+                with open(schema_path, "w", encoding="utf-8") as f:
+                    json.dump(schema, f, indent=2)
+                    f.write("\n")
+
+                variables = config.get("variables", {})
+                data_path = os.path.join(env_dir, "data.json")
+                with open(data_path, "w", encoding="utf-8") as f:
+                    json.dump(variables, f, indent=2)
+                    f.write("\n")
+
+                results.append(
+                    {
+                        "environment": client_env,
+                        "schema_file": schema_path,
+                        "data_file": data_path,
+                    }
+                )
+
+            if output_json:
+                json_print({"success": True, "files_written": results})
+            else:
+                for result in results:
+                    success(f"Pulled {result['environment']} — {result['schema_file']}")
+                    success(f"Pulled {result['environment']} — {result['data_file']}")
+
+        except requests.HTTPError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+                sys.exit(1)
+            else:
+                raise
+
+    @classmethod
+    def rtc_push(
+        cls,
+        base_path: str,
+        env: str,
+        force: bool = False,
+        output_json: bool = False,
+    ) -> None:
+        """Push RTC from local files to Agent Studio.
+
+        Args:
+            base_path: Base path for the project.
+            env: Environment to push to — sandbox, pre-release, or live.
+            force: If True, skip confirmation for live environment.
+            output_json: If True, emit machine-readable JSON.
+        """
+        project = load_project(base_path, output_json=output_json)
+        project_root = project.root_path
+
+        dir_name = RTC_ENV_TO_DIR[env]
+        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
+
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        if not os.path.exists(schema_path):
+            msg = f"schema.json not found at {schema_path}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        if not os.path.exists(data_path):
+            msg = f"data.json not found at {data_path}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        with open(schema_path, "r", encoding="utf-8") as f:
+            schema = json.load(f)
+
+        with open(data_path, "r", encoding="utf-8") as f:
+            variables = json.load(f)
+
+        if env == "live" and not force:
+            if output_json:
+                json_print(
+                    {"success": False, "error": "Refusing to push RTC to live without --force."}
+                )
+                sys.exit(1)
+            confirm = questionary.confirm(
+                f"Push RTC to {env}? This will update live configuration.",
+                auto_enter=False,
+                default=False,
+            ).ask()
+            if not confirm:
+                info("Push cancelled.")
+                return
+
+        try:
+            AgentStudioInterface.put_rtc_schema(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+                schema=schema,
+            )
+        except requests.HTTPError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e), "step": "schema"})
+                sys.exit(1)
+            else:
+                raise
+
+        try:
+            AgentStudioInterface.patch_rtc_variables(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+                variables=variables,
+            )
+        except requests.HTTPError as e:
+            # Schema was already pushed — warn so the user knows the state is partial
+            msg = f"Schema pushed but variables failed: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg, "step": "variables"})
+                sys.exit(1)
+            else:
+                error(f"Warning: schema was pushed to {env}, but variables update failed.")
+                raise
+
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "environment": env,
+                    "schema_file": schema_path,
+                    "data_file": data_path,
+                }
+            )
+        else:
+            success(f"Pushed RTC to {env}")

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -649,6 +649,10 @@ class RTCCommand(BaseCommand):
                     variables=variables,
                 )
             except requests.HTTPError as e:
+                # Schema was already pushed — update metadata so drift check
+                # doesn't falsely trigger on retry.
+                if last_response and last_response.get("lastUpdated"):
+                    _set_rtc_last_updated(project, env, last_response["lastUpdated"])
                 if not output_json and schema is not None:
                     error(f"Warning: schema was pushed to {env}, but variables update failed.")
                 return {

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -268,6 +268,38 @@ class RTCCommand(BaseCommand):
             help="Push data only.",
         )
 
+        rtc_edit_parser = rtc_subparsers.add_parser(
+            "edit",
+            parents=[parents.path, parents.verbose, parents.debug],
+            help="Pull, edit, and push RTC in one step.",
+            description=(
+                "Pull the latest RTC config, open it in your editor, and push changes\n"
+                "back immediately. Set $EDITOR or $VISUAL to your preferred editor.\n\n"
+                "Examples:\n"
+                "  poly rtc edit --env sandbox\n"
+                "  poly rtc edit --env sandbox --schema\n"
+                "  poly rtc edit --env live --force\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_edit_parser.add_argument(
+            "--env",
+            type=str,
+            required=True,
+            choices=["sandbox", "pre-release", "live"],
+            help="Environment to edit.",
+        )
+        rtc_edit_parser.add_argument(
+            "--schema",
+            action="store_true",
+            help="Edit the schema instead of the data variables.",
+        )
+        rtc_edit_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Skip confirmation prompt for live environment.",
+        )
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching RTC sub-handler."""
@@ -312,6 +344,13 @@ class RTCCommand(BaseCommand):
                     error(result["error"])
                     sys.exit(1)
                 success(f"Pushed RTC to {args.env}")
+        elif args.rtc_subcommand == "edit":
+            cls.rtc_edit(
+                args.path,
+                args.env,
+                edit_schema=getattr(args, "schema", False),
+                force=getattr(args, "force", False),
+            )
 
     @classmethod
     def rtc_pull(
@@ -638,3 +677,123 @@ class RTCCommand(BaseCommand):
             "schema_file": os.path.join(env_dir, "schema.json"),
             "data_file": os.path.join(env_dir, "data.json"),
         }
+
+    @classmethod
+    def rtc_edit(
+        cls,
+        base_path: str,
+        env: str,
+        edit_schema: bool = False,
+        force: bool = False,
+    ) -> None:
+        """Pull latest RTC, open in editor, and push back.
+
+        Args:
+            base_path: Base path for the project.
+            env: Environment to edit.
+            edit_schema: If True, edit schema instead of data.
+            force: If True, skip confirmation for live environment.
+        """
+        project = load_project(base_path)
+        project_root = project.root_path
+
+        try:
+            config = AgentStudioInterface.get_rtc_config(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+            )
+        except requests.HTTPError as e:
+            error(f"Failed to fetch RTC config: {e}")
+            sys.exit(1)
+
+        baseline_last_updated = config.get("lastUpdated")
+
+        if edit_schema:
+            content = config.get("schema", {})
+            filename = "schema.json"
+        else:
+            content = config.get("variables", {})
+            filename = "data.json"
+
+        content_str = json.dumps(content, indent=2, sort_keys=True) + "\n"
+
+        try:
+            edited_str = edit_in_editor(content_str, extension=".json", filename=filename)
+        except ValueError:
+            info("No changes made.")
+            return
+        except (FileNotFoundError, OSError) as e:
+            error(f"Could not open editor: {e}. Check your $EDITOR or $VISUAL setting.")
+            sys.exit(1)
+
+        try:
+            edited = json.loads(edited_str)
+        except json.JSONDecodeError as e:
+            error(f"Invalid JSON: {e}")
+            sys.exit(1)
+
+        # Race check: ensure remote hasn't changed while editing
+        try:
+            current_config = AgentStudioInterface.get_rtc_config(
+                region=project.region,
+                project_id=project.project_id,
+                client_env=env,
+            )
+        except requests.HTTPError as e:
+            error(f"Failed to check remote state: {e}")
+            sys.exit(1)
+
+        if current_config.get("lastUpdated") != baseline_last_updated:
+            error(
+                "Remote config was modified while you were editing. "
+                "Your changes have NOT been pushed. Please try again."
+            )
+            sys.exit(1)
+
+        if env == "live" and not force:
+            confirm = questionary.confirm(
+                f"Push RTC to {env}? This will update live configuration.",
+                auto_enter=False,
+                default=False,
+            ).ask()
+            if not confirm:
+                info("Push cancelled.")
+                return
+
+        try:
+            if edit_schema:
+                response = AgentStudioInterface.put_rtc_schema(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=env,
+                    schema=edited,
+                )
+            else:
+                response = AgentStudioInterface.patch_rtc_variables(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=env,
+                    variables=edited,
+                )
+        except requests.HTTPError as e:
+            error(f"Push failed: {e}")
+            sys.exit(1)
+
+        if response and response.get("lastUpdated"):
+            _set_rtc_last_updated(project, env, response["lastUpdated"])
+
+        # Update local files if the env directory exists
+        dir_name = RTC_ENV_TO_DIR[env]
+        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
+        if os.path.isdir(env_dir):
+            if edit_schema:
+                write_json_file(os.path.join(env_dir, "schema.json"), edited)
+                base_schema, base_variables = _load_rtc_base(env_dir)
+                _save_rtc_base(env_dir, edited, base_variables or {})
+            else:
+                write_json_file(os.path.join(env_dir, "data.json"), edited)
+                base_schema, base_variables = _load_rtc_base(env_dir)
+                _save_rtc_base(env_dir, base_schema or {}, edited)
+
+        success(f"Edited and pushed RTC {filename} to {env}")

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -7,7 +7,6 @@ import json
 import os
 import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
-from datetime import datetime, timezone
 from typing import Optional
 
 import questionary
@@ -16,10 +15,11 @@ import requests
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project
 from poly.handlers.interface import AgentStudioInterface
-from poly.project import AgentStudioProject
 from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
+from poly.project import AgentStudioProject
 from poly.resources.resource_utils import contains_merge_conflict
+from poly.utils import merge_dicts, read_json_file, write_json_file
 
 RTC_ENV_TO_DIR = {
     "sandbox": "draft_and_sandbox",
@@ -28,50 +28,20 @@ RTC_ENV_TO_DIR = {
 }
 RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
 
-RTC_METADATA_FILE = ".rtc_metadata.json"
 RTC_BASE_SCHEMA_FILE = ".rtc_base_schema.json"
 RTC_BASE_DATA_FILE = ".rtc_base_data.json"
 
 
-def _write_json_file(path: str, data: dict) -> None:
-    """Write a dict as pretty-printed JSON with trailing newline."""
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, sort_keys=True)
-        f.write("\n")
-
-
-def _read_json_file(path: str) -> Optional[dict]:
-    """Read a JSON file, or None if it doesn't exist."""
-    if not os.path.exists(path):
-        return None
-    with open(path, "r", encoding="utf-8") as f:
-        return json.load(f)
-
-
-def _save_rtc_metadata(env_dir: str, last_updated: Optional[str]) -> None:
-    """Write RTC metadata after a pull or successful push."""
-    metadata = {
-        "last_updated": last_updated,
-        "pulled_at": datetime.now(timezone.utc).isoformat(),
-    }
-    _write_json_file(os.path.join(env_dir, RTC_METADATA_FILE), metadata)
-
-
-def _load_rtc_metadata(env_dir: str) -> Optional[dict]:
-    """Load RTC metadata from disk, or None if not present."""
-    return _read_json_file(os.path.join(env_dir, RTC_METADATA_FILE))
-
-
 def _save_rtc_base(env_dir: str, schema: dict, variables: dict) -> None:
     """Save base copies of schema and data for 3-way merge on push."""
-    _write_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE), schema)
-    _write_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE), variables)
+    write_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE), schema)
+    write_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE), variables)
 
 
 def _load_rtc_base(env_dir: str) -> tuple[Optional[dict], Optional[dict]]:
     """Load base copies, returning (schema, variables) or (None, None)."""
-    schema = _read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
-    variables = _read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
+    schema = read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
+    variables = read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
     return schema, variables
 
 
@@ -80,40 +50,24 @@ def _to_sorted_json(data: dict) -> str:
     return json.dumps(data, indent=2, sort_keys=True) + "\n"
 
 
-_MISSING = object()
+def _get_rtc_last_updated(project: AgentStudioProject, env: str) -> Optional[str]:
+    """Get the stored lastUpdated for an RTC environment from project config."""
+    if not project.rtc_metadata:
+        return None
+    env_meta = project.rtc_metadata.get(env)
+    if not env_meta:
+        return None
+    return env_meta.get("last_updated")
 
 
-def _merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
-    """3-way merge at the dict key level.
-
-    Returns:
-        (merged_dict, list_of_conflict_keys). If conflict_keys is empty, the
-        merge is clean.
-    """
-    all_keys = set(base) | set(local) | set(remote)
-    merged = {}
-    conflicts = []
-
-    for key in sorted(all_keys):
-        base_val = base.get(key, _MISSING)
-        local_val = local.get(key, _MISSING)
-        remote_val = remote.get(key, _MISSING)
-
-        resolved = _MISSING
-        if local_val == remote_val:
-            resolved = local_val
-        elif local_val == base_val:
-            resolved = remote_val
-        elif remote_val == base_val:
-            resolved = local_val
-        else:
-            conflicts.append(key)
-            resolved = local_val
-
-        if resolved is not _MISSING:
-            merged[key] = resolved
-
-    return merged, conflicts
+def _set_rtc_last_updated(
+    project: AgentStudioProject, env: str, last_updated: Optional[str]
+) -> None:
+    """Set the lastUpdated for an RTC environment and save project config."""
+    if project.rtc_metadata is None:
+        project.rtc_metadata = {}
+    project.rtc_metadata[env] = {"last_updated": last_updated}
+    project.save_config()
 
 
 def _merge_rtc_file(
@@ -125,13 +79,6 @@ def _merge_rtc_file(
 ) -> Optional[dict]:
     """Attempt 3-way merge on a single RTC JSON file.
 
-    Args:
-        filename: Display name (e.g. "data.json").
-        base: The pulled version.
-        local: The user's local version.
-        remote: The current remote version.
-        output_json: If True, skip interactive resolution.
-
     Returns:
         Merged dict, or None if the user cancelled.
     """
@@ -142,7 +89,7 @@ def _merge_rtc_file(
     if remote == base:
         return local
 
-    merged, conflict_keys = _merge_dicts(base, local, remote)
+    merged, conflict_keys = merge_dicts(base, local, remote)
 
     if not conflict_keys:
         if not output_json:
@@ -253,6 +200,7 @@ class RTCCommand(BaseCommand):
                 "  poly rtc pull\n"
                 "  poly rtc pull --env sandbox\n"
                 "  poly rtc pull --env all\n"
+                "  poly rtc pull --env sandbox --schema\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -263,6 +211,16 @@ class RTCCommand(BaseCommand):
             choices=["sandbox", "pre-release", "live", "all"],
             help="Environment to pull. Defaults to all.",
         )
+        rtc_pull_parser.add_argument(
+            "--schema",
+            action="store_true",
+            help="Pull schema only.",
+        )
+        rtc_pull_parser.add_argument(
+            "--data",
+            action="store_true",
+            help="Pull data only.",
+        )
 
         rtc_push_parser = rtc_subparsers.add_parser(
             "push",
@@ -272,6 +230,7 @@ class RTCCommand(BaseCommand):
                 "Push Real-Time Configuration from local files to Agent Studio.\n\n"
                 "Examples:\n"
                 "  poly rtc push --env sandbox\n"
+                "  poly rtc push --env sandbox --schema\n"
                 "  poly rtc push --env live --force\n"
             ),
             formatter_class=RawTextHelpFormatter,
@@ -293,16 +252,33 @@ class RTCCommand(BaseCommand):
             action="store_true",
             help="Disable automatic merge on drift; fail with error instead.",
         )
+        rtc_push_parser.add_argument(
+            "--schema",
+            action="store_true",
+            help="Push schema only.",
+        )
+        rtc_push_parser.add_argument(
+            "--data",
+            action="store_true",
+            help="Push data only.",
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching RTC sub-handler."""
+        schema_only = getattr(args, "schema", False)
+        data_only = getattr(args, "data", False)
+
         if args.rtc_subcommand == "pull":
-            result = cls.rtc_pull(args.path, args.env, output_json=args.json)
+            result = cls.rtc_pull(
+                args.path,
+                args.env,
+                output_json=args.json,
+                schema_only=schema_only,
+                data_only=data_only,
+            )
             if args.json:
                 json_print(result)
-                if not result["success"]:
-                    sys.exit(1)
             else:
                 if not result["success"]:
                     error(result["error"])
@@ -317,13 +293,13 @@ class RTCCommand(BaseCommand):
                 force=getattr(args, "force", False),
                 output_json=args.json,
                 no_merge=getattr(args, "no_merge", False),
+                schema_only=schema_only,
+                data_only=data_only,
             )
             if result is None:
                 return
             if args.json:
                 json_print(result)
-                if not result["success"]:
-                    sys.exit(1)
             else:
                 if not result["success"]:
                     error(result["error"])
@@ -336,6 +312,8 @@ class RTCCommand(BaseCommand):
         base_path: str,
         env: str = "all",
         output_json: bool = False,
+        schema_only: bool = False,
+        data_only: bool = False,
     ) -> dict:
         """Pull RTC from Agent Studio and write to local files.
 
@@ -343,6 +321,8 @@ class RTCCommand(BaseCommand):
             base_path: Base path for the project.
             env: Environment(s) to pull — sandbox, pre-release, live, or all.
             output_json: If True, format errors as JSON on failure.
+            schema_only: If True, only pull schema.
+            data_only: If True, only pull data.
 
         Returns:
             dict: Result with success status and files_written list.
@@ -373,16 +353,22 @@ class RTCCommand(BaseCommand):
                 schema = config.get("schema", {})
                 variables = config.get("variables", {})
 
-                _write_json_file(os.path.join(env_dir, "schema.json"), schema)
-                _write_json_file(os.path.join(env_dir, "data.json"), variables)
+                schema_path = os.path.join(env_dir, "schema.json")
+                data_path = os.path.join(env_dir, "data.json")
+
+                if not data_only:
+                    write_json_file(schema_path, schema)
+                if not schema_only:
+                    write_json_file(data_path, variables)
+
                 _save_rtc_base(env_dir, schema, variables)
-                _save_rtc_metadata(env_dir, config.get("lastUpdated"))
+                _set_rtc_last_updated(project, client_env, config.get("lastUpdated"))
 
                 results.append(
                     {
                         "environment": client_env,
-                        "schema_file": os.path.join(env_dir, "schema.json"),
-                        "data_file": os.path.join(env_dir, "data.json"),
+                        "schema_file": schema_path,
+                        "data_file": data_path,
                     }
                 )
 
@@ -399,6 +385,8 @@ class RTCCommand(BaseCommand):
         force: bool = False,
         output_json: bool = False,
         no_merge: bool = False,
+        schema_only: bool = False,
+        data_only: bool = False,
     ) -> Optional[dict]:
         """Push RTC from local files to Agent Studio.
 
@@ -408,6 +396,8 @@ class RTCCommand(BaseCommand):
             force: If True, skip drift check and confirmation prompt.
             output_json: If True, format errors as JSON on failure.
             no_merge: If True, disable merge on drift; hard-fail instead.
+            schema_only: If True, only push schema.
+            data_only: If True, only push data.
 
         Returns:
             dict with success status, or None if the user cancelled interactively.
@@ -421,24 +411,28 @@ class RTCCommand(BaseCommand):
         schema_path = os.path.join(env_dir, "schema.json")
         data_path = os.path.join(env_dir, "data.json")
 
-        if not os.path.exists(schema_path):
+        if not data_only and not os.path.exists(schema_path):
             return {"success": False, "error": f"schema.json not found at {schema_path}"}
 
-        if not os.path.exists(data_path):
+        if not schema_only and not os.path.exists(data_path):
             return {"success": False, "error": f"data.json not found at {data_path}"}
 
         try:
-            with open(schema_path, "r", encoding="utf-8") as f:
-                schema = json.load(f)
-            with open(data_path, "r", encoding="utf-8") as f:
-                variables = json.load(f)
+            schema = None
+            variables = None
+            if not data_only:
+                with open(schema_path, "r", encoding="utf-8") as f:
+                    schema = json.load(f)
+            if not schema_only:
+                with open(data_path, "r", encoding="utf-8") as f:
+                    variables = json.load(f)
         except json.JSONDecodeError as e:
             return {"success": False, "error": f"Invalid JSON in local RTC file: {e}"}
 
         # Drift protection
         if not force:
-            metadata = _load_rtc_metadata(env_dir)
-            if metadata is None:
+            local_last_updated = _get_rtc_last_updated(project, env)
+            if local_last_updated is None:
                 if not output_json:
                     info(
                         "No RTC metadata found; skipping drift check. "
@@ -452,7 +446,6 @@ class RTCCommand(BaseCommand):
                         client_env=env,
                     )
                     remote_last_updated = remote_config.get("lastUpdated")
-                    local_last_updated = metadata.get("last_updated")
 
                     if remote_last_updated != local_last_updated:
                         merge_result = cls._handle_drift(
@@ -470,8 +463,10 @@ class RTCCommand(BaseCommand):
                             return None
                         if not merge_result["success"]:
                             return merge_result
-                        schema = merge_result["schema"]
-                        variables = merge_result["variables"]
+                        if merge_result.get("schema") is not None:
+                            schema = merge_result["schema"]
+                        if merge_result.get("variables") is not None:
+                            variables = merge_result["variables"]
 
                 except requests.HTTPError as e:
                     return {"success": False, "error": f"Drift check failed: {e}"}
@@ -491,28 +486,24 @@ class RTCCommand(BaseCommand):
                 info("Push cancelled.")
                 return None
 
-        return cls._do_push(project, env, env_dir, schema, variables, output_json)
+        return cls._do_push(
+            project, env, env_dir, schema, variables, output_json, schema_only, data_only
+        )
 
     @classmethod
     def _handle_drift(
         cls,
         env_dir: str,
         remote_config: dict,
-        local_schema: dict,
-        local_variables: dict,
+        local_schema: Optional[dict],
+        local_variables: Optional[dict],
         output_json: bool,
         no_merge: bool,
         env: str,
         local_last_updated: Optional[str],
         remote_last_updated: Optional[str],
     ) -> Optional[dict]:
-        """Handle drift between local and remote RTC config.
-
-        Returns:
-            dict with "success" and merged "schema"/"variables" on merge success,
-            dict with "success": False on error,
-            or None if the user cancelled.
-        """
+        """Handle drift between local and remote RTC config."""
         drift_msg = (
             f"Remote RTC config has changed since your last pull "
             f"(local: {local_last_updated}, remote: {remote_last_updated}). "
@@ -540,21 +531,33 @@ class RTCCommand(BaseCommand):
         if not output_json:
             info("Remote has changed since your last pull. Attempting merge...")
 
-        merged_schema = _merge_rtc_file(
-            "schema.json", base_schema, local_schema, remote_schema, output_json
-        )
-        if merged_schema is None and not output_json:
-            return None
-        if merged_schema is None:
-            return {"success": False, "error": drift_msg + "Schema conflicts.", "conflicts": True}
+        merged_schema = local_schema
+        if local_schema is not None:
+            merged_schema = _merge_rtc_file(
+                "schema.json", base_schema, local_schema, remote_schema, output_json
+            )
+            if merged_schema is None and not output_json:
+                return None
+            if merged_schema is None:
+                return {
+                    "success": False,
+                    "error": drift_msg + "Schema conflicts.",
+                    "conflicts": True,
+                }
 
-        merged_variables = _merge_rtc_file(
-            "data.json", base_variables, local_variables, remote_variables, output_json
-        )
-        if merged_variables is None and not output_json:
-            return None
-        if merged_variables is None:
-            return {"success": False, "error": drift_msg + "Data conflicts.", "conflicts": True}
+        merged_variables = local_variables
+        if local_variables is not None:
+            merged_variables = _merge_rtc_file(
+                "data.json", base_variables, local_variables, remote_variables, output_json
+            )
+            if merged_variables is None and not output_json:
+                return None
+            if merged_variables is None:
+                return {
+                    "success": False,
+                    "error": drift_msg + "Data conflicts.",
+                    "conflicts": True,
+                }
 
         if not output_json:
             info("Merge complete.")
@@ -567,42 +570,49 @@ class RTCCommand(BaseCommand):
         project: AgentStudioProject,
         env: str,
         env_dir: str,
-        schema: dict,
-        variables: dict,
+        schema: Optional[dict],
+        variables: Optional[dict],
         output_json: bool,
+        schema_only: bool = False,
+        data_only: bool = False,
     ) -> dict:
         """Execute the actual push to the API and update local state."""
-        try:
-            AgentStudioInterface.put_rtc_schema(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-                schema=schema,
-            )
-        except requests.HTTPError as e:
-            return {"success": False, "error": str(e), "step": "schema"}
+        if schema is not None and not data_only:
+            try:
+                AgentStudioInterface.put_rtc_schema(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=env,
+                    schema=schema,
+                )
+            except requests.HTTPError as e:
+                return {"success": False, "error": str(e), "step": "schema"}
 
-        try:
-            push_response = AgentStudioInterface.patch_rtc_variables(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-                variables=variables,
-            )
-        except requests.HTTPError as e:
-            if not output_json:
-                error(f"Warning: schema was pushed to {env}, but variables update failed.")
-            return {
-                "success": False,
-                "error": f"Schema pushed but variables failed: {e}",
-                "step": "variables",
-            }
+        push_response = None
+        if variables is not None and not schema_only:
+            try:
+                push_response = AgentStudioInterface.patch_rtc_variables(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=env,
+                    variables=variables,
+                )
+            except requests.HTTPError as e:
+                if not output_json and schema is not None:
+                    error(f"Warning: schema was pushed to {env}, but variables update failed.")
+                return {
+                    "success": False,
+                    "error": f"Schema pushed but variables failed: {e}",
+                    "step": "variables",
+                }
 
         new_last_updated = push_response.get("lastUpdated") if push_response else None
-        _save_rtc_metadata(env_dir, new_last_updated)
-        _save_rtc_base(env_dir, schema, variables)
-        _write_json_file(os.path.join(env_dir, "schema.json"), schema)
-        _write_json_file(os.path.join(env_dir, "data.json"), variables)
+        _set_rtc_last_updated(project, env, new_last_updated)
+
+        if schema is not None and variables is not None:
+            _save_rtc_base(env_dir, schema, variables)
+            write_json_file(os.path.join(env_dir, "schema.json"), schema)
+            write_json_file(os.path.join(env_dir, "data.json"), variables)
 
         return {
             "success": True,

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -550,7 +550,12 @@ class RTCCommand(BaseCommand):
             }
 
         base_schema, base_variables = project.get_rtc_base(env)
-        if base_schema is None or base_variables is None:
+
+        needs_schema_base = local_schema is not None
+        needs_data_base = local_variables is not None
+        if (needs_schema_base and base_schema is None) or (
+            needs_data_base and base_variables is None
+        ):
             return {
                 "success": False,
                 "error": drift_msg + "Cannot merge: no base version available. "
@@ -565,7 +570,7 @@ class RTCCommand(BaseCommand):
             info("Remote has changed since your last pull. Attempting merge...")
 
         merged_schema = local_schema
-        if local_schema is not None:
+        if local_schema is not None and base_schema is not None:
             merged_schema = _merge_rtc_file(
                 "schema.json", base_schema, local_schema, remote_schema, output_json
             )
@@ -579,7 +584,7 @@ class RTCCommand(BaseCommand):
                 }
 
         merged_variables = local_variables
-        if local_variables is not None:
+        if local_variables is not None and base_variables is not None:
             merged_variables = _merge_rtc_file(
                 "data.json", base_variables, local_variables, remote_variables, output_json
             )

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -19,7 +19,7 @@ from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
 from poly.project import AgentStudioProject
 from poly.resources.resource_utils import contains_merge_conflict
-from poly.utils import merge_dicts, read_json_file, write_json_file
+from poly.utils import merge_rtc_dicts, read_json_file, write_json_file
 
 RTC_ENV_TO_DIR = {
     "sandbox": "draft_and_sandbox",
@@ -89,7 +89,7 @@ def _merge_rtc_file(
     if remote == base:
         return local
 
-    merged, conflict_keys = merge_dicts(base, local, remote)
+    merged, conflict_keys = merge_rtc_dicts(base, local, remote)
 
     if not conflict_keys:
         if not output_json:

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -4,7 +4,6 @@ Copyright PolyAI Limited
 """
 
 import json
-import os
 import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
 from typing import Optional
@@ -14,12 +13,11 @@ import requests
 
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project
-from poly.handlers.interface import AgentStudioInterface
 from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
 from poly.project import AgentStudioProject
 from poly.resources.resource_utils import contains_merge_conflict
-from poly.utils import diff_dicts, merge_rtc_dicts, write_json_file
+from poly.utils import merge_rtc_dicts
 
 
 def _to_sorted_json(data: dict) -> str:
@@ -320,9 +318,9 @@ class RTCCommand(BaseCommand):
                     error(result["error"])
                     sys.exit(1)
                 for f in result["files_written"]:
-                    if not data_only:
+                    if not data_only and "schema_file" in f:
                         success(f"Pulled {f['environment']} — {f['schema_file']}")
-                    if not schema_only:
+                    if not schema_only and "data_file" in f:
                         success(f"Pulled {f['environment']} — {f['data_file']}")
         elif args.rtc_subcommand == "push":
             result = cls.rtc_push(
@@ -345,12 +343,19 @@ class RTCCommand(BaseCommand):
                     sys.exit(1)
                 success(f"Pushed RTC to {args.env}")
         elif args.rtc_subcommand == "edit":
-            cls.rtc_edit(
+            result = cls.rtc_edit(
                 args.path,
                 args.env,
                 edit_schema=getattr(args, "schema", False),
                 force=getattr(args, "force", False),
             )
+            if result is None:
+                return
+            if not result["success"]:
+                error(result["error"])
+                sys.exit(1)
+            what = "schema.json" if getattr(args, "schema", False) else "data.json"
+            success(f"Edited and pushed RTC {what} to {args.env}")
         elif args.rtc_subcommand == "diff":
             result = cls.rtc_diff(args.path, args.env, output_json=args.json)
             if args.json:
@@ -420,28 +425,15 @@ class RTCCommand(BaseCommand):
             dict with success status, or None if the user cancelled interactively.
         """
         project = load_project(base_path, output_json=output_json)
-        env_dir = project._rtc_env_dir(env)
 
-        schema_path = os.path.join(env_dir, "schema.json")
-        data_path = os.path.join(env_dir, "data.json")
-
-        if not data_only and not os.path.exists(schema_path):
-            return {"success": False, "error": f"schema.json not found at {schema_path}"}
-
-        if not schema_only and not os.path.exists(data_path):
-            return {"success": False, "error": f"data.json not found at {data_path}"}
-
+        # Load local files
         try:
-            schema = None
-            variables = None
-            if not data_only:
-                with open(schema_path, "r", encoding="utf-8") as f:
-                    schema = json.load(f)
-            if not schema_only:
-                with open(data_path, "r", encoding="utf-8") as f:
-                    variables = json.load(f)
-        except json.JSONDecodeError as e:
-            return {"success": False, "error": f"Invalid JSON in local RTC file: {e}"}
+            local = project.rtc_load_local(env, schema_only=schema_only, data_only=data_only)
+        except (FileNotFoundError, ValueError) as e:
+            return {"success": False, "error": str(e)}
+
+        schema = local["schema"]
+        variables = local["variables"]
 
         # Schema validation
         if not skip_validation and schema is not None and variables is not None:
@@ -457,45 +449,37 @@ class RTCCommand(BaseCommand):
 
         # Drift protection
         if not force:
-            local_last_updated = project.get_rtc_last_updated(env)
-            if local_last_updated is None:
+            try:
+                drift = project.check_rtc_drift(env)
+            except requests.HTTPError as e:
+                return {"success": False, "error": f"Drift check failed: {e}"}
+
+            if drift["status"] == "no_metadata":
                 if not output_json:
                     info(
                         "No RTC metadata found; skipping drift check. "
                         "Run 'poly rtc pull' to enable drift protection."
                     )
-            else:
-                try:
-                    remote_config = AgentStudioInterface.get_rtc_config(
-                        region=project.region,
-                        project_id=project.project_id,
-                        client_env=env,
-                    )
-                    remote_last_updated = remote_config.get("lastUpdated")
-
-                    if remote_last_updated != local_last_updated:
-                        merge_result = cls._handle_drift(
-                            project=project,
-                            remote_config=remote_config,
-                            local_schema=schema,
-                            local_variables=variables,
-                            output_json=output_json,
-                            no_merge=no_merge,
-                            env=env,
-                            local_last_updated=local_last_updated,
-                            remote_last_updated=remote_last_updated,
-                        )
-                        if merge_result is None:
-                            return None
-                        if not merge_result["success"]:
-                            return merge_result
-                        if merge_result.get("schema") is not None:
-                            schema = merge_result["schema"]
-                        if merge_result.get("variables") is not None:
-                            variables = merge_result["variables"]
-
-                except requests.HTTPError as e:
-                    return {"success": False, "error": f"Drift check failed: {e}"}
+            elif drift["status"] == "drifted":
+                merge_result = cls._handle_drift(
+                    project=project,
+                    remote_config=drift["remote_config"],
+                    local_schema=schema,
+                    local_variables=variables,
+                    output_json=output_json,
+                    no_merge=no_merge,
+                    env=env,
+                    local_last_updated=drift["local_last_updated"],
+                    remote_last_updated=drift["remote_last_updated"],
+                )
+                if merge_result is None:
+                    return None
+                if not merge_result["success"]:
+                    return merge_result
+                if merge_result.get("schema") is not None:
+                    schema = merge_result["schema"]
+                if merge_result.get("variables") is not None:
+                    variables = merge_result["variables"]
 
         if env == "live" and not force:
             if output_json:
@@ -609,27 +593,28 @@ class RTCCommand(BaseCommand):
         env: str,
         edit_schema: bool = False,
         force: bool = False,
-    ) -> None:
-        """Pull latest RTC, open in editor, and push back."""
+    ) -> Optional[dict]:
+        """Pull latest RTC, open in editor, and push back.
+
+        Returns:
+            dict with success status, or None if cancelled/no changes.
+        """
         project = load_project(base_path)
 
         try:
-            config = AgentStudioInterface.get_rtc_config(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-            )
+            config = project.rtc_fetch_config(env)
         except requests.HTTPError as e:
-            error(f"Failed to fetch RTC config: {e}")
-            sys.exit(1)
+            return {"success": False, "error": f"Failed to fetch RTC config: {e}"}
 
         baseline_last_updated = config.get("lastUpdated")
+        schema = config.get("schema", {})
+        variables = config.get("variables", {})
 
         if edit_schema:
-            content = config.get("schema", {})
+            content = schema
             filename = "schema.json"
         else:
-            content = config.get("variables", {})
+            content = variables
             filename = "data.json"
 
         content_str = json.dumps(content, indent=2, sort_keys=True) + "\n"
@@ -638,34 +623,41 @@ class RTCCommand(BaseCommand):
             edited_str = edit_in_editor(content_str, extension=".json", filename=filename)
         except ValueError:
             info("No changes made.")
-            return
+            return None
         except (FileNotFoundError, OSError) as e:
-            error(f"Could not open editor: {e}. Check your $EDITOR or $VISUAL setting.")
-            sys.exit(1)
+            return {
+                "success": False,
+                "error": f"Could not open editor: {e}. Check your $EDITOR or $VISUAL setting.",
+            }
 
         try:
             edited = json.loads(edited_str)
         except json.JSONDecodeError as e:
-            error(f"Invalid JSON: {e}")
-            sys.exit(1)
+            return {"success": False, "error": f"Invalid JSON: {e}"}
+
+        # Schema validation (validate edited data against schema, or check edited schema)
+        if not edit_schema and schema:
+            validation_errors = AgentStudioProject.validate_rtc_data(schema, edited)
+            if validation_errors:
+                err_lines = "\n  ".join(validation_errors)
+                return {
+                    "success": False,
+                    "error": f"RTC validation failed:\n  {err_lines}",
+                    "validation_errors": validation_errors,
+                }
 
         # Race check
         try:
-            current_config = AgentStudioInterface.get_rtc_config(
-                region=project.region,
-                project_id=project.project_id,
-                client_env=env,
-            )
+            current_config = project.rtc_fetch_config(env)
         except requests.HTTPError as e:
-            error(f"Failed to check remote state: {e}")
-            sys.exit(1)
+            return {"success": False, "error": f"Failed to check remote state: {e}"}
 
         if current_config.get("lastUpdated") != baseline_last_updated:
-            error(
-                "Remote config was modified while you were editing. "
-                "Your changes have NOT been pushed. Please try again."
-            )
-            sys.exit(1)
+            return {
+                "success": False,
+                "error": "Remote config was modified while you were editing. "
+                "Your changes have NOT been pushed. Please try again.",
+            }
 
         if env == "live" and not force:
             confirm = questionary.confirm(
@@ -675,44 +667,14 @@ class RTCCommand(BaseCommand):
             ).ask()
             if not confirm:
                 info("Push cancelled.")
-                return
+                return None
 
-        try:
-            if edit_schema:
-                response = AgentStudioInterface.put_rtc_schema(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=env,
-                    schema=edited,
-                )
-            else:
-                response = AgentStudioInterface.patch_rtc_variables(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=env,
-                    variables=edited,
-                )
-        except requests.HTTPError as e:
-            error(f"Push failed: {e}")
-            sys.exit(1)
-
-        if response and response.get("lastUpdated"):
-            project.set_rtc_last_updated(env, response["lastUpdated"])
-
-        # Update base and local files
         if edit_schema:
-            project.set_rtc_base(env, schema=edited)
+            result = project.rtc_push_to_api(env, schema=edited)
         else:
-            project.set_rtc_base(env, variables=edited)
+            result = project.rtc_push_to_api(env, variables=edited)
 
-        env_dir = project._rtc_env_dir(env)
-        if os.path.isdir(env_dir):
-            if edit_schema:
-                write_json_file(os.path.join(env_dir, "schema.json"), edited)
-            else:
-                write_json_file(os.path.join(env_dir, "data.json"), edited)
-
-        success(f"Edited and pushed RTC {filename} to {env}")
+        return result
 
     @classmethod
     def rtc_diff(
@@ -736,40 +698,13 @@ class RTCCommand(BaseCommand):
         diffs = []
         try:
             for client_env in envs_to_diff:
-                env_dir = project._rtc_env_dir(client_env)
-                schema_path = os.path.join(env_dir, "schema.json")
-                data_path = os.path.join(env_dir, "data.json")
-
-                if not os.path.exists(schema_path) and not os.path.exists(data_path):
-                    if not output_json:
-                        info(f"  {client_env}: no local files — run poly rtc pull first")
-                    diffs.append({"environment": client_env, "status": "no_local_files"})
-                    continue
-
-                remote_config = AgentStudioInterface.get_rtc_config(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=client_env,
-                )
-
-                env_diff = {"environment": client_env, "schema": [], "data": []}
-
-                if os.path.exists(schema_path):
-                    with open(schema_path, "r", encoding="utf-8") as f:
-                        local_schema = json.load(f)
-                    remote_schema = remote_config.get("schema", {})
-                    schema_changes = diff_dicts(local_schema, remote_schema)
-                    env_diff["schema"] = schema_changes
-
-                if os.path.exists(data_path):
-                    with open(data_path, "r", encoding="utf-8") as f:
-                        local_data = json.load(f)
-                    remote_data = remote_config.get("variables", {})
-                    data_changes = diff_dicts(local_data, remote_data)
-                    env_diff["data"] = data_changes
+                env_diff = project.rtc_diff_env(client_env)
 
                 if not output_json:
-                    _print_env_diff(client_env, env_diff)
+                    if env_diff.get("status") == "no_local_files":
+                        info(f"  {client_env}: no local files — run poly rtc pull first")
+                    else:
+                        _print_env_diff(client_env, env_diff)
 
                 diffs.append(env_diff)
 
@@ -801,52 +736,22 @@ class RTCCommand(BaseCommand):
         all_valid = True
 
         for client_env in envs_to_validate:
-            env_dir = project._rtc_env_dir(client_env)
-            schema_path = os.path.join(env_dir, "schema.json")
-            data_path = os.path.join(env_dir, "data.json")
+            result = project.rtc_validate_env(client_env)
 
-            if not os.path.exists(schema_path) or not os.path.exists(data_path):
+            if result.get("status") == "skipped":
                 if not output_json:
                     info(f"  {client_env}: skipped — missing local files")
-                results.append({"environment": client_env, "status": "skipped"})
-                continue
-
-            try:
-                with open(schema_path, "r", encoding="utf-8") as f:
-                    schema = json.load(f)
-                with open(data_path, "r", encoding="utf-8") as f:
-                    data = json.load(f)
-            except json.JSONDecodeError as e:
+            elif result.get("valid") is False:
                 all_valid = False
-                results.append(
-                    {
-                        "environment": client_env,
-                        "valid": False,
-                        "errors": [f"Invalid JSON: {e}"],
-                    }
-                )
-                if not output_json:
-                    error(f"  {client_env}: invalid JSON — {e}")
-                continue
-
-            validation_errors = AgentStudioProject.validate_rtc_data(schema, data)
-            if validation_errors:
-                all_valid = False
-                results.append(
-                    {
-                        "environment": client_env,
-                        "valid": False,
-                        "errors": validation_errors,
-                    }
-                )
                 if not output_json:
                     error(f"  {client_env}: validation failed")
-                    for err in validation_errors:
+                    for err in result["errors"]:
                         error(f"    {err}")
             else:
-                results.append({"environment": client_env, "valid": True})
                 if not output_json:
                     success(f"  {client_env}: valid")
+
+            results.append(result)
 
         return {"success": all_valid, "results": results}
 

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -4,7 +4,6 @@ Copyright PolyAI Limited
 """
 
 import json
-import logging
 import os
 import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
@@ -18,8 +17,6 @@ from poly.cli_commands.shared import load_project
 from poly.handlers.interface import AgentStudioInterface
 from poly.output.console import error, info, success
 from poly.output.json_output import json_print
-
-logger = logging.getLogger(__name__)
 
 RTC_ENV_TO_DIR = {
     "sandbox": "draft_and_sandbox",
@@ -104,7 +101,7 @@ class RTCCommand(BaseCommand):
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching RTC sub-handler."""
         if args.rtc_subcommand == "pull":
-            result = cls.rtc_pull(args.path, args.env)
+            result = cls.rtc_pull(args.path, args.env, output_json=args.json)
             if args.json:
                 json_print(result)
             else:

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -211,12 +211,13 @@ class RTCCommand(BaseCommand):
             choices=["sandbox", "pre-release", "live", "all"],
             help="Environment to pull. Defaults to all.",
         )
-        rtc_pull_parser.add_argument(
+        rtc_pull_mode = rtc_pull_parser.add_mutually_exclusive_group()
+        rtc_pull_mode.add_argument(
             "--schema",
             action="store_true",
             help="Pull schema only.",
         )
-        rtc_pull_parser.add_argument(
+        rtc_pull_mode.add_argument(
             "--data",
             action="store_true",
             help="Pull data only.",
@@ -252,12 +253,13 @@ class RTCCommand(BaseCommand):
             action="store_true",
             help="Disable automatic merge on drift; fail with error instead.",
         )
-        rtc_push_parser.add_argument(
+        rtc_push_mode = rtc_push_parser.add_mutually_exclusive_group()
+        rtc_push_mode.add_argument(
             "--schema",
             action="store_true",
             help="Push schema only.",
         )
-        rtc_push_parser.add_argument(
+        rtc_push_mode.add_argument(
             "--data",
             action="store_true",
             help="Push data only.",
@@ -284,8 +286,10 @@ class RTCCommand(BaseCommand):
                     error(result["error"])
                     sys.exit(1)
                 for f in result["files_written"]:
-                    success(f"Pulled {f['environment']} — {f['schema_file']}")
-                    success(f"Pulled {f['environment']} — {f['data_file']}")
+                    if not data_only:
+                        success(f"Pulled {f['environment']} — {f['schema_file']}")
+                    if not schema_only:
+                        success(f"Pulled {f['environment']} — {f['data_file']}")
         elif args.rtc_subcommand == "push":
             result = cls.rtc_push(
                 args.path,
@@ -361,7 +365,12 @@ class RTCCommand(BaseCommand):
                 if not schema_only:
                     write_json_file(data_path, variables)
 
-                _save_rtc_base(env_dir, schema, variables)
+                base_schema, base_variables = _load_rtc_base(env_dir)
+                _save_rtc_base(
+                    env_dir,
+                    schema if not data_only else (base_schema or schema),
+                    variables if not schema_only else (base_variables or variables),
+                )
                 _set_rtc_last_updated(project, client_env, config.get("lastUpdated"))
 
                 results.append(
@@ -577,9 +586,10 @@ class RTCCommand(BaseCommand):
         data_only: bool = False,
     ) -> dict:
         """Execute the actual push to the API and update local state."""
+        last_response = None
         if schema is not None and not data_only:
             try:
-                AgentStudioInterface.put_rtc_schema(
+                last_response = AgentStudioInterface.put_rtc_schema(
                     region=project.region,
                     project_id=project.project_id,
                     client_env=env,
@@ -588,10 +598,9 @@ class RTCCommand(BaseCommand):
             except requests.HTTPError as e:
                 return {"success": False, "error": str(e), "step": "schema"}
 
-        push_response = None
         if variables is not None and not schema_only:
             try:
-                push_response = AgentStudioInterface.patch_rtc_variables(
+                last_response = AgentStudioInterface.patch_rtc_variables(
                     region=project.region,
                     project_id=project.project_id,
                     client_env=env,
@@ -606,12 +615,18 @@ class RTCCommand(BaseCommand):
                     "step": "variables",
                 }
 
-        new_last_updated = push_response.get("lastUpdated") if push_response else None
-        _set_rtc_last_updated(project, env, new_last_updated)
+        if last_response and last_response.get("lastUpdated"):
+            _set_rtc_last_updated(project, env, last_response["lastUpdated"])
 
-        if schema is not None and variables is not None:
-            _save_rtc_base(env_dir, schema, variables)
+        base_schema, base_variables = _load_rtc_base(env_dir)
+        _save_rtc_base(
+            env_dir,
+            schema if schema is not None else (base_schema or {}),
+            variables if variables is not None else (base_variables or {}),
+        )
+        if schema is not None:
             write_json_file(os.path.join(env_dir, "schema.json"), schema)
+        if variables is not None:
             write_json_file(os.path.join(env_dir, "data.json"), variables)
 
         return {

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -8,6 +8,7 @@ import logging
 import os
 import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+from typing import Optional
 
 import questionary
 import requests
@@ -103,9 +104,27 @@ class RTCCommand(BaseCommand):
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching RTC sub-handler."""
         if args.rtc_subcommand == "pull":
-            cls.rtc_pull(args.path, args.env, args.json)
+            result = cls.rtc_pull(args.path, args.env)
+            if args.json:
+                json_print(result)
+            else:
+                if not result["success"]:
+                    error(result["error"])
+                    sys.exit(1)
+                for f in result["files_written"]:
+                    success(f"Pulled {f['environment']} — {f['schema_file']}")
+                    success(f"Pulled {f['environment']} — {f['data_file']}")
         elif args.rtc_subcommand == "push":
-            cls.rtc_push(args.path, args.env, getattr(args, "force", False), args.json)
+            result = cls.rtc_push(args.path, args.env, getattr(args, "force", False), args.json)
+            if result is None:
+                return
+            if args.json:
+                json_print(result)
+            else:
+                if not result["success"]:
+                    error(result["error"])
+                    sys.exit(1)
+                success(f"Pushed RTC to {args.env}")
 
     @classmethod
     def rtc_pull(
@@ -113,19 +132,22 @@ class RTCCommand(BaseCommand):
         base_path: str,
         env: str = "all",
         output_json: bool = False,
-    ) -> None:
+    ) -> dict:
         """Pull RTC from Agent Studio and write to local files.
 
         Args:
             base_path: Base path for the project.
             env: Environment(s) to pull — sandbox, pre-release, live, or all.
-            output_json: If True, emit machine-readable JSON.
+            output_json: If True, format errors as JSON on failure.
+
+        Returns:
+            dict: Result with success status and files_written list.
         """
         project = load_project(base_path, output_json=output_json)
         project_root = project.root_path
 
         if env == "all":
-            envs_to_fetch = ["sandbox", "pre-release", "live"]
+            envs_to_fetch = list(RTC_ENV_TO_DIR.keys())
         else:
             envs_to_fetch = [env]
 
@@ -164,19 +186,10 @@ class RTCCommand(BaseCommand):
                     }
                 )
 
-            if output_json:
-                json_print({"success": True, "files_written": results})
-            else:
-                for result in results:
-                    success(f"Pulled {result['environment']} — {result['schema_file']}")
-                    success(f"Pulled {result['environment']} — {result['data_file']}")
+            return {"success": True, "files_written": results}
 
         except requests.HTTPError as e:
-            if output_json:
-                json_print({"success": False, "error": str(e)})
-                sys.exit(1)
-            else:
-                raise
+            return {"success": False, "error": str(e), "files_written": results}
 
     @classmethod
     def rtc_push(
@@ -185,14 +198,17 @@ class RTCCommand(BaseCommand):
         env: str,
         force: bool = False,
         output_json: bool = False,
-    ) -> None:
+    ) -> Optional[dict]:
         """Push RTC from local files to Agent Studio.
 
         Args:
             base_path: Base path for the project.
             env: Environment to push to — sandbox, pre-release, or live.
             force: If True, skip confirmation for live environment.
-            output_json: If True, emit machine-readable JSON.
+            output_json: If True, format errors as JSON on failure.
+
+        Returns:
+            dict with success status, or None if the user cancelled interactively.
         """
         project = load_project(base_path, output_json=output_json)
         project_root = project.root_path
@@ -204,33 +220,25 @@ class RTCCommand(BaseCommand):
         data_path = os.path.join(env_dir, "data.json")
 
         if not os.path.exists(schema_path):
-            msg = f"schema.json not found at {schema_path}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+            return {"success": False, "error": f"schema.json not found at {schema_path}"}
 
         if not os.path.exists(data_path):
-            msg = f"data.json not found at {data_path}"
-            if output_json:
-                json_print({"success": False, "error": msg})
-            else:
-                error(msg)
-            sys.exit(1)
+            return {"success": False, "error": f"data.json not found at {data_path}"}
 
-        with open(schema_path, "r", encoding="utf-8") as f:
-            schema = json.load(f)
-
-        with open(data_path, "r", encoding="utf-8") as f:
-            variables = json.load(f)
+        try:
+            with open(schema_path, "r", encoding="utf-8") as f:
+                schema = json.load(f)
+            with open(data_path, "r", encoding="utf-8") as f:
+                variables = json.load(f)
+        except json.JSONDecodeError as e:
+            return {"success": False, "error": f"Invalid JSON in local RTC file: {e}"}
 
         if env == "live" and not force:
             if output_json:
-                json_print(
-                    {"success": False, "error": "Refusing to push RTC to live without --force."}
-                )
-                sys.exit(1)
+                return {
+                    "success": False,
+                    "error": "Refusing to push RTC to live without --force.",
+                }
             confirm = questionary.confirm(
                 f"Push RTC to {env}? This will update live configuration.",
                 auto_enter=False,
@@ -238,7 +246,7 @@ class RTCCommand(BaseCommand):
             ).ask()
             if not confirm:
                 info("Push cancelled.")
-                return
+                return None
 
         try:
             AgentStudioInterface.put_rtc_schema(
@@ -248,11 +256,7 @@ class RTCCommand(BaseCommand):
                 schema=schema,
             )
         except requests.HTTPError as e:
-            if output_json:
-                json_print({"success": False, "error": str(e), "step": "schema"})
-                sys.exit(1)
-            else:
-                raise
+            return {"success": False, "error": str(e), "step": "schema"}
 
         try:
             AgentStudioInterface.patch_rtc_variables(
@@ -262,23 +266,17 @@ class RTCCommand(BaseCommand):
                 variables=variables,
             )
         except requests.HTTPError as e:
-            # Schema was already pushed — warn so the user knows the state is partial
-            msg = f"Schema pushed but variables failed: {e}"
-            if output_json:
-                json_print({"success": False, "error": msg, "step": "variables"})
-                sys.exit(1)
-            else:
+            if not output_json:
                 error(f"Warning: schema was pushed to {env}, but variables update failed.")
-                raise
+            return {
+                "success": False,
+                "error": f"Schema pushed but variables failed: {e}",
+                "step": "variables",
+            }
 
-        if output_json:
-            json_print(
-                {
-                    "success": True,
-                    "environment": env,
-                    "schema_file": schema_path,
-                    "data_file": data_path,
-                }
-            )
-        else:
-            success(f"Pushed RTC to {env}")
+        return {
+            "success": True,
+            "environment": env,
+            "schema_file": schema_path,
+            "data_file": data_path,
+        }

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -19,7 +19,7 @@ from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
 from poly.project import AgentStudioProject
 from poly.resources.resource_utils import contains_merge_conflict
-from poly.utils import merge_rtc_dicts, write_json_file
+from poly.utils import diff_dicts, merge_rtc_dicts, write_json_file
 
 
 def _to_sorted_json(data: dict) -> str:
@@ -210,6 +210,11 @@ class RTCCommand(BaseCommand):
             action="store_true",
             help="Disable automatic merge on drift; fail with error instead.",
         )
+        rtc_push_parser.add_argument(
+            "--skip-validation",
+            action="store_true",
+            help="Skip schema validation before pushing.",
+        )
         rtc_push_mode = rtc_push_parser.add_mutually_exclusive_group()
         rtc_push_mode.add_argument(
             "--schema",
@@ -254,6 +259,46 @@ class RTCCommand(BaseCommand):
             help="Skip confirmation prompt for live environment.",
         )
 
+        rtc_diff_parser = rtc_subparsers.add_parser(
+            "diff",
+            parents=[parents.path, parents.json, parents.verbose, parents.debug],
+            help="Show differences between local and remote RTC config.",
+            description=(
+                "Compare local RTC files against the remote Agent Studio config.\n\n"
+                "Examples:\n"
+                "  poly rtc diff --env sandbox\n"
+                "  poly rtc diff --env all\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_diff_parser.add_argument(
+            "--env",
+            type=str,
+            default="all",
+            choices=["sandbox", "pre-release", "live", "all"],
+            help="Environment to diff. Defaults to all.",
+        )
+
+        rtc_validate_parser = rtc_subparsers.add_parser(
+            "validate",
+            parents=[parents.path, parents.json, parents.verbose, parents.debug],
+            help="Validate local RTC data against its schema.",
+            description=(
+                "Validate that local data.json conforms to its schema.json.\n\n"
+                "Examples:\n"
+                "  poly rtc validate --env sandbox\n"
+                "  poly rtc validate --env all\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        rtc_validate_parser.add_argument(
+            "--env",
+            type=str,
+            default="all",
+            choices=["sandbox", "pre-release", "live", "all"],
+            help="Environment to validate. Defaults to all.",
+        )
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching RTC sub-handler."""
@@ -288,6 +333,7 @@ class RTCCommand(BaseCommand):
                 no_merge=getattr(args, "no_merge", False),
                 schema_only=schema_only,
                 data_only=data_only,
+                skip_validation=getattr(args, "skip_validation", False),
             )
             if result is None:
                 return
@@ -305,6 +351,22 @@ class RTCCommand(BaseCommand):
                 edit_schema=getattr(args, "schema", False),
                 force=getattr(args, "force", False),
             )
+        elif args.rtc_subcommand == "diff":
+            result = cls.rtc_diff(args.path, args.env, output_json=args.json)
+            if args.json:
+                json_print(result)
+            else:
+                if not result["success"]:
+                    error(result["error"])
+                    sys.exit(1)
+        elif args.rtc_subcommand == "validate":
+            result = cls.rtc_validate(args.path, args.env, output_json=args.json)
+            if args.json:
+                json_print(result)
+            else:
+                if not result["success"]:
+                    error(result["error"])
+                    sys.exit(1)
 
     @classmethod
     def rtc_pull(
@@ -350,6 +412,7 @@ class RTCCommand(BaseCommand):
         no_merge: bool = False,
         schema_only: bool = False,
         data_only: bool = False,
+        skip_validation: bool = False,
     ) -> Optional[dict]:
         """Push RTC from local files to Agent Studio.
 
@@ -379,6 +442,18 @@ class RTCCommand(BaseCommand):
                     variables = json.load(f)
         except json.JSONDecodeError as e:
             return {"success": False, "error": f"Invalid JSON in local RTC file: {e}"}
+
+        # Schema validation
+        if not skip_validation and schema is not None and variables is not None:
+            validation_errors = AgentStudioProject.validate_rtc_data(schema, variables)
+            if validation_errors:
+                err_lines = "\n  ".join(validation_errors)
+                return {
+                    "success": False,
+                    "error": f"RTC validation failed:\n  {err_lines}\n"
+                    "Use --skip-validation to bypass.",
+                    "validation_errors": validation_errors,
+                }
 
         # Drift protection
         if not force:
@@ -633,3 +708,177 @@ class RTCCommand(BaseCommand):
                 write_json_file(os.path.join(env_dir, "data.json"), edited)
 
         success(f"Edited and pushed RTC {filename} to {env}")
+
+    @classmethod
+    def rtc_diff(
+        cls,
+        base_path: str,
+        env: str = "all",
+        output_json: bool = False,
+    ) -> dict:
+        """Show differences between local and remote RTC config.
+
+        Returns:
+            dict with success status and per-environment diffs.
+        """
+        project = load_project(base_path, output_json=output_json)
+
+        if env == "all":
+            envs_to_diff = list(AgentStudioProject.RTC_ENV_TO_DIR.keys())
+        else:
+            envs_to_diff = [env]
+
+        diffs = []
+        try:
+            for client_env in envs_to_diff:
+                env_dir = project._rtc_env_dir(client_env)
+                schema_path = os.path.join(env_dir, "schema.json")
+                data_path = os.path.join(env_dir, "data.json")
+
+                if not os.path.exists(schema_path) and not os.path.exists(data_path):
+                    if not output_json:
+                        info(f"  {client_env}: no local files — run poly rtc pull first")
+                    diffs.append({"environment": client_env, "status": "no_local_files"})
+                    continue
+
+                remote_config = AgentStudioInterface.get_rtc_config(
+                    region=project.region,
+                    project_id=project.project_id,
+                    client_env=client_env,
+                )
+
+                env_diff = {"environment": client_env, "schema": [], "data": []}
+
+                if os.path.exists(schema_path):
+                    with open(schema_path, "r", encoding="utf-8") as f:
+                        local_schema = json.load(f)
+                    remote_schema = remote_config.get("schema", {})
+                    schema_changes = diff_dicts(local_schema, remote_schema)
+                    env_diff["schema"] = schema_changes
+
+                if os.path.exists(data_path):
+                    with open(data_path, "r", encoding="utf-8") as f:
+                        local_data = json.load(f)
+                    remote_data = remote_config.get("variables", {})
+                    data_changes = diff_dicts(local_data, remote_data)
+                    env_diff["data"] = data_changes
+
+                if not output_json:
+                    _print_env_diff(client_env, env_diff)
+
+                diffs.append(env_diff)
+
+            return {"success": True, "diffs": diffs}
+
+        except requests.HTTPError as e:
+            return {"success": False, "error": str(e)}
+
+    @classmethod
+    def rtc_validate(
+        cls,
+        base_path: str,
+        env: str = "all",
+        output_json: bool = False,
+    ) -> dict:
+        """Validate local RTC data against its schema.
+
+        Returns:
+            dict with success status and per-environment validation results.
+        """
+        project = load_project(base_path, output_json=output_json)
+
+        if env == "all":
+            envs_to_validate = list(AgentStudioProject.RTC_ENV_TO_DIR.keys())
+        else:
+            envs_to_validate = [env]
+
+        results = []
+        all_valid = True
+
+        for client_env in envs_to_validate:
+            env_dir = project._rtc_env_dir(client_env)
+            schema_path = os.path.join(env_dir, "schema.json")
+            data_path = os.path.join(env_dir, "data.json")
+
+            if not os.path.exists(schema_path) or not os.path.exists(data_path):
+                if not output_json:
+                    info(f"  {client_env}: skipped — missing local files")
+                results.append({"environment": client_env, "status": "skipped"})
+                continue
+
+            try:
+                with open(schema_path, "r", encoding="utf-8") as f:
+                    schema = json.load(f)
+                with open(data_path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except json.JSONDecodeError as e:
+                all_valid = False
+                results.append(
+                    {
+                        "environment": client_env,
+                        "valid": False,
+                        "errors": [f"Invalid JSON: {e}"],
+                    }
+                )
+                if not output_json:
+                    error(f"  {client_env}: invalid JSON — {e}")
+                continue
+
+            validation_errors = AgentStudioProject.validate_rtc_data(schema, data)
+            if validation_errors:
+                all_valid = False
+                results.append(
+                    {
+                        "environment": client_env,
+                        "valid": False,
+                        "errors": validation_errors,
+                    }
+                )
+                if not output_json:
+                    error(f"  {client_env}: validation failed")
+                    for err in validation_errors:
+                        error(f"    {err}")
+            else:
+                results.append({"environment": client_env, "valid": True})
+                if not output_json:
+                    success(f"  {client_env}: valid")
+
+        return {"success": all_valid, "results": results}
+
+
+def _print_env_diff(env: str, env_diff: dict) -> None:
+    """Print a human-readable diff for one environment."""
+    schema_changes = env_diff.get("schema", [])
+    data_changes = env_diff.get("data", [])
+
+    if not schema_changes and not data_changes:
+        success(f"  {env}: no changes")
+        return
+
+    info(f"  === {env} ===")
+    if schema_changes:
+        info("  schema.json:")
+        for c in schema_changes:
+            _print_change(c)
+    else:
+        info("  schema.json: (no changes)")
+
+    if data_changes:
+        info("  data.json:")
+        for c in data_changes:
+            _print_change(c)
+    else:
+        info("  data.json: (no changes)")
+
+
+def _print_change(change: dict) -> None:
+    """Print a single field-level change."""
+    path = change["path"]
+    change_type = change["type"]
+
+    if change_type == "added_locally":
+        info(f"    + {path}: {json.dumps(change['local'])}")
+    elif change_type == "only_remote":
+        info(f"    - {path}: {json.dumps(change['remote'])} (only on remote)")
+    elif change_type == "changed":
+        info(f"    ~ {path}: {json.dumps(change['remote'])} → {json.dumps(change['local'])}")

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -80,6 +80,9 @@ def _to_sorted_json(data: dict) -> str:
     return json.dumps(data, indent=2, sort_keys=True) + "\n"
 
 
+_MISSING = object()
+
+
 def _merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
     """3-way merge at the dict key level.
 
@@ -92,19 +95,23 @@ def _merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]
     conflicts = []
 
     for key in sorted(all_keys):
-        base_val = base.get(key)
-        local_val = local.get(key)
-        remote_val = remote.get(key)
+        base_val = base.get(key, _MISSING)
+        local_val = local.get(key, _MISSING)
+        remote_val = remote.get(key, _MISSING)
 
+        resolved = _MISSING
         if local_val == remote_val:
-            merged[key] = local_val
+            resolved = local_val
         elif local_val == base_val:
-            merged[key] = remote_val
+            resolved = remote_val
         elif remote_val == base_val:
-            merged[key] = local_val
+            resolved = local_val
         else:
             conflicts.append(key)
-            merged[key] = local_val
+            resolved = local_val
+
+        if resolved is not _MISSING:
+            merged[key] = resolved
 
     return merged, conflicts
 
@@ -294,6 +301,8 @@ class RTCCommand(BaseCommand):
             result = cls.rtc_pull(args.path, args.env, output_json=args.json)
             if args.json:
                 json_print(result)
+                if not result["success"]:
+                    sys.exit(1)
             else:
                 if not result["success"]:
                     error(result["error"])
@@ -313,6 +322,8 @@ class RTCCommand(BaseCommand):
                 return
             if args.json:
                 json_print(result)
+                if not result["success"]:
+                    sys.exit(1)
             else:
                 if not result["success"]:
                     error(result["error"])

--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -19,58 +19,12 @@ from poly.output.console import edit_in_editor, error, info, success, warning
 from poly.output.json_output import json_print
 from poly.project import AgentStudioProject
 from poly.resources.resource_utils import contains_merge_conflict
-from poly.utils import merge_rtc_dicts, read_json_file, write_json_file
-
-RTC_ENV_TO_DIR = {
-    "sandbox": "draft_and_sandbox",
-    "pre-release": "pre_release",
-    "live": "live",
-}
-RTC_DIR_TO_ENV = {v: k for k, v in RTC_ENV_TO_DIR.items()}
-
-RTC_BASE_SCHEMA_FILE = ".rtc_base_schema.json"
-RTC_BASE_DATA_FILE = ".rtc_base_data.json"
-
-
-def _save_rtc_base(env_dir: str, schema: dict, variables: dict) -> None:
-    """Save base copies of schema and data for 3-way merge on push."""
-    write_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE), schema)
-    write_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE), variables)
-
-
-def _load_rtc_base(env_dir: str) -> tuple[Optional[dict], Optional[dict]]:
-    """Load base copies, returning (schema, variables) or (None, None)."""
-    try:
-        schema = read_json_file(os.path.join(env_dir, RTC_BASE_SCHEMA_FILE))
-        variables = read_json_file(os.path.join(env_dir, RTC_BASE_DATA_FILE))
-    except json.JSONDecodeError:
-        return None, None
-    return schema, variables
+from poly.utils import merge_rtc_dicts, write_json_file
 
 
 def _to_sorted_json(data: dict) -> str:
     """Serialize a dict to deterministically ordered JSON for merging."""
     return json.dumps(data, indent=2, sort_keys=True) + "\n"
-
-
-def _get_rtc_last_updated(project: AgentStudioProject, env: str) -> Optional[str]:
-    """Get the stored lastUpdated for an RTC environment from project config."""
-    if not project.rtc_metadata:
-        return None
-    env_meta = project.rtc_metadata.get(env)
-    if not env_meta:
-        return None
-    return env_meta.get("last_updated")
-
-
-def _set_rtc_last_updated(
-    project: AgentStudioProject, env: str, last_updated: Optional[str]
-) -> None:
-    """Set the lastUpdated for an RTC environment and save project config."""
-    if project.rtc_metadata is None:
-        project.rtc_metadata = {}
-    project.rtc_metadata[env] = {"last_updated": last_updated}
-    project.save_config()
 
 
 def _merge_rtc_file(
@@ -363,65 +317,23 @@ class RTCCommand(BaseCommand):
     ) -> dict:
         """Pull RTC from Agent Studio and write to local files.
 
-        Args:
-            base_path: Base path for the project.
-            env: Environment(s) to pull — sandbox, pre-release, live, or all.
-            output_json: If True, format errors as JSON on failure.
-            schema_only: If True, only pull schema.
-            data_only: If True, only pull data.
-
         Returns:
             dict: Result with success status and files_written list.
         """
         project = load_project(base_path, output_json=output_json)
-        project_root = project.root_path
 
         if env == "all":
-            envs_to_fetch = list(RTC_ENV_TO_DIR.keys())
+            envs_to_fetch = list(AgentStudioProject.RTC_ENV_TO_DIR.keys())
         else:
             envs_to_fetch = [env]
 
-        rtc_root = os.path.join(project_root, "real_time_configuration")
         results = []
-
         try:
             for client_env in envs_to_fetch:
-                config = AgentStudioInterface.get_rtc_config(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=client_env,
+                result = project.rtc_pull_env(
+                    client_env, schema_only=schema_only, data_only=data_only
                 )
-
-                dir_name = RTC_ENV_TO_DIR[client_env]
-                env_dir = os.path.join(rtc_root, dir_name)
-                os.makedirs(env_dir, exist_ok=True)
-
-                schema = config.get("schema", {})
-                variables = config.get("variables", {})
-
-                schema_path = os.path.join(env_dir, "schema.json")
-                data_path = os.path.join(env_dir, "data.json")
-
-                if not data_only:
-                    write_json_file(schema_path, schema)
-                if not schema_only:
-                    write_json_file(data_path, variables)
-
-                base_schema, base_variables = _load_rtc_base(env_dir)
-                _save_rtc_base(
-                    env_dir,
-                    schema if not data_only else (base_schema or schema),
-                    variables if not schema_only else (base_variables or variables),
-                )
-                _set_rtc_last_updated(project, client_env, config.get("lastUpdated"))
-
-                results.append(
-                    {
-                        "environment": client_env,
-                        "schema_file": schema_path,
-                        "data_file": data_path,
-                    }
-                )
+                results.append(result)
 
             return {"success": True, "files_written": results}
 
@@ -441,23 +353,11 @@ class RTCCommand(BaseCommand):
     ) -> Optional[dict]:
         """Push RTC from local files to Agent Studio.
 
-        Args:
-            base_path: Base path for the project.
-            env: Environment to push to — sandbox, pre-release, or live.
-            force: If True, skip drift check and confirmation prompt.
-            output_json: If True, format errors as JSON on failure.
-            no_merge: If True, disable merge on drift; hard-fail instead.
-            schema_only: If True, only push schema.
-            data_only: If True, only push data.
-
         Returns:
             dict with success status, or None if the user cancelled interactively.
         """
         project = load_project(base_path, output_json=output_json)
-        project_root = project.root_path
-
-        dir_name = RTC_ENV_TO_DIR[env]
-        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
+        env_dir = project._rtc_env_dir(env)
 
         schema_path = os.path.join(env_dir, "schema.json")
         data_path = os.path.join(env_dir, "data.json")
@@ -482,7 +382,7 @@ class RTCCommand(BaseCommand):
 
         # Drift protection
         if not force:
-            local_last_updated = _get_rtc_last_updated(project, env)
+            local_last_updated = project.get_rtc_last_updated(env)
             if local_last_updated is None:
                 if not output_json:
                     info(
@@ -500,7 +400,7 @@ class RTCCommand(BaseCommand):
 
                     if remote_last_updated != local_last_updated:
                         merge_result = cls._handle_drift(
-                            env_dir=env_dir,
+                            project=project,
                             remote_config=remote_config,
                             local_schema=schema,
                             local_variables=variables,
@@ -537,14 +437,21 @@ class RTCCommand(BaseCommand):
                 info("Push cancelled.")
                 return None
 
-        return cls._do_push(
-            project, env, env_dir, schema, variables, output_json, schema_only, data_only
+        result = project.rtc_push_to_api(
+            env,
+            schema=schema,
+            variables=variables,
+            schema_only=schema_only,
+            data_only=data_only,
         )
+        if not result["success"] and not output_json and result.get("step") == "variables":
+            error(f"Warning: schema was pushed to {env}, but variables update failed.")
+        return result
 
     @classmethod
     def _handle_drift(
         cls,
-        env_dir: str,
+        project: AgentStudioProject,
         remote_config: dict,
         local_schema: Optional[dict],
         local_variables: Optional[dict],
@@ -567,7 +474,7 @@ class RTCCommand(BaseCommand):
                 "or use --force to override.",
             }
 
-        base_schema, base_variables = _load_rtc_base(env_dir)
+        base_schema, base_variables = project.get_rtc_base(env)
         if base_schema is None or base_variables is None:
             return {
                 "success": False,
@@ -616,73 +523,6 @@ class RTCCommand(BaseCommand):
         return {"success": True, "schema": merged_schema, "variables": merged_variables}
 
     @classmethod
-    def _do_push(
-        cls,
-        project: AgentStudioProject,
-        env: str,
-        env_dir: str,
-        schema: Optional[dict],
-        variables: Optional[dict],
-        output_json: bool,
-        schema_only: bool = False,
-        data_only: bool = False,
-    ) -> dict:
-        """Execute the actual push to the API and update local state."""
-        last_response = None
-        if schema is not None and not data_only:
-            try:
-                last_response = AgentStudioInterface.put_rtc_schema(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=env,
-                    schema=schema,
-                )
-            except requests.HTTPError as e:
-                return {"success": False, "error": str(e), "step": "schema"}
-
-        if variables is not None and not schema_only:
-            try:
-                last_response = AgentStudioInterface.patch_rtc_variables(
-                    region=project.region,
-                    project_id=project.project_id,
-                    client_env=env,
-                    variables=variables,
-                )
-            except requests.HTTPError as e:
-                # Schema was already pushed — update metadata so drift check
-                # doesn't falsely trigger on retry.
-                if last_response and last_response.get("lastUpdated"):
-                    _set_rtc_last_updated(project, env, last_response["lastUpdated"])
-                if not output_json and schema is not None:
-                    error(f"Warning: schema was pushed to {env}, but variables update failed.")
-                return {
-                    "success": False,
-                    "error": f"Schema pushed but variables failed: {e}",
-                    "step": "variables",
-                }
-
-        if last_response and last_response.get("lastUpdated"):
-            _set_rtc_last_updated(project, env, last_response["lastUpdated"])
-
-        base_schema, base_variables = _load_rtc_base(env_dir)
-        _save_rtc_base(
-            env_dir,
-            schema if schema is not None else (base_schema or {}),
-            variables if variables is not None else (base_variables or {}),
-        )
-        if schema is not None:
-            write_json_file(os.path.join(env_dir, "schema.json"), schema)
-        if variables is not None:
-            write_json_file(os.path.join(env_dir, "data.json"), variables)
-
-        return {
-            "success": True,
-            "environment": env,
-            "schema_file": os.path.join(env_dir, "schema.json"),
-            "data_file": os.path.join(env_dir, "data.json"),
-        }
-
-    @classmethod
     def rtc_edit(
         cls,
         base_path: str,
@@ -690,16 +530,8 @@ class RTCCommand(BaseCommand):
         edit_schema: bool = False,
         force: bool = False,
     ) -> None:
-        """Pull latest RTC, open in editor, and push back.
-
-        Args:
-            base_path: Base path for the project.
-            env: Environment to edit.
-            edit_schema: If True, edit schema instead of data.
-            force: If True, skip confirmation for live environment.
-        """
+        """Pull latest RTC, open in editor, and push back."""
         project = load_project(base_path)
-        project_root = project.root_path
 
         try:
             config = AgentStudioInterface.get_rtc_config(
@@ -737,7 +569,7 @@ class RTCCommand(BaseCommand):
             error(f"Invalid JSON: {e}")
             sys.exit(1)
 
-        # Race check: ensure remote hasn't changed while editing
+        # Race check
         try:
             current_config = AgentStudioInterface.get_rtc_config(
                 region=project.region,
@@ -785,19 +617,19 @@ class RTCCommand(BaseCommand):
             sys.exit(1)
 
         if response and response.get("lastUpdated"):
-            _set_rtc_last_updated(project, env, response["lastUpdated"])
+            project.set_rtc_last_updated(env, response["lastUpdated"])
 
-        # Update local files if the env directory exists
-        dir_name = RTC_ENV_TO_DIR[env]
-        env_dir = os.path.join(project_root, "real_time_configuration", dir_name)
+        # Update base and local files
+        if edit_schema:
+            project.set_rtc_base(env, schema=edited)
+        else:
+            project.set_rtc_base(env, variables=edited)
+
+        env_dir = project._rtc_env_dir(env)
         if os.path.isdir(env_dir):
             if edit_schema:
                 write_json_file(os.path.join(env_dir, "schema.json"), edited)
-                base_schema, base_variables = _load_rtc_base(env_dir)
-                _save_rtc_base(env_dir, edited, base_variables or {})
             else:
                 write_json_file(os.path.join(env_dir, "data.json"), edited)
-                base_schema, base_variables = _load_rtc_base(env_dir)
-                _save_rtc_base(env_dir, base_schema or {}, edited)
 
         success(f"Edited and pushed RTC {filename} to {env}")

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -245,15 +245,10 @@ class PushCommand(BaseCommand):
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Execute the push command."""
-        include_rtc = getattr(args, "include_rtc", False)
-        rtc_env = getattr(args, "rtc_env", None)
-
-        if rtc_env is not None and not include_rtc:
+        if args.rtc_env is not None and not args.include_rtc:
             from poly.output.console import warning
 
             warning("--rtc-env has no effect without --include-rtc.")
-
-        rtc_env = rtc_env or "sandbox"
 
         cls.push(
             args.path,
@@ -264,8 +259,8 @@ class PushCommand(BaseCommand):
             args.from_projection,
             output_json=args.json,
             output_commands=args.output_json_commands,
-            include_rtc=include_rtc,
-            rtc_env=rtc_env,
+            include_rtc=args.include_rtc,
+            rtc_env=args.rtc_env or "sandbox",
         )
 
     @classmethod

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -141,7 +141,7 @@ class PullCommand(BaseCommand):
             if include_rtc and not files_with_conflicts:
                 from poly.cli_commands.rtc import RTCCommand
 
-                rtc_result = RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
+                rtc_result = RTCCommand.rtc_pull(base_path, env="all", output_json=True)
                 json_output["rtc"] = rtc_result
                 if not rtc_result["success"]:
                     json_output["success"] = False

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -65,6 +65,12 @@ class PullCommand(BaseCommand):
             help=SUPPRESS,
             default=False,
         )
+        pull_parser.add_argument(
+            "--include-rtc",
+            action="store_true",
+            default=False,
+            help="Also pull Real-Time Configuration for all environments.",
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
@@ -76,6 +82,7 @@ class PullCommand(BaseCommand):
             args.from_projection,
             output_json=args.json,
             output_json_projection=args.output_json_projection,
+            include_rtc=getattr(args, "include_rtc", False),
         )
 
     @classmethod
@@ -87,6 +94,7 @@ class PullCommand(BaseCommand):
         from_projection: str = None,
         output_json: bool = False,
         output_json_projection: bool = False,
+        include_rtc: bool = False,
     ) -> None:
         """Pull the latest project configuration from the Agent Studio."""
         from poly.output.console import console, info, print_file_list, success, warning
@@ -131,6 +139,10 @@ class PullCommand(BaseCommand):
             if output_json_projection:
                 json_output["projection"] = projection
             json_print(json_output)
+            if include_rtc:
+                from poly.cli import AgentStudioCLI
+
+                AgentStudioCLI.rtc_pull(base_path, env="all", output_json=output_json)
             if files_with_conflicts:
                 sys.exit(1)
             return
@@ -143,6 +155,11 @@ class PullCommand(BaseCommand):
             print_file_list("Merge conflicts detected", files_with_conflicts, "filename.conflict")
 
         success(f"Pulled {project.account_id}/{project.project_id}")
+
+        if include_rtc:
+            from poly.cli import AgentStudioCLI
+
+            AgentStudioCLI.rtc_pull(base_path, env="all", output_json=output_json)
 
 
 class PushCommand(BaseCommand):
@@ -201,6 +218,19 @@ class PushCommand(BaseCommand):
             help=SUPPRESS,
             default=False,
         )
+        push_parser.add_argument(
+            "--include-rtc",
+            action="store_true",
+            default=False,
+            help="Also push Real-Time Configuration. Defaults to sandbox; use --rtc-env to override.",
+        )
+        push_parser.add_argument(
+            "--rtc-env",
+            type=str,
+            default="sandbox",
+            choices=["sandbox", "pre-release", "live"],
+            help="RTC environment to push to (only used with --include-rtc). Defaults to sandbox.",
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
@@ -214,6 +244,8 @@ class PushCommand(BaseCommand):
             args.from_projection,
             output_json=args.json,
             output_commands=args.output_json_commands,
+            include_rtc=getattr(args, "include_rtc", False),
+            rtc_env=getattr(args, "rtc_env", "sandbox"),
         )
 
     @classmethod
@@ -227,6 +259,8 @@ class PushCommand(BaseCommand):
         from_projection: str = None,
         output_json: bool = False,
         output_commands: bool = False,
+        include_rtc: bool = False,
+        rtc_env: str = "sandbox",
     ) -> None:
         """Push the project configuration to the Agent Studio."""
         from poly.output.console import error, info, plain, success, warning
@@ -265,6 +299,12 @@ class PushCommand(BaseCommand):
             if output_commands:
                 json_output["commands"] = commands_to_dicts(commands)
             json_print(json_output)
+            if include_rtc and push_ok:
+                from poly.cli import AgentStudioCLI
+
+                AgentStudioCLI.rtc_push(
+                    base_path, env=rtc_env, force=force, output_json=output_json
+                )
             if not push_ok:
                 sys.exit(1)
             return
@@ -276,6 +316,11 @@ class PushCommand(BaseCommand):
         else:
             error(f"Failed to push {project.account_id}/{project.project_id} to Agent Studio.")
             plain(output)
+
+        if include_rtc and push_ok:
+            from poly.cli import AgentStudioCLI
+
+            AgentStudioCLI.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
 
 
 class StatusCommand(BaseCommand):

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -141,7 +141,9 @@ class PullCommand(BaseCommand):
             if include_rtc and not files_with_conflicts:
                 from poly.cli_commands.rtc import RTCCommand
 
-                json_output["rtc"] = RTCCommand.rtc_pull(base_path, env="all")
+                json_output["rtc"] = RTCCommand.rtc_pull(
+                    base_path, env="all", output_json=output_json
+                )
             json_print(json_output)
             if files_with_conflicts:
                 sys.exit(1)

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -338,7 +338,8 @@ class PushCommand(BaseCommand):
 
             rtc_result = RTCCommand.rtc_push(base_path, env=rtc_env, force=force)
             if rtc_result is None:
-                pass
+                error("RTC push cancelled.")
+                sys.exit(1)
             elif rtc_result["success"]:
                 success(f"Pushed RTC to {rtc_env}")
             else:

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -139,7 +139,7 @@ class PullCommand(BaseCommand):
             if output_json_projection:
                 json_output["projection"] = projection
             json_print(json_output)
-            if include_rtc:
+            if include_rtc and not files_with_conflicts:
                 from poly.cli_commands.rtc import RTCCommand
 
                 RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
@@ -156,7 +156,7 @@ class PullCommand(BaseCommand):
 
         success(f"Pulled {project.account_id}/{project.project_id}")
 
-        if include_rtc:
+        if include_rtc and not files_with_conflicts:
             from poly.cli_commands.rtc import RTCCommand
 
             RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -312,7 +312,10 @@ class PushCommand(BaseCommand):
                 from poly.cli_commands.rtc import RTCCommand
 
                 rtc_result = RTCCommand.rtc_push(
-                    base_path, env=rtc_env, force=force, output_json=output_json
+                    base_path,
+                    env=rtc_env,
+                    force=force,
+                    output_json=(output_json or output_commands),
                 )
                 json_output["rtc"] = rtc_result
                 if rtc_result and not rtc_result.get("success"):

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -140,9 +140,9 @@ class PullCommand(BaseCommand):
                 json_output["projection"] = projection
             json_print(json_output)
             if include_rtc:
-                from poly.cli import AgentStudioCLI
+                from poly.cli_commands.rtc import RTCCommand
 
-                AgentStudioCLI.rtc_pull(base_path, env="all", output_json=output_json)
+                RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
             if files_with_conflicts:
                 sys.exit(1)
             return
@@ -157,9 +157,9 @@ class PullCommand(BaseCommand):
         success(f"Pulled {project.account_id}/{project.project_id}")
 
         if include_rtc:
-            from poly.cli import AgentStudioCLI
+            from poly.cli_commands.rtc import RTCCommand
 
-            AgentStudioCLI.rtc_pull(base_path, env="all", output_json=output_json)
+            RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
 
 
 class PushCommand(BaseCommand):
@@ -300,11 +300,9 @@ class PushCommand(BaseCommand):
                 json_output["commands"] = commands_to_dicts(commands)
             json_print(json_output)
             if include_rtc and push_ok:
-                from poly.cli import AgentStudioCLI
+                from poly.cli_commands.rtc import RTCCommand
 
-                AgentStudioCLI.rtc_push(
-                    base_path, env=rtc_env, force=force, output_json=output_json
-                )
+                RTCCommand.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
             if not push_ok:
                 sys.exit(1)
             return
@@ -318,9 +316,9 @@ class PushCommand(BaseCommand):
             plain(output)
 
         if include_rtc and push_ok:
-            from poly.cli import AgentStudioCLI
+            from poly.cli_commands.rtc import RTCCommand
 
-            AgentStudioCLI.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
+            RTCCommand.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
 
 
 class StatusCommand(BaseCommand):

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -138,11 +138,11 @@ class PullCommand(BaseCommand):
                 json_output["new_branch_id"] = project.branch_id
             if output_json_projection:
                 json_output["projection"] = projection
-            json_print(json_output)
             if include_rtc and not files_with_conflicts:
                 from poly.cli_commands.rtc import RTCCommand
 
-                RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
+                json_output["rtc"] = RTCCommand.rtc_pull(base_path, env="all")
+            json_print(json_output)
             if files_with_conflicts:
                 sys.exit(1)
             return
@@ -159,7 +159,13 @@ class PullCommand(BaseCommand):
         if include_rtc and not files_with_conflicts:
             from poly.cli_commands.rtc import RTCCommand
 
-            RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
+            rtc_result = RTCCommand.rtc_pull(base_path, env="all")
+            if rtc_result["success"]:
+                for f in rtc_result["files_written"]:
+                    success(f"Pulled RTC {f['environment']} — {f['schema_file']}")
+                    success(f"Pulled RTC {f['environment']} — {f['data_file']}")
+            else:
+                error(f"RTC pull failed: {rtc_result['error']}")
 
 
 class PushCommand(BaseCommand):
@@ -298,11 +304,13 @@ class PushCommand(BaseCommand):
                 json_output["new_branch_id"] = project.branch_id
             if output_commands:
                 json_output["commands"] = commands_to_dicts(commands)
-            json_print(json_output)
             if include_rtc and push_ok:
                 from poly.cli_commands.rtc import RTCCommand
 
-                RTCCommand.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
+                json_output["rtc"] = RTCCommand.rtc_push(
+                    base_path, env=rtc_env, force=force, output_json=output_json
+                )
+            json_print(json_output)
             if not push_ok:
                 sys.exit(1)
             return
@@ -318,7 +326,13 @@ class PushCommand(BaseCommand):
         if include_rtc and push_ok:
             from poly.cli_commands.rtc import RTCCommand
 
-            RTCCommand.rtc_push(base_path, env=rtc_env, force=force, output_json=output_json)
+            rtc_result = RTCCommand.rtc_push(base_path, env=rtc_env, force=force)
+            if rtc_result is None:
+                pass
+            elif rtc_result["success"]:
+                success(f"Pushed RTC to {rtc_env}")
+            else:
+                error(f"RTC push failed: {rtc_result['error']}")
 
 
 class StatusCommand(BaseCommand):

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -317,9 +317,13 @@ class PushCommand(BaseCommand):
                     force=force,
                     output_json=(output_json or output_commands),
                 )
-                json_output["rtc"] = rtc_result
-                if rtc_result and not rtc_result.get("success"):
+                if rtc_result is None:
+                    json_output["rtc"] = {"success": False, "error": "RTC push cancelled."}
                     json_output["success"] = False
+                else:
+                    json_output["rtc"] = rtc_result
+                    if not rtc_result.get("success"):
+                        json_output["success"] = False
             json_print(json_output)
             if not json_output["success"]:
                 sys.exit(1)

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -97,7 +97,7 @@ class PullCommand(BaseCommand):
         include_rtc: bool = False,
     ) -> None:
         """Pull the latest project configuration from the Agent Studio."""
-        from poly.output.console import console, info, print_file_list, success, warning
+        from poly.output.console import console, error, info, print_file_list, success, warning
 
         project = load_project(base_path, output_json=output_json)
         if not output_json:

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -308,7 +308,7 @@ class PushCommand(BaseCommand):
                 json_output["new_branch_id"] = project.branch_id
             if output_commands:
                 json_output["commands"] = commands_to_dicts(commands)
-            if include_rtc and push_ok:
+            if include_rtc and push_ok and not dry_run:
                 from poly.cli_commands.rtc import RTCCommand
 
                 rtc_result = RTCCommand.rtc_push(
@@ -333,7 +333,7 @@ class PushCommand(BaseCommand):
             error(f"Failed to push {project.account_id}/{project.project_id} to Agent Studio.")
             plain(output)
 
-        if include_rtc and push_ok:
+        if include_rtc and push_ok and not dry_run:
             from poly.cli_commands.rtc import RTCCommand
 
             rtc_result = RTCCommand.rtc_push(base_path, env=rtc_env, force=force)

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -237,14 +237,24 @@ class PushCommand(BaseCommand):
         push_parser.add_argument(
             "--rtc-env",
             type=str,
-            default="sandbox",
+            default=None,
             choices=["sandbox", "pre-release", "live"],
-            help="RTC environment to push to (only used with --include-rtc). Defaults to sandbox.",
+            help="RTC environment to push to. Requires --include-rtc. Defaults to sandbox.",
         )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Execute the push command."""
+        include_rtc = getattr(args, "include_rtc", False)
+        rtc_env = getattr(args, "rtc_env", None)
+
+        if rtc_env is not None and not include_rtc:
+            from poly.output.console import warning
+
+            warning("--rtc-env has no effect without --include-rtc.")
+
+        rtc_env = rtc_env or "sandbox"
+
         cls.push(
             args.path,
             args.force,
@@ -254,8 +264,8 @@ class PushCommand(BaseCommand):
             args.from_projection,
             output_json=args.json,
             output_commands=args.output_json_commands,
-            include_rtc=getattr(args, "include_rtc", False),
-            rtc_env=getattr(args, "rtc_env", "sandbox"),
+            include_rtc=include_rtc,
+            rtc_env=rtc_env,
         )
 
     @classmethod

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -141,11 +141,12 @@ class PullCommand(BaseCommand):
             if include_rtc and not files_with_conflicts:
                 from poly.cli_commands.rtc import RTCCommand
 
-                json_output["rtc"] = RTCCommand.rtc_pull(
-                    base_path, env="all", output_json=output_json
-                )
+                rtc_result = RTCCommand.rtc_pull(base_path, env="all", output_json=output_json)
+                json_output["rtc"] = rtc_result
+                if not rtc_result["success"]:
+                    json_output["success"] = False
             json_print(json_output)
-            if files_with_conflicts:
+            if files_with_conflicts or not json_output["success"]:
                 sys.exit(1)
             return
 
@@ -168,6 +169,7 @@ class PullCommand(BaseCommand):
                     success(f"Pulled RTC {f['environment']} — {f['data_file']}")
             else:
                 error(f"RTC pull failed: {rtc_result['error']}")
+                sys.exit(1)
 
 
 class PushCommand(BaseCommand):
@@ -309,11 +311,14 @@ class PushCommand(BaseCommand):
             if include_rtc and push_ok:
                 from poly.cli_commands.rtc import RTCCommand
 
-                json_output["rtc"] = RTCCommand.rtc_push(
+                rtc_result = RTCCommand.rtc_push(
                     base_path, env=rtc_env, force=force, output_json=output_json
                 )
+                json_output["rtc"] = rtc_result
+                if rtc_result and not rtc_result.get("success"):
+                    json_output["success"] = False
             json_print(json_output)
-            if not push_ok:
+            if not json_output["success"]:
                 sys.exit(1)
             return
 
@@ -335,6 +340,7 @@ class PushCommand(BaseCommand):
                 success(f"Pushed RTC to {rtc_env}")
             else:
                 error(f"RTC push failed: {rtc_result['error']}")
+                sys.exit(1)
 
 
 class StatusCommand(BaseCommand):

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1097,3 +1097,77 @@ class AgentStudioInterface:
             dict: The created test run response.
         """
         return PlatformAPIHandler.trigger_test_run(region, project_id, test_case_ids, branch_id)
+
+    @staticmethod
+    def list_rtc_configs(
+        region: str,
+        project_id: str,
+    ) -> dict:
+        """List all RTC config pages for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+
+        Returns:
+            dict: The API response with all RTC configs.
+        """
+        return PlatformAPIHandler.list_rtc_configs(region, project_id)
+
+    @staticmethod
+    def get_rtc_config(
+        region: str,
+        project_id: str,
+        client_env: str,
+    ) -> dict:
+        """Get RTC config for a specific environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+
+        Returns:
+            dict: The RTC config with schema, variables, clientEnv, lastUpdated.
+        """
+        return PlatformAPIHandler.get_rtc_config(region, project_id, client_env)
+
+    @staticmethod
+    def put_rtc_schema(
+        region: str,
+        project_id: str,
+        client_env: str,
+        schema: dict,
+    ) -> dict:
+        """Update the RTC schema for an environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+            schema: The JSON Schema Draft 7 object.
+
+        Returns:
+            dict: The updated RTC config.
+        """
+        return PlatformAPIHandler.put_rtc_schema(region, project_id, client_env, schema)
+
+    @staticmethod
+    def patch_rtc_variables(
+        region: str,
+        project_id: str,
+        client_env: str,
+        variables: dict,
+    ) -> dict:
+        """Update the RTC variables (data) for an environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+            variables: The config variables object.
+
+        Returns:
+            dict: The updated RTC config.
+        """
+        return PlatformAPIHandler.patch_rtc_variables(region, project_id, client_env, variables)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -42,6 +42,10 @@ TEST_RUNS_URL = "/v1/agents/{project_id}/testing/test-runs"
 TEST_RUN_URL = "/v1/agents/{project_id}/testing/test-runs/{test_run_id}"
 TEST_HISTORY_URL = "/v1/agents/{project_id}/testing/test-history"
 TRIGGER_TEST_RUN_URL = "/v1/agents/{project_id}/testing/test-runs/trigger"
+RTC_CONFIGS_URL = "/v1/agents/{project_id}/real-time-configs"
+RTC_CONFIG_URL = "/v1/agents/{project_id}/real-time-configs/{client_env}"
+RTC_SCHEMA_URL = "/v1/agents/{project_id}/real-time-configs/{client_env}/schema"
+RTC_VARIABLES_URL = "/v1/agents/{project_id}/real-time-configs/{client_env}/variables"
 
 
 class PlatformAPIHandler:
@@ -1044,3 +1048,83 @@ class PlatformAPIHandler:
             "branchId": branch_id,
         }
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def list_rtc_configs(
+        region: str,
+        project_id: str,
+    ) -> dict:
+        """List all RTC config pages for a project.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+
+        Returns:
+            dict: The API response with all RTC configs.
+        """
+        endpoint = RTC_CONFIGS_URL.format(project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
+
+    @staticmethod
+    def get_rtc_config(
+        region: str,
+        project_id: str,
+        client_env: str,
+    ) -> dict:
+        """Get RTC config for a specific environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+
+        Returns:
+            dict: The RTC config with schema, variables, clientEnv, lastUpdated.
+        """
+        endpoint = RTC_CONFIG_URL.format(project_id=project_id, client_env=client_env)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
+
+    @staticmethod
+    def put_rtc_schema(
+        region: str,
+        project_id: str,
+        client_env: str,
+        schema: dict,
+    ) -> dict:
+        """Update the RTC schema for an environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+            schema: The JSON Schema Draft 7 object.
+
+        Returns:
+            dict: The updated RTC config.
+        """
+        endpoint = RTC_SCHEMA_URL.format(project_id=project_id, client_env=client_env)
+        data = {"schema": schema}
+        return PlatformAPIHandler.make_request(region, endpoint, "PUT", data=data)
+
+    @staticmethod
+    def patch_rtc_variables(
+        region: str,
+        project_id: str,
+        client_env: str,
+        variables: dict,
+    ) -> dict:
+        """Update the RTC variables (data) for an environment.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            client_env: The environment (sandbox, pre-release, live).
+            variables: The config variables object.
+
+        Returns:
+            dict: The updated RTC config.
+        """
+        endpoint = RTC_VARIABLES_URL.format(project_id=project_id, client_env=client_env)
+        data = {"variables": variables}
+        return PlatformAPIHandler.make_request(region, endpoint, "PATCH", data=data)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3113,6 +3113,11 @@ class AgentStudioProject:
             return []
 
         try:
+            jsonschema.Draft7Validator.check_schema(schema)
+        except (jsonschema.SchemaError, jsonschema.exceptions.UnknownType) as e:
+            return [f"Invalid schema: {e}"]
+
+        try:
             validator = jsonschema.Draft7Validator(schema)
             errors = sorted(
                 validator.iter_errors(data),

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3017,12 +3017,7 @@ class AgentStudioProject:
         if not schema_only:
             utils.write_json_file(data_path, variables)
 
-        base_schema, base_data = self.get_rtc_base(env)
-        self.set_rtc_base(
-            env,
-            schema=schema if not data_only else base_schema,
-            variables=variables if not schema_only else base_data,
-        )
+        self.set_rtc_base(env, schema=schema, variables=variables)
         self.set_rtc_last_updated(env, config.get("lastUpdated"))
 
         return {

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3114,6 +3114,9 @@ class AgentStudioProject:
         """
         import jsonschema
 
+        if not schema:
+            return []
+
         try:
             validator = jsonschema.Draft7Validator(schema)
             errors = sorted(

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -102,6 +102,7 @@ class AgentStudioProject:
     _api_handler: AgentStudioInterface = None
     file_structure_info: dict[str, dict[str, str]] = None
     _migration_flags: set[MigrationFlag] = None
+    rtc_metadata: Optional[dict[str, dict]] = None
 
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
@@ -218,6 +219,7 @@ class AgentStudioProject:
             account_name=config_dict.get("account_name") or status_dict.get("account_name"),
             _not_loaded_resources=not_loaded_resources,
             _migration_flags=migration_flags,
+            rtc_metadata=status_dict.get("rtc_metadata"),
         )
 
     def to_dict(self) -> dict:
@@ -240,6 +242,7 @@ class AgentStudioProject:
             "migration_flags": [flag.value for flag in self._migration_flags]
             if self._migration_flags
             else [],
+            "rtc_metadata": self.rtc_metadata or {},
         }
 
     @classmethod
@@ -265,6 +268,7 @@ class AgentStudioProject:
             account_name=data.get("account_name"),
             _migration_flags=migration_flags,
             _not_loaded_resources=not_loaded_resources,
+            rtc_metadata=data.get("rtc_metadata"),
         )
 
     @staticmethod

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3104,3 +3104,22 @@ class AgentStudioProject:
             "schema_file": os.path.join(env_dir, "schema.json"),
             "data_file": os.path.join(env_dir, "data.json"),
         }
+
+    @staticmethod
+    def validate_rtc_data(schema: dict, data: dict) -> list[str]:
+        """Validate RTC data against its schema using JSON Schema Draft 7.
+
+        Returns:
+            List of validation error messages, empty if valid.
+        """
+        import jsonschema
+
+        try:
+            validator = jsonschema.Draft7Validator(schema)
+            errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+            return [
+                f"{'.'.join(str(p) for p in e.absolute_path) or '(root)'}: {e.message}"
+                for e in errors
+            ]
+        except (jsonschema.SchemaError, jsonschema.exceptions.UnknownType) as e:
+            return [f"Invalid schema: {e}"]

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2936,12 +2936,7 @@ class AgentStudioProject:
 
     def set_rtc_last_updated(self, env: str, last_updated: Optional[str]) -> None:
         """Set the lastUpdated for an RTC environment and save."""
-        if self.rtc_metadata is None:
-            self.rtc_metadata = {}
-        if env not in self.rtc_metadata:
-            self.rtc_metadata[env] = {}
-        self.rtc_metadata[env]["last_updated"] = last_updated
-        self.save_config()
+        self._update_rtc_metadata(env, last_updated=last_updated)
 
     def get_rtc_base(self, env: str) -> tuple[Optional[dict], Optional[dict]]:
         """Get the base copies of schema and data for an environment.
@@ -2966,10 +2961,22 @@ class AgentStudioProject:
 
         Only updates the fields that are provided (not None).
         """
+        self._update_rtc_metadata(env, schema=schema, variables=variables)
+
+    def _update_rtc_metadata(
+        self,
+        env: str,
+        last_updated: Optional[str] = None,
+        schema: Optional[dict] = None,
+        variables: Optional[dict] = None,
+    ) -> None:
+        """Update RTC metadata for an environment in a single write."""
         if self.rtc_metadata is None:
             self.rtc_metadata = {}
         if env not in self.rtc_metadata:
             self.rtc_metadata[env] = {}
+        if last_updated is not None:
+            self.rtc_metadata[env]["last_updated"] = last_updated
         if schema is not None:
             self.rtc_metadata[env]["base_schema"] = schema
         if variables is not None:
@@ -3109,8 +3116,12 @@ class AgentStudioProject:
         if not schema_only:
             utils.write_json_file(data_path, variables)
 
-        self.set_rtc_base(env, schema=schema, variables=variables)
-        self.set_rtc_last_updated(env, config.get("lastUpdated"))
+        self._update_rtc_metadata(
+            env,
+            last_updated=config.get("lastUpdated"),
+            schema=schema,
+            variables=variables,
+        )
 
         result = {"environment": env}
         if not data_only:
@@ -3170,12 +3181,10 @@ class AgentStudioProject:
                     "step": "variables",
                 }
 
-        if last_response and last_response.get("lastUpdated"):
-            self.set_rtc_last_updated(env, last_response["lastUpdated"])
-
         base_schema, base_data = self.get_rtc_base(env)
-        self.set_rtc_base(
+        self._update_rtc_metadata(
             env,
+            last_updated=last_response.get("lastUpdated") if last_response else None,
             schema=schema if schema is not None else base_schema,
             variables=variables if variables is not None else base_data,
         )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2981,6 +2981,102 @@ class AgentStudioProject:
         dir_name = self.RTC_ENV_TO_DIR[env]
         return os.path.join(self.root_path, "real_time_configuration", dir_name)
 
+    def rtc_fetch_config(self, env: str) -> dict:
+        """Fetch RTC config for an environment from the API.
+
+        Args:
+            env: The environment (sandbox, pre-release, live).
+
+        Returns:
+            dict: The RTC config with schema, variables, clientEnv, lastUpdated.
+        """
+        return AgentStudioInterface.get_rtc_config(
+            region=self.region,
+            project_id=self.project_id,
+            client_env=env,
+        )
+
+    def rtc_load_local(
+        self,
+        env: str,
+        schema_only: bool = False,
+        data_only: bool = False,
+    ) -> dict:
+        """Load local RTC files for an environment.
+
+        Args:
+            env: The environment to load.
+            schema_only: If True, only load schema.
+            data_only: If True, only load data.
+
+        Returns:
+            dict with 'schema' and 'variables' keys (None if not loaded).
+
+        Raises:
+            FileNotFoundError: If required files are missing.
+            ValueError: If JSON is invalid.
+        """
+        env_dir = self._rtc_env_dir(env)
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        schema = None
+        variables = None
+
+        if not data_only:
+            if not os.path.exists(schema_path):
+                raise FileNotFoundError(f"schema.json not found at {schema_path}")
+            try:
+                with open(schema_path, "r", encoding="utf-8") as f:
+                    schema = json.load(f)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in {schema_path}: {e}") from e
+
+        if not schema_only:
+            if not os.path.exists(data_path):
+                raise FileNotFoundError(f"data.json not found at {data_path}")
+            try:
+                with open(data_path, "r", encoding="utf-8") as f:
+                    variables = json.load(f)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Invalid JSON in {data_path}: {e}") from e
+
+        return {"schema": schema, "variables": variables}
+
+    def check_rtc_drift(self, env: str) -> dict:
+        """Check for drift between local and remote RTC config.
+
+        Args:
+            env: The environment to check.
+
+        Returns:
+            dict with:
+                - status: "no_metadata" | "in_sync" | "drifted"
+                - remote_config: dict (only when drifted)
+                - local_last_updated: str (when metadata exists)
+                - remote_last_updated: str (when metadata exists)
+        """
+        local_last_updated = self.get_rtc_last_updated(env)
+        if local_last_updated is None:
+            return {"status": "no_metadata"}
+
+        remote_config = self.rtc_fetch_config(env)
+        remote_last_updated = remote_config.get("lastUpdated")
+
+        if remote_last_updated == local_last_updated:
+            return {
+                "status": "in_sync",
+                "local_last_updated": local_last_updated,
+                "remote_last_updated": remote_last_updated,
+            }
+
+        return {
+            "status": "drifted",
+            "remote_config": remote_config,
+            "local_last_updated": local_last_updated,
+            "remote_last_updated": remote_last_updated,
+        }
+
     def rtc_pull_env(
         self,
         env: str,
@@ -2997,11 +3093,7 @@ class AgentStudioProject:
         Returns:
             dict with environment, schema_file, data_file paths.
         """
-        config = AgentStudioInterface.get_rtc_config(
-            region=self.region,
-            project_id=self.project_id,
-            client_env=env,
-        )
+        config = self.rtc_fetch_config(env)
 
         env_dir = self._rtc_env_dir(env)
         os.makedirs(env_dir, exist_ok=True)
@@ -3020,11 +3112,12 @@ class AgentStudioProject:
         self.set_rtc_base(env, schema=schema, variables=variables)
         self.set_rtc_last_updated(env, config.get("lastUpdated"))
 
-        return {
-            "environment": env,
-            "schema_file": schema_path,
-            "data_file": data_path,
-        }
+        result = {"environment": env}
+        if not data_only:
+            result["schema_file"] = schema_path
+        if not schema_only:
+            result["data_file"] = data_path
+        return result
 
     def rtc_push_to_api(
         self,
@@ -3088,6 +3181,7 @@ class AgentStudioProject:
         )
 
         env_dir = self._rtc_env_dir(env)
+        os.makedirs(env_dir, exist_ok=True)
         if schema is not None:
             utils.write_json_file(os.path.join(env_dir, "schema.json"), schema)
         if variables is not None:
@@ -3099,6 +3193,68 @@ class AgentStudioProject:
             "schema_file": os.path.join(env_dir, "schema.json"),
             "data_file": os.path.join(env_dir, "data.json"),
         }
+
+    def rtc_diff_env(self, env: str) -> dict:
+        """Compare local RTC files against remote for one environment.
+
+        Args:
+            env: The environment to diff.
+
+        Returns:
+            dict with environment, schema changes, data changes.
+        """
+        env_dir = self._rtc_env_dir(env)
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        if not os.path.exists(schema_path) and not os.path.exists(data_path):
+            return {"environment": env, "status": "no_local_files"}
+
+        remote_config = self.rtc_fetch_config(env)
+        env_diff: dict = {"environment": env, "schema": [], "data": []}
+
+        if os.path.exists(schema_path):
+            with open(schema_path, "r", encoding="utf-8") as f:
+                local_schema = json.load(f)
+            remote_schema = remote_config.get("schema", {})
+            env_diff["schema"] = utils.diff_dicts(local_schema, remote_schema)
+
+        if os.path.exists(data_path):
+            with open(data_path, "r", encoding="utf-8") as f:
+                local_data = json.load(f)
+            remote_data = remote_config.get("variables", {})
+            env_diff["data"] = utils.diff_dicts(local_data, remote_data)
+
+        return env_diff
+
+    def rtc_validate_env(self, env: str) -> dict:
+        """Validate local RTC data against its schema for one environment.
+
+        Args:
+            env: The environment to validate.
+
+        Returns:
+            dict with environment, valid status, and any errors.
+        """
+        env_dir = self._rtc_env_dir(env)
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        if not os.path.exists(schema_path) or not os.path.exists(data_path):
+            return {"environment": env, "status": "skipped"}
+
+        try:
+            with open(schema_path, "r", encoding="utf-8") as f:
+                schema = json.load(f)
+            with open(data_path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except json.JSONDecodeError as e:
+            return {"environment": env, "valid": False, "errors": [f"Invalid JSON: {e}"]}
+
+        validation_errors = self.validate_rtc_data(schema, data)
+        if validation_errors:
+            return {"environment": env, "valid": False, "errors": validation_errors}
+        return {"environment": env, "valid": True}
 
     @staticmethod
     def validate_rtc_data(schema: dict, data: dict) -> list[str]:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3116,7 +3116,10 @@ class AgentStudioProject:
 
         try:
             validator = jsonschema.Draft7Validator(schema)
-            errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+            errors = sorted(
+                validator.iter_errors(data),
+                key=lambda e: [str(p) for p in e.absolute_path],
+            )
             return [
                 f"{'.'.join(str(p) for p in e.absolute_path) or '(root)'}: {e.message}"
                 for e in errors

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2916,3 +2916,191 @@ class AgentStudioProject:
             ab_test_id=ab_test_id,
             traffic_percentage=traffic_percentage,
         )
+
+    # ── RTC (Real-Time Configuration) ──
+
+    RTC_ENV_TO_DIR = {
+        "sandbox": "draft_and_sandbox",
+        "pre-release": "pre_release",
+        "live": "live",
+    }
+
+    def get_rtc_last_updated(self, env: str) -> Optional[str]:
+        """Get the stored lastUpdated for an RTC environment."""
+        if not self.rtc_metadata:
+            return None
+        env_meta = self.rtc_metadata.get(env)
+        if not env_meta:
+            return None
+        return env_meta.get("last_updated")
+
+    def set_rtc_last_updated(self, env: str, last_updated: Optional[str]) -> None:
+        """Set the lastUpdated for an RTC environment and save."""
+        if self.rtc_metadata is None:
+            self.rtc_metadata = {}
+        if env not in self.rtc_metadata:
+            self.rtc_metadata[env] = {}
+        self.rtc_metadata[env]["last_updated"] = last_updated
+        self.save_config()
+
+    def get_rtc_base(self, env: str) -> tuple[Optional[dict], Optional[dict]]:
+        """Get the base copies of schema and data for an environment.
+
+        Returns:
+            (base_schema, base_data) or (None, None) if not stored.
+        """
+        if not self.rtc_metadata:
+            return None, None
+        env_meta = self.rtc_metadata.get(env)
+        if not env_meta:
+            return None, None
+        return env_meta.get("base_schema"), env_meta.get("base_data")
+
+    def set_rtc_base(
+        self,
+        env: str,
+        schema: Optional[dict] = None,
+        variables: Optional[dict] = None,
+    ) -> None:
+        """Set the base copies for an RTC environment.
+
+        Only updates the fields that are provided (not None).
+        """
+        if self.rtc_metadata is None:
+            self.rtc_metadata = {}
+        if env not in self.rtc_metadata:
+            self.rtc_metadata[env] = {}
+        if schema is not None:
+            self.rtc_metadata[env]["base_schema"] = schema
+        if variables is not None:
+            self.rtc_metadata[env]["base_data"] = variables
+        self.save_config()
+
+    def _rtc_env_dir(self, env: str) -> str:
+        """Get the local directory path for an RTC environment."""
+        dir_name = self.RTC_ENV_TO_DIR[env]
+        return os.path.join(self.root_path, "real_time_configuration", dir_name)
+
+    def rtc_pull_env(
+        self,
+        env: str,
+        schema_only: bool = False,
+        data_only: bool = False,
+    ) -> dict:
+        """Pull RTC config for a single environment from the API and write to disk.
+
+        Args:
+            env: The environment to pull (sandbox, pre-release, live).
+            schema_only: If True, only pull schema.
+            data_only: If True, only pull data.
+
+        Returns:
+            dict with environment, schema_file, data_file paths.
+        """
+        config = AgentStudioInterface.get_rtc_config(
+            region=self.region,
+            project_id=self.project_id,
+            client_env=env,
+        )
+
+        env_dir = self._rtc_env_dir(env)
+        os.makedirs(env_dir, exist_ok=True)
+
+        schema = config.get("schema", {})
+        variables = config.get("variables", {})
+
+        schema_path = os.path.join(env_dir, "schema.json")
+        data_path = os.path.join(env_dir, "data.json")
+
+        if not data_only:
+            utils.write_json_file(schema_path, schema)
+        if not schema_only:
+            utils.write_json_file(data_path, variables)
+
+        base_schema, base_data = self.get_rtc_base(env)
+        self.set_rtc_base(
+            env,
+            schema=schema if not data_only else base_schema,
+            variables=variables if not schema_only else base_data,
+        )
+        self.set_rtc_last_updated(env, config.get("lastUpdated"))
+
+        return {
+            "environment": env,
+            "schema_file": schema_path,
+            "data_file": data_path,
+        }
+
+    def rtc_push_to_api(
+        self,
+        env: str,
+        schema: Optional[dict] = None,
+        variables: Optional[dict] = None,
+        schema_only: bool = False,
+        data_only: bool = False,
+    ) -> dict:
+        """Push RTC config to the API and update local state.
+
+        Args:
+            env: The environment to push to.
+            schema: Schema dict to push (None to skip).
+            variables: Variables dict to push (None to skip).
+            schema_only: If True, only push schema.
+            data_only: If True, only push data.
+
+        Returns:
+            dict with success status.
+        """
+        import requests
+
+        last_response = None
+        if schema is not None and not data_only:
+            try:
+                last_response = AgentStudioInterface.put_rtc_schema(
+                    region=self.region,
+                    project_id=self.project_id,
+                    client_env=env,
+                    schema=schema,
+                )
+            except requests.HTTPError as e:
+                return {"success": False, "error": str(e), "step": "schema"}
+
+        if variables is not None and not schema_only:
+            try:
+                last_response = AgentStudioInterface.patch_rtc_variables(
+                    region=self.region,
+                    project_id=self.project_id,
+                    client_env=env,
+                    variables=variables,
+                )
+            except requests.HTTPError as e:
+                if last_response and last_response.get("lastUpdated"):
+                    self.set_rtc_last_updated(env, last_response["lastUpdated"])
+                return {
+                    "success": False,
+                    "error": f"Schema pushed but variables failed: {e}",
+                    "step": "variables",
+                }
+
+        if last_response and last_response.get("lastUpdated"):
+            self.set_rtc_last_updated(env, last_response["lastUpdated"])
+
+        base_schema, base_data = self.get_rtc_base(env)
+        self.set_rtc_base(
+            env,
+            schema=schema if schema is not None else base_schema,
+            variables=variables if variables is not None else base_data,
+        )
+
+        env_dir = self._rtc_env_dir(env)
+        if schema is not None:
+            utils.write_json_file(os.path.join(env_dir, "schema.json"), schema)
+        if variables is not None:
+            utils.write_json_file(os.path.join(env_dir, "data.json"), variables)
+
+        return {
+            "success": True,
+            "environment": env,
+            "schema_file": os.path.join(env_dir, "schema.json"),
+            "data_file": os.path.join(env_dir, "data.json"),
+        }

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -3,7 +3,6 @@
 Copyright PolyAI Limited
 """
 
-import json
 import os
 import tempfile
 import unittest
@@ -31,7 +30,7 @@ class TestRTC(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_env_mapping_roundtrip(self):
-        """Verify AgentStudioProject.RTC_ENV_TO_DIR and {v: k for k, v in AgentStudioProject.RTC_ENV_TO_DIR.items()} are consistent."""
+        """Verify AgentStudioProject.RTC_ENV_TO_DIR and reverse are consistent."""
         for env, dir_name in AgentStudioProject.RTC_ENV_TO_DIR.items():
             self.assertEqual(
                 {v: k for k, v in AgentStudioProject.RTC_ENV_TO_DIR.items()}[dir_name], env
@@ -125,27 +124,17 @@ class TestRTC(unittest.TestCase):
 
     @patch("poly.cli_commands.rtc.load_project")
     def test_rtc_push_schema_and_variables(self, mock_load_project):
-        """Verify rtc push reads files and calls rtc_push_to_api."""
+        """Verify rtc push loads local files and calls rtc_push_to_api."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.get_rtc_last_updated.return_value = None
-        mock_load_project.return_value = mock_project
-
-        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
-        os.makedirs(sandbox_dir)
-        mock_project._rtc_env_dir.return_value = sandbox_dir
-
         schema_obj = {"type": "object"}
         variables_obj = {"mock_api": False}
-
-        with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
-            json.dump(schema_obj, f)
-        with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
-            json.dump(variables_obj, f)
-
+        mock_project.rtc_load_local.return_value = {
+            "schema": schema_obj,
+            "variables": variables_obj,
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
 
@@ -158,14 +147,10 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_missing_schema_returns_error(self, mock_load_project):
         """Verify rtc push returns error if schema.json is missing."""
         mock_project = MagicMock()
-        mock_project.root_path = self.temp_dir
-        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
-        os.makedirs(sandbox_dir)
-        mock_project._rtc_env_dir.return_value = sandbox_dir
+        mock_project.rtc_load_local.side_effect = FileNotFoundError(
+            "schema.json not found at /path/schema.json"
+        )
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
-            json.dump({}, f)
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
         self.assertFalse(result["success"])
@@ -175,14 +160,10 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_missing_data_returns_error(self, mock_load_project):
         """Verify rtc push returns error if data.json is missing."""
         mock_project = MagicMock()
-        mock_project.root_path = self.temp_dir
-        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
-        os.makedirs(sandbox_dir)
-        mock_project._rtc_env_dir.return_value = sandbox_dir
+        mock_project.rtc_load_local.side_effect = FileNotFoundError(
+            "data.json not found at /path/data.json"
+        )
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
-            json.dump({}, f)
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
         self.assertFalse(result["success"])
@@ -192,17 +173,9 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_live_without_force_json_returns_error(self, mock_load_project):
         """Verify pushing to live in JSON mode without --force returns error."""
         mock_project = MagicMock()
-        mock_project.root_path = self.temp_dir
-        mock_project.get_rtc_last_updated.return_value = None
-        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
-        os.makedirs(live_dir)
-        mock_project._rtc_env_dir.return_value = live_dir
+        mock_project.rtc_load_local.return_value = {"schema": {}, "variables": {}}
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(live_dir, "schema.json"), "w") as f:
-            json.dump({}, f)
-        with open(os.path.join(live_dir, "data.json"), "w") as f:
-            json.dump({}, f)
 
         result = RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
         self.assertFalse(result["success"])
@@ -212,19 +185,12 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_live_with_force_succeeds(self, mock_load_project):
         """Verify pushing to live with --force bypasses the safety gate."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "val"},
+        }
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "live"}
-        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
-        os.makedirs(live_dir)
-        mock_project._rtc_env_dir.return_value = live_dir
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(live_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(live_dir, "data.json"), "w") as f:
-            json.dump({"key": "val"}, f)
 
         result = RTCCommand.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
         self.assertTrue(result["success"])
@@ -235,20 +201,13 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_live_interactive_confirm(self, mock_load_project, mock_questionary):
         """Verify interactive live push proceeds when user confirms."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.get_rtc_last_updated.return_value = None
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "val"},
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "live"}
         mock_questionary.confirm.return_value.ask.return_value = True
-
-        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
-        os.makedirs(live_dir)
-        mock_project._rtc_env_dir.return_value = live_dir
-        with open(os.path.join(live_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(live_dir, "data.json"), "w") as f:
-            json.dump({"key": "val"}, f)
         mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
@@ -261,19 +220,12 @@ class TestRTC(unittest.TestCase):
     def test_rtc_push_live_interactive_decline(self, mock_load_project, mock_questionary):
         """Verify interactive live push is cancelled when user declines."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.get_rtc_last_updated.return_value = None
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "val"},
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_questionary.confirm.return_value.ask.return_value = False
-
-        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
-        os.makedirs(live_dir)
-        mock_project._rtc_env_dir.return_value = live_dir
-        with open(os.path.join(live_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(live_dir, "data.json"), "w") as f:
-            json.dump({"key": "val"}, f)
         mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
@@ -288,14 +240,6 @@ class TestRTCDriftProtection(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.temp_dir = tempfile.mkdtemp()
-        self.sandbox_dir = os.path.join(
-            self.temp_dir, "real_time_configuration", "draft_and_sandbox"
-        )
-        os.makedirs(self.sandbox_dir)
-        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
-            json.dump({"key": "value"}, f)
 
     def tearDown(self):
         """Clean up temporary files."""
@@ -321,38 +265,41 @@ class TestRTCDriftProtection(unittest.TestCase):
         )
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_detects_drift(self, mock_get_rtc, mock_load_project):
+    def test_push_detects_drift(self, mock_load_project):
         """Verify push refuses when remote lastUpdated differs from local."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "drifted",
+            "remote_config": {"lastUpdated": "T2"},
+            "local_last_updated": "T1",
+            "remote_last_updated": "T2",
+        }
         mock_project.get_rtc_base.return_value = (None, None)
         mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertFalse(result["success"])
         self.assertIn("no base version", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_allows_when_no_drift(self, mock_get_rtc, mock_load_project):
+    def test_push_allows_when_no_drift(self, mock_load_project):
         """Verify push proceeds when remote lastUpdated matches local."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "in_sync",
+            "local_last_updated": "T1",
+            "remote_last_updated": "T1",
+        }
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {"lastUpdated": "T1"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
@@ -362,26 +309,27 @@ class TestRTCDriftProtection(unittest.TestCase):
     def test_push_force_bypasses_drift_check(self, mock_load_project):
         """Verify --force skips drift check entirely."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", force=True)
         self.assertTrue(result["success"])
         mock_project.rtc_push_to_api.assert_called_once()
+        mock_project.check_rtc_drift.assert_not_called()
 
     @patch("poly.cli_commands.rtc.load_project")
     def test_push_no_metadata_warns_and_proceeds(self, mock_load_project):
         """Verify push proceeds with warning when no metadata exists."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = None
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
 
@@ -390,19 +338,20 @@ class TestRTCDriftProtection(unittest.TestCase):
         mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_updates_metadata_after_success(self, mock_get_rtc, mock_load_project):
+    def test_push_updates_metadata_after_success(self, mock_load_project):
         """Verify push calls rtc_push_to_api which handles metadata update."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "in_sync",
+            "local_last_updated": "T1",
+            "remote_last_updated": "T1",
+        }
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {"lastUpdated": "T1"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
@@ -415,10 +364,6 @@ class TestRTCMerge(unittest.TestCase):
     def setUp(self):
         """Set up test fixtures."""
         self.temp_dir = tempfile.mkdtemp()
-        self.sandbox_dir = os.path.join(
-            self.temp_dir, "real_time_configuration", "draft_and_sandbox"
-        )
-        os.makedirs(self.sandbox_dir)
 
     def tearDown(self):
         """Clean up temporary files."""
@@ -440,7 +385,6 @@ class TestRTCMerge(unittest.TestCase):
         RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
 
         mock_project.rtc_pull_env.assert_called_once()
-        # set_rtc_base is called inside rtc_pull_env on the real project
 
     def test_merge_clean_non_overlapping_changes(self):
         """Verify clean merge when local and remote change different fields."""
@@ -511,29 +455,26 @@ class TestRTCMerge(unittest.TestCase):
         self.assertIsNone(result)
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_drift_clean_merge_succeeds(self, mock_get_rtc, mock_load_project):
+    def test_push_drift_clean_merge_succeeds(self, mock_load_project):
         """Verify push with clean merge auto-resolves and pushes."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"a": 10, "b": 2},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "drifted",
+            "remote_config": {
+                "lastUpdated": "T2",
+                "schema": {"type": "object"},
+                "variables": {"a": 1, "b": 20},
+            },
+            "local_last_updated": "T1",
+            "remote_last_updated": "T2",
+        }
         mock_project.get_rtc_base.return_value = ({"type": "object"}, {"a": 1, "b": 2})
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
-            json.dump({"a": 10, "b": 2}, f)
-
-        mock_get_rtc.return_value = {
-            "lastUpdated": "T2",
-            "schema": {"type": "object"},
-            "variables": {"a": 1, "b": 20},
-        }
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
@@ -543,47 +484,41 @@ class TestRTCMerge(unittest.TestCase):
         self.assertEqual(call_kwargs["variables"]["b"], 20)
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_drift_no_base_returns_error(self, mock_get_rtc, mock_load_project):
+    def test_push_drift_no_base_returns_error(self, mock_load_project):
         """Verify push fails gracefully when no base copies exist."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"a": 10},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "drifted",
+            "remote_config": {"lastUpdated": "T2", "schema": {}, "variables": {}},
+            "local_last_updated": "T1",
+            "remote_last_updated": "T2",
+        }
         mock_project.get_rtc_base.return_value = (None, None)
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
-            json.dump({"a": 10}, f)
-
-        mock_get_rtc.return_value = {"lastUpdated": "T2", "schema": {}, "variables": {}}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertFalse(result["success"])
         self.assertIn("no base version", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_drift_no_merge_flag_hard_fails(self, mock_get_rtc, mock_load_project):
+    def test_push_drift_no_merge_flag_hard_fails(self, mock_load_project):
         """Verify --no-merge disables merge and hard-fails on drift."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"a": 10},
+        }
+        mock_project.check_rtc_drift.return_value = {
+            "status": "drifted",
+            "remote_config": {"lastUpdated": "T2"},
+            "local_last_updated": "T1",
+            "remote_last_updated": "T2",
+        }
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
-            json.dump({"type": "object"}, f)
-        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
-            json.dump({"a": 10}, f)
-
-        mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", no_merge=True)
         self.assertFalse(result["success"])
@@ -722,194 +657,152 @@ class TestRTCEdit(unittest.TestCase):
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_happy_path(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+    def test_edit_happy_path(self, mock_load_project, mock_editor):
         """Verify edit pulls, opens editor, and pushes data."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
-
-        config = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {"type": "object"},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
-        mock_get_rtc.return_value = config
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
         mock_editor.return_value = '{\n  "flag": true\n}\n'
-        mock_patch_vars.return_value = {"lastUpdated": "T2"}
 
         RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
 
-        mock_patch_vars.assert_called_once()
-        pushed = mock_patch_vars.call_args[1]["variables"]
-        self.assertEqual(pushed["flag"], True)
+        mock_project.rtc_push_to_api.assert_called_once()
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
+        self.assertEqual(call_kwargs["variables"]["flag"], True)
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    def test_edit_schema_flag(self, mock_put_schema, mock_get_rtc, mock_load_project, mock_editor):
+    def test_edit_schema_flag(self, mock_load_project, mock_editor):
         """Verify --schema edits and pushes schema instead of data."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
-
-        config = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {"type": "object"},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
-        mock_get_rtc.return_value = config
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
         mock_editor.return_value = '{\n  "type": "object",\n  "title": "Config"\n}\n'
-        mock_put_schema.return_value = {"lastUpdated": "T2"}
 
         RTCCommand.rtc_edit(self.temp_dir, env="sandbox", edit_schema=True)
 
-        mock_put_schema.assert_called_once()
-        pushed = mock_put_schema.call_args[1]["schema"]
-        self.assertEqual(pushed["title"], "Config")
+        mock_project.rtc_push_to_api.assert_called_once()
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
+        self.assertEqual(call_kwargs["schema"]["title"], "Config")
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_no_changes(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+    def test_edit_no_changes(self, mock_load_project, mock_editor):
         """Verify no push when editor reports no changes."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
+        mock_load_project.return_value = mock_project
         mock_editor.side_effect = ValueError("No changes")
 
         RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
 
-        mock_patch_vars.assert_not_called()
+        mock_project.rtc_push_to_api.assert_not_called()
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_invalid_json(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+    def test_edit_invalid_json(self, mock_load_project, mock_editor):
         """Verify no push when editor returns invalid JSON."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
+        mock_load_project.return_value = mock_project
         mock_editor.return_value = "not valid json {{"
 
-        with self.assertRaises(SystemExit):
-            RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
-
-        mock_patch_vars.assert_not_called()
+        result = RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+        self.assertFalse(result["success"])
+        self.assertIn("Invalid JSON", result["error"])
+        mock_project.rtc_push_to_api.assert_not_called()
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_race_detected(
-        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor
-    ):
+    def test_edit_race_detected(self, mock_load_project, mock_editor):
         """Verify push aborted when remote changed during editing."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        mock_get_rtc.side_effect = [
+        mock_project.rtc_fetch_config.side_effect = [
             {"schema": {}, "variables": {"flag": False}, "lastUpdated": "T1"},
             {"schema": {}, "variables": {"flag": False}, "lastUpdated": "T2"},
         ]
+        mock_load_project.return_value = mock_project
         mock_editor.return_value = '{"flag": true}'
 
-        with self.assertRaises(SystemExit):
-            RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
-
-        mock_patch_vars.assert_not_called()
+        result = RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+        self.assertFalse(result["success"])
+        self.assertIn("modified while you were editing", result["error"])
+        mock_project.rtc_push_to_api.assert_not_called()
 
     @patch("poly.cli_commands.rtc.questionary")
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_live_declined(
-        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor, mock_questionary
-    ):
+    def test_edit_live_declined(self, mock_load_project, mock_editor, mock_questionary):
         """Verify live edit cancelled when user declines confirmation."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-        mock_questionary.confirm.return_value.ask.return_value = False
-
-        mock_get_rtc.return_value = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
+        mock_load_project.return_value = mock_project
+        mock_questionary.confirm.return_value.ask.return_value = False
         mock_editor.return_value = '{"flag": true}'
 
         RTCCommand.rtc_edit(self.temp_dir, env="live")
 
-        mock_patch_vars.assert_not_called()
+        mock_project.rtc_push_to_api.assert_not_called()
 
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_edit_updates_local_files(
-        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor
-    ):
-        """Verify edit updates local data.json and calls set_rtc_base."""
+    def test_edit_updates_via_rtc_push_to_api(self, mock_load_project, mock_editor):
+        """Verify edit delegates push to project.rtc_push_to_api."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project._rtc_env_dir.return_value = self.sandbox_dir
-        mock_load_project.return_value = mock_project
-
-        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
-            json.dump({"flag": False}, f)
-
-        mock_get_rtc.return_value = {
+        mock_project.rtc_fetch_config.return_value = {
             "schema": {},
             "variables": {"flag": False},
             "lastUpdated": "T1",
         }
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
         mock_editor.return_value = '{\n  "flag": true\n}\n'
-        mock_patch_vars.return_value = {"lastUpdated": "T2"}
 
         RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
 
-        with open(os.path.join(self.sandbox_dir, "data.json"), "r") as f:
-            local = json.load(f)
-        self.assertTrue(local["flag"])
-
-        mock_project.set_rtc_base.assert_called_once()
-        call_kwargs = mock_project.set_rtc_base.call_args[1]
+        mock_project.rtc_push_to_api.assert_called_once()
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
         self.assertTrue(call_kwargs["variables"]["flag"])
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_edit_validates_data_against_schema(self, mock_load_project, mock_editor):
+        """Verify edit validates edited data against schema before pushing."""
+        mock_project = MagicMock()
+        mock_project.rtc_fetch_config.return_value = {
+            "schema": {"type": "object", "properties": {"flag": {"type": "boolean"}}},
+            "variables": {"flag": True},
+            "lastUpdated": "T1",
+        }
+        mock_load_project.return_value = mock_project
+        mock_editor.return_value = '{"flag": "not_a_boolean"}'
+
+        result = RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+        self.assertFalse(result["success"])
+        self.assertIn("validation failed", result["error"])
+        mock_project.rtc_push_to_api.assert_not_called()
 
 
 class TestRTCDiff(unittest.TestCase):
@@ -958,39 +851,32 @@ class TestRTCDiff(unittest.TestCase):
         self.assertEqual(result[0]["path"], "config.b")
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_rtc_diff_command(self, mock_get_rtc, mock_load_project):
-        """Verify rtc diff fetches remote and compares."""
-        temp_dir = tempfile.mkdtemp()
-        try:
-            mock_project = MagicMock()
-            mock_project.region = "studio"
-            mock_project.project_id = "test-project"
-            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
-            os.makedirs(sandbox_dir)
-            mock_project._rtc_env_dir.return_value = sandbox_dir
-            mock_load_project.return_value = mock_project
+    def test_rtc_diff_command(self, mock_load_project):
+        """Verify rtc diff delegates to project.rtc_diff_env."""
+        mock_project = MagicMock()
+        mock_project.rtc_diff_env.return_value = {
+            "environment": "sandbox",
+            "schema": [],
+            "data": [{"path": "flag", "type": "changed", "local": True, "remote": False}],
+        }
+        mock_load_project.return_value = mock_project
 
-            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
-                json.dump({"type": "object"}, f)
-            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
-                json.dump({"flag": True, "timeout": 60}, f)
+        result = RTCCommand.rtc_diff(self.temp_dir, env="sandbox", output_json=True)
+        self.assertTrue(result["success"])
+        self.assertEqual(len(result["diffs"]), 1)
+        data_changes = result["diffs"][0]["data"]
+        self.assertEqual(len(data_changes), 1)
+        self.assertEqual(data_changes[0]["path"], "flag")
 
-            mock_get_rtc.return_value = {
-                "schema": {"type": "object"},
-                "variables": {"flag": False, "timeout": 60},
-            }
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
 
-            result = RTCCommand.rtc_diff(temp_dir, env="sandbox", output_json=True)
-            self.assertTrue(result["success"])
-            self.assertEqual(len(result["diffs"]), 1)
-            data_changes = result["diffs"][0]["data"]
-            self.assertEqual(len(data_changes), 1)
-            self.assertEqual(data_changes[0]["path"], "flag")
-        finally:
-            import shutil
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
 
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
 
 
 class TestRTCValidation(unittest.TestCase):
@@ -1036,67 +922,35 @@ class TestRTCValidation(unittest.TestCase):
     @patch("poly.cli_commands.rtc.load_project")
     def test_push_with_invalid_data_fails(self, mock_load_project):
         """Verify push refuses when data doesn't match schema."""
-        temp_dir = tempfile.mkdtemp()
-        try:
-            mock_project = MagicMock()
-            mock_project.region = "studio"
-            mock_project.project_id = "test-project"
-            mock_project.root_path = temp_dir
-            mock_project.get_rtc_last_updated.return_value = None
-            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
-            os.makedirs(sandbox_dir)
-            mock_project._rtc_env_dir.return_value = sandbox_dir
-            mock_load_project.return_value = mock_project
+        mock_project = MagicMock()
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object", "properties": {"flag": {"type": "boolean"}}},
+            "variables": {"flag": "not_a_boolean"},
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
+        mock_load_project.return_value = mock_project
 
-            schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
-            data = {"flag": "not_a_boolean"}
-
-            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
-                json.dump(schema, f)
-            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
-                json.dump(data, f)
-
-            result = RTCCommand.rtc_push(temp_dir, env="sandbox", output_json=True)
-            self.assertFalse(result["success"])
-            self.assertIn("validation failed", result["error"])
-        finally:
-            import shutil
-
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        result = RTCCommand.rtc_push("/tmp/test", env="sandbox", output_json=True)
+        self.assertFalse(result["success"])
+        self.assertIn("validation failed", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
     def test_push_with_skip_validation_bypasses(self, mock_load_project):
         """Verify --skip-validation allows push with invalid data."""
-        temp_dir = tempfile.mkdtemp()
-        try:
-            mock_project = MagicMock()
-            mock_project.region = "studio"
-            mock_project.project_id = "test-project"
-            mock_project.root_path = temp_dir
-            mock_project.get_rtc_last_updated.return_value = None
-            mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
-            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
-            os.makedirs(sandbox_dir)
-            mock_project._rtc_env_dir.return_value = sandbox_dir
-            mock_load_project.return_value = mock_project
+        mock_project = MagicMock()
+        mock_project.rtc_load_local.return_value = {
+            "schema": {"type": "object", "properties": {"flag": {"type": "boolean"}}},
+            "variables": {"flag": "not_a_boolean"},
+        }
+        mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
 
-            schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
-            data = {"flag": "not_a_boolean"}
-
-            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
-                json.dump(schema, f)
-            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
-                json.dump(data, f)
-
-            result = RTCCommand.rtc_push(
-                temp_dir, env="sandbox", output_json=True, skip_validation=True
-            )
-            self.assertTrue(result["success"])
-            mock_project.rtc_push_to_api.assert_called_once()
-        finally:
-            import shutil
-
-            shutil.rmtree(temp_dir, ignore_errors=True)
+        result = RTCCommand.rtc_push(
+            "/tmp/test", env="sandbox", output_json=True, skip_validation=True
+        )
+        self.assertTrue(result["success"])
+        mock_project.rtc_push_to_api.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -14,6 +14,7 @@ from poly.cli_commands.rtc import (
     _merge_rtc_file,
 )
 from poly.project import AgentStudioProject
+from poly.utils import diff_dicts
 
 
 class TestRTC(unittest.TestCase):
@@ -909,6 +910,193 @@ class TestRTCEdit(unittest.TestCase):
         mock_project.set_rtc_base.assert_called_once()
         call_kwargs = mock_project.set_rtc_base.call_args[1]
         self.assertTrue(call_kwargs["variables"]["flag"])
+
+
+class TestRTCDiff(unittest.TestCase):
+    """Test suite for poly rtc diff command."""
+
+    def test_diff_no_changes(self):
+        """Verify diff returns empty when local and remote are identical."""
+        local = {"flag": True, "timeout": 30}
+        remote = {"flag": True, "timeout": 30}
+        result = diff_dicts(local, remote)
+        self.assertEqual(result, [])
+
+    def test_diff_changed_field(self):
+        """Verify diff detects a changed field."""
+        local = {"flag": True}
+        remote = {"flag": False}
+        result = diff_dicts(local, remote)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["path"], "flag")
+        self.assertEqual(result[0]["type"], "changed")
+
+    def test_diff_added_locally(self):
+        """Verify diff detects a field added locally."""
+        local = {"flag": True, "new_field": "hello"}
+        remote = {"flag": True}
+        result = diff_dicts(local, remote)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["path"], "new_field")
+        self.assertEqual(result[0]["type"], "added_locally")
+
+    def test_diff_only_remote(self):
+        """Verify diff detects a field only on remote."""
+        local = {"flag": True}
+        remote = {"flag": True, "remote_field": "hello"}
+        result = diff_dicts(local, remote)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["path"], "remote_field")
+        self.assertEqual(result[0]["type"], "only_remote")
+
+    def test_diff_nested(self):
+        """Verify diff recurses into nested dicts."""
+        local = {"config": {"a": 1, "b": 2}}
+        remote = {"config": {"a": 1, "b": 20}}
+        result = diff_dicts(local, remote)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["path"], "config.b")
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    def test_rtc_diff_command(self, mock_get_rtc, mock_load_project):
+        """Verify rtc diff fetches remote and compares."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            mock_project = MagicMock()
+            mock_project.region = "studio"
+            mock_project.project_id = "test-project"
+            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
+            os.makedirs(sandbox_dir)
+            mock_project._rtc_env_dir.return_value = sandbox_dir
+            mock_load_project.return_value = mock_project
+
+            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
+                json.dump({"type": "object"}, f)
+            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
+                json.dump({"flag": True, "timeout": 60}, f)
+
+            mock_get_rtc.return_value = {
+                "schema": {"type": "object"},
+                "variables": {"flag": False, "timeout": 60},
+            }
+
+            result = RTCCommand.rtc_diff(temp_dir, env="sandbox", output_json=True)
+            self.assertTrue(result["success"])
+            self.assertEqual(len(result["diffs"]), 1)
+            data_changes = result["diffs"][0]["data"]
+            self.assertEqual(len(data_changes), 1)
+            self.assertEqual(data_changes[0]["path"], "flag")
+        finally:
+            import shutil
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+class TestRTCValidation(unittest.TestCase):
+    """Test suite for RTC schema validation."""
+
+    def test_valid_data(self):
+        """Verify valid data passes validation."""
+        schema = {
+            "type": "object",
+            "properties": {"flag": {"type": "boolean"}, "timeout": {"type": "integer"}},
+        }
+        data = {"flag": True, "timeout": 30}
+        errors = AgentStudioProject.validate_rtc_data(schema, data)
+        self.assertEqual(errors, [])
+
+    def test_invalid_type(self):
+        """Verify wrong type is caught."""
+        schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+        data = {"flag": "not_a_boolean"}
+        errors = AgentStudioProject.validate_rtc_data(schema, data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("flag", errors[0])
+
+    def test_missing_required_field(self):
+        """Verify missing required field is caught."""
+        schema = {
+            "type": "object",
+            "properties": {"flag": {"type": "boolean"}},
+            "required": ["flag"],
+        }
+        data = {}
+        errors = AgentStudioProject.validate_rtc_data(schema, data)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("flag", errors[0])
+
+    def test_invalid_schema(self):
+        """Verify invalid schema returns error."""
+        schema = {"type": "not_a_real_type"}
+        data = {"flag": True}
+        errors = AgentStudioProject.validate_rtc_data(schema, data)
+        self.assertTrue(len(errors) > 0)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_push_with_invalid_data_fails(self, mock_load_project):
+        """Verify push refuses when data doesn't match schema."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            mock_project = MagicMock()
+            mock_project.region = "studio"
+            mock_project.project_id = "test-project"
+            mock_project.root_path = temp_dir
+            mock_project.get_rtc_last_updated.return_value = None
+            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
+            os.makedirs(sandbox_dir)
+            mock_project._rtc_env_dir.return_value = sandbox_dir
+            mock_load_project.return_value = mock_project
+
+            schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+            data = {"flag": "not_a_boolean"}
+
+            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
+                json.dump(schema, f)
+            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
+                json.dump(data, f)
+
+            result = RTCCommand.rtc_push(temp_dir, env="sandbox", output_json=True)
+            self.assertFalse(result["success"])
+            self.assertIn("validation failed", result["error"])
+        finally:
+            import shutil
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_push_with_skip_validation_bypasses(self, mock_load_project):
+        """Verify --skip-validation allows push with invalid data."""
+        temp_dir = tempfile.mkdtemp()
+        try:
+            mock_project = MagicMock()
+            mock_project.region = "studio"
+            mock_project.project_id = "test-project"
+            mock_project.root_path = temp_dir
+            mock_project.get_rtc_last_updated.return_value = None
+            mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+            sandbox_dir = os.path.join(temp_dir, "real_time_configuration", "draft_and_sandbox")
+            os.makedirs(sandbox_dir)
+            mock_project._rtc_env_dir.return_value = sandbox_dir
+            mock_load_project.return_value = mock_project
+
+            schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+            data = {"flag": "not_a_boolean"}
+
+            with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
+                json.dump(schema, f)
+            with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
+                json.dump(data, f)
+
+            result = RTCCommand.rtc_push(
+                temp_dir, env="sandbox", output_json=True, skip_validation=True
+            )
+            self.assertTrue(result["success"])
+            mock_project.rtc_push_to_api.assert_called_once()
+        finally:
+            import shutil
+
+            shutil.rmtree(temp_dir, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 from poly.cli import AgentStudioCLI, RTC_ENV_TO_DIR, RTC_DIR_TO_ENV
 
 
-class TestRTCIntegration(unittest.TestCase):
+class TestRTC(unittest.TestCase):
     """Test suite for poly rtc command."""
 
     def setUp(self):
@@ -22,6 +22,7 @@ class TestRTCIntegration(unittest.TestCase):
     def tearDown(self):
         """Clean up temporary files."""
         import shutil
+
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_env_mapping_roundtrip(self):
@@ -55,6 +56,7 @@ class TestRTCIntegration(unittest.TestCase):
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         # Mock API responses
@@ -83,6 +85,7 @@ class TestRTCIntegration(unittest.TestCase):
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         rtc_response = {
@@ -105,6 +108,7 @@ class TestRTCIntegration(unittest.TestCase):
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         rtc_response = {
@@ -127,6 +131,7 @@ class TestRTCIntegration(unittest.TestCase):
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         schema_obj = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
@@ -170,6 +175,7 @@ class TestRTCIntegration(unittest.TestCase):
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         # Create test files
@@ -204,6 +210,7 @@ class TestRTCIntegration(unittest.TestCase):
     def test_rtc_push_missing_schema_raises(self, mock_load_project):
         """Verify rtc push raises if schema.json is missing."""
         mock_project = MagicMock()
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         # Create only data.json
@@ -219,6 +226,7 @@ class TestRTCIntegration(unittest.TestCase):
     def test_rtc_push_missing_data_raises(self, mock_load_project):
         """Verify rtc push raises if data.json is missing."""
         mock_project = MagicMock()
+        mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
         # Create only schema.json
@@ -229,6 +237,161 @@ class TestRTCIntegration(unittest.TestCase):
 
         with self.assertRaises(SystemExit):
             AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+
+    @patch("poly.cli.load_project")
+    def test_rtc_push_live_without_force_json_exits(self, mock_load_project):
+        """Verify pushing to live in JSON mode without --force is refused."""
+        mock_project = MagicMock()
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
+        os.makedirs(live_dir)
+        with open(os.path.join(live_dir, "schema.json"), "w") as f:
+            json.dump({}, f)
+        with open(os.path.join(live_dir, "data.json"), "w") as f:
+            json.dump({}, f)
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli.AgentStudioInterface.patch_rtc_variables")
+    def test_rtc_push_live_with_force_succeeds(
+        self, mock_patch_vars, mock_put_schema, mock_load_project
+    ):
+        """Verify pushing to live with --force bypasses the safety gate."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
+        os.makedirs(live_dir)
+        with open(os.path.join(live_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(live_dir, "data.json"), "w") as f:
+            json.dump({"key": "val"}, f)
+
+        AgentStudioCLI.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
+
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+
+class TestIncludeRTC(unittest.TestCase):
+    """Test suite for --include-rtc on pull/push commands."""
+
+    @patch("poly.cli.AgentStudioCLI.rtc_pull")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_pull_include_rtc_calls_rtc_pull(self, mock_load_project, mock_rtc_pull):
+        """Verify pull --include-rtc calls rtc_pull after normal pull."""
+        from poly.cli_commands.sync import PullCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.pull_project.return_value = ([], {})
+        mock_load_project.return_value = mock_project
+
+        PullCommand.pull("/tmp/test", include_rtc=True, output_json=True)
+
+        mock_rtc_pull.assert_called_once_with("/tmp/test", env="all", output_json=True)
+
+    @patch("poly.cli.AgentStudioCLI.rtc_pull")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_pull_without_include_rtc_does_not_call_rtc(self, mock_load_project, mock_rtc_pull):
+        """Verify pull without --include-rtc does not call rtc_pull."""
+        from poly.cli_commands.sync import PullCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.pull_project.return_value = ([], {})
+        mock_load_project.return_value = mock_project
+
+        PullCommand.pull("/tmp/test", include_rtc=False, output_json=True)
+
+        mock_rtc_pull.assert_not_called()
+
+    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_push_include_rtc_calls_rtc_push_sandbox_default(
+        self, mock_load_project, mock_rtc_push
+    ):
+        """Verify push --include-rtc calls rtc_push with sandbox default."""
+        from poly.cli_commands.sync import PushCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.push_project.return_value = (True, "ok", [])
+        mock_load_project.return_value = mock_project
+
+        PushCommand.push("/tmp/test", include_rtc=True, output_json=True)
+
+        mock_rtc_push.assert_called_once_with(
+            "/tmp/test", env="sandbox", force=False, output_json=True
+        )
+
+    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_push_include_rtc_with_custom_env(self, mock_load_project, mock_rtc_push):
+        """Verify push --include-rtc --rtc-env live passes the correct env."""
+        from poly.cli_commands.sync import PushCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.push_project.return_value = (True, "ok", [])
+        mock_load_project.return_value = mock_project
+
+        PushCommand.push(
+            "/tmp/test", include_rtc=True, rtc_env="live", force=True, output_json=True
+        )
+
+        mock_rtc_push.assert_called_once_with("/tmp/test", env="live", force=True, output_json=True)
+
+    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_push_without_include_rtc_does_not_call_rtc(self, mock_load_project, mock_rtc_push):
+        """Verify push without --include-rtc does not call rtc_push."""
+        from poly.cli_commands.sync import PushCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.push_project.return_value = (True, "ok", [])
+        mock_load_project.return_value = mock_project
+
+        PushCommand.push("/tmp/test", include_rtc=False, output_json=True)
+
+        mock_rtc_push.assert_not_called()
+
+    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.sync.load_project")
+    def test_push_include_rtc_skipped_on_failed_push(self, mock_load_project, mock_rtc_push):
+        """Verify rtc_push is not called when the main push fails."""
+        from poly.cli_commands.sync import PushCommand
+
+        mock_project = MagicMock()
+        mock_project.branch_id = "branch-1"
+        mock_project.account_id = "acc"
+        mock_project.project_id = "proj"
+        mock_project.push_project.return_value = (False, "error", [])
+        mock_load_project.return_value = mock_project
+
+        with self.assertRaises(SystemExit):
+            PushCommand.push("/tmp/test", include_rtc=True, output_json=True)
+
+        mock_rtc_push.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -837,5 +837,214 @@ class TestIncludeRTC(unittest.TestCase):
         mock_rtc_push.assert_not_called()
 
 
+class TestRTCEdit(unittest.TestCase):
+    """Test suite for poly rtc edit command."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.sandbox_dir = os.path.join(
+            self.temp_dir, "real_time_configuration", "draft_and_sandbox"
+        )
+        os.makedirs(self.sandbox_dir)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_happy_path(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+        """Verify edit pulls, opens editor, and pushes data."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
+        mock_load_project.return_value = mock_project
+
+        config = {
+            "schema": {"type": "object"},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_get_rtc.return_value = config
+        mock_editor.return_value = '{\n  "flag": true\n}\n'
+        mock_patch_vars.return_value = {"lastUpdated": "T2"}
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        mock_patch_vars.assert_called_once()
+        pushed = mock_patch_vars.call_args[1]["variables"]
+        self.assertEqual(pushed["flag"], True)
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    def test_edit_schema_flag(self, mock_put_schema, mock_get_rtc, mock_load_project, mock_editor):
+        """Verify --schema edits and pushes schema instead of data."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
+        mock_load_project.return_value = mock_project
+
+        config = {
+            "schema": {"type": "object"},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_get_rtc.return_value = config
+        mock_editor.return_value = '{\n  "type": "object",\n  "title": "Config"\n}\n'
+        mock_put_schema.return_value = {"lastUpdated": "T2"}
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox", edit_schema=True)
+
+        mock_put_schema.assert_called_once()
+        pushed = mock_put_schema.call_args[1]["schema"]
+        self.assertEqual(pushed["title"], "Config")
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_no_changes(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+        """Verify no push when editor reports no changes."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        mock_get_rtc.return_value = {
+            "schema": {},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_editor.side_effect = ValueError("No changes")
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        mock_patch_vars.assert_not_called()
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_invalid_json(self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor):
+        """Verify no push when editor returns invalid JSON."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        mock_get_rtc.return_value = {
+            "schema": {},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_editor.return_value = "not valid json {{"
+
+        with self.assertRaises(SystemExit):
+            RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        mock_patch_vars.assert_not_called()
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_race_detected(
+        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor
+    ):
+        """Verify push aborted when remote changed during editing."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        mock_get_rtc.side_effect = [
+            {"schema": {}, "variables": {"flag": False}, "lastUpdated": "T1"},
+            {"schema": {}, "variables": {"flag": False}, "lastUpdated": "T2"},
+        ]
+        mock_editor.return_value = '{"flag": true}'
+
+        with self.assertRaises(SystemExit):
+            RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        mock_patch_vars.assert_not_called()
+
+    @patch("poly.cli_commands.rtc.questionary")
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_live_declined(
+        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor, mock_questionary
+    ):
+        """Verify live edit cancelled when user declines confirmation."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_questionary.confirm.return_value.ask.return_value = False
+
+        mock_get_rtc.return_value = {
+            "schema": {},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_editor.return_value = '{"flag": true}'
+
+        RTCCommand.rtc_edit(self.temp_dir, env="live")
+
+        mock_patch_vars.assert_not_called()
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_edit_updates_local_files(
+        self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor
+    ):
+        """Verify edit updates local data.json and base file when env dir exists."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
+        mock_load_project.return_value = mock_project
+
+        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"flag": False})
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), {"flag": False})
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {})
+
+        mock_get_rtc.return_value = {
+            "schema": {},
+            "variables": {"flag": False},
+            "lastUpdated": "T1",
+        }
+        mock_editor.return_value = '{\n  "flag": true\n}\n'
+        mock_patch_vars.return_value = {"lastUpdated": "T2"}
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        with open(os.path.join(self.sandbox_dir, "data.json"), "r") as f:
+            local = json.load(f)
+        self.assertTrue(local["flag"])
+
+        _, base_vars = _load_rtc_base(self.sandbox_dir)
+        self.assertTrue(base_vars["flag"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -280,6 +280,62 @@ class TestRTC(unittest.TestCase):
         mock_put_schema.assert_called_once()
         mock_patch_vars.assert_called_once()
 
+    @patch("poly.cli_commands.rtc.questionary")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_rtc_push_live_interactive_confirm(
+        self, mock_patch_vars, mock_put_schema, mock_load_project, mock_questionary
+    ):
+        """Verify interactive live push proceeds when user confirms."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_questionary.confirm.return_value.ask.return_value = True
+
+        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
+        os.makedirs(live_dir)
+        with open(os.path.join(live_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(live_dir, "data.json"), "w") as f:
+            json.dump({"key": "val"}, f)
+
+        RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
+
+        mock_questionary.confirm.assert_called_once()
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+    @patch("poly.cli_commands.rtc.questionary")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_rtc_push_live_interactive_decline(
+        self, mock_patch_vars, mock_put_schema, mock_load_project, mock_questionary
+    ):
+        """Verify interactive live push is cancelled when user declines."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_questionary.confirm.return_value.ask.return_value = False
+
+        live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
+        os.makedirs(live_dir)
+        with open(os.path.join(live_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(live_dir, "data.json"), "w") as f:
+            json.dump({"key": "val"}, f)
+
+        RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
+
+        mock_questionary.confirm.assert_called_once()
+        mock_put_schema.assert_not_called()
+        mock_patch_vars.assert_not_called()
+
 
 class TestIncludeRTC(unittest.TestCase):
     """Test suite for --include-rtc on pull/push commands."""

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -10,15 +10,10 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from poly.cli_commands.rtc import (
-    RTC_BASE_DATA_FILE,
-    RTC_BASE_SCHEMA_FILE,
-    RTC_DIR_TO_ENV,
-    RTC_ENV_TO_DIR,
     RTCCommand,
-    _load_rtc_base,
     _merge_rtc_file,
 )
-from poly.utils import write_json_file
+from poly.project import AgentStudioProject
 
 
 class TestRTC(unittest.TestCase):
@@ -35,197 +30,139 @@ class TestRTC(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_env_mapping_roundtrip(self):
-        """Verify RTC_ENV_TO_DIR and RTC_DIR_TO_ENV are consistent."""
-        for env, dir_name in RTC_ENV_TO_DIR.items():
-            self.assertEqual(RTC_DIR_TO_ENV[dir_name], env)
+        """Verify AgentStudioProject.RTC_ENV_TO_DIR and {v: k for k, v in AgentStudioProject.RTC_ENV_TO_DIR.items()} are consistent."""
+        for env, dir_name in AgentStudioProject.RTC_ENV_TO_DIR.items():
+            self.assertEqual(
+                {v: k for k, v in AgentStudioProject.RTC_ENV_TO_DIR.items()}[dir_name], env
+            )
 
     def test_env_mapping_coverage(self):
         """Verify all 3 standard environments are mapped."""
-        self.assertEqual(len(RTC_ENV_TO_DIR), 3)
-        self.assertIn("sandbox", RTC_ENV_TO_DIR)
-        self.assertIn("pre-release", RTC_ENV_TO_DIR)
-        self.assertIn("live", RTC_ENV_TO_DIR)
+        self.assertEqual(len(AgentStudioProject.RTC_ENV_TO_DIR), 3)
+        self.assertIn("sandbox", AgentStudioProject.RTC_ENV_TO_DIR)
+        self.assertIn("pre-release", AgentStudioProject.RTC_ENV_TO_DIR)
+        self.assertIn("live", AgentStudioProject.RTC_ENV_TO_DIR)
 
     def test_sandbox_maps_to_draft_and_sandbox(self):
         """Verify sandbox API env maps to draft_and_sandbox directory."""
-        self.assertEqual(RTC_ENV_TO_DIR["sandbox"], "draft_and_sandbox")
+        self.assertEqual(AgentStudioProject.RTC_ENV_TO_DIR["sandbox"], "draft_and_sandbox")
 
     def test_pre_release_maps_to_pre_release(self):
         """Verify pre-release API env maps to pre_release directory."""
-        self.assertEqual(RTC_ENV_TO_DIR["pre-release"], "pre_release")
+        self.assertEqual(AgentStudioProject.RTC_ENV_TO_DIR["pre-release"], "pre_release")
 
     def test_live_maps_to_live(self):
         """Verify live API env maps to live directory."""
-        self.assertEqual(RTC_ENV_TO_DIR["live"], "live")
+        self.assertEqual(AgentStudioProject.RTC_ENV_TO_DIR["live"], "live")
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_rtc_pull_all_envs(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull writes all 3 environments."""
+    def test_rtc_pull_all_envs(self, mock_load_project):
+        """Verify rtc pull calls rtc_pull_env for all 3 environments."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        # Mock API responses
-        rtc_response = {
-            "clientEnv": "sandbox",
-            "schema": {"type": "object", "properties": {}},
-            "variables": {"mock_api": False},
-            "lastUpdated": "2024-01-01T00:00:00Z",
+        mock_project.rtc_pull_env.return_value = {
+            "environment": "sandbox",
+            "schema_file": "schema.json",
+            "data_file": "data.json",
         }
-        mock_get_rtc.return_value = rtc_response
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_pull(self.temp_dir, env="all", output_json=True)
 
-        # Verify API was called for each environment
-        self.assertEqual(mock_get_rtc.call_count, 3)
-        call_args_list = [call[1] for call in mock_get_rtc.call_args_list]
-        envs_called = [call["client_env"] for call in call_args_list]
+        self.assertEqual(mock_project.rtc_pull_env.call_count, 3)
+        envs_called = [c[0][0] for c in mock_project.rtc_pull_env.call_args_list]
         self.assertIn("sandbox", envs_called)
         self.assertIn("pre-release", envs_called)
         self.assertIn("live", envs_called)
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_rtc_pull_single_env(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull --env sandbox only calls API once."""
+    def test_rtc_pull_single_env(self, mock_load_project):
+        """Verify rtc pull --env sandbox calls rtc_pull_env once."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        rtc_response = {
-            "clientEnv": "sandbox",
-            "schema": {"type": "object"},
-            "variables": {"mock_api": False},
+        mock_project.rtc_pull_env.return_value = {
+            "environment": "sandbox",
+            "schema_file": "schema.json",
+            "data_file": "data.json",
         }
-        mock_get_rtc.return_value = rtc_response
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
 
-        # Verify API was called once
-        mock_get_rtc.assert_called_once()
-        self.assertEqual(mock_get_rtc.call_args[1]["client_env"], "sandbox")
-
-    @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_rtc_pull_creates_directories(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull creates necessary directories."""
-        mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        rtc_response = {
-            "clientEnv": "sandbox",
-            "schema": {"type": "object"},
-            "variables": {"key": "value"},
-        }
-        mock_get_rtc.return_value = rtc_response
-
-        RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
-
-        # Verify directories were created
-        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
-        self.assertTrue(os.path.isdir(sandbox_dir))
-
-    @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_rtc_pull_writes_json_files(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull writes valid JSON files."""
-        mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        schema_obj = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
-        variables_obj = {"flag": True, "nested": {"key": "value"}}
-
-        rtc_response = {
-            "clientEnv": "sandbox",
-            "schema": schema_obj,
-            "variables": variables_obj,
-        }
-        mock_get_rtc.return_value = rtc_response
-
-        RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
-
-        # Verify files exist and contain correct content
-        schema_path = os.path.join(
-            self.temp_dir, "real_time_configuration", "draft_and_sandbox", "schema.json"
-        )
-        data_path = os.path.join(
-            self.temp_dir, "real_time_configuration", "draft_and_sandbox", "data.json"
+        mock_project.rtc_pull_env.assert_called_once_with(
+            "sandbox", schema_only=False, data_only=False
         )
 
-        self.assertTrue(os.path.exists(schema_path))
-        self.assertTrue(os.path.exists(data_path))
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_rtc_pull_creates_directories(self, mock_load_project):
+        """Verify rtc pull delegates to project.rtc_pull_env."""
+        mock_project = MagicMock()
+        mock_project.rtc_pull_env.return_value = {
+            "environment": "sandbox",
+            "schema_file": "schema.json",
+            "data_file": "data.json",
+        }
+        mock_load_project.return_value = mock_project
 
-        with open(schema_path, "r") as f:
-            loaded_schema = json.load(f)
-        self.assertEqual(loaded_schema, schema_obj)
-
-        with open(data_path, "r") as f:
-            loaded_variables = json.load(f)
-        self.assertEqual(loaded_variables, variables_obj)
+        result = RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+        self.assertTrue(result["success"])
+        mock_project.rtc_pull_env.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_rtc_push_schema_and_variables(
-        self, mock_patch_vars, mock_put_schema, mock_load_project
-    ):
-        """Verify rtc push calls both schema and variables APIs."""
+    def test_rtc_pull_returns_files_written(self, mock_load_project):
+        """Verify rtc pull returns the files_written from rtc_pull_env."""
+        mock_project = MagicMock()
+        expected = {
+            "environment": "sandbox",
+            "schema_file": "/path/schema.json",
+            "data_file": "/path/data.json",
+        }
+        mock_project.rtc_pull_env.return_value = expected
+        mock_load_project.return_value = mock_project
+
+        result = RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+        self.assertTrue(result["success"])
+        self.assertEqual(result["files_written"], [expected])
+
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_rtc_push_schema_and_variables(self, mock_load_project):
+        """Verify rtc push reads files and calls rtc_push_to_api."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
+        mock_project.get_rtc_last_updated.return_value = None
         mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
-        # Create test files
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         os.makedirs(sandbox_dir)
+        mock_project._rtc_env_dir.return_value = sandbox_dir
 
         schema_obj = {"type": "object"}
         variables_obj = {"mock_api": False}
 
         with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
             json.dump(schema_obj, f)
-
         with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
             json.dump(variables_obj, f)
 
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+
         RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
 
-        # Verify both APIs were called
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
-
-        # Verify arguments
-        schema_call = mock_put_schema.call_args[1]
-        self.assertEqual(schema_call["client_env"], "sandbox")
-        self.assertEqual(schema_call["schema"], schema_obj)
-
-        vars_call = mock_patch_vars.call_args[1]
-        self.assertEqual(vars_call["client_env"], "sandbox")
-        self.assertEqual(vars_call["variables"], variables_obj)
+        mock_project.rtc_push_to_api.assert_called_once()
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
+        self.assertEqual(call_kwargs["schema"], schema_obj)
+        self.assertEqual(call_kwargs["variables"], variables_obj)
 
     @patch("poly.cli_commands.rtc.load_project")
     def test_rtc_push_missing_schema_returns_error(self, mock_load_project):
         """Verify rtc push returns error if schema.json is missing."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         os.makedirs(sandbox_dir)
+        mock_project._rtc_env_dir.return_value = sandbox_dir
+        mock_load_project.return_value = mock_project
+
         with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
             json.dump({}, f)
 
@@ -238,10 +175,11 @@ class TestRTC(unittest.TestCase):
         """Verify rtc push returns error if data.json is missing."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         os.makedirs(sandbox_dir)
+        mock_project._rtc_env_dir.return_value = sandbox_dir
+        mock_load_project.return_value = mock_project
+
         with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
             json.dump({}, f)
 
@@ -254,11 +192,12 @@ class TestRTC(unittest.TestCase):
         """Verify pushing to live in JSON mode without --force returns error."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
-
+        mock_project.get_rtc_last_updated.return_value = None
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
         os.makedirs(live_dir)
+        mock_project._rtc_env_dir.return_value = live_dir
+        mock_load_project.return_value = mock_project
+
         with open(os.path.join(live_dir, "schema.json"), "w") as f:
             json.dump({}, f)
         with open(os.path.join(live_dir, "data.json"), "w") as f:
@@ -269,89 +208,77 @@ class TestRTC(unittest.TestCase):
         self.assertIn("--force", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_rtc_push_live_with_force_succeeds(
-        self, mock_patch_vars, mock_put_schema, mock_load_project
-    ):
+    def test_rtc_push_live_with_force_succeeds(self, mock_load_project):
         """Verify pushing to live with --force bypasses the safety gate."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T1"}
-
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "live"}
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
         os.makedirs(live_dir)
+        mock_project._rtc_env_dir.return_value = live_dir
+        mock_load_project.return_value = mock_project
+
         with open(os.path.join(live_dir, "schema.json"), "w") as f:
             json.dump({"type": "object"}, f)
         with open(os.path.join(live_dir, "data.json"), "w") as f:
             json.dump({"key": "val"}, f)
 
-        RTCCommand.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
-
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
+        result = RTCCommand.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
+        self.assertTrue(result["success"])
+        mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.questionary")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_rtc_push_live_interactive_confirm(
-        self, mock_patch_vars, mock_put_schema, mock_load_project, mock_questionary
-    ):
+    def test_rtc_push_live_interactive_confirm(self, mock_load_project, mock_questionary):
         """Verify interactive live push proceeds when user confirms."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T1"}
+        mock_project.get_rtc_last_updated.return_value = None
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "live"}
         mock_questionary.confirm.return_value.ask.return_value = True
 
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
         os.makedirs(live_dir)
+        mock_project._rtc_env_dir.return_value = live_dir
         with open(os.path.join(live_dir, "schema.json"), "w") as f:
             json.dump({"type": "object"}, f)
         with open(os.path.join(live_dir, "data.json"), "w") as f:
             json.dump({"key": "val"}, f)
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
 
         mock_questionary.confirm.assert_called_once()
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
+        mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.questionary")
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_rtc_push_live_interactive_decline(
-        self, mock_patch_vars, mock_put_schema, mock_load_project, mock_questionary
-    ):
+    def test_rtc_push_live_interactive_decline(self, mock_load_project, mock_questionary):
         """Verify interactive live push is cancelled when user declines."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
+        mock_project.get_rtc_last_updated.return_value = None
         mock_questionary.confirm.return_value.ask.return_value = False
 
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
         os.makedirs(live_dir)
+        mock_project._rtc_env_dir.return_value = live_dir
         with open(os.path.join(live_dir, "schema.json"), "w") as f:
             json.dump({"type": "object"}, f)
         with open(os.path.join(live_dir, "data.json"), "w") as f:
             json.dump({"key": "val"}, f)
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
 
         mock_questionary.confirm.assert_called_once()
-        mock_put_schema.assert_not_called()
-        mock_patch_vars.assert_not_called()
+        mock_project.rtc_push_to_api.assert_not_called()
 
 
 class TestRTCDriftProtection(unittest.TestCase):
@@ -376,140 +303,109 @@ class TestRTCDriftProtection(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_pull_stores_metadata_in_project(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull stores lastUpdated in project.rtc_metadata."""
+    def test_pull_calls_rtc_pull_env(self, mock_load_project):
+        """Verify rtc pull calls project.rtc_pull_env for each environment."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
-        mock_load_project.return_value = mock_project
-
-        mock_get_rtc.return_value = {
-            "schema": {"type": "object"},
-            "variables": {"key": "value"},
-            "lastUpdated": "2024-06-01T12:00:00Z",
+        mock_project.rtc_pull_env.return_value = {
+            "environment": "sandbox",
+            "schema_file": "schema.json",
+            "data_file": "data.json",
         }
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
 
-        self.assertEqual(
-            mock_project.rtc_metadata["sandbox"]["last_updated"], "2024-06-01T12:00:00Z"
+        mock_project.rtc_pull_env.assert_called_once_with(
+            "sandbox", schema_only=False, data_only=False
         )
-        mock_project.save_config.assert_called()
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_detects_drift(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
+    def test_push_detects_drift(self, mock_get_rtc, mock_load_project):
         """Verify push refuses when remote lastUpdated differs from local."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.get_rtc_base.return_value = (None, None)
         mock_load_project.return_value = mock_project
 
         mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertFalse(result["success"])
-        self.assertIn("changed since your last pull", result["error"])
-        mock_put_schema.assert_not_called()
-        mock_patch_vars.assert_not_called()
+        self.assertIn("no base version", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_allows_when_no_drift(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
+    def test_push_allows_when_no_drift(self, mock_get_rtc, mock_load_project):
         """Verify push proceeds when remote lastUpdated matches local."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
         mock_get_rtc.return_value = {"lastUpdated": "T1"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
+        mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_force_bypasses_drift_check(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
+    def test_push_force_bypasses_drift_check(self, mock_load_project):
         """Verify --force skips drift check entirely."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T3"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", force=True)
         self.assertTrue(result["success"])
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
-        mock_get_rtc.assert_not_called()
+        mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_no_metadata_warns_and_proceeds(
-        self, mock_patch_vars, mock_put_schema, mock_load_project
-    ):
+    def test_push_no_metadata_warns_and_proceeds(self, mock_load_project):
         """Verify push proceeds with warning when no metadata exists."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = None
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
+        mock_project.rtc_push_to_api.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_updates_metadata_after_success(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
-        """Verify push updates rtc_metadata with new lastUpdated."""
+    def test_push_updates_metadata_after_success(self, mock_get_rtc, mock_load_project):
+        """Verify push calls rtc_push_to_api which handles metadata update."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
 
         mock_get_rtc.return_value = {"lastUpdated": "T1"}
-        mock_patch_vars.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
-
-        self.assertEqual(mock_project.rtc_metadata["sandbox"]["last_updated"], "T2")
-        mock_project.save_config.assert_called()
+        mock_project.rtc_push_to_api.assert_called_once()
 
 
 class TestRTCMerge(unittest.TestCase):
@@ -530,28 +426,20 @@ class TestRTCMerge(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_pull_writes_base_files(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull writes .rtc_base_schema.json and .rtc_base_data.json."""
+    def test_pull_stores_base_in_metadata(self, mock_load_project):
+        """Verify rtc pull stores base copies in project metadata."""
         mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_load_project.return_value = mock_project
-
-        schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
-        variables = {"flag": True}
-        mock_get_rtc.return_value = {
-            "schema": schema,
-            "variables": variables,
-            "lastUpdated": "T1",
+        mock_project.rtc_pull_env.return_value = {
+            "environment": "sandbox",
+            "schema_file": "schema.json",
+            "data_file": "data.json",
         }
+        mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
 
-        base_schema, base_variables = _load_rtc_base(self.sandbox_dir)
-        self.assertEqual(base_schema, schema)
-        self.assertEqual(base_variables, variables)
+        mock_project.rtc_pull_env.assert_called_once()
+        # set_rtc_base is called inside rtc_pull_env on the real project
 
     def test_merge_clean_non_overlapping_changes(self):
         """Verify clean merge when local and remote change different fields."""
@@ -623,57 +511,53 @@ class TestRTCMerge(unittest.TestCase):
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_drift_clean_merge_succeeds(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
+    def test_push_drift_clean_merge_succeeds(self, mock_get_rtc, mock_load_project):
         """Verify push with clean merge auto-resolves and pushes."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.get_rtc_base.return_value = ({"type": "object"}, {"a": 1, "b": 2})
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
         mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T3"}
 
-        base_schema = {"type": "object"}
-        base_variables = {"a": 1, "b": 2}
-
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), base_schema)
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_variables)
-
-        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), base_schema)
-        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
+        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
+            json.dump({"a": 10, "b": 2}, f)
 
         mock_get_rtc.return_value = {
             "lastUpdated": "T2",
-            "schema": base_schema,
+            "schema": {"type": "object"},
             "variables": {"a": 1, "b": 20},
         }
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
-        mock_put_schema.assert_called_once()
-        mock_patch_vars.assert_called_once()
 
-        pushed_vars = mock_patch_vars.call_args[1]["variables"]
-        self.assertEqual(pushed_vars["a"], 10)
-        self.assertEqual(pushed_vars["b"], 20)
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
+        self.assertEqual(call_kwargs["variables"]["a"], 10)
+        self.assertEqual(call_kwargs["variables"]["b"], 20)
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_push_drift_no_base_files_returns_error(self, mock_get_rtc, mock_load_project):
-        """Verify push fails gracefully when base files don't exist."""
+    def test_push_drift_no_base_returns_error(self, mock_get_rtc, mock_load_project):
+        """Verify push fails gracefully when no base copies exist."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
+        mock_project.get_rtc_base.return_value = (None, None)
         mock_load_project.return_value = mock_project
 
-        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
+            json.dump({"a": 10}, f)
 
         mock_get_rtc.return_value = {"lastUpdated": "T2", "schema": {}, "variables": {}}
 
@@ -689,59 +573,20 @@ class TestRTCMerge(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
+        mock_project.get_rtc_last_updated.return_value = "T1"
         mock_load_project.return_value = mock_project
 
-        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
+            json.dump({"a": 10}, f)
 
         mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", no_merge=True)
         self.assertFalse(result["success"])
         self.assertIn("Run 'poly rtc pull", result["error"])
-
-    @patch("poly.cli_commands.rtc.load_project")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
-    def test_push_updates_base_and_local_files_after_merge(
-        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
-    ):
-        """Verify base and local files are updated after a successful merge+push."""
-        mock_project = MagicMock()
-        mock_project.region = "studio"
-        mock_project.project_id = "test-project"
-        mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
-        mock_load_project.return_value = mock_project
-        mock_patch_vars.return_value = {"lastUpdated": "T3"}
-
-        base_vars = {"a": 1, "b": 2}
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {"type": "object"})
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_vars)
-        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
-
-        mock_get_rtc.return_value = {
-            "lastUpdated": "T2",
-            "schema": {"type": "object"},
-            "variables": {"a": 1, "b": 20},
-        }
-
-        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
-        self.assertTrue(result["success"])
-
-        # Base files should reflect merged content
-        base_schema, base_variables = _load_rtc_base(self.sandbox_dir)
-        self.assertEqual(base_variables["a"], 10)
-        self.assertEqual(base_variables["b"], 20)
-
-        # Local files should also reflect merged content
-        with open(os.path.join(self.sandbox_dir, "data.json"), "r") as f:
-            local_vars = json.load(f)
-        self.assertEqual(local_vars["a"], 10)
-        self.assertEqual(local_vars["b"], 20)
 
 
 class TestIncludeRTC(unittest.TestCase):
@@ -1036,17 +881,16 @@ class TestRTCEdit(unittest.TestCase):
     def test_edit_updates_local_files(
         self, mock_patch_vars, mock_get_rtc, mock_load_project, mock_editor
     ):
-        """Verify edit updates local data.json and base file when env dir exists."""
+        """Verify edit updates local data.json and calls set_rtc_base."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
-        mock_project.rtc_metadata = None
+        mock_project._rtc_env_dir.return_value = self.sandbox_dir
         mock_load_project.return_value = mock_project
 
-        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"flag": False})
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), {"flag": False})
-        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {})
+        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
+            json.dump({"flag": False}, f)
 
         mock_get_rtc.return_value = {
             "schema": {},
@@ -1062,8 +906,9 @@ class TestRTCEdit(unittest.TestCase):
             local = json.load(f)
         self.assertTrue(local["flag"])
 
-        _, base_vars = _load_rtc_base(self.sandbox_dir)
-        self.assertTrue(base_vars["flag"])
+        mock_project.set_rtc_base.assert_called_once()
+        call_kwargs = mock_project.set_rtc_base.call_args[1]
+        self.assertTrue(call_kwargs["variables"]["flag"])
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -449,10 +449,11 @@ class TestRTCDriftProtection(unittest.TestCase):
         mock_patch_vars.assert_called_once()
 
     @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
     def test_push_force_bypasses_drift_check(
-        self, mock_patch_vars, mock_put_schema, mock_load_project
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
     ):
         """Verify --force skips drift check entirely."""
         mock_project = MagicMock()
@@ -470,6 +471,7 @@ class TestRTCDriftProtection(unittest.TestCase):
         self.assertTrue(result["success"])
         mock_put_schema.assert_called_once()
         mock_patch_vars.assert_called_once()
+        mock_get_rtc.assert_not_called()
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -10,17 +10,15 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from poly.cli_commands.rtc import (
-    RTCCommand,
-    RTC_ENV_TO_DIR,
-    RTC_DIR_TO_ENV,
     RTC_BASE_DATA_FILE,
     RTC_BASE_SCHEMA_FILE,
-    RTC_METADATA_FILE,
+    RTC_DIR_TO_ENV,
+    RTC_ENV_TO_DIR,
+    RTCCommand,
     _load_rtc_base,
-    _load_rtc_metadata,
     _merge_rtc_file,
-    _write_json_file,
 )
+from poly.utils import write_json_file
 
 
 class TestRTC(unittest.TestCase):
@@ -187,6 +185,7 @@ class TestRTC(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
@@ -255,6 +254,7 @@ class TestRTC(unittest.TestCase):
         """Verify pushing to live in JSON mode without --force returns error."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
 
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
@@ -306,6 +306,7 @@ class TestRTC(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T1"}
         mock_questionary.confirm.return_value.ask.return_value = True
@@ -335,6 +336,7 @@ class TestRTC(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
         mock_questionary.confirm.return_value.ask.return_value = False
 
@@ -375,12 +377,13 @@ class TestRTCDriftProtection(unittest.TestCase):
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
-    def test_pull_writes_metadata_file(self, mock_get_rtc, mock_load_project):
-        """Verify rtc pull writes .rtc_metadata.json with lastUpdated."""
+    def test_pull_stores_metadata_in_project(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull stores lastUpdated in project.rtc_metadata."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
 
         mock_get_rtc.return_value = {
@@ -391,10 +394,10 @@ class TestRTCDriftProtection(unittest.TestCase):
 
         RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
 
-        metadata = _load_rtc_metadata(self.sandbox_dir)
-        self.assertIsNotNone(metadata)
-        self.assertEqual(metadata["last_updated"], "2024-06-01T12:00:00Z")
-        self.assertIn("pulled_at", metadata)
+        self.assertEqual(
+            mock_project.rtc_metadata["sandbox"]["last_updated"], "2024-06-01T12:00:00Z"
+        )
+        mock_project.save_config.assert_called()
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
@@ -408,13 +411,9 @@ class TestRTCDriftProtection(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
 
-        # Local metadata says T1
-        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
-            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
-
-        # Remote says T2
         mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
@@ -435,11 +434,9 @@ class TestRTCDriftProtection(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T1"}
-
-        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
-            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
 
         mock_get_rtc.return_value = {"lastUpdated": "T1"}
 
@@ -460,12 +457,9 @@ class TestRTCDriftProtection(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T3"}
-
-        # Metadata says T1 but we don't even check remote with --force
-        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
-            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
 
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", force=True)
         self.assertTrue(result["success"])
@@ -479,15 +473,15 @@ class TestRTCDriftProtection(unittest.TestCase):
     def test_push_no_metadata_warns_and_proceeds(
         self, mock_patch_vars, mock_put_schema, mock_load_project
     ):
-        """Verify push proceeds with warning when no metadata file exists."""
+        """Verify push proceeds with warning when no metadata exists."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = None
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
-        # No .rtc_metadata.json on disk
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
         mock_put_schema.assert_called_once()
@@ -500,15 +494,13 @@ class TestRTCDriftProtection(unittest.TestCase):
     def test_push_updates_metadata_after_success(
         self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
     ):
-        """Verify push updates .rtc_metadata.json with new lastUpdated."""
+        """Verify push updates rtc_metadata with new lastUpdated."""
         mock_project = MagicMock()
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
-
-        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
-            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
 
         mock_get_rtc.return_value = {"lastUpdated": "T1"}
         mock_patch_vars.return_value = {"lastUpdated": "T2"}
@@ -516,8 +508,8 @@ class TestRTCDriftProtection(unittest.TestCase):
         result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
         self.assertTrue(result["success"])
 
-        metadata = _load_rtc_metadata(self.sandbox_dir)
-        self.assertEqual(metadata["last_updated"], "T2")
+        self.assertEqual(mock_project.rtc_metadata["sandbox"]["last_updated"], "T2")
+        mock_project.save_config.assert_called()
 
 
 class TestRTCMerge(unittest.TestCase):
@@ -621,25 +613,19 @@ class TestRTCMerge(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T3"}
 
         base_schema = {"type": "object"}
         base_variables = {"a": 1, "b": 2}
 
-        # Write base files (from a previous pull)
-        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), base_schema)
-        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_variables)
-        _write_json_file(
-            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
-            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
-        )
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), base_schema)
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_variables)
 
-        # Local user changed "a"
-        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), base_schema)
-        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
+        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), base_schema)
+        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
 
-        # Remote changed "b"
         mock_get_rtc.return_value = {
             "lastUpdated": "T2",
             "schema": base_schema,
@@ -663,14 +649,11 @@ class TestRTCMerge(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
 
-        _write_json_file(
-            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
-            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
-        )
-        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
 
         mock_get_rtc.return_value = {"lastUpdated": "T2", "schema": {}, "variables": {}}
 
@@ -686,14 +669,11 @@ class TestRTCMerge(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
 
-        _write_json_file(
-            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
-            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
-        )
-        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
 
         mock_get_rtc.return_value = {"lastUpdated": "T2"}
 
@@ -713,18 +693,15 @@ class TestRTCMerge(unittest.TestCase):
         mock_project.region = "studio"
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
+        mock_project.rtc_metadata = {"sandbox": {"last_updated": "T1"}}
         mock_load_project.return_value = mock_project
         mock_patch_vars.return_value = {"lastUpdated": "T3"}
 
         base_vars = {"a": 1, "b": 2}
-        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {"type": "object"})
-        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_vars)
-        _write_json_file(
-            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
-            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
-        )
-        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
-        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {"type": "object"})
+        write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_vars)
+        write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
 
         mock_get_rtc.return_value = {
             "lastUpdated": "T2",

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -9,7 +9,7 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from poly.cli import AgentStudioCLI, RTC_ENV_TO_DIR, RTC_DIR_TO_ENV
+from poly.cli_commands.rtc import RTCCommand, RTC_ENV_TO_DIR, RTC_DIR_TO_ENV
 
 
 class TestRTC(unittest.TestCase):
@@ -49,8 +49,8 @@ class TestRTC(unittest.TestCase):
         """Verify live API env maps to live directory."""
         self.assertEqual(RTC_ENV_TO_DIR["live"], "live")
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
     def test_rtc_pull_all_envs(self, mock_get_rtc, mock_load_project):
         """Verify rtc pull writes all 3 environments."""
         mock_project = MagicMock()
@@ -68,7 +68,7 @@ class TestRTC(unittest.TestCase):
         }
         mock_get_rtc.return_value = rtc_response
 
-        AgentStudioCLI.rtc_pull(self.temp_dir, env="all", output_json=True)
+        RTCCommand.rtc_pull(self.temp_dir, env="all", output_json=True)
 
         # Verify API was called for each environment
         self.assertEqual(mock_get_rtc.call_count, 3)
@@ -78,8 +78,8 @@ class TestRTC(unittest.TestCase):
         self.assertIn("pre-release", envs_called)
         self.assertIn("live", envs_called)
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
     def test_rtc_pull_single_env(self, mock_get_rtc, mock_load_project):
         """Verify rtc pull --env sandbox only calls API once."""
         mock_project = MagicMock()
@@ -95,14 +95,14 @@ class TestRTC(unittest.TestCase):
         }
         mock_get_rtc.return_value = rtc_response
 
-        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+        RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
 
         # Verify API was called once
         mock_get_rtc.assert_called_once()
         self.assertEqual(mock_get_rtc.call_args[1]["client_env"], "sandbox")
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
     def test_rtc_pull_creates_directories(self, mock_get_rtc, mock_load_project):
         """Verify rtc pull creates necessary directories."""
         mock_project = MagicMock()
@@ -118,14 +118,14 @@ class TestRTC(unittest.TestCase):
         }
         mock_get_rtc.return_value = rtc_response
 
-        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+        RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
 
         # Verify directories were created
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         self.assertTrue(os.path.isdir(sandbox_dir))
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
     def test_rtc_pull_writes_json_files(self, mock_get_rtc, mock_load_project):
         """Verify rtc pull writes valid JSON files."""
         mock_project = MagicMock()
@@ -144,7 +144,7 @@ class TestRTC(unittest.TestCase):
         }
         mock_get_rtc.return_value = rtc_response
 
-        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+        RTCCommand.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
 
         # Verify files exist and contain correct content
         schema_path = os.path.join(
@@ -165,9 +165,9 @@ class TestRTC(unittest.TestCase):
             loaded_variables = json.load(f)
         self.assertEqual(loaded_variables, variables_obj)
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli.AgentStudioInterface.patch_rtc_variables")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
     def test_rtc_push_schema_and_variables(
         self, mock_patch_vars, mock_put_schema, mock_load_project
     ):
@@ -191,7 +191,7 @@ class TestRTC(unittest.TestCase):
         with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
             json.dump(variables_obj, f)
 
-        AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+        RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
 
         # Verify both APIs were called
         mock_put_schema.assert_called_once()
@@ -206,7 +206,7 @@ class TestRTC(unittest.TestCase):
         self.assertEqual(vars_call["client_env"], "sandbox")
         self.assertEqual(vars_call["variables"], variables_obj)
 
-    @patch("poly.cli.load_project")
+    @patch("poly.cli_commands.rtc.load_project")
     def test_rtc_push_missing_schema_raises(self, mock_load_project):
         """Verify rtc push raises if schema.json is missing."""
         mock_project = MagicMock()
@@ -220,9 +220,9 @@ class TestRTC(unittest.TestCase):
             json.dump({}, f)
 
         with self.assertRaises(SystemExit):
-            AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+            RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
 
-    @patch("poly.cli.load_project")
+    @patch("poly.cli_commands.rtc.load_project")
     def test_rtc_push_missing_data_raises(self, mock_load_project):
         """Verify rtc push raises if data.json is missing."""
         mock_project = MagicMock()
@@ -236,9 +236,9 @@ class TestRTC(unittest.TestCase):
             json.dump({}, f)
 
         with self.assertRaises(SystemExit):
-            AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+            RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
 
-    @patch("poly.cli.load_project")
+    @patch("poly.cli_commands.rtc.load_project")
     def test_rtc_push_live_without_force_json_exits(self, mock_load_project):
         """Verify pushing to live in JSON mode without --force is refused."""
         mock_project = MagicMock()
@@ -253,11 +253,11 @@ class TestRTC(unittest.TestCase):
             json.dump({}, f)
 
         with self.assertRaises(SystemExit):
-            AgentStudioCLI.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
+            RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
 
-    @patch("poly.cli.load_project")
-    @patch("poly.cli.AgentStudioInterface.put_rtc_schema")
-    @patch("poly.cli.AgentStudioInterface.patch_rtc_variables")
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
     def test_rtc_push_live_with_force_succeeds(
         self, mock_patch_vars, mock_put_schema, mock_load_project
     ):
@@ -275,7 +275,7 @@ class TestRTC(unittest.TestCase):
         with open(os.path.join(live_dir, "data.json"), "w") as f:
             json.dump({"key": "val"}, f)
 
-        AgentStudioCLI.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
+        RTCCommand.rtc_push(self.temp_dir, env="live", force=True, output_json=True)
 
         mock_put_schema.assert_called_once()
         mock_patch_vars.assert_called_once()
@@ -284,7 +284,7 @@ class TestRTC(unittest.TestCase):
 class TestIncludeRTC(unittest.TestCase):
     """Test suite for --include-rtc on pull/push commands."""
 
-    @patch("poly.cli.AgentStudioCLI.rtc_pull")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_pull")
     @patch("poly.cli_commands.sync.load_project")
     def test_pull_include_rtc_calls_rtc_pull(self, mock_load_project, mock_rtc_pull):
         """Verify pull --include-rtc calls rtc_pull after normal pull."""
@@ -301,7 +301,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         mock_rtc_pull.assert_called_once_with("/tmp/test", env="all", output_json=True)
 
-    @patch("poly.cli.AgentStudioCLI.rtc_pull")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_pull")
     @patch("poly.cli_commands.sync.load_project")
     def test_pull_without_include_rtc_does_not_call_rtc(self, mock_load_project, mock_rtc_pull):
         """Verify pull without --include-rtc does not call rtc_pull."""
@@ -318,7 +318,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         mock_rtc_pull.assert_not_called()
 
-    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_push")
     @patch("poly.cli_commands.sync.load_project")
     def test_push_include_rtc_calls_rtc_push_sandbox_default(
         self, mock_load_project, mock_rtc_push
@@ -339,7 +339,7 @@ class TestIncludeRTC(unittest.TestCase):
             "/tmp/test", env="sandbox", force=False, output_json=True
         )
 
-    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_push")
     @patch("poly.cli_commands.sync.load_project")
     def test_push_include_rtc_with_custom_env(self, mock_load_project, mock_rtc_push):
         """Verify push --include-rtc --rtc-env live passes the correct env."""
@@ -358,7 +358,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         mock_rtc_push.assert_called_once_with("/tmp/test", env="live", force=True, output_json=True)
 
-    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_push")
     @patch("poly.cli_commands.sync.load_project")
     def test_push_without_include_rtc_does_not_call_rtc(self, mock_load_project, mock_rtc_push):
         """Verify push without --include-rtc does not call rtc_push."""
@@ -375,7 +375,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         mock_rtc_push.assert_not_called()
 
-    @patch("poly.cli.AgentStudioCLI.rtc_push")
+    @patch("poly.cli_commands.rtc.RTCCommand.rtc_push")
     @patch("poly.cli_commands.sync.load_project")
     def test_push_include_rtc_skipped_on_failed_push(self, mock_load_project, mock_rtc_push):
         """Verify rtc_push is not called when the main push fails."""

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -356,7 +356,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         PullCommand.pull("/tmp/test", include_rtc=True, output_json=True)
 
-        mock_rtc_pull.assert_called_once_with("/tmp/test", env="all")
+        mock_rtc_pull.assert_called_once_with("/tmp/test", env="all", output_json=True)
 
     @patch("poly.cli_commands.rtc.RTCCommand.rtc_pull")
     @patch("poly.cli_commands.sync.load_project")

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -207,40 +207,40 @@ class TestRTC(unittest.TestCase):
         self.assertEqual(vars_call["variables"], variables_obj)
 
     @patch("poly.cli_commands.rtc.load_project")
-    def test_rtc_push_missing_schema_raises(self, mock_load_project):
-        """Verify rtc push raises if schema.json is missing."""
+    def test_rtc_push_missing_schema_returns_error(self, mock_load_project):
+        """Verify rtc push returns error if schema.json is missing."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
-        # Create only data.json
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         os.makedirs(sandbox_dir)
         with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
             json.dump({}, f)
 
-        with self.assertRaises(SystemExit):
-            RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+        self.assertFalse(result["success"])
+        self.assertIn("schema.json not found", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
-    def test_rtc_push_missing_data_raises(self, mock_load_project):
-        """Verify rtc push raises if data.json is missing."""
+    def test_rtc_push_missing_data_returns_error(self, mock_load_project):
+        """Verify rtc push returns error if data.json is missing."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
 
-        # Create only schema.json
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
         os.makedirs(sandbox_dir)
         with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
             json.dump({}, f)
 
-        with self.assertRaises(SystemExit):
-            RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+        self.assertFalse(result["success"])
+        self.assertIn("data.json not found", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
-    def test_rtc_push_live_without_force_json_exits(self, mock_load_project):
-        """Verify pushing to live in JSON mode without --force is refused."""
+    def test_rtc_push_live_without_force_json_returns_error(self, mock_load_project):
+        """Verify pushing to live in JSON mode without --force returns error."""
         mock_project = MagicMock()
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
@@ -252,8 +252,9 @@ class TestRTC(unittest.TestCase):
         with open(os.path.join(live_dir, "data.json"), "w") as f:
             json.dump({}, f)
 
-        with self.assertRaises(SystemExit):
-            RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
+        result = RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=True)
+        self.assertFalse(result["success"])
+        self.assertIn("--force", result["error"])
 
     @patch("poly.cli_commands.rtc.load_project")
     @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
@@ -355,7 +356,7 @@ class TestIncludeRTC(unittest.TestCase):
 
         PullCommand.pull("/tmp/test", include_rtc=True, output_json=True)
 
-        mock_rtc_pull.assert_called_once_with("/tmp/test", env="all", output_json=True)
+        mock_rtc_pull.assert_called_once_with("/tmp/test", env="all")
 
     @patch("poly.cli_commands.rtc.RTCCommand.rtc_pull")
     @patch("poly.cli_commands.sync.load_project")

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -9,7 +9,18 @@ import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from poly.cli_commands.rtc import RTCCommand, RTC_ENV_TO_DIR, RTC_DIR_TO_ENV
+from poly.cli_commands.rtc import (
+    RTCCommand,
+    RTC_ENV_TO_DIR,
+    RTC_DIR_TO_ENV,
+    RTC_BASE_DATA_FILE,
+    RTC_BASE_SCHEMA_FILE,
+    RTC_METADATA_FILE,
+    _load_rtc_base,
+    _load_rtc_metadata,
+    _merge_rtc_file,
+    _write_json_file,
+)
 
 
 class TestRTC(unittest.TestCase):
@@ -177,6 +188,7 @@ class TestRTC(unittest.TestCase):
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
         # Create test files
         sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
@@ -268,6 +280,7 @@ class TestRTC(unittest.TestCase):
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T1"}
 
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
         os.makedirs(live_dir)
@@ -294,6 +307,7 @@ class TestRTC(unittest.TestCase):
         mock_project.project_id = "test-project"
         mock_project.root_path = self.temp_dir
         mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T1"}
         mock_questionary.confirm.return_value.ask.return_value = True
 
         live_dir = os.path.join(self.temp_dir, "real_time_configuration", "live")
@@ -336,6 +350,399 @@ class TestRTC(unittest.TestCase):
         mock_questionary.confirm.assert_called_once()
         mock_put_schema.assert_not_called()
         mock_patch_vars.assert_not_called()
+
+
+class TestRTCDriftProtection(unittest.TestCase):
+    """Test suite for RTC drift protection on push."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.sandbox_dir = os.path.join(
+            self.temp_dir, "real_time_configuration", "draft_and_sandbox"
+        )
+        os.makedirs(self.sandbox_dir)
+        with open(os.path.join(self.sandbox_dir, "schema.json"), "w") as f:
+            json.dump({"type": "object"}, f)
+        with open(os.path.join(self.sandbox_dir, "data.json"), "w") as f:
+            json.dump({"key": "value"}, f)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    def test_pull_writes_metadata_file(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull writes .rtc_metadata.json with lastUpdated."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        mock_get_rtc.return_value = {
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+            "lastUpdated": "2024-06-01T12:00:00Z",
+        }
+
+        RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
+
+        metadata = _load_rtc_metadata(self.sandbox_dir)
+        self.assertIsNotNone(metadata)
+        self.assertEqual(metadata["last_updated"], "2024-06-01T12:00:00Z")
+        self.assertIn("pulled_at", metadata)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_detects_drift(
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
+    ):
+        """Verify push refuses when remote lastUpdated differs from local."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        # Local metadata says T1
+        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
+            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
+
+        # Remote says T2
+        mock_get_rtc.return_value = {"lastUpdated": "T2"}
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertFalse(result["success"])
+        self.assertIn("changed since your last pull", result["error"])
+        mock_put_schema.assert_not_called()
+        mock_patch_vars.assert_not_called()
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_allows_when_no_drift(
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
+    ):
+        """Verify push proceeds when remote lastUpdated matches local."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T1"}
+
+        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
+            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
+
+        mock_get_rtc.return_value = {"lastUpdated": "T1"}
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertTrue(result["success"])
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_force_bypasses_drift_check(
+        self, mock_patch_vars, mock_put_schema, mock_load_project
+    ):
+        """Verify --force skips drift check entirely."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T3"}
+
+        # Metadata says T1 but we don't even check remote with --force
+        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
+            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", force=True)
+        self.assertTrue(result["success"])
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_no_metadata_warns_and_proceeds(
+        self, mock_patch_vars, mock_put_schema, mock_load_project
+    ):
+        """Verify push proceeds with warning when no metadata file exists."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T1"}
+
+        # No .rtc_metadata.json on disk
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertTrue(result["success"])
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_updates_metadata_after_success(
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
+    ):
+        """Verify push updates .rtc_metadata.json with new lastUpdated."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        with open(os.path.join(self.sandbox_dir, RTC_METADATA_FILE), "w") as f:
+            json.dump({"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"}, f)
+
+        mock_get_rtc.return_value = {"lastUpdated": "T1"}
+        mock_patch_vars.return_value = {"lastUpdated": "T2"}
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertTrue(result["success"])
+
+        metadata = _load_rtc_metadata(self.sandbox_dir)
+        self.assertEqual(metadata["last_updated"], "T2")
+
+
+class TestRTCMerge(unittest.TestCase):
+    """Test suite for RTC 3-way merge on push."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.sandbox_dir = os.path.join(
+            self.temp_dir, "real_time_configuration", "draft_and_sandbox"
+        )
+        os.makedirs(self.sandbox_dir)
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    def test_pull_writes_base_files(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull writes .rtc_base_schema.json and .rtc_base_data.json."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+        variables = {"flag": True}
+        mock_get_rtc.return_value = {
+            "schema": schema,
+            "variables": variables,
+            "lastUpdated": "T1",
+        }
+
+        RTCCommand.rtc_pull(self.temp_dir, env="sandbox")
+
+        base_schema, base_variables = _load_rtc_base(self.sandbox_dir)
+        self.assertEqual(base_schema, schema)
+        self.assertEqual(base_variables, variables)
+
+    def test_merge_clean_non_overlapping_changes(self):
+        """Verify clean merge when local and remote change different fields."""
+        base = {"a": 1, "b": 2, "c": 3}
+        local = {"a": 10, "b": 2, "c": 3}
+        remote = {"a": 1, "b": 20, "c": 3}
+
+        result = _merge_rtc_file("data.json", base, local, remote, output_json=True)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["a"], 10)
+        self.assertEqual(result["b"], 20)
+        self.assertEqual(result["c"], 3)
+
+    def test_merge_local_only_changes(self):
+        """Verify merge returns local when only local changed."""
+        base = {"a": 1, "b": 2}
+        local = {"a": 10, "b": 2}
+        remote = {"a": 1, "b": 2}
+
+        result = _merge_rtc_file("data.json", base, local, remote)
+        self.assertEqual(result, local)
+
+    def test_merge_remote_only_changes(self):
+        """Verify merge returns remote when only remote changed."""
+        base = {"a": 1, "b": 2}
+        local = {"a": 1, "b": 2}
+        remote = {"a": 1, "b": 20}
+
+        result = _merge_rtc_file("data.json", base, local, remote)
+        self.assertEqual(result, remote)
+
+    def test_merge_identical_changes(self):
+        """Verify merge succeeds when both sides made the same change."""
+        base = {"a": 1, "b": 2}
+        local = {"a": 10, "b": 2}
+        remote = {"a": 10, "b": 2}
+
+        result = _merge_rtc_file("data.json", base, local, remote)
+        self.assertEqual(result["a"], 10)
+
+    def test_merge_conflict_returns_none_in_json_mode(self):
+        """Verify conflicting changes return None in JSON mode."""
+        base = {"a": 1}
+        local = {"a": 10}
+        remote = {"a": 20}
+
+        result = _merge_rtc_file("data.json", base, local, remote, output_json=True)
+        self.assertIsNone(result)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_drift_clean_merge_succeeds(
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
+    ):
+        """Verify push with clean merge auto-resolves and pushes."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T3"}
+
+        base_schema = {"type": "object"}
+        base_variables = {"a": 1, "b": 2}
+
+        # Write base files (from a previous pull)
+        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), base_schema)
+        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_variables)
+        _write_json_file(
+            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
+            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
+        )
+
+        # Local user changed "a"
+        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), base_schema)
+        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
+
+        # Remote changed "b"
+        mock_get_rtc.return_value = {
+            "lastUpdated": "T2",
+            "schema": base_schema,
+            "variables": {"a": 1, "b": 20},
+        }
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertTrue(result["success"])
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+        pushed_vars = mock_patch_vars.call_args[1]["variables"]
+        self.assertEqual(pushed_vars["a"], 10)
+        self.assertEqual(pushed_vars["b"], 20)
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    def test_push_drift_no_base_files_returns_error(self, mock_get_rtc, mock_load_project):
+        """Verify push fails gracefully when base files don't exist."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        _write_json_file(
+            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
+            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
+        )
+        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+
+        mock_get_rtc.return_value = {"lastUpdated": "T2", "schema": {}, "variables": {}}
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertFalse(result["success"])
+        self.assertIn("no base version", result["error"])
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    def test_push_drift_no_merge_flag_hard_fails(self, mock_get_rtc, mock_load_project):
+        """Verify --no-merge disables merge and hard-fails on drift."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+
+        _write_json_file(
+            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
+            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
+        )
+        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10})
+
+        mock_get_rtc.return_value = {"lastUpdated": "T2"}
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox", no_merge=True)
+        self.assertFalse(result["success"])
+        self.assertIn("Run 'poly rtc pull", result["error"])
+
+    @patch("poly.cli_commands.rtc.load_project")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.get_rtc_config")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli_commands.rtc.AgentStudioInterface.patch_rtc_variables")
+    def test_push_updates_base_and_local_files_after_merge(
+        self, mock_patch_vars, mock_put_schema, mock_get_rtc, mock_load_project
+    ):
+        """Verify base and local files are updated after a successful merge+push."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_project.root_path = self.temp_dir
+        mock_load_project.return_value = mock_project
+        mock_patch_vars.return_value = {"lastUpdated": "T3"}
+
+        base_vars = {"a": 1, "b": 2}
+        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_SCHEMA_FILE), {"type": "object"})
+        _write_json_file(os.path.join(self.sandbox_dir, RTC_BASE_DATA_FILE), base_vars)
+        _write_json_file(
+            os.path.join(self.sandbox_dir, RTC_METADATA_FILE),
+            {"last_updated": "T1", "pulled_at": "2024-01-01T00:00:00Z"},
+        )
+        _write_json_file(os.path.join(self.sandbox_dir, "schema.json"), {"type": "object"})
+        _write_json_file(os.path.join(self.sandbox_dir, "data.json"), {"a": 10, "b": 2})
+
+        mock_get_rtc.return_value = {
+            "lastUpdated": "T2",
+            "schema": {"type": "object"},
+            "variables": {"a": 1, "b": 20},
+        }
+
+        result = RTCCommand.rtc_push(self.temp_dir, env="sandbox")
+        self.assertTrue(result["success"])
+
+        # Base files should reflect merged content
+        base_schema, base_variables = _load_rtc_base(self.sandbox_dir)
+        self.assertEqual(base_variables["a"], 10)
+        self.assertEqual(base_variables["b"], 20)
+
+        # Local files should also reflect merged content
+        with open(os.path.join(self.sandbox_dir, "data.json"), "r") as f:
+            local_vars = json.load(f)
+        self.assertEqual(local_vars["a"], 10)
+        self.assertEqual(local_vars["b"], 20)
 
 
 class TestIncludeRTC(unittest.TestCase):

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -592,6 +592,26 @@ class TestRTCMerge(unittest.TestCase):
         result = _merge_rtc_file("data.json", base, local, remote)
         self.assertEqual(result["a"], 10)
 
+    def test_merge_nested_non_overlapping(self):
+        """Verify nested dict changes on different keys merge cleanly."""
+        base = {"config": {"a": 1, "b": 2}}
+        local = {"config": {"a": 10, "b": 2}}
+        remote = {"config": {"a": 1, "b": 20}}
+
+        result = _merge_rtc_file("data.json", base, local, remote, output_json=True)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["config"]["a"], 10)
+        self.assertEqual(result["config"]["b"], 20)
+
+    def test_merge_nested_conflict_returns_none_in_json_mode(self):
+        """Verify nested dict conflict on same key returns None in JSON mode."""
+        base = {"config": {"a": 1}}
+        local = {"config": {"a": 10}}
+        remote = {"config": {"a": 20}}
+
+        result = _merge_rtc_file("data.json", base, local, remote, output_json=True)
+        self.assertIsNone(result)
+
     def test_merge_conflict_returns_none_in_json_mode(self):
         """Verify conflicting changes return None in JSON mode."""
         base = {"a": 1}

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -1,0 +1,235 @@
+"""Tests for RTC (Real-Time Configuration) functionality.
+
+Copyright PolyAI Limited
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+from poly.cli import AgentStudioCLI, RTC_ENV_TO_DIR, RTC_DIR_TO_ENV
+
+
+class TestRTCIntegration(unittest.TestCase):
+    """Test suite for poly rtc command."""
+
+    def setUp(self):
+        """Set up test fixtures."""
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Clean up temporary files."""
+        import shutil
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_env_mapping_roundtrip(self):
+        """Verify RTC_ENV_TO_DIR and RTC_DIR_TO_ENV are consistent."""
+        for env, dir_name in RTC_ENV_TO_DIR.items():
+            self.assertEqual(RTC_DIR_TO_ENV[dir_name], env)
+
+    def test_env_mapping_coverage(self):
+        """Verify all 3 standard environments are mapped."""
+        self.assertEqual(len(RTC_ENV_TO_DIR), 3)
+        self.assertIn("sandbox", RTC_ENV_TO_DIR)
+        self.assertIn("pre-release", RTC_ENV_TO_DIR)
+        self.assertIn("live", RTC_ENV_TO_DIR)
+
+    def test_sandbox_maps_to_draft_and_sandbox(self):
+        """Verify sandbox API env maps to draft_and_sandbox directory."""
+        self.assertEqual(RTC_ENV_TO_DIR["sandbox"], "draft_and_sandbox")
+
+    def test_pre_release_maps_to_pre_release(self):
+        """Verify pre-release API env maps to pre_release directory."""
+        self.assertEqual(RTC_ENV_TO_DIR["pre-release"], "pre_release")
+
+    def test_live_maps_to_live(self):
+        """Verify live API env maps to live directory."""
+        self.assertEqual(RTC_ENV_TO_DIR["live"], "live")
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    def test_rtc_pull_all_envs(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull writes all 3 environments."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_load_project.return_value = mock_project
+
+        # Mock API responses
+        rtc_response = {
+            "clientEnv": "sandbox",
+            "schema": {"type": "object", "properties": {}},
+            "variables": {"mock_api": False},
+            "lastUpdated": "2024-01-01T00:00:00Z",
+        }
+        mock_get_rtc.return_value = rtc_response
+
+        AgentStudioCLI.rtc_pull(self.temp_dir, env="all", output_json=True)
+
+        # Verify API was called for each environment
+        self.assertEqual(mock_get_rtc.call_count, 3)
+        call_args_list = [call[1] for call in mock_get_rtc.call_args_list]
+        envs_called = [call["client_env"] for call in call_args_list]
+        self.assertIn("sandbox", envs_called)
+        self.assertIn("pre-release", envs_called)
+        self.assertIn("live", envs_called)
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    def test_rtc_pull_single_env(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull --env sandbox only calls API once."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_load_project.return_value = mock_project
+
+        rtc_response = {
+            "clientEnv": "sandbox",
+            "schema": {"type": "object"},
+            "variables": {"mock_api": False},
+        }
+        mock_get_rtc.return_value = rtc_response
+
+        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+
+        # Verify API was called once
+        mock_get_rtc.assert_called_once()
+        self.assertEqual(mock_get_rtc.call_args[1]["client_env"], "sandbox")
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    def test_rtc_pull_creates_directories(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull creates necessary directories."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_load_project.return_value = mock_project
+
+        rtc_response = {
+            "clientEnv": "sandbox",
+            "schema": {"type": "object"},
+            "variables": {"key": "value"},
+        }
+        mock_get_rtc.return_value = rtc_response
+
+        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+
+        # Verify directories were created
+        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
+        self.assertTrue(os.path.isdir(sandbox_dir))
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.get_rtc_config")
+    def test_rtc_pull_writes_json_files(self, mock_get_rtc, mock_load_project):
+        """Verify rtc pull writes valid JSON files."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_load_project.return_value = mock_project
+
+        schema_obj = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+        variables_obj = {"flag": True, "nested": {"key": "value"}}
+
+        rtc_response = {
+            "clientEnv": "sandbox",
+            "schema": schema_obj,
+            "variables": variables_obj,
+        }
+        mock_get_rtc.return_value = rtc_response
+
+        AgentStudioCLI.rtc_pull(self.temp_dir, env="sandbox", output_json=True)
+
+        # Verify files exist and contain correct content
+        schema_path = os.path.join(
+            self.temp_dir, "real_time_configuration", "draft_and_sandbox", "schema.json"
+        )
+        data_path = os.path.join(
+            self.temp_dir, "real_time_configuration", "draft_and_sandbox", "data.json"
+        )
+
+        self.assertTrue(os.path.exists(schema_path))
+        self.assertTrue(os.path.exists(data_path))
+
+        with open(schema_path, "r") as f:
+            loaded_schema = json.load(f)
+        self.assertEqual(loaded_schema, schema_obj)
+
+        with open(data_path, "r") as f:
+            loaded_variables = json.load(f)
+        self.assertEqual(loaded_variables, variables_obj)
+
+    @patch("poly.cli.load_project")
+    @patch("poly.cli.AgentStudioInterface.put_rtc_schema")
+    @patch("poly.cli.AgentStudioInterface.patch_rtc_variables")
+    def test_rtc_push_schema_and_variables(
+        self, mock_patch_vars, mock_put_schema, mock_load_project
+    ):
+        """Verify rtc push calls both schema and variables APIs."""
+        mock_project = MagicMock()
+        mock_project.region = "studio"
+        mock_project.project_id = "test-project"
+        mock_load_project.return_value = mock_project
+
+        # Create test files
+        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
+        os.makedirs(sandbox_dir)
+
+        schema_obj = {"type": "object"}
+        variables_obj = {"mock_api": False}
+
+        with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
+            json.dump(schema_obj, f)
+
+        with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
+            json.dump(variables_obj, f)
+
+        AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+
+        # Verify both APIs were called
+        mock_put_schema.assert_called_once()
+        mock_patch_vars.assert_called_once()
+
+        # Verify arguments
+        schema_call = mock_put_schema.call_args[1]
+        self.assertEqual(schema_call["client_env"], "sandbox")
+        self.assertEqual(schema_call["schema"], schema_obj)
+
+        vars_call = mock_patch_vars.call_args[1]
+        self.assertEqual(vars_call["client_env"], "sandbox")
+        self.assertEqual(vars_call["variables"], variables_obj)
+
+    @patch("poly.cli.load_project")
+    def test_rtc_push_missing_schema_raises(self, mock_load_project):
+        """Verify rtc push raises if schema.json is missing."""
+        mock_project = MagicMock()
+        mock_load_project.return_value = mock_project
+
+        # Create only data.json
+        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
+        os.makedirs(sandbox_dir)
+        with open(os.path.join(sandbox_dir, "data.json"), "w") as f:
+            json.dump({}, f)
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+
+    @patch("poly.cli.load_project")
+    def test_rtc_push_missing_data_raises(self, mock_load_project):
+        """Verify rtc push raises if data.json is missing."""
+        mock_project = MagicMock()
+        mock_load_project.return_value = mock_project
+
+        # Create only schema.json
+        sandbox_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
+        os.makedirs(sandbox_dir)
+        with open(os.path.join(sandbox_dir, "schema.json"), "w") as f:
+            json.dump({}, f)
+
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI.rtc_push(self.temp_dir, env="sandbox", output_json=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/utils/__init__.py
+++ b/src/poly/utils/__init__.py
@@ -21,7 +21,7 @@ from poly.utils.decorators import (
     func_latency_control,
     func_parameter,
 )
-from poly.utils.json_io import read_json_file, write_json_file
+from poly.utils.json_io import diff_dicts, read_json_file, write_json_file
 from poly.utils.merge import merge_rtc_dicts, merge_strings
 from poly.utils.stub_gen import create_import_file_contents, save_imports
 from poly.utils.variable_references import (
@@ -34,6 +34,7 @@ __all__ = [
     "FUNCTION_TYPE_TO_VAR_REF_FIELD",
     "any_credentials_exist",
     "compute_variable_references",
+    "diff_dicts",
     "create_command_webchat_channel_update_status",
     "create_import_file_contents",
     "export_decorators",

--- a/src/poly/utils/__init__.py
+++ b/src/poly/utils/__init__.py
@@ -22,7 +22,7 @@ from poly.utils.decorators import (
     func_parameter,
 )
 from poly.utils.json_io import read_json_file, write_json_file
-from poly.utils.merge import merge_dicts, merge_strings
+from poly.utils.merge import merge_rtc_dicts, merge_strings
 from poly.utils.stub_gen import create_import_file_contents, save_imports
 from poly.utils.variable_references import (
     FUNCTION_TYPE_TO_VAR_REF_FIELD,
@@ -40,7 +40,7 @@ __all__ = [
     "func_description",
     "func_latency_control",
     "func_parameter",
-    "merge_dicts",
+    "merge_rtc_dicts",
     "merge_strings",
     "read_json_file",
     "retrieve_api_key",

--- a/src/poly/utils/__init__.py
+++ b/src/poly/utils/__init__.py
@@ -21,7 +21,8 @@ from poly.utils.decorators import (
     func_latency_control,
     func_parameter,
 )
-from poly.utils.merge import merge_strings
+from poly.utils.json_io import read_json_file, write_json_file
+from poly.utils.merge import merge_dicts, merge_strings
 from poly.utils.stub_gen import create_import_file_contents, save_imports
 from poly.utils.variable_references import (
     FUNCTION_TYPE_TO_VAR_REF_FIELD,
@@ -39,8 +40,11 @@ __all__ = [
     "func_description",
     "func_latency_control",
     "func_parameter",
+    "merge_dicts",
     "merge_strings",
+    "read_json_file",
     "retrieve_api_key",
     "save_api_key_credential_file",
     "save_imports",
+    "write_json_file",
 ]

--- a/src/poly/utils/json_io.py
+++ b/src/poly/utils/json_io.py
@@ -1,0 +1,23 @@
+"""JSON file I/O helpers.
+
+Copyright PolyAI Limited
+"""
+
+import json
+import os
+from typing import Optional
+
+
+def write_json_file(path: str, data: object) -> None:
+    """Write data as pretty-printed JSON with trailing newline."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def read_json_file(path: str) -> Optional[dict]:
+    """Read a JSON file, or None if it doesn't exist."""
+    if not os.path.exists(path):
+        return None
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)

--- a/src/poly/utils/json_io.py
+++ b/src/poly/utils/json_io.py
@@ -29,6 +29,8 @@ def diff_dicts(local: dict, remote: dict, prefix: str = "") -> list[dict]:
     Recurses into nested dicts. Each difference is a dict with 'path', 'type',
     and the relevant values.
     """
+    local = local or {}
+    remote = remote or {}
     changes = []
     all_keys = sorted(set(local) | set(remote))
 

--- a/src/poly/utils/json_io.py
+++ b/src/poly/utils/json_io.py
@@ -1,4 +1,4 @@
-"""JSON file I/O helpers.
+"""JSON file I/O and comparison helpers.
 
 Copyright PolyAI Limited
 """
@@ -21,3 +21,37 @@ def read_json_file(path: str) -> Optional[dict]:
         return None
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
+
+
+def diff_dicts(local: dict, remote: dict, prefix: str = "") -> list[dict]:
+    """Compare two dicts and return a list of field-level differences.
+
+    Recurses into nested dicts. Each difference is a dict with 'path', 'type',
+    and the relevant values.
+    """
+    changes = []
+    all_keys = sorted(set(local) | set(remote))
+
+    for key in all_keys:
+        path = f"{prefix}.{key}" if prefix else key
+        in_local = key in local
+        in_remote = key in remote
+
+        if in_local and not in_remote:
+            changes.append({"path": path, "type": "added_locally", "local": local[key]})
+        elif in_remote and not in_local:
+            changes.append({"path": path, "type": "only_remote", "remote": remote[key]})
+        elif local[key] != remote[key]:
+            if isinstance(local[key], dict) and isinstance(remote[key], dict):
+                changes.extend(diff_dicts(local[key], remote[key], prefix=path))
+            else:
+                changes.append(
+                    {
+                        "path": path,
+                        "type": "changed",
+                        "local": local[key],
+                        "remote": remote[key],
+                    }
+                )
+
+    return changes

--- a/src/poly/utils/merge.py
+++ b/src/poly/utils/merge.py
@@ -1,9 +1,44 @@
-"""3-way string merge used when pulling remote changes over local edits.
+"""3-way merge utilities for pulling remote changes over local edits.
 
 Copyright PolyAI Limited
 """
 
 import difflib
+
+_MISSING = object()
+
+
+def merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
+    """3-way merge at the dict key level.
+
+    Returns:
+        (merged_dict, list_of_conflict_keys). If conflict_keys is empty, the
+        merge is clean.
+    """
+    all_keys = set(base) | set(local) | set(remote)
+    merged = {}
+    conflicts = []
+
+    for key in sorted(all_keys):
+        base_val = base.get(key, _MISSING)
+        local_val = local.get(key, _MISSING)
+        remote_val = remote.get(key, _MISSING)
+
+        resolved = _MISSING
+        if local_val == remote_val:
+            resolved = local_val
+        elif local_val == base_val:
+            resolved = remote_val
+        elif remote_val == base_val:
+            resolved = local_val
+        else:
+            conflicts.append(key)
+            resolved = local_val
+
+        if resolved is not _MISSING:
+            merged[key] = resolved
+
+    return merged, conflicts
 
 
 def merge_strings(original: str, updated: str, incoming: str) -> str:

--- a/src/poly/utils/merge.py
+++ b/src/poly/utils/merge.py
@@ -32,8 +32,17 @@ def merge_rtc_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[s
         elif remote_val == base_val:
             resolved = local_val
         else:
-            conflicts.append(key)
-            resolved = local_val
+            if (
+                isinstance(base_val, dict)
+                and isinstance(local_val, dict)
+                and isinstance(remote_val, dict)
+            ):
+                nested_merged, nested_conflicts = merge_rtc_dicts(base_val, local_val, remote_val)
+                conflicts.extend([f"{key}.{c}" for c in nested_conflicts])
+                resolved = nested_merged
+            else:
+                conflicts.append(str(key))
+                resolved = local_val
 
         if resolved is not _MISSING:
             merged[key] = resolved

--- a/src/poly/utils/merge.py
+++ b/src/poly/utils/merge.py
@@ -8,7 +8,7 @@ import difflib
 _MISSING = object()
 
 
-def merge_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
+def merge_rtc_dicts(base: dict, local: dict, remote: dict) -> tuple[dict, list[str]]:
     """3-way merge at the dict key level.
 
     Returns:

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.34.3"
+version = "0.34.5"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

Adds `poly rtc pull`, `push`, and `edit` commands to sync Real-Time Configuration between local files and Agent Studio, with drift protection, 3-way merge on conflicts, and `--include-rtc` integration on existing pull/push.

## Motivation

RTC config is currently only manageable through the Agent Studio UI. This lets teams version-control their RTC schema and variables alongside the rest of their agent project, and push changes from the CLI — with safeguards against overwriting each other's changes.

## Changes

- poly rtc pull — fetches schema + variables per environment, writes schema.json and data.json to real_time_configuration/<env>/
- poly rtc push — reads local files, validates data against schema, and uploads to Agent Studio (schema via PUT, variables via PATCH)
- poly rtc edit — pulls latest, opens in $EDITOR, validates JSON, and pushes back in one step with race detection
- poly rtc diff — compares local files against remote config, shows field-level changes (added, removed, changed)
- poly rtc validate — validates local data.json against its schema.json using JSON Schema Draft 7
- --env sandbox|pre-release|live|all for pull, diff, and validate; --env required for push and edit
- --schema / --data flags for selective pull/push (mutually exclusive, default does both)
- --schema flag on edit to edit the schema instead of data variables
- --skip-validation on push to bypass schema validation
- Live push/edit requires --force or interactive confirmation
- --include-rtc on regular poly pull / poly push to sync RTC alongside normal resources
- Drift protection — compares lastUpdated from API against stored metadata before pushing
- 3-way merge when drift is detected — auto-merges non-conflicting field changes (including nested dicts), interactive resolution for true conflicts (local/remote/base/edit in $EDITOR)
- --no-merge flag to disable merge and hard-fail on drift
- RTC metadata and base copies stored in .agent_studio_config (no extra dotfiles for tracking)
- Partial push failure updates metadata so retries don't falsely trigger drift
- RTC IO logic lives in project.py, CLI/interactive logic in cli_commands/rtc.py
- Helpers (write_json_file, read_json_file, diff_dicts, merge_rtc_dicts) in utils/json_io.py and utils/merge.py
- Schema validation (validate_rtc_data) as a static method on AgentStudioProject
- RTC failures propagate to the overall exit code for CI/automation

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly rtc pull`, `poly rtc push`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- TODO: add terminal output after manual testing -->
### push / pull
<img width="1630" height="98" alt="image (18)" src="https://github.com/user-attachments/assets/3e30aaeb-73b5-4474-bb5b-990ca9510968" />
<img width="1600" height="664" alt="image (17)" src="https://github.com/user-attachments/assets/f9ee7e48-75b0-4a69-a258-65cf5aa82438" />
<img width="591" height="299" alt="image" src="https://github.com/user-attachments/assets/75524385-7137-4cc7-9069-31854a5a9606" />

### rtc pull --data
<img width="737" height="97" alt="image" src="https://github.com/user-attachments/assets/41254f5c-05d4-4c8e-9529-2ff2bc3d8d05" />

### edit command:
<img width="796" height="399" alt="image" src="https://github.com/user-attachments/assets/cabd353c-178b-4cf3-b302-64773fc6cd67" />
<img width="672" height="151" alt="image" src="https://github.com/user-attachments/assets/a323e579-7ef9-438d-a5aa-e9c4ed923348" />

#### edit alidation  
<img width="651" height="60" alt="image" src="https://github.com/user-attachments/assets/960e8217-84dc-4ab4-942b-07a9afe3245a" />


tested with [firebirds](https://jupiter.polyai.app/firebirds-us/firebirds-usp/real-time-configuration/sandbox?panel=config-builder): 
<img width="767" height="290" alt="image" src="https://github.com/user-attachments/assets/277116a4-de71-40e3-b570-0a8df28fae5c" />

### diff
<img width="651" height="125" alt="image" src="https://github.com/user-attachments/assets/30490468-48e5-452d-8229-faeac5398621" />
<img width="658" height="147" alt="image" src="https://github.com/user-attachments/assets/1f48b816-174f-4565-8079-5a03b3ba11ea" />
<img width="580" height="96" alt="image" src="https://github.com/user-attachments/assets/a1d330e8-19dd-4fdc-aa62-bf1d795fec18" />

### validate
<img width="663" height="197" alt="image" src="https://github.com/user-attachments/assets/02dd5cbf-a4d6-494d-bbcf-a8820887e5cc" />
<img width="616" height="64" alt="image" src="https://github.com/user-attachments/assets/d4e84680-f72d-46f5-b858-873fca070e77" />
<img width="669" height="241" alt="image" src="https://github.com/user-attachments/assets/6fb1e1e3-02ed-47e5-8a34-0d6519312f77" />

**push with validation error**
<img width="656" height="86" alt="image" src="https://github.com/user-attachments/assets/9801d822-63b6-4301-95e4-6590a63456c2" />


## Ticket and scoop
https://poly-ai.atlassian.net/browse/TYT-1376?search_id=a334215f-41b7-4842-943d-f3d4cadc111b
https://poly-ai.atlassian.net/browse/TYT-1375