### PR TITLE
feat: Allow validating experimental config against custom schema

### DIFF
--- a/src/poly/resources/experimental_config.py
+++ b/src/poly/resources/experimental_config.py
@@ -63,12 +63,13 @@ class ExperimentalConfig(Resource):
 
     def validate(self, **kwargs):
         # Validate against schema
-        openapi_schema = utils.load_yaml(
-            open(
-                os.path.join(os.path.dirname(__file__), "experimental_config_schema.yaml"),
-                encoding="utf-8",
-            )
+        schema_path = os.environ.get("ADK_EXPERIMENTAL_CONFIG_SCHEMA_PATH") or os.path.join(
+            os.path.dirname(__file__), "experimental_config_schema.yaml"
         )
+
+        with open(schema_path, encoding="utf-8") as schema_file:
+            openapi_schema = utils.load_yaml(schema_file.read())
+
         additional_features = openapi_schema["components"]["schemas"]["additional_features"]
         resolver = jsonschema.RefResolver.from_schema(openapi_schema)
 


### PR DESCRIPTION
## Summary

Allow overriding the experimental config validation schema via the `ADK_EXPERIMENTAL_CONFIG_SCHEMA_PATH` environment variable, falling back to the bundled schema.

## Motivation

The bundled `experimental_config_schema.yaml` may not always match the schema expected by a given Agent Studio environment. This lets users point validation at a custom schema file without modifying the package.

## Changes

- Read `ADK_EXPERIMENTAL_CONFIG_SCHEMA_PATH` env var in `ExperimentalConfig.validate()`; fall back to the bundled schema when unset
- Use a context manager (`with open(...)`) for the schema file handle

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)