### PR TITLE
fix: Bump experimental config schema with Soniox ASR

### DIFF
--- a/src/poly/resources/experimental_config_schema.yaml
+++ b/src/poly/resources/experimental_config_schema.yaml
@@ -30,6 +30,7 @@ components:
         - nemo
         - deepgram
         - raven
+        - soniox
 
     asr_common_config_properties:
       type: object
@@ -45,6 +46,7 @@ components:
             - openai: OpenAI realtime API
             - deepgram: Deepgram cloud speech recognition
             - raven: PolyAI Raven Omni speech recognition
+            - soniox: Soniox cloud speech recognition
         model:
           type: string
           minLength: 1
@@ -58,6 +60,7 @@ components:
             - openai: "gpt-4o-transcribe", "gpt-4o-mini-transcribe", "whisper-1"
             - deepgram: "nova-3", "nova-2"
             - raven: "raven-omni"
+            - soniox: "stt-rt-v5"
         language:
           type: string
           minLength: 2


### PR DESCRIPTION
## Summary

Adds `soniox` as a supported ASR provider in the experimental config schema.

## Motivation

The Soniox speech recognition provider (poly_core #43628) needs to be a valid option in the experimental config schema so projects using it pass validation. Agent Studio already accepts `soniox` in published configs, so the reverse-synced `experimental_config.json` currently fails ADK validation in agent-deployments CI (e.g. PolyAI-LDN/agent-deployments#8033) until the config is manually stripped.

## Changes

- Added `soniox` to the ASR provider enum list
- Added `soniox: Soniox cloud speech recognition` to the provider description enum
- Added `soniox: "stt-rt-v5"` to the model documentation

## Test strategy

- [x] Validated the real reverse-synced Corilus `experimental_config.json` (soniox language overrides) against the updated schema with `jsonschema.Draft202012Validator`; unknown providers are still rejected
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)