### PR TITLE
fix: use flow_id instead of flow_name as resource ID prefix for flow steps

### DIFF
--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -532,7 +532,7 @@ class SyncClientHandler:
             )
 
             for step_id, step in flow_data.get("steps", {}).get("entities", {}).items():
-                local_resource_id = f"{flow_data['name']}_{step_id}"
+                local_resource_id = f"{flow_id}_{step_id}"
 
                 if step.get("type") == "function_step":
                     function = step.get("function", {})

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -18,6 +18,7 @@ class MigrationFlag(Enum):
     """
 
     MIGRATED_LEGACY_TOPIC_FILES = "migrated_legacy_topic_files"
+    MIGRATED_FLOW_STEP_RESOURCE_IDS = "migrated_flow_step_resource_ids"
 
 
 def load_migration_flags(flags: list[str]) -> set[MigrationFlag]:
@@ -43,13 +44,19 @@ def get_all_migration_flags() -> set[MigrationFlag]:
     return set(flag for flag in MigrationFlag)
 
 
-def run_migrations(root_path: str, applied_migrations: set[MigrationFlag]) -> set[MigrationFlag]:
+def run_migrations(
+    root_path: str,
+    applied_migrations: set[MigrationFlag],
+    status_dict: dict | None = None,
+) -> set[MigrationFlag]:
     """Run necessary migrations based on the current state of the project and
     which migrations have already been applied.
 
     Args:
         root_path: The root path of the project.
         applied_migrations: A set of MigrationFlag indicating which migrations have already been applied.
+        status_dict: The raw status dict. Required for dict-level migrations
+            that re-key entries before resources are loaded.
 
     Returns:
         A new set of MigrationFlag indicating which migrations have been applied after running this function.
@@ -59,7 +66,50 @@ def run_migrations(root_path: str, applied_migrations: set[MigrationFlag]) -> se
         migrate_legacy_topic_files(root_path)
         new_flags.add(MigrationFlag.MIGRATED_LEGACY_TOPIC_FILES)
 
+    if (
+        MigrationFlag.MIGRATED_FLOW_STEP_RESOURCE_IDS not in applied_migrations
+        and status_dict is not None
+    ):
+        migrate_flow_step_resource_ids(status_dict)
+        new_flags.add(MigrationFlag.MIGRATED_FLOW_STEP_RESOURCE_IDS)
+
     return new_flags
+
+
+def migrate_flow_step_resource_ids(status_dict: dict) -> None:
+    """Re-key flow step resource IDs from {flow_name}_{step_id} to {flow_id}_{step_id}."""
+    resources = status_dict.get("resources", {})
+    file_structure_info = status_dict.get("file_structure_info", {})
+
+    for resource_key in ("flow_steps", "function_steps"):
+        entries = resources.get(resource_key)
+        if not entries:
+            continue
+
+        rekeyed = {}
+        for old_id, resource_dict in entries.items():
+            flow_name = resource_dict.get("flow_name")
+            flow_id = resource_dict.get("flow_id")
+            if not flow_name or not flow_id:
+                rekeyed[old_id] = resource_dict
+                continue
+
+            step_id = old_id.removeprefix(f"{flow_name}_")
+            if step_id == old_id:
+                # Prefix didn't match — may already be migrated or have a different format
+                rekeyed[old_id] = resource_dict
+                continue
+
+            new_id = f"{flow_id}_{step_id}"
+            resource_dict["resource_id"] = new_id
+            rekeyed[new_id] = resource_dict
+
+            # Update file_structure_info entries that reference the old resource_id
+            for file_info in file_structure_info.values():
+                if file_info.get("resource_id") == old_id:
+                    file_info["resource_id"] = new_id
+
+        resources[resource_key] = rekeyed
 
 
 def migrate_legacy_topic_files(root_path: str) -> None:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2303,7 +2303,7 @@ class AgentStudioProject:
                         ResourceMapping(
                             resource_id=resource_info["resource_id"],
                             resource_type=resource_type,
-                            resource_name=resource_info["resource_name"],
+                            resource_name=resource_name,
                             file_path=file_path,
                             flow_name=flow_name,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -262,6 +262,9 @@ class AgentStudioProject:
             json_bytes = base64.b64decode(encoded)
             status_dict = json.loads(json_bytes.decode("utf-8"))
 
+        migration_flags = load_migration_flags(status_dict.get("migration_flags", []))
+        migration_flags = run_migrations(root_path, migration_flags, status_dict=status_dict)
+
         # Load resources
         resources, not_loaded_resources = cls._load_resources_from_status_dict(status_dict)
 
@@ -270,9 +273,6 @@ class AgentStudioProject:
             last_updated = datetime.fromisoformat(last_updated_str)
         else:
             last_updated = datetime.now()
-
-        migration_flags = load_migration_flags(status_dict.get("migration_flags", []))
-        migration_flags = run_migrations(root_path, migration_flags)
 
         return cls(
             region=config_dict.get("region", ""),
@@ -314,12 +314,12 @@ class AgentStudioProject:
     @classmethod
     def from_dict(cls, data: dict, root_path: str) -> "AgentStudioProject":
         """Load whole project class from a dictionary"""
+        migration_flags = load_migration_flags(data.get("migration_flags", []))
+        migration_flags = run_migrations(root_path, migration_flags, status_dict=data)
+
         resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
 
         file_structure_info = cls.compute_file_structure_info(resources)
-
-        migration_flags = load_migration_flags(data.get("migration_flags", []))
-        migration_flags = run_migrations(root_path, migration_flags)
 
         return cls(
             region=data.get("region", ""),
@@ -1523,7 +1523,7 @@ class AgentStudioProject:
                 # Create a dummy default step
                 dummy_step_id = f"{function_start_step.step_id}_start_step_temp"
                 dummy = FlowStep(
-                    resource_id=f"{flow_config.name}_{dummy_step_id}",
+                    resource_id=f"{flow_config.resource_id}_{dummy_step_id}",
                     step_id=dummy_step_id,
                     name=f"{flow_config.name}-temp",
                     flow_id=flow_config.resource_id,
@@ -1562,7 +1562,7 @@ class AgentStudioProject:
             if flow_config_id in new_resources.get(FlowConfig, {}):
                 continue
             old_flow_config = self.resources.get(FlowConfig, {}).get(flow_config_id)
-            old_step_resource_id = f"{old_flow_config.name}_{old_flow_config.start_step}"
+            old_step_resource_id = f"{old_flow_config.resource_id}_{old_flow_config.start_step}"
 
             old_start_step = self.resources.get(FlowStep, {}).get(
                 old_step_resource_id
@@ -1573,7 +1573,7 @@ class AgentStudioProject:
             if flow_config.start_step != old_start_step.step_id:
                 if old_start_step.resource_id in deleted_resources.get(type(old_start_step), {}):
                     # If it's being recreated with the same name (sync ids) we need to create a dummy step
-                    new_step_resource_id = f"{flow_config.name}_{flow_config.start_step}"
+                    new_step_resource_id = f"{flow_config.resource_id}_{flow_config.start_step}"
                     if (
                         (
                             new_start_step := (
@@ -1586,7 +1586,7 @@ class AgentStudioProject:
                     ):
                         dummy_step_id = f"{old_start_step.step_id}_temp"
                         dummy = FlowStep(
-                            resource_id=f"{new_start_step.flow_name}_{dummy_step_id}",
+                            resource_id=f"{new_start_step.flow_id}_{dummy_step_id}",
                             step_id=dummy_step_id,
                             name=f"{new_start_step.name}-temp",
                             flow_id=new_start_step.flow_id,
@@ -1635,7 +1635,7 @@ class AgentStudioProject:
                 if is_start_step:
                     dummy_step_id = f"{original_flow_step.step_id}_temp"
                     dummy = FlowStep(
-                        resource_id=f"{original_flow_step.flow_name}_{dummy_step_id}",
+                        resource_id=f"{original_flow_step.flow_id}_{dummy_step_id}",
                         step_id=dummy_step_id,
                         name=f"{original_flow_step.name}-temp",
                         flow_id=original_flow_step.flow_id,
@@ -2224,6 +2224,11 @@ class AgentStudioProject:
             )
             flow_paths_to_names[resource_utils.clean_name(flow_config.name)] = flow_config.name
 
+        # Build a map of clean flow folder names to flow IDs (from existing resources)
+        flow_paths_to_ids: dict[str, str] = {}
+        for flow_id, flow_cfg in self.resources.get(FlowConfig, {}).items():
+            flow_paths_to_ids[resource_utils.clean_name(flow_cfg.name)] = flow_id
+
         if not self.file_structure_info:
             self.file_structure_info = self.compute_file_structure_info(self.resources)
 
@@ -2268,6 +2273,10 @@ class AgentStudioProject:
                         )
                         resource_name = resource.name
 
+                    flow_id = flow_paths_to_ids.get(
+                        resource_utils.get_flow_name_from_path(file_path),
+                    )
+
                     kept_resource_mappings.append(
                         ResourceMapping(
                             resource_id=resource_info["resource_id"],
@@ -2276,6 +2285,7 @@ class AgentStudioProject:
                             file_path=file_path,
                             flow_name=flow_name,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
+                            flow_id=flow_id,
                         )
                     )
 
@@ -2283,6 +2293,9 @@ class AgentStudioProject:
                     # Flow step names are not from file names, so we need to handle them separately
                     resource_name = os.path.splitext(os.path.basename(file_path))[0]
                     flow_name = flow_paths_to_names.get(
+                        resource_utils.get_flow_name_from_path(file_path),
+                    )
+                    flow_id = flow_paths_to_ids.get(
                         resource_utils.get_flow_name_from_path(file_path),
                     )
                     resource_id = self.generate_uuid(resource_type)
@@ -2304,10 +2317,14 @@ class AgentStudioProject:
                             resource_mappings=[],
                         )
                         resource_name = flow_step.name
-                        resource_id = f"{flow_name}_{resource_id}"
+                        resource_id = (
+                            f"{flow_id}_{resource_id}" if flow_id else f"{flow_name}_{resource_id}"
+                        )
 
                     elif resource_type == FunctionStep:
-                        resource_id = f"{flow_name}_{resource_id}"
+                        resource_id = (
+                            f"{flow_id}_{resource_id}" if flow_id else f"{flow_name}_{resource_id}"
+                        )
 
                     if resource_type == FlowConfig:
                         resource_name = flow_name
@@ -2332,6 +2349,9 @@ class AgentStudioProject:
                         )
                         resource_name = resource.name
 
+                    if resource_type == FlowConfig:
+                        flow_paths_to_ids[resource_utils.clean_name(flow_name)] = resource_id
+
                     new_resource_mappings.append(
                         ResourceMapping(
                             resource_id=resource_id,
@@ -2340,6 +2360,7 @@ class AgentStudioProject:
                             file_path=file_path,
                             flow_name=flow_name,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
+                            flow_id=flow_id if resource_type != FlowConfig else resource_id,
                         )
                     )
 
@@ -2366,6 +2387,9 @@ class AgentStudioProject:
                 ),
                 file_path=file_path,
                 resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
+                flow_id=flow_paths_to_ids.get(
+                    resource_utils.get_flow_name_from_path(file_path),
+                ),
             )
             deleted_resource_mappings.append(resource_mapping)
 
@@ -2656,6 +2680,11 @@ class AgentStudioProject:
                 else getattr(resource, "flow_name", None)
             ),
             resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
+            flow_id=(
+                resource.resource_id
+                if isinstance(resource, FlowConfig)
+                else getattr(resource, "flow_id", None)
+            ),
         )
 
     def format_files(
@@ -2931,6 +2960,11 @@ class AgentStudioProject:
                             else getattr(resource, "flow_name", None)
                         ),
                         resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
+                        flow_id=(
+                            mapping_resource_id
+                            if isinstance(resource, FlowConfig)
+                            else getattr(resource, "flow_id", None)
+                        ),
                     )
                 )
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2319,9 +2319,7 @@ class AgentStudioProject:
                         resource_id = os.path.basename(file_path)
 
                     if resource_type in (FlowStep, FunctionStep):
-                        resource_id = (
-                            f"{flow_id}_{resource_id}" if flow_id else f"{flow_name}_{resource_id}"
-                        )
+                        resource_id = f"{flow_id}_{resource_id}"
 
                     if resource_type == FlowConfig:
                         resource_id = flow_id

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2229,6 +2229,14 @@ class AgentStudioProject:
         for flow_id, flow_cfg in self.resources.get(FlowConfig, {}).items():
             flow_paths_to_ids[resource_utils.clean_name(flow_cfg.name)] = flow_id
 
+        # Add to mapping for new flows
+        for flow_path in discovered_resources.get(FlowConfig, []):
+            flow_name = resource_utils.get_flow_name_from_path(flow_path)
+            if flow_name not in flow_paths_to_ids:
+                flow_paths_to_ids[resource_utils.clean_name(flow_name)] = self.generate_uuid(
+                    FlowConfig
+                )
+
         if not self.file_structure_info:
             self.file_structure_info = self.compute_file_structure_info(self.resources)
 
@@ -2239,49 +2247,63 @@ class AgentStudioProject:
 
         for resource_type, resource_files in discovered_resources.items():
             # Build a map of resource name to resource instance for current resources
-
             for file_path in resource_files:
                 discovered_files.add(file_path)
+
+                # Load resource name, flow name, flow id
+                resource_name = os.path.splitext(os.path.basename(file_path))[0]
+
+                flow_name = flow_paths_to_names.get(
+                    resource_utils.get_flow_name_from_path(file_path),
+                )
+                flow_id = flow_paths_to_ids.get(
+                    resource_utils.get_flow_name_from_path(file_path),
+                )
+
+                if resource_type == FlowStep:
+                    flow_step: FlowStep = self.read_local_resource(
+                        ResourceMapping(
+                            resource_id="temp_id",
+                            resource_type=FlowStep,
+                            resource_name=resource_name,
+                            file_path=file_path,
+                            flow_name=flow_name,
+                            resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
+                        ),
+                        resource_mappings=[],
+                    )
+                    resource_name = flow_step.name
+
+                if resource_type == FlowConfig:
+                    resource_name = flow_name
+
+                # Resource name in file path is cleaned, so we need to get the original name
+                if issubclass(resource_type, MultiResourceYamlResource) or resource_type == Topic:
+                    resource = self.read_local_resource(
+                        ResourceMapping(
+                            resource_id="temp_id",
+                            resource_type=resource_type,
+                            resource_name=resource_name,
+                            file_path=file_path,
+                            flow_name=flow_name,
+                            resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
+                        ),
+                        resource_mappings=[],
+                    )
+                    resource_name = resource.name
+
                 if file_path in known_files:
-                    # Remove root path from file path
                     resource_info = self.file_structure_info.get(
                         os.path.relpath(file_path, self.root_path)
                     )
                     if not resource_info:
                         raise ValueError(f"Resource info not found for {file_path}")
 
-                    resource_name = resource_info["resource_name"]
-                    flow_name = flow_paths_to_names.get(
-                        resource_utils.get_flow_name_from_path(file_path),
-                    )
-
-                    # Default Language will only be modified, but name must
-                    # be read from file
-                    if resource_type == DefaultLanguage:
-                        resource = self.read_local_resource(
-                            ResourceMapping(
-                                resource_id=resource_info["resource_id"],
-                                resource_type=resource_type,
-                                resource_name=resource_name,
-                                file_path=file_path,
-                                flow_name=flow_name,
-                                resource_prefix=resource_type.get_resource_prefix(
-                                    file_path=file_path
-                                ),
-                            ),
-                            resource_mappings=[],
-                        )
-                        resource_name = resource.name
-
-                    flow_id = flow_paths_to_ids.get(
-                        resource_utils.get_flow_name_from_path(file_path),
-                    )
-
                     kept_resource_mappings.append(
                         ResourceMapping(
                             resource_id=resource_info["resource_id"],
                             resource_type=resource_type,
-                            resource_name=resource_name,
+                            resource_name=resource_info["resource_name"],
                             file_path=file_path,
                             flow_name=flow_name,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
@@ -2290,67 +2312,19 @@ class AgentStudioProject:
                     )
 
                 else:
-                    # Flow step names are not from file names, so we need to handle them separately
-                    resource_name = os.path.splitext(os.path.basename(file_path))[0]
-                    flow_name = flow_paths_to_names.get(
-                        resource_utils.get_flow_name_from_path(file_path),
-                    )
-                    flow_id = flow_paths_to_ids.get(
-                        resource_utils.get_flow_name_from_path(file_path),
-                    )
+                    # Compute new resource ID
                     resource_id = self.generate_uuid(resource_type)
+
                     if resource_type == Document:
                         resource_id = os.path.basename(file_path)
 
-                    if resource_type == FlowStep:
-                        flow_step: FlowStep = self.read_local_resource(
-                            ResourceMapping(
-                                resource_id="temp_id",
-                                resource_type=FlowStep,
-                                resource_name=resource_name,
-                                file_path=file_path,
-                                flow_name=flow_name,
-                                resource_prefix=resource_type.get_resource_prefix(
-                                    file_path=file_path
-                                ),
-                            ),
-                            resource_mappings=[],
-                        )
-                        resource_name = flow_step.name
-                        resource_id = (
-                            f"{flow_id}_{resource_id}" if flow_id else f"{flow_name}_{resource_id}"
-                        )
-
-                    elif resource_type == FunctionStep:
+                    if resource_type in (FlowStep, FunctionStep):
                         resource_id = (
                             f"{flow_id}_{resource_id}" if flow_id else f"{flow_name}_{resource_id}"
                         )
 
                     if resource_type == FlowConfig:
-                        resource_name = flow_name
-
-                    # Resource name in file path is cleaned, so we need to get the original name
-                    if (
-                        issubclass(resource_type, MultiResourceYamlResource)
-                        or resource_type == Topic
-                    ):
-                        resource = self.read_local_resource(
-                            ResourceMapping(
-                                resource_id="temp_id",
-                                resource_type=resource_type,
-                                resource_name=resource_name,
-                                file_path=file_path,
-                                flow_name=flow_name,
-                                resource_prefix=resource_type.get_resource_prefix(
-                                    file_path=file_path
-                                ),
-                            ),
-                            resource_mappings=[],
-                        )
-                        resource_name = resource.name
-
-                    if resource_type == FlowConfig:
-                        flow_paths_to_ids[resource_utils.clean_name(flow_name)] = resource_id
+                        resource_id = flow_id
 
                     new_resource_mappings.append(
                         ResourceMapping(
@@ -2359,8 +2333,8 @@ class AgentStudioProject:
                             resource_name=resource_name,
                             file_path=file_path,
                             flow_name=flow_name,
+                            flow_id=flow_id,
                             resource_prefix=resource_type.get_resource_prefix(file_path=file_path),
-                            flow_id=flow_id if resource_type != FlowConfig else resource_id,
                         )
                     )
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2232,7 +2232,7 @@ class AgentStudioProject:
         # Add to mapping for new flows
         for flow_path in discovered_resources.get(FlowConfig, []):
             flow_name = resource_utils.get_flow_name_from_path(flow_path)
-            if flow_name not in flow_paths_to_ids:
+            if resource_utils.clean_name(flow_name) not in flow_paths_to_ids:
                 flow_paths_to_ids[resource_utils.clean_name(flow_name)] = self.generate_uuid(
                     FlowConfig
                 )

--- a/src/poly/resources/api_integration.py
+++ b/src/poly/resources/api_integration.py
@@ -328,7 +328,7 @@ class ApiIntegration(MultiResourceYamlResource):
         operations = [ApiIntegrationOperation.from_dict(o) for o in ops_data]
         return cls(
             resource_id=resource_id,
-            name=name,
+            name=yaml_dict.get("name") or name,
             description=yaml_dict.get("description", ""),
             environments=environments,
             operations=operations,

--- a/src/poly/resources/entities.py
+++ b/src/poly/resources/entities.py
@@ -131,7 +131,7 @@ class Entity(MultiResourceYamlResource):
         """Create an instance from YAML data and identity fields."""
         return cls(
             resource_id=resource_id,
-            name=yaml_data.get("name", ""),
+            name=yaml_data.get("name") or name,
             description=(yaml_data.get("description") or "").strip(),
             entity_type=EntityType(yaml_data.get("entity_type")),
             config=yaml_data.get("config", {}),

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -144,10 +144,7 @@ class FlowConfig(YamlResource):
                 if (
                     issubclass(resource.resource_type, BaseFlowStep)
                     and resource_name == resource.flow_name
-                    and resource.resource_id.removeprefix(
-                        (resource.flow_id or resource.flow_name) + "_"
-                    )
-                    == start_step_id
+                    and resource.resource_id.removeprefix(resource.flow_id + "_") == start_step_id
                 ):
                     d["start_step"] = resource.resource_name
                     break
@@ -171,7 +168,7 @@ class FlowConfig(YamlResource):
                     and resource.resource_name == start_step_name
                 ):
                     yaml_dict["start_step"] = resource.resource_id.removeprefix(
-                        (resource.flow_id or resource.flow_name) + "_"
+                        resource.flow_id + "_" + "_"
                     )
                     break
         return yaml_dict
@@ -408,9 +405,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                     if (
                         issubclass(resource.resource_type, BaseFlowStep)
                         and resource.flow_name == flow_name
-                        and resource.resource_id.removeprefix(
-                            (resource.flow_id or resource.flow_name) + "_"
-                        )
+                        and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
                         == child_step_id
                     ):
                         if issubclass(resource.resource_type, FunctionStep):
@@ -521,9 +516,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                             issubclass(resource.resource_type, BaseFlowStep)
                             and flow_folder_name
                             in os.path.normpath(resource.file_path).split(os.sep)
-                            and resource.resource_id.removeprefix(
-                                (resource.flow_id or resource.flow_name) + "_"
-                            )
+                            and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
                             == child_step_id
                         ):
                             condition["child_step"] = resource.resource_name
@@ -578,7 +571,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                             and resource.resource_name == child_step_name
                         ):
                             condition["child_step"] = resource.resource_id.removeprefix(
-                                (resource.flow_id or resource.flow_name) + "_"
+                                resource.flow_id + "_" + "_"
                             )
                             break
 
@@ -1329,9 +1322,7 @@ class Condition(SubResource):
             if (
                 not found_step
                 and issubclass(resource.resource_type, BaseFlowStep)
-                and resource.resource_id.removeprefix(
-                    (resource.flow_id or resource.flow_name) + "_"
-                )
+                and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
                 == self.child_step
             ):
                 found_step = True

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -144,7 +144,10 @@ class FlowConfig(YamlResource):
                 if (
                     issubclass(resource.resource_type, BaseFlowStep)
                     and resource_name == resource.flow_name
-                    and resource.resource_id.removeprefix(resource.flow_name + "_") == start_step_id
+                    and resource.resource_id.removeprefix(
+                        (resource.flow_id or resource.flow_name) + "_"
+                    )
+                    == start_step_id
                 ):
                     d["start_step"] = resource.resource_name
                     break
@@ -168,7 +171,7 @@ class FlowConfig(YamlResource):
                     and resource.resource_name == start_step_name
                 ):
                     yaml_dict["start_step"] = resource.resource_id.removeprefix(
-                        resource.flow_name + "_"
+                        (resource.flow_id or resource.flow_name) + "_"
                     )
                     break
         return yaml_dict
@@ -180,7 +183,7 @@ class FlowConfig(YamlResource):
 
         # Check flow step exists in resource mappings
         found_step = False
-        expected_step_resource_id = f"{self.name}_{self.start_step}"
+        expected_step_resource_id = f"{self.resource_id}_{self.start_step}"
         for resource in resource_mappings or []:
             if (
                 issubclass(resource.resource_type, BaseFlowStep)
@@ -391,7 +394,7 @@ class FlowStep(BaseFlowStep, YamlResource):
         known_conditions = known_conditions or []
         condition_name_map = {cond.name: cond for cond in known_conditions}
 
-        step_id = resource_id.removeprefix(f"{flow_name}_")
+        step_id = resource_id.removeprefix(f"{flow_id}_")
 
         conditions = []
         for condition_yaml in yaml_dict.get("conditions", []):
@@ -405,7 +408,10 @@ class FlowStep(BaseFlowStep, YamlResource):
                     if (
                         issubclass(resource.resource_type, BaseFlowStep)
                         and resource.flow_name == flow_name
-                        and resource.resource_id.removeprefix(f"{flow_name}_") == child_step_id
+                        and resource.resource_id.removeprefix(
+                            (resource.flow_id or resource.flow_name) + "_"
+                        )
+                        == child_step_id
                     ):
                         if issubclass(resource.resource_type, FunctionStep):
                             child_step_type = StepType.FUNCTION_STEP
@@ -515,7 +521,9 @@ class FlowStep(BaseFlowStep, YamlResource):
                             issubclass(resource.resource_type, BaseFlowStep)
                             and flow_folder_name
                             in os.path.normpath(resource.file_path).split(os.sep)
-                            and resource.resource_id.removeprefix(resource.flow_name + "_")
+                            and resource.resource_id.removeprefix(
+                                (resource.flow_id or resource.flow_name) + "_"
+                            )
                             == child_step_id
                         ):
                             condition["child_step"] = resource.resource_name
@@ -570,7 +578,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                             and resource.resource_name == child_step_name
                         ):
                             condition["child_step"] = resource.resource_id.removeprefix(
-                                resource.flow_name + "_"
+                                (resource.flow_id or resource.flow_name) + "_"
                             )
                             break
 
@@ -1321,7 +1329,10 @@ class Condition(SubResource):
             if (
                 not found_step
                 and issubclass(resource.resource_type, BaseFlowStep)
-                and resource.resource_id.removeprefix(resource.flow_name + "_") == self.child_step
+                and resource.resource_id.removeprefix(
+                    (resource.flow_id or resource.flow_name) + "_"
+                )
+                == self.child_step
             ):
                 found_step = True
 
@@ -1440,7 +1451,7 @@ class FunctionStep(Function, BaseFlowStep):
                 flow_folder_name, resource_mappings
             )
 
-        step_id = resource_id.removeprefix(f"{flow_name}_")
+        step_id = resource_id.removeprefix(f"{flow_id}_")
 
         function_id = known_function_id or f"FUNCTION-{uuid.uuid4().hex[:8]}"
 

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -168,7 +168,7 @@ class FlowConfig(YamlResource):
                     and resource.resource_name == start_step_name
                 ):
                     yaml_dict["start_step"] = resource.resource_id.removeprefix(
-                        resource.flow_id + "_" + "_"
+                        resource.flow_id + "_"
                     )
                     break
         return yaml_dict
@@ -405,7 +405,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                     if (
                         issubclass(resource.resource_type, BaseFlowStep)
                         and resource.flow_name == flow_name
-                        and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
+                        and resource.resource_id.removeprefix(resource.flow_id + "_")
                         == child_step_id
                     ):
                         if issubclass(resource.resource_type, FunctionStep):
@@ -516,7 +516,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                             issubclass(resource.resource_type, BaseFlowStep)
                             and flow_folder_name
                             in os.path.normpath(resource.file_path).split(os.sep)
-                            and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
+                            and resource.resource_id.removeprefix(resource.flow_id + "_")
                             == child_step_id
                         ):
                             condition["child_step"] = resource.resource_name
@@ -571,7 +571,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                             and resource.resource_name == child_step_name
                         ):
                             condition["child_step"] = resource.resource_id.removeprefix(
-                                resource.flow_id + "_" + "_"
+                                resource.flow_id + "_"
                             )
                             break
 
@@ -1322,8 +1322,7 @@ class Condition(SubResource):
             if (
                 not found_step
                 and issubclass(resource.resource_type, BaseFlowStep)
-                and resource.resource_id.removeprefix(resource.flow_id + "_" + "_")
-                == self.child_step
+                and resource.resource_id.removeprefix(resource.flow_id + "_") == self.child_step
             ):
                 found_step = True
 

--- a/src/poly/resources/handoff.py
+++ b/src/poly/resources/handoff.py
@@ -124,7 +124,7 @@ class Handoff(MultiResourceYamlResource):
     ) -> "Handoff":
         return cls(
             resource_id=resource_id,
-            name=name,
+            name=yaml_dict.get("name") or name,
             description=yaml_dict.get("description", ""),
             is_default=yaml_dict.get("is_default", False),
             sip_config=yaml_dict.get("sip_config", {}),

--- a/src/poly/resources/phrase_filter.py
+++ b/src/poly/resources/phrase_filter.py
@@ -76,7 +76,7 @@ class PhraseFilter(MultiResourceYamlResource):
     ) -> "PhraseFilter":
         return cls(
             resource_id=resource_id,
-            name=(yaml_dict.get("name") or name or ""),
+            name=yaml_dict.get("name") or name,
             description=(yaml_dict.get("description") or "").strip(),
             regular_expressions=yaml_dict.get("regular_expressions", []),
             say_phrase=yaml_dict.get("say_phrase", False),

--- a/src/poly/resources/pronunciation.py
+++ b/src/poly/resources/pronunciation.py
@@ -81,7 +81,7 @@ class Pronunciation(MultiResourceYamlResource):
     ) -> "Pronunciation":
         return cls(
             resource_id=resource_id,
-            name=yaml_dict.get("name", ""),
+            name=yaml_dict.get("name") or name,
             regex=yaml_dict.get("regex", ""),
             replacement=yaml_dict.get("replacement", ""),
             case_sensitive=yaml_dict.get("case_sensitive", False),

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -23,6 +23,7 @@ class ResourceMapping:
     file_path: Optional[str]
     flow_name: Optional[str]
     resource_prefix: Optional[str]
+    flow_id: Optional[str] = None
 
 
 @dataclass

--- a/src/poly/resources/sms.py
+++ b/src/poly/resources/sms.py
@@ -98,7 +98,7 @@ class SMSTemplate(MultiResourceYamlResource):
     ) -> "SMSTemplate":
         return cls(
             resource_id=resource_id,
-            name=yaml_data.get("name", ""),
+            name=yaml_data.get("name") or name,
             text=yaml_data.get("text", ""),
             env_phone_numbers=yaml_data.get("env_phone_numbers", {}),
         )

--- a/src/poly/resources/translations.py
+++ b/src/poly/resources/translations.py
@@ -57,7 +57,7 @@ class Translation(MultiResourceYamlResource):
     ) -> "Translation":
         return cls(
             resource_id=resource_id,
-            name=name,
+            name=yaml_dict.get("name") or name,
             translations=yaml_dict.get("translations", {}),
         )
 

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -53,7 +53,7 @@ class Variant(MultiResourceYamlResource):
     def from_yaml_dict(cls, yaml_dict: dict, resource_id: str, name: str, **kwargs) -> "Variant":
         return cls(
             resource_id=resource_id,
-            name=yaml_dict.get("name"),
+            name=yaml_dict.get("name") or name,
             is_default=yaml_dict.get("is_default", False),
         )
 
@@ -191,7 +191,7 @@ class VariantAttribute(MultiResourceYamlResource):
         clean_mapping = {key: value.strip() for key, value in yaml_dict.get("values", {}).items()}
         return cls(
             resource_id=resource_id,
-            name=yaml_dict.get("name"),
+            name=yaml_dict.get("name") or name,
             mappings=clean_mapping,
         )
 

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -663,7 +663,7 @@ class ProjectStatusTest(unittest.TestCase):
             "function_type": "global",
         }
         # Modify a flow step so it seems there's a modified one
-        project_data["resources"]["flow_steps"]["test_flow_start_step"]["prompt"] = (
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_start_step"]["prompt"] = (
             "Modified prompt"
         )
 
@@ -877,7 +877,9 @@ class GetDiffsTest(unittest.TestCase):
         """Reordering extracted_entities should not produce a diff."""
         project_data = deepcopy(PROJECT_DATA)
         # Reverse the extracted_entities order so it differs from local YAML
-        step = project_data["resources"]["flow_steps"]["test_flow_with_punctuation!_welcome_step"]
+        step = project_data["resources"]["flow_steps"][
+            "FLOW_CONFIG-test_flow_with_punctuation_welcome_step"
+        ]
         step["extracted_entities"] = list(reversed(step["extracted_entities"]))
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         diffs = project.get_diffs()
@@ -1112,7 +1114,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
 
         # Pre-push: dummy step and flow config switch to dummy
         self.assertIn(FlowStep, pre_push_new)
-        dummy_id = "Test Flow_step-1_temp"
+        dummy_id = "flow-123_step-1_temp"
         self.assertIn(dummy_id, pre_push_new[FlowStep])
         dummy = pre_push_new[FlowStep][dummy_id]
         self.assertEqual(dummy.step_id, "step-1_temp")
@@ -1154,7 +1156,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-1",
         )
         old_start_step = FlowStep(
-            resource_id="Test Flow_step-1",
+            resource_id="flow-123_step-1",
             step_id="step-1",
             name="Start Step",
             flow_id="flow-123",
@@ -1166,7 +1168,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             extracted_entities=[],
         )
         new_start_step = FlowStep(
-            resource_id="Test Flow_step-2",
+            resource_id="flow-123_step-2",
             step_id="step-2",
             name="Other Step",
             flow_id="flow-123",
@@ -1184,12 +1186,12 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-2",
         )
 
-        self.project.resources.setdefault(FlowStep, {})["Test Flow_step-1"] = old_start_step
+        self.project.resources.setdefault(FlowStep, {})["flow-123_step-1"] = old_start_step
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
-        new_resources = {FlowStep: {"Test Flow_step-2": new_start_step}}
+        new_resources = {FlowStep: {"flow-123_step-2": new_start_step}}
         updated_resources = {FlowConfig: {"flow-123": updated_flow_config}}
-        deleted_resources = {FlowStep: {"Test Flow_step-1": old_start_step}}
+        deleted_resources = {FlowStep: {"flow-123_step-1": old_start_step}}
 
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1203,12 +1205,12 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         post_push_deleted = push_changes.post.deleted
 
         # Old step should be moved to post-push deleted (not in main push deleted)
-        self.assertNotIn("Test Flow_step-1", cleaned_deleted.get(FlowStep, {}))
+        self.assertNotIn("flow-123_step-1", cleaned_deleted.get(FlowStep, {}))
         self.assertIn(FlowStep, post_push_deleted)
-        self.assertIn("Test Flow_step-1", post_push_deleted[FlowStep])
+        self.assertIn("flow-123_step-1", post_push_deleted[FlowStep])
 
         # New step in new, flow config in updated
-        self.assertIn("Test Flow_step-2", cleaned_new[FlowStep])
+        self.assertIn("flow-123_step-2", cleaned_new[FlowStep])
         self.assertIn(FlowConfig, cleaned_updated)
         self.assertEqual(cleaned_updated[FlowConfig]["flow-123"].start_step, "step-2")
 
@@ -1229,7 +1231,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         )
         # Old step from branch - different step_id (e.g. from UUID before sync)
         old_start_step = FlowStep(
-            resource_id="Test Flow_step-abc123",
+            resource_id="flow-123_step-abc123",
             step_id="step-abc123",
             name="Start Step",
             flow_id="flow-123",
@@ -1242,7 +1244,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         )
         # New step from main - same name, step_id from file
         new_start_step = FlowStep(
-            resource_id="Test Flow_step-1",
+            resource_id="flow-123_step-1",
             step_id="step-1",
             name="Start Step",
             flow_id="flow-123",
@@ -1260,12 +1262,12 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-1",
         )
 
-        self.project.resources.setdefault(FlowStep, {})["Test Flow_step-abc123"] = old_start_step
+        self.project.resources.setdefault(FlowStep, {})["flow-123_step-abc123"] = old_start_step
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
-        new_resources = {FlowStep: {"Test Flow_step-1": new_start_step}}
+        new_resources = {FlowStep: {"flow-123_step-1": new_start_step}}
         updated_resources = {FlowConfig: {"flow-123": updated_flow_config}}
-        deleted_resources = {FlowStep: {"Test Flow_step-abc123": old_start_step}}
+        deleted_resources = {FlowStep: {"flow-123_step-abc123": old_start_step}}
 
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1282,7 +1284,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
 
         # Pre-push: dummy step and flow config switch to dummy
         self.assertIn(FlowStep, pre_push_new)
-        dummy_id = "Test Flow_step-abc123_temp"
+        dummy_id = "flow-123_step-abc123_temp"
         self.assertIn(dummy_id, pre_push_new[FlowStep])
         dummy = pre_push_new[FlowStep][dummy_id]
         self.assertEqual(dummy.step_id, "step-abc123_temp")
@@ -1295,8 +1297,8 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         self.assertIn(dummy_id, post_push_deleted[FlowStep])
 
         # Main push: old in deleted, new in new, flow config in updated
-        self.assertIn("Test Flow_step-abc123", cleaned_deleted[FlowStep])
-        self.assertIn("Test Flow_step-1", cleaned_new[FlowStep])
+        self.assertIn("flow-123_step-abc123", cleaned_deleted[FlowStep])
+        self.assertIn("flow-123_step-1", cleaned_new[FlowStep])
         self.assertIn(FlowConfig, cleaned_updated)
         self.assertEqual(cleaned_updated[FlowConfig]["flow-123"].start_step, "step-1")
 
@@ -1311,7 +1313,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="func_step",
         )
         old_function_step = FunctionStep(
-            resource_id="Test Flow_func_step",
+            resource_id="flow-123_func_step",
             step_id="func_step",
             name="Func Start",
             flow_id="flow-123",
@@ -1321,7 +1323,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             function_id="FUNC-123",
         )
         new_flow_step = FlowStep(
-            resource_id="Test Flow_step-2",
+            resource_id="flow-123_step-2",
             step_id="step-2",
             name="New Start",
             flow_id="flow-123",
@@ -1339,14 +1341,14 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="step-2",
         )
 
-        self.project.resources.setdefault(FunctionStep, {})["Test Flow_func_step"] = (
+        self.project.resources.setdefault(FunctionStep, {})["flow-123_func_step"] = (
             old_function_step
         )
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
-        new_resources = {FlowStep: {"Test Flow_step-2": new_flow_step}}
+        new_resources = {FlowStep: {"flow-123_step-2": new_flow_step}}
         updated_resources = {FlowConfig: {"flow-123": updated_flow_config}}
-        deleted_resources = {FunctionStep: {"Test Flow_func_step": old_function_step}}
+        deleted_resources = {FunctionStep: {"flow-123_func_step": old_function_step}}
 
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1358,9 +1360,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
         post_push_deleted = push_changes.post.deleted
 
         # Old FunctionStep should be in post-push deleted
-        self.assertNotIn("Test Flow_func_step", cleaned_deleted.get(FunctionStep, {}))
+        self.assertNotIn("flow-123_func_step", cleaned_deleted.get(FunctionStep, {}))
         self.assertIn(FunctionStep, post_push_deleted)
-        self.assertIn("Test Flow_func_step", post_push_deleted[FunctionStep])
+        self.assertIn("flow-123_func_step", post_push_deleted[FunctionStep])
 
     def test_clean_resources_before_push_function_step_same_name_uses_dummy(
         self,
@@ -1378,7 +1380,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="func_step_old",
         )
         old_function_step = FunctionStep(
-            resource_id="Test Flow_func_step_old",
+            resource_id="flow-123_func_step_old",
             step_id="func_step_old",
             name="Func Start",
             flow_id="flow-123",
@@ -1388,7 +1390,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             function_id="FUNC-123",
         )
         new_function_step = FunctionStep(
-            resource_id="Test Flow_func_step",
+            resource_id="flow-123_func_step",
             step_id="func_step",
             name="Func Start",
             flow_id="flow-123",
@@ -1404,14 +1406,14 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="func_step",
         )
 
-        self.project.resources.setdefault(FunctionStep, {})["Test Flow_func_step_old"] = (
+        self.project.resources.setdefault(FunctionStep, {})["flow-123_func_step_old"] = (
             old_function_step
         )
         self.project.resources.setdefault(FlowConfig, {})["flow-123"] = flow_config
 
-        new_resources = {FunctionStep: {"Test Flow_func_step": new_function_step}}
+        new_resources = {FunctionStep: {"flow-123_func_step": new_function_step}}
         updated_resources = {FlowConfig: {"flow-123": updated_flow_config}}
-        deleted_resources = {FunctionStep: {"Test Flow_func_step_old": old_function_step}}
+        deleted_resources = {FunctionStep: {"flow-123_func_step_old": old_function_step}}
 
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1427,16 +1429,16 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
 
         # Pre-push: dummy step (uses old step_id for dummy)
         self.assertIn(FlowStep, pre_push_new)
-        self.assertIn("Test Flow_func_step_old_temp", pre_push_new[FlowStep])
+        self.assertIn("flow-123_func_step_old_temp", pre_push_new[FlowStep])
         self.assertIn(FlowConfig, pre_push_updated)
 
         # Post-push: delete dummy
         self.assertIn(FlowStep, post_push_deleted)
-        self.assertIn("Test Flow_func_step_old_temp", post_push_deleted[FlowStep])
+        self.assertIn("flow-123_func_step_old_temp", post_push_deleted[FlowStep])
 
         # Main push: old in deleted, new in new
-        self.assertIn("Test Flow_func_step_old", cleaned_deleted[FunctionStep])
-        self.assertIn("Test Flow_func_step", cleaned_new[FunctionStep])
+        self.assertIn("flow-123_func_step_old", cleaned_deleted[FunctionStep])
+        self.assertIn("flow-123_func_step", cleaned_new[FunctionStep])
 
     def test_clean_resources_before_push_new_flow_function_step_as_start_fixes_with_dummy(
         self,
@@ -1455,7 +1457,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             start_step="entry_func",
         )
         function_start_step = FunctionStep(
-            resource_id="New Flow_entry_func",
+            resource_id="flow-new-func-start_entry_func",
             step_id="entry_func",
             name="Entry",
             flow_id=flow_config_id,
@@ -1467,7 +1469,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
 
         new_resources = {
             FlowConfig: {flow_config_id: flow_config},
-            FunctionStep: {"New Flow_entry_func": function_start_step},
+            FunctionStep: {"flow-new-func-start_entry_func": function_start_step},
         }
         push_changes = self.project._clean_resources_before_push(
             {},
@@ -1497,7 +1499,7 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
 
         # Dummy step is scheduled for post-push deletion
         self.assertIn(FlowStep, post_deleted)
-        self.assertIn("New Flow_entry_func_start_step_temp", post_deleted[FlowStep])
+        self.assertIn("flow-new-func-start_entry_func_start_step_temp", post_deleted[FlowStep])
 
     def test_clean_resources_before_push_orphaned_variable_delete_and_recreate(self):
         """When all functions referencing a variable are deleted, variable is delete+recreated."""
@@ -2041,7 +2043,7 @@ class PushProjectTest(unittest.TestCase):
 
     def test_push_project_modified_sub_resources_dtmf(self):
         project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["flow_steps"]["test_flow_start_step"]["dtmf_config"][
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_start_step"]["dtmf_config"][
             "is_enabled"
         ] = True
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
@@ -2057,7 +2059,9 @@ class PushProjectTest(unittest.TestCase):
     def test_push_project_new_sub_resources_condition(self):
         project_data = deepcopy(PROJECT_DATA)
         # Delete condition in project_data to mimic new condition locally
-        project_data["resources"]["flow_steps"]["test_flow_collect_name"]["conditions"] = []
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_collect_name"][
+            "conditions"
+        ] = []
 
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
 
@@ -2074,7 +2078,9 @@ class PushProjectTest(unittest.TestCase):
     def test_push_project_deleted_sub_resource_condition(self):
         project_data = deepcopy(PROJECT_DATA)
         # Mimic deleting a condition locally by adding to project data
-        project_data["resources"]["flow_steps"]["test_flow_collect_name"]["conditions"].append(
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_collect_name"][
+            "conditions"
+        ].append(
             {
                 "name": "delete_condition",
                 "description": "A condition to be deleted",
@@ -2104,7 +2110,7 @@ class PushProjectTest(unittest.TestCase):
         """Test pushing an updated ASRBiasing sub-resource"""
         project_data = deepcopy(PROJECT_DATA)
         # Modify ASR biasing in project_data
-        project_data["resources"]["flow_steps"]["test_flow_start_step"]["asr_biasing"][
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_start_step"]["asr_biasing"][
             "custom_keywords"
         ] = ["NewKeyword1", "NewKeyword2"]
 
@@ -2135,7 +2141,7 @@ class PushProjectTest(unittest.TestCase):
             "function_type": "global",
         }
         # Modified resource in subresource
-        project_data["resources"]["flow_steps"]["test_flow_start_step"]["asr_biasing"][
+        project_data["resources"]["flow_steps"]["FLOW_CONFIG-test_flow_start_step"]["asr_biasing"][
             "is_enabled"
         ] = False
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
@@ -3550,6 +3556,81 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
             [],
             "Should not delete files for resource types in _not_loaded_resources",
         )
+
+class MigrateFlowStepResourceIdsTest(unittest.TestCase):
+    """Tests for migrate_flow_step_resource_ids status dict migration."""
+
+    def test_rekeys_flow_steps_from_flow_name_to_flow_id(self):
+        """Old-format keys are re-keyed using flow_id."""
+        from poly.migration_utils import migrate_flow_step_resource_ids
+
+        status_dict = {
+            "resources": {
+                "flow_steps": {
+                    "SMS Flow_step-1": {
+                        "resource_id": "SMS Flow_step-1",
+                        "flow_name": "SMS Flow",
+                        "flow_id": "FLOW-abc",
+                    },
+                },
+                "function_steps": {
+                    "SMS Flow_func-1": {
+                        "resource_id": "SMS Flow_func-1",
+                        "flow_name": "SMS Flow",
+                        "flow_id": "FLOW-abc",
+                    },
+                },
+            },
+            "file_structure_info": {
+                "flows/sms_flow/steps/step_1.yaml": {
+                    "resource_id": "SMS Flow_step-1",
+                },
+                "flows/sms_flow/function_steps/func_1.py": {
+                    "resource_id": "SMS Flow_func-1",
+                },
+            },
+        }
+
+        migrate_flow_step_resource_ids(status_dict)
+
+        flow_steps = status_dict["resources"]["flow_steps"]
+        self.assertNotIn("SMS Flow_step-1", flow_steps)
+        self.assertIn("FLOW-abc_step-1", flow_steps)
+        self.assertEqual(flow_steps["FLOW-abc_step-1"]["resource_id"], "FLOW-abc_step-1")
+
+        func_steps = status_dict["resources"]["function_steps"]
+        self.assertNotIn("SMS Flow_func-1", func_steps)
+        self.assertIn("FLOW-abc_func-1", func_steps)
+        self.assertEqual(func_steps["FLOW-abc_func-1"]["resource_id"], "FLOW-abc_func-1")
+
+        fsi = status_dict["file_structure_info"]
+        self.assertEqual(fsi["flows/sms_flow/steps/step_1.yaml"]["resource_id"], "FLOW-abc_step-1")
+        self.assertEqual(
+            fsi["flows/sms_flow/function_steps/func_1.py"]["resource_id"], "FLOW-abc_func-1"
+        )
+
+    def test_already_migrated_entries_are_unchanged(self):
+        """Entries whose key doesn't start with flow_name_ are left as-is."""
+        from poly.migration_utils import migrate_flow_step_resource_ids
+
+        status_dict = {
+            "resources": {
+                "flow_steps": {
+                    "FLOW-abc_step-1": {
+                        "resource_id": "FLOW-abc_step-1",
+                        "flow_name": "SMS Flow",
+                        "flow_id": "FLOW-abc",
+                    },
+                },
+            },
+            "file_structure_info": {},
+        }
+
+        migrate_flow_step_resource_ids(status_dict)
+
+        flow_steps = status_dict["resources"]["flow_steps"]
+        self.assertIn("FLOW-abc_step-1", flow_steps)
+        self.assertEqual(flow_steps["FLOW-abc_step-1"]["resource_id"], "FLOW-abc_step-1")
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -567,6 +567,40 @@ class FindNewKeptDeletedTest(unittest.TestCase):
         deleted_mapping = deleted_mappings[0]
         self.assertEqual(deleted_mapping.resource_type, Function)
 
+    def test_find_new_kept_deleted_new_flow_steps_use_flow_id_prefix(self):
+        """When flow resources are not loaded, new flow steps should use
+        the FlowConfig's generated flow_id as their resource_id prefix,
+        not the flow_name."""
+        project_data = deepcopy(PROJECT_DATA)
+        # Remove all flow resources so they appear as new (not loaded)
+        project_data["resources"].pop("flow_config", None)
+        project_data["resources"].pop("flow_steps", None)
+        project_data["resources"].pop("function_steps", None)
+
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+        local_resources = project.discover_local_resources()
+        new_mappings, kept_mappings, _ = project.find_new_kept_deleted(local_resources)
+
+        new_flow_configs = [m for m in new_mappings if m.resource_type == FlowConfig]
+        new_flow_steps = [m for m in new_mappings if m.resource_type == FlowStep]
+        new_function_steps = [m for m in new_mappings if m.resource_type == FunctionStep]
+
+        self.assertTrue(len(new_flow_configs) > 0)
+        self.assertTrue(len(new_flow_steps) > 0)
+
+        # Build flow_name -> flow_id map from the new FlowConfig mappings
+        flow_id_by_name = {m.flow_name: m.resource_id for m in new_flow_configs}
+
+        # Every new flow step's resource_id should start with its flow's flow_id
+        for step_mapping in new_flow_steps + new_function_steps:
+            expected_flow_id = flow_id_by_name[step_mapping.flow_name]
+            self.assertTrue(
+                step_mapping.resource_id.startswith(expected_flow_id + "_"),
+                f"Step {step_mapping.resource_name} resource_id '{step_mapping.resource_id}' "
+                f"should start with flow_id '{expected_flow_id}_'",
+            )
+            self.assertEqual(step_mapping.flow_id, expected_flow_id)
+
 
 class ProjectStatusTest(unittest.TestCase):
     """Tests for the project_status method"""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -2795,7 +2795,7 @@ conditions:
                 flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="flow-123_step-2",  # Format: flow_name_step_id
+                resource_id="flow-123_step-2",  # Format: flow_id_step_id
                 resource_name="Step 2",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/step_2.yaml",
@@ -2806,7 +2806,7 @@ conditions:
         ]
 
         # Test with valid condition
-        # child_step should match the step_id part after removing flow_name prefix from resource_id
+        # child_step should match the step_id part after removing flow_id prefix from resource_id
         valid_condition = Condition(
             resource_id="cond-1",
             name="Valid Condition",

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -2300,12 +2300,13 @@ start_step: step-1
 
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow: Main_step-1",
+                resource_id="flow-colon_step-1",
                 resource_name="Step: Start",
                 resource_type=FlowStep,
                 file_path="flows/test_flow_main/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow: Main",
+                flow_id="flow-colon",
             )
         ]
 
@@ -2606,12 +2607,13 @@ conditions:
 
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow: Main_step-2",
+                resource_id="flow-colon_step-2",
                 resource_name="Step: Next",
                 resource_type=FlowStep,
                 file_path="flows/test_flow_main/steps/next_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow: Main",
+                flow_id="flow-colon",
             ),
             ResourceMapping(
                 resource_id="entity-123",

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -708,30 +708,34 @@ def test_code(conv: Conversation, test_param: int):
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Step One",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/step_one.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_process_payment",
+                resource_id="flow-123_process_payment",
                 resource_name="process_payment",
                 resource_type=FunctionStep,
                 file_path="flows/test_flow/function_steps/process_payment.py",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_dont_know",
+                resource_id="flow-123_dont_know",
                 resource_name="Don't know/ Can't Find",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/dont_know.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
         ]
 
@@ -804,6 +808,7 @@ def test_code(conv: Conversation, test_param: int):
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
                 resource_id="flow-456",
@@ -2083,12 +2088,13 @@ class FlowConfigTests(unittest.TestCase):
         """Test converting flow config to pretty format with start_step name mapping."""
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
         pretty_content = TEST_FLOW_CONFIG.to_pretty(
@@ -2108,12 +2114,13 @@ class FlowConfigTests(unittest.TestCase):
         """Test roundtrip conversion: to_pretty -> from_pretty."""
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
         converted_config = TEST_FLOW_CONFIG.to_pretty(
@@ -2133,15 +2140,16 @@ class FlowConfigTests(unittest.TestCase):
 
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_step-2",
+                resource_id="flow-123_step-2",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow_2/steps/start_step.yaml",
@@ -2171,12 +2179,13 @@ class FlowConfigTests(unittest.TestCase):
         """Test validation of flow config."""
         resource_mappings = [
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
         self.assertIsNone(TEST_FLOW_CONFIG.validate(resource_mappings=resource_mappings))
@@ -2242,14 +2251,16 @@ start_step: Start Step
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_step-1",
+                resource_id="flow-123_step-1",
                 resource_name="Start Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/start_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
         ]
 
@@ -2503,7 +2514,7 @@ class FlowStepTests(unittest.TestCase):
         yaml_dict = yaml.safe_load(FLOW_STEP_RAW_NO_ASR_DTMF)
         step = FlowStep.from_yaml_dict(
             yaml_dict,
-            resource_id="Test Flow_step-1",
+            resource_id="flow-123_step-1",
             file_name="test_step",
             flow_id="flow-123",
             flow_name="Test Flow",
@@ -2519,7 +2530,7 @@ class FlowStepTests(unittest.TestCase):
         )
         step = FlowStep.from_yaml_dict(
             yaml_dict,
-            resource_id="Test Flow_step-1",
+            resource_id="flow-123_step-1",
             file_name="test_step",
             flow_id="flow-123",
             flow_name="Test Flow",
@@ -2532,7 +2543,7 @@ class FlowStepTests(unittest.TestCase):
         yaml_dict = yaml.safe_load("step_type: advanced_step\nname: Test Step\n")
         step = FlowStep.from_yaml_dict(
             yaml_dict,
-            resource_id="Test Flow_step-1",
+            resource_id="flow-123_step-1",
             file_name="test_step",
             flow_id="flow-123",
             flow_name="Test Flow",
@@ -2643,6 +2654,7 @@ conditions:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
         self.assertIsNone(TEST_FLOW_STEP.validate(resource_mappings=resource_mappings))
@@ -2730,6 +2742,7 @@ conditions:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
         for valid_name in ("Test Step", "Step_1", "Step & 2", "Step 1, 2", "a/b", "v1.0", "café"):
@@ -2777,14 +2790,16 @@ conditions:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_step-2",  # Format: flow_name_step_id
+                resource_id="flow-123_step-2",  # Format: flow_name_step_id
                 resource_name="Step 2",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/step_2.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
         ]
 
@@ -3275,6 +3290,7 @@ dtmf_config:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             )
         ]
 
@@ -3324,14 +3340,16 @@ conditions:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_step-2",
+                resource_id="flow-123_step-2",
                 resource_name="Step 2",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/step_2.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
         ]
 
@@ -3443,30 +3461,34 @@ conditions:
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_advanced-step-1",
+                resource_id="flow-123_advanced-step-1",
                 resource_name="Advanced Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/advanced_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_default-step-1",
+                resource_id="flow-123_default-step-1",
                 resource_name="Default Step",
                 resource_type=FlowStep,
                 file_path="flows/test_flow/steps/default_step.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
             ResourceMapping(
-                resource_id="Test Flow_function-step-1",
+                resource_id="flow-123_function-step-1",
                 resource_name="function_step",
                 resource_type=FunctionStep,
                 file_path="flows/test_flow/function_steps/function_step.py",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="flow-123",
             ),
         ]
 
@@ -3725,19 +3747,20 @@ class FunctionStepTests(unittest.TestCase):
                 file_path="flows/test_flow/flow_config.yaml",
                 resource_prefix=None,
                 flow_name="Test Flow",
+                flow_id="test_flow",
             )
         ]
 
         with mock_read_from_file(test_file_pretty_content):
             result = FunctionStep.read_local_resource(
                 file_path="flows/test_flow/function_steps/process_data.py",
-                resource_id="Test Flow_process_data",
+                resource_id="test_flow_process_data",
                 resource_name="process_data",
                 resource_mappings=resource_mappings,
                 known_latency_control={},
             )
 
-            self.assertEqual(result.resource_id, "Test Flow_process_data")
+            self.assertEqual(result.resource_id, "test_flow_process_data")
             self.assertEqual(result.step_id, "process_data")
             self.assertEqual(result.name, "process_data")
             self.assertEqual(result.flow_id, "test_flow")
@@ -8115,15 +8138,11 @@ class DocumentTests(unittest.TestCase):
     """Tests for the Document resource."""
 
     def test_file_path(self):
-        doc = Document(
-            resource_id="test.md", name="test", path="test.md", contents="hello"
-        )
+        doc = Document(resource_id="test.md", name="test", path="test.md", contents="hello")
         self.assertEqual(doc.file_path, os.path.join("context", "test.md"))
 
     def test_raw(self):
-        doc = Document(
-            resource_id="test.md", name="test", path="test.md", contents="some content"
-        )
+        doc = Document(resource_id="test.md", name="test", path="test.md", contents="some content")
         self.assertEqual(doc.raw, "some content")
 
     def test_make_pretty_from_pretty_passthrough(self):

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -445,8 +445,8 @@
       }
     },
     "flow_steps": {
-      "test_flow_start_step": {
-        "resource_id": "test_flow_start_step",
+      "FLOW_CONFIG-test_flow_start_step": {
+        "resource_id": "FLOW_CONFIG-test_flow_start_step",
         "step_id": "start_step",
         "name": "start_step",
         "flow_id": "FLOW_CONFIG-test_flow",
@@ -488,8 +488,8 @@
           "y": 0.0
         }
       },
-      "test_flow_collect_name": {
-        "resource_id": "test_flow_collect_name",
+      "FLOW_CONFIG-test_flow_collect_name": {
+        "resource_id": "FLOW_CONFIG-test_flow_collect_name",
         "step_id": "collect_name",
         "name": "collect_name",
         "flow_id": "FLOW_CONFIG-test_flow",
@@ -532,8 +532,8 @@
           "y": 500.0
         }
       },
-      "test_flow_confirm_details": {
-        "resource_id": "test_flow_confirm_details",
+      "FLOW_CONFIG-test_flow_confirm_details": {
+        "resource_id": "FLOW_CONFIG-test_flow_confirm_details",
         "step_id": "confirm_details",
         "name": "confirm_details",
         "flow_id": "FLOW_CONFIG-test_flow",
@@ -575,8 +575,8 @@
           "y": 500.0
         }
       },
-      "test_flow_collect_phone": {
-        "resource_id": "test_flow_collect_phone",
+      "FLOW_CONFIG-test_flow_collect_phone": {
+        "resource_id": "FLOW_CONFIG-test_flow_collect_phone",
         "step_id": "collect_phone",
         "name": "collect_phone",
         "flow_id": "FLOW_CONFIG-test_flow",
@@ -619,8 +619,8 @@
           "y": 500.0
         }
       },
-      "test_flow_final_step": {
-        "resource_id": "test_flow_final_step",
+      "FLOW_CONFIG-test_flow_final_step": {
+        "resource_id": "FLOW_CONFIG-test_flow_final_step",
         "step_id": "final_step",
         "name": "final_step",
         "flow_id": "FLOW_CONFIG-test_flow",
@@ -662,8 +662,8 @@
           "y": 1000.0
         }
       },
-      "test_flow_with_punctuation!_welcome_step": {
-        "resource_id": "test_flow_with_punctuation!_welcome_step",
+      "FLOW_CONFIG-test_flow_with_punctuation_welcome_step": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_welcome_step",
         "step_id": "welcome_step",
         "name": "welcome_step",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
@@ -719,8 +719,8 @@
           "y": 0.0
         }
       },
-      "test_flow_with_punctuation!_collect_party_size": {
-        "resource_id": "test_flow_with_punctuation!_collect_party_size",
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size",
         "step_id": "collect_party_size",
         "name": "collect_party_size",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
@@ -763,8 +763,8 @@
           "y": 500.0
         }
       },
-      "test_flow_with_punctuation!_collect_email": {
-        "resource_id": "test_flow_with_punctuation!_collect_email",
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_email": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_email",
         "step_id": "collect_email",
         "name": "collect_email",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
@@ -806,8 +806,8 @@
           "y": 500.0
         }
       },
-      "test_flow_with_punctuation!_status_result": {
-        "resource_id": "test_flow_with_punctuation!_status_result",
+      "FLOW_CONFIG-test_flow_with_punctuation_status_result": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_status_result",
         "step_id": "status_result",
         "name": "status_result",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
@@ -874,8 +874,8 @@
       }
     },
     "function_steps": {
-      "test_flow_process_payment": {
-        "resource_id": "test_flow_process_payment",
+      "FLOW_CONFIG-test_flow_process_payment": {
+        "resource_id": "FLOW_CONFIG-test_flow_process_payment",
         "step_id": "process_payment",
         "flow_id": "FLOW_CONFIG-test_flow",
         "flow_name": "test_flow",
@@ -892,8 +892,8 @@
           "y": 0.0
         }
       },
-      "test_flow_process_data": {
-        "resource_id": "test_flow_with_punctuation!_calculate_discount",
+      "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount",
         "step_id": "calculate_discount",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "flow_name": "test_flow_with_punctuation!",


### PR DESCRIPTION
## Summary

Flow step resource IDs now use the stable `flow_id` (FlowConfig's resource_id) as their prefix instead of the mutable `flow_name`, preventing step_id extraction failures when a flow is renamed with a casing change.

## Motivation

When a flow was renamed with only a casing change (e.g. "SMS Flow" → "sms flow"), `clean_name()` produced the same folder, so `find_new_kept_deleted` preserved the old resource_id. But `removeprefix(f"{flow_name}_")` used the new name against the old resource_id — the prefix didn't match, silently producing wrong step_ids.

## Changes

- Added `flow_id` field to `ResourceMapping` dataclass
- Changed resource ID construction from `{flow_name}_{step_id}` to `{flow_id}_{step_id}` in `sync_client.py`, `project.py`, and `flows.py`
- Updated all `removeprefix` calls (~8 sites) to strip `flow_id` prefix
- Updated `FlowConfig.validate` to use `resource_id` for step lookup
- Added migration in `run_migrations` to re-key existing status dict entries from old to new format
- Updated test fixtures and added migration tests

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)