### PR TITLE
docs: add Document resource type

### DIFF
--- a/docs/docs/concepts/working-locally.md
+++ b/docs/docs/concepts/working-locally.md
@@ -65,6 +65,8 @@ A typical project structure looks like this:
 │   ├── sms_templates.yaml              # Optional
 │   ├── translations.yaml               # Optional
 │   └── variant_attributes.yaml         # Optional
+├── context/                            # Optional - document context files
+│   └── {document_name}.md
 ├── voice/                              # Voice channel settings
 │   ├── configuration.yaml
 │   ├── safety_filters.yaml             # Optional

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -554,11 +554,37 @@ Examples:
 
 ~~~bash
 poly docs flows functions topics
+poly docs context
 poly docs --all
 poly docs --all --output rules.md
 ~~~
 
 Use `--output` to write the documentation to a local file. This is useful when working with AI coding tools — pass the output file as context to give the agent accurate knowledge of ADK resource types and conventions.
+
+Available resource names include:
+
+| Name | Description |
+|---|---|
+| `agent_settings` | Personality, role, rules |
+| `api_integrations` | External HTTP API definitions |
+| `chat_settings` | Chat greeting, style prompt |
+| `context` | Context files for agent knowledge |
+| `entities` | Structured data collection |
+| `experimental_config` | Feature flags |
+| `flows` | Multistep processes with steps, functions, conditions |
+| `handoffs` | SIP call transfers |
+| `functions` | Global and flow functions, decorators, state, metrics |
+| `languages` | Default and additional language configuration |
+| `tests` | Simulated conversation test cases |
+| `safety_filters` | Content moderation settings |
+| `sms` | Text message templates |
+| `speech_recognition` | ASR settings, keyphrase boosting, transcript corrections |
+| `response_control` | Pronunciations, phrase filters |
+| `topics` | Knowledge base for RAG |
+| `translations` | Localized text strings per language |
+| `variants` | Per-variant configuration |
+| `voice_settings` | Voice greeting, disclaimer, style prompt |
+| `variables` | State variables referenced in code |
 
 ### `poly deployments`
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->

## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->

Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [ ] `ruff check .` and `ruff format --check .` pass
- [ ] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->