### PR TITLE
fix: normalize personality adjectives on pull and send removals on push

### DIFF
--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -54,7 +54,10 @@ class SettingsPersonality(YamlResource):
 
     def to_yaml_dict(self) -> dict:
         """Convert the personality settings to a YAML-serializable dict."""
-        return {"adjectives": self.adjectives, "custom": self.custom}
+        return {
+            "adjectives": {adj: enabled for adj, enabled in self.adjectives.items() if enabled},
+            "custom": self.custom,
+        }
 
     @classmethod
     def to_pretty_dict(
@@ -104,11 +107,7 @@ class SettingsPersonality(YamlResource):
 
         return Personality_UpdatePersonality(
             adjectives={
-                "values": {
-                    adj: enabled
-                    for adj, enabled in self.adjectives.items()
-                    if adj in ALLOWED_ADJECTIVES
-                },
+                "values": {adj: self.adjectives.get(adj, False) for adj in ALLOWED_ADJECTIVES},
             },
             custom=self.custom,
         )

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -12,6 +12,7 @@ from jsonschema import ValidationError
 import poly.resources.resource_utils as resource_utils
 from poly.handlers.sync_client import SyncClientHandler
 from poly.resources.agent_settings import (
+    ALLOWED_ADJECTIVES,
     SettingsPersonality,
     SettingsRole,
     SettingsRules,
@@ -1676,7 +1677,6 @@ TEST_PERSONALITY = SettingsPersonality(
 PERSONALITY_RAW = """adjectives:
   Polite: true
   Calm: true
-  Kind: false
 custom: ''
 """
 
@@ -1685,6 +1685,26 @@ class SettingsPersonalityTests(unittest.TestCase):
     def test_get_raw(self):
         """Test that raw property returns correct YAML representation."""
         self.assertEqual(TEST_PERSONALITY.raw, PERSONALITY_RAW)
+
+    def test_to_yaml_dict_strips_disabled_adjectives(self):
+        """Test that to_yaml_dict excludes adjectives set to False."""
+        yaml_dict = TEST_PERSONALITY.to_yaml_dict()
+        self.assertEqual(yaml_dict["adjectives"], {"Polite": True, "Calm": True})
+        self.assertNotIn("Kind", yaml_dict["adjectives"])
+
+    def test_to_yaml_dict_normalizes_empty_and_all_false(self):
+        """Test that both empty and all-false adjectives produce the same YAML dict."""
+        empty = SettingsPersonality(
+            resource_id="p1", name="personality", adjectives={}, custom=""
+        )
+        all_false = SettingsPersonality(
+            resource_id="p2",
+            name="personality",
+            adjectives={"Polite": False, "Calm": False},
+            custom="",
+        )
+        self.assertEqual(empty.to_yaml_dict()["adjectives"], {})
+        self.assertEqual(all_false.to_yaml_dict()["adjectives"], {})
 
     def test_to_pretty(self):
         """Test converting personality to pretty format."""
@@ -1758,8 +1778,8 @@ class SettingsPersonalityTests(unittest.TestCase):
             str(cm.exception),
         )
 
-    def test_build_update_proto_filters_invalid_adjectives(self):
-        """Test that build_update_proto excludes non-allowed adjectives from the payload."""
+    def test_build_update_proto_sends_all_allowed_adjectives(self):
+        """Test that build_update_proto sends all allowed adjectives, defaulting unset to False."""
         personality = SettingsPersonality(
             resource_id="personality_123",
             name="personality",
@@ -1768,8 +1788,12 @@ class SettingsPersonalityTests(unittest.TestCase):
         )
         proto = personality.build_update_proto()
         adjective_values = proto.adjectives.values
-        self.assertEqual(adjective_values, {"Polite": True, "Calm": True})
         self.assertNotIn("InvalidAdjective", adjective_values)
+        self.assertEqual(set(adjective_values.keys()), ALLOWED_ADJECTIVES)
+        self.assertTrue(adjective_values["Polite"])
+        self.assertTrue(adjective_values["Calm"])
+        self.assertFalse(adjective_values["Kind"])
+        self.assertFalse(adjective_values["Funny"])
 
     def test_read_local_resource(self):
         """Test reading a personality from a YAML file."""


### PR DESCRIPTION
## Summary

Fix two bugs in personality adjective handling that caused phantom diffs on pull and silent no-ops when removing adjectives.

## Motivation

1. Pulling a project could produce spurious diffs because the platform may return `{Friendly: false}` or `{}` for the same state — both mean "not enabled" but produced different YAML.
2. Removing an adjective from the local YAML and pushing had no effect because `build_update_proto` only sent adjectives present in the local dict, never signalling a removal.

## Changes

- `to_yaml_dict` now filters out disabled (`false`) adjectives so pull always writes the same YAML regardless of API representation
- `build_update_proto` now iterates all `ALLOWED_ADJECTIVES`, defaulting missing ones to `false`, so removals are explicitly sent to the platform
- Updated and added tests for both behaviors

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)