### PR TITLE
fix: normalize local multi-resource content before merge

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -814,20 +814,47 @@ class AgentStudioProject:
             for file, (_, top_level_yaml_dict) in MultiResourceYamlResource._file_cache.items()
         }
 
-        # Compute current file (formatted)
+        # Normalise local resources through resource classes to ensure
+        # serialization differences don't cause merge conflicts
         local_file_contents = {}
         MultiResourceYamlResource._file_cache.clear()
         if not force:
-            for file in incoming_file_contents.keys():
-                try:
-                    contents = Resource.read_from_file(file)
-                    if format:
-                        contents = MultiResourceYamlResource.format_resource(
-                            contents, file_name=file
+            for resource_type, resources in incoming_resources.items():
+                if not issubclass(resource_type, MultiResourceYamlResource):
+                    continue
+                for resource in resources.values():
+                    try:
+                        mapping = self._make_resource_mapping(resource)
+                        local_resource = self.read_local_resource(
+                            resource=mapping,
+                            resource_mappings=incoming_resource_mappings,
                         )
-                    local_file_contents[file] = contents
-                except FileNotFoundError:
-                    local_file_contents[file] = ""
+                        local_resource.save(
+                            self.root_path,
+                            resource_name=local_resource.name,
+                            resource_mappings=incoming_resource_mappings,
+                            format=format,
+                            save_to_cache=True,
+                        )
+                    except (FileNotFoundError, ValueError, TypeError):
+                        continue
+
+            local_file_contents = {
+                file: resource_utils.dump_yaml(top_level_yaml_dict)
+                for file, (_, top_level_yaml_dict) in MultiResourceYamlResource._file_cache.items()
+            }
+
+            for file in incoming_file_contents:
+                if file not in local_file_contents:
+                    try:
+                        contents = Resource.read_from_file(file)
+                        if format:
+                            contents = MultiResourceYamlResource.format_resource(
+                                contents, file_name=file
+                            )
+                        local_file_contents[file] = contents
+                    except FileNotFoundError:
+                        local_file_contents[file] = ""
 
         # Save and compute merges
         for file, incoming_content in incoming_file_contents.items():

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3065,6 +3065,39 @@ class PullProjectTest(unittest.TestCase):
         files_with_conflicts, _ = project.pull_project()
         self.assertEqual(files_with_conflicts, [])
 
+    def test_pull_multi_resource_local_normalization_no_false_conflict(self):
+        """Local multi-resource files should be normalised through resource classes
+        before the three-way merge, so formatting differences don't cause conflicts.
+
+        KeyphraseBoosting lowercases the level field in __init__. If the local file
+        has 'level: Boosted' (mixed case), a raw read would differ from the canonical
+        'level: boosted', causing a false merge conflict. Reading through the resource
+        class normalises this.
+        """
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+        incoming_resources = deepcopy(project.resources)
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+
+        # Local file has mixed-case level values (not yet normalised)
+        local_keyphrases_yaml = (
+            "keyphrases:\n"
+            "- keyphrase: PolyAI\n"
+            "  level: Maximum\n"
+            "- keyphrase: reservation\n"
+            "  level: Boosted\n"
+            "- keyphrase: check-in\n"
+            "  level: Default\n"
+        )
+        keyphrases_yaml_path = os.path.join(
+            TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml"
+        )
+
+        with mock_read_from_file({keyphrases_yaml_path: local_keyphrases_yaml}):
+            files_with_conflicts, _ = project.pull_project(force=False)
+
+        self.assertEqual(files_with_conflicts, [])
+
 
 class PullProjectFromEnvTest(unittest.TestCase):
     """Tests for pull_project_from_env when targeting deployment environments.
@@ -3590,6 +3623,7 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
             [],
             "Should not delete files for resource types in _not_loaded_resources",
         )
+
 
 class MigrateFlowStepResourceIdsTest(unittest.TestCase):
     """Tests for migrate_flow_step_resource_ids status dict migration."""


### PR DESCRIPTION
## Summary

Normalize local multi-resource YAML content through resource classes before the three-way merge on pull, preventing false merge conflicts caused by serialization differences.

## Motivation

The three-way merge for multi-resource files (entities, keyphrases, etc.) read local files raw from disk, while original and incoming content went through resource objects (`read_local_resource` → `save(save_to_cache=True)`). Serialization differences — such as default values (`relative_date: false` vs `config: {}`), case normalization (`Boosted` vs `boosted`), or whitespace stripping — caused false merge conflicts on pull even when the logical content was identical.

The non-multi-resource path already normalizes local content via `read_local_resource` → `to_pretty` (with the comment "Normalise the local resource to ensure formatting differences don't cause unnecessary merge conflicts"). The multi-resource path was missing this normalization.

## Changes

- Replaced raw `Resource.read_from_file()` local read in `_update_multi_resource_yaml_resources` with `read_local_resource` → `save(save_to_cache=True)`, mirroring how original and incoming content are already computed
- Falls back to raw read for files not covered by the object-based path (e.g. edge cases)
- Added test verifying that mixed-case keyphrase levels in local YAML don't cause false conflicts on pull

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)