### PR TITLE
fix(agent-setting): agent setting sort

### DIFF
--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -55,7 +55,7 @@ class SettingsPersonality(YamlResource):
     def to_yaml_dict(self) -> dict:
         """Convert the personality settings to a YAML-serializable dict."""
         return {
-            "adjectives": {adj: enabled for adj, enabled in self.adjectives.items() if enabled},
+            "adjectives": {adj: enabled for adj, enabled in sorted(self.adjectives.items()) if enabled},
             "custom": self.custom,
         }
 

--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -55,7 +55,9 @@ class SettingsPersonality(YamlResource):
     def to_yaml_dict(self) -> dict:
         """Convert the personality settings to a YAML-serializable dict."""
         return {
-            "adjectives": {adj: enabled for adj, enabled in sorted(self.adjectives.items()) if enabled},
+            "adjectives": {
+                adj: enabled for adj, enabled in sorted(self.adjectives.items()) if enabled
+            },
             "custom": self.custom,
         }
 

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1710,9 +1710,7 @@ class SettingsPersonalityTests(unittest.TestCase):
 
     def test_to_yaml_dict_normalizes_empty_and_all_false(self):
         """Test that both empty and all-false adjectives produce the same YAML dict."""
-        empty = SettingsPersonality(
-            resource_id="p1", name="personality", adjectives={}, custom=""
-        )
+        empty = SettingsPersonality(resource_id="p1", name="personality", adjectives={}, custom="")
         all_false = SettingsPersonality(
             resource_id="p2",
             name="personality",

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1680,8 +1680,8 @@ TEST_PERSONALITY = SettingsPersonality(
 )
 
 PERSONALITY_RAW = """adjectives:
-  Polite: true
   Calm: true
+  Polite: true
 custom: ''
 """
 

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1697,6 +1697,17 @@ class SettingsPersonalityTests(unittest.TestCase):
         self.assertEqual(yaml_dict["adjectives"], {"Polite": True, "Calm": True})
         self.assertNotIn("Kind", yaml_dict["adjectives"])
 
+    def test_to_yaml_dict_sorts_adjectives(self):
+        """Test that to_yaml_dict returns adjectives in sorted order."""
+        unsorted = SettingsPersonality(
+            resource_id="p1",
+            name="personality",
+            adjectives={"Polite": True, "Calm": True, "Energetic": True, "Kind": False},
+            custom="",
+        )
+        yaml_dict = unsorted.to_yaml_dict()
+        self.assertEqual(list(yaml_dict["adjectives"].keys()), ["Calm", "Energetic", "Polite"])
+
     def test_to_yaml_dict_normalizes_empty_and_all_false(self):
         """Test that both empty and all-false adjectives produce the same YAML dict."""
         empty = SettingsPersonality(

--- a/uv.lock
+++ b/uv.lock
@@ -341,7 +341,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.23.1"
+version = "0.34.3"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Keep it to 1-3 sentences. -->
Fix agent setting sort to prevent merge conflicts
## Motivation

<!-- Why is this change needed? Link to an issue if applicable. -->
The order of the keys can sometimes change causing merge conflicts.
Closes #<!-- issue number -->

## Changes

<!-- Bullet list of the key changes. Focus on *what* changed, not *how*. -->

-

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented)
- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<!-- Optional: paste terminal output, screenshots, or before/after diffs if helpful. -->