### PR TITLE
fix: remove unused `# type: ignore` from secret_vault.py types stub

### DIFF
--- a/src/poly/tests/test_projects/test_project/_gen/secret_vault.py
+++ b/src/poly/tests/test_projects/test_project/_gen/secret_vault.py
@@ -1,6 +1,5 @@
 # flake8: noqa
 # ruff: noqa
-# type: ignore
 __all__ = ["InvalidInput", "MissingAccess", "SecretNotFound"]
 
 

--- a/src/poly/types/secret_vault.py
+++ b/src/poly/types/secret_vault.py
@@ -1,7 +1,6 @@
 # Copyright PolyAI Limited
 # flake8: noqa
 # ruff: noqa
-# type: ignore
 __all__ = ["InvalidInput", "MissingAccess", "SecretNotFound"]
 
 


### PR DESCRIPTION
## Summary

- Removes the blanket `# type: ignore` directive from `src/poly/types/secret_vault.py`

The `# type: ignore` comment triggers an `unused-type-ignore-comment` warning with `ty`, which `agent-deployments` uses as a pre-commit hook. This causes commits that touch `_gen/secret_vault.py` to fail:

```
warning[unused-type-ignore-comment]: Unused blanket `type: ignore` directive
 --> agents/.../sticks-n-sushi-ukp/_gen/secret_vault.py:4:1
  |
4 | # type: ignore
  | ^^^^^^^^^^^^^^
```

This will prevent having to manually delete that line of code every time you initialize a project.

## Test plan

- [x] Verified `ty check src/poly/types/secret_vault.py` passes after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)