### PR TITLE
fix: use flow_id instead of flow_name in from_projection resource ID construction

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -382,7 +382,7 @@ class FlowStep(BaseFlowStep, YamlResource):
                 if step.get("type") == "function_step":
                     continue
 
-                local_resource_id = f"{flow_data['name']}_{step_id}"
+                local_resource_id = f"{flow_id}_{step_id}"
                 asr_biasing_data = step.get("asrBiasing", {})
                 dtmf_config_data = step.get("dtmfConfig", {})
                 references = step.get("references", {})
@@ -1493,7 +1493,7 @@ class FunctionStep(Function, BaseFlowStep):
                 if step.get("type") != "function_step":
                     continue
 
-                local_resource_id = f"{flow_data['name']}_{step_id}"
+                local_resource_id = f"{flow_id}_{step_id}"
                 function = step.get("function", {})
                 func_steps[local_resource_id] = cls(
                     resource_id=local_resource_id,

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -8466,8 +8466,8 @@ class FlowStepFromProjection(unittest.TestCase):
             }
         }
         steps = FlowStep.from_projection(projection)
-        # Key format is {flow_name}_{step_id}
-        expected_key = "Booking_STEP-A"
+        # Key format is {flow_id}_{step_id}
+        expected_key = "FLOW-1_STEP-A"
         self.assertEqual(list(steps), [expected_key])
         step = steps[expected_key]
         self.assertIsInstance(step, FlowStep)
@@ -8535,7 +8535,7 @@ class FunctionStepFromProjection(unittest.TestCase):
             }
         }
         func_steps = FunctionStep.from_projection(projection)
-        expected_key = "Booking_STEP-F"
+        expected_key = "FLOW-1_STEP-F"
         self.assertEqual(list(func_steps), [expected_key])
         fs = func_steps[expected_key]
         self.assertIsInstance(fs, FunctionStep)


### PR DESCRIPTION
## Summary

Fix flow validation regression introduced in v0.34.6 where `poly validate` reports "Start step not found" for all flows.

## Motivation

PR #216 introduced `from_projection` methods on `FlowStep` and `FunctionStep` that construct resource IDs as `{flow_name}_{step_id}`. However, PR #220 had already changed the convention to `{flow_id}_{step_id}`. The merge didn't produce a textual conflict, so the old convention slipped through. `FlowConfig.validate` builds expected IDs with `flow_id`, so the lookup fails.

## Changes

- Changed `FlowStep.from_projection` to use `flow_id` instead of `flow_data['name']` for resource ID prefix
- Changed `FunctionStep.from_projection` to use `flow_id` instead of `flow_data['name']` for resource ID prefix
- Updated corresponding test assertions

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)