### PR TITLE
chore: add testpaths to pytest config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ omit = [
 ]
 
 [tool.pytest.ini_options]
+testpaths = ["src/poly/tests"]
 norecursedirs = [
     "test_projects",
 ]


### PR DESCRIPTION
## Summary

Add `testpaths` to pytest config so bare `uv run pytest` only collects from `src/poly/tests/`.

## Motivation

Running `uv run pytest` without an explicit path caused pytest to collect `src/poly/resources/test_suite.py` as a test module (it matches the `test_*.py` pattern). This interfered with `TestCase` resource registration and caused 6 tests to fail. Running `uv run pytest src/poly/tests/` worked fine, masking the issue in CI.

## Changes

- Add `testpaths = ["src/poly/tests"]` to `[tool.pytest.ini_options]` in `pyproject.toml`

## Test strategy

- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)