### PR TITLE
perf: avoid YAML serialize/reparse roundtrip in multi-resource reads

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -175,6 +175,9 @@ class FlowConfig(YamlResource):
         **kwargs,
     ) -> dict:
         """Replace start_step name with ID in a parsed YAML dict."""
+        yaml_dict = super().from_pretty_dict(
+            yaml_dict, resource_mappings=resource_mappings, resource_name=resource_name, **kwargs
+        )
         start_step_name = yaml_dict.get("start_step")
         if start_step_name:
             for resource in resource_mappings or []:

--- a/src/poly/resources/languages.py
+++ b/src/poly/resources/languages.py
@@ -119,6 +119,7 @@ class DefaultLanguage(MultiResourceYamlResource):
 
     @classmethod
     def _get_matching(cls, file_path: str) -> dict:
+        """Return the default language as a dict, reshaped from its bare scalar on-disk form."""
         true_file_path, _ = _parse_multi_resource_path(file_path)
         value = cls._get_top_level_data(true_file_path).get("default_language")
         if not value:
@@ -240,6 +241,8 @@ class AdditionalLanguage(MultiResourceYamlResource):
 
     @classmethod
     def _get_matching(cls, file_path: str) -> dict:
+        """Return the named additional language as a dict, reshaped from its bare scalar
+        on-disk form."""
         true_file_path, segments = _parse_multi_resource_path(file_path)
         resource_name = segments[-1]
         additional = cls._get_top_level_data(true_file_path).get("additional_languages") or []

--- a/src/poly/resources/languages.py
+++ b/src/poly/resources/languages.py
@@ -118,13 +118,12 @@ class DefaultLanguage(MultiResourceYamlResource):
         _write_languages(type(self), true_file_path, top_level, save_to_cache)
 
     @classmethod
-    def read_from_file(cls, file_path: str) -> str:
+    def _get_matching(cls, file_path: str) -> dict:
         true_file_path, _ = _parse_multi_resource_path(file_path)
-        top_level = cls._get_top_level_data(true_file_path)
-        value = top_level.get("default_language")
+        value = cls._get_top_level_data(true_file_path).get("default_language")
         if not value:
             raise FileNotFoundError(f"default_language not found in {true_file_path}")
-        return utils.dump_yaml({"language_code": value})
+        return {"language_code": value}
 
     @classmethod
     def delete_resource(cls, file_path: str, save_to_cache: bool = False) -> None:
@@ -240,14 +239,13 @@ class AdditionalLanguage(MultiResourceYamlResource):
         _write_languages(type(self), true_file_path, top_level, save_to_cache)
 
     @classmethod
-    def read_from_file(cls, file_path: str) -> str:
+    def _get_matching(cls, file_path: str) -> dict:
         true_file_path, segments = _parse_multi_resource_path(file_path)
         resource_name = segments[-1]
-        top_level = cls._get_top_level_data(true_file_path)
-        additional = top_level.get("additional_languages") or []
+        additional = cls._get_top_level_data(true_file_path).get("additional_languages") or []
         if resource_name not in additional:
             raise FileNotFoundError(f"Language {resource_name} not found in {true_file_path}")
-        return utils.dump_yaml({"language_code": resource_name})
+        return {"language_code": resource_name}
 
     @classmethod
     def delete_resource(cls, file_path: str, save_to_cache: bool = False) -> None:

--- a/src/poly/resources/phrase_filter.py
+++ b/src/poly/resources/phrase_filter.py
@@ -129,6 +129,9 @@ class PhraseFilter(MultiResourceYamlResource):
         cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> dict:
         """Replace function name with ID in a parsed YAML dict."""
+        yaml_dict = super().from_pretty_dict(
+            yaml_dict, resource_mappings=resource_mappings, **kwargs
+        )
         function_name = yaml_dict.get("function")
         if function_name:
             for resource in resource_mappings or []:

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -532,6 +532,7 @@ class MultiResourceYamlResource(YamlResource, ABC):
 
     @classmethod
     def read_from_file(cls, file_path: str) -> str:
+        """Read a single resource's contents from its multi-resource file, as YAML."""
         return utils.dump_yaml(cls._get_matching(file_path))
 
     @classmethod

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -352,8 +352,8 @@ class YamlResource(Resource, ABC):
     def from_pretty_dict(
         cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> dict:
-        """Replace resource names with IDs in a parsed YAML dict. Override in subclasses."""
-        return yaml_dict
+        """Replace resource names with IDs in a parsed YAML dict, returning a new dict."""
+        return utils.replace_resource_names_with_ids_in_data(yaml_dict, resource_mappings or [])
 
     @classmethod
     def from_pretty(
@@ -369,17 +369,21 @@ class YamlResource(Resource, ABC):
         return utils.dump_yaml(yaml_dict)
 
     @classmethod
+    def _read_yaml_dict(cls, file_path: str) -> dict:
+        """Read and parse the resource's YAML file into a dict."""
+        contents = cls.read_from_file(file_path)
+        try:
+            return utils.load_yaml(contents) or {}
+        except Exception as e:
+            raise ValueError(f"Error loading YAML file: {file_path}") from e
+
+    @classmethod
     def read_local_resource(
         cls, file_path: str, resource_id: str, resource_name: str, **kwargs
     ) -> "YamlResource":
         """Read a local YAML resource from the given file path."""
-        contents = cls.read_from_file(file_path)
         resource_mappings = kwargs.pop("resource_mappings", None)
-        contents = utils.replace_resource_names_with_ids(contents, resource_mappings or [])
-        try:
-            yaml_dict = utils.load_yaml(contents) or {}
-        except Exception as e:
-            raise ValueError(f"Error loading YAML file: {file_path}") from e
+        yaml_dict = cls._read_yaml_dict(file_path)
         yaml_dict = cls.from_pretty_dict(
             yaml_dict,
             resource_mappings=resource_mappings,
@@ -492,7 +496,13 @@ class MultiResourceYamlResource(YamlResource, ABC):
         cls._file_cache[true_file_path] = (new_mtime, top_level_yaml_dict)
 
     @classmethod
-    def read_from_file(cls, file_path: str) -> str:
+    def _get_matching(cls, file_path: str) -> dict:
+        """Return the parsed sub-dict for a single resource from its multi-resource file.
+
+        This is the single read seam: read_from_file dumps it to a string and _read_yaml_dict
+        returns it directly. Subclasses whose on-disk format is not a standard sub-dict (e.g.
+        a bare scalar) override this to reshape it into a dict.
+        """
         true_file_path, segments = _parse_multi_resource_path(file_path)
         top_level_name = segments[0]
         top_level_yaml_dict = cls._get_top_level_data(true_file_path)
@@ -503,7 +513,7 @@ class MultiResourceYamlResource(YamlResource, ABC):
                 raise ValueError(f"Top level YAML data is not a dict: {top_level_yaml_dict}")
             if not yaml_dict:
                 raise FileNotFoundError(f"Resource not found in {true_file_path}")
-            return utils.dump_yaml(yaml_dict)
+            return yaml_dict
 
         resource_clean_name = segments[-1]
         yaml_list = top_level_yaml_dict.get(top_level_name, [])
@@ -518,7 +528,16 @@ class MultiResourceYamlResource(YamlResource, ABC):
             raise FileNotFoundError(
                 f"Resource with name {resource_clean_name} not found in {true_file_path}"
             )
-        return utils.dump_yaml(matching_resource)
+        return matching_resource
+
+    @classmethod
+    def read_from_file(cls, file_path: str) -> str:
+        return utils.dump_yaml(cls._get_matching(file_path))
+
+    @classmethod
+    def _read_yaml_dict(cls, file_path: str) -> dict:
+        """Return the single resource's parsed sub-dict from the multi-resource file."""
+        return cls._get_matching(file_path)
 
     @classmethod
     def _find_matching(cls, yaml_list, resource_clean_name) -> Optional[dict]:

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -19,7 +19,7 @@ from dataclasses import fields, is_dataclass
 from difflib import unified_diff
 from enum import Enum
 from io import StringIO
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import langcodes
 import ruamel.yaml as yaml
@@ -279,27 +279,47 @@ def validate_references(
     return len(invalid_references) == 0, invalid_references
 
 
+def _build_reference_replacer(
+    resource_mappings: list["ResourceMapping"],
+    flow_folder_name: str = None,
+    *,
+    names_to_ids: bool,
+) -> "Callable[[re.Match], str]":
+    """Build a regex replacer that rewrites {{prefix:from}} references to {{prefix:to}}.
+
+    Args:
+        resource_mappings: Mappings providing the name<->id lookup.
+        flow_folder_name: Restricts flow-scoped mappings to the current flow.
+        names_to_ids: When True, map names -> ids; when False, ids -> names.
+    """
+    # Build dict for O(1) lookups: (prefix, from) -> to
+    lookup: dict[tuple[str, str], str] = {}
+    for rm in resource_mappings:
+        if rm.flow_name and clean_name(rm.flow_name) not in (None, flow_folder_name):
+            continue
+        if rm.resource_prefix:
+            if names_to_ids:
+                lookup[(rm.resource_prefix, rm.resource_name)] = rm.resource_id
+            else:
+                lookup[(rm.resource_prefix, rm.resource_id)] = rm.resource_name
+
+    def _replacer(match: re.Match) -> str:
+        key = (match.group(1), match.group(2))
+        if key in lookup:
+            return f"{{{{{key[0]}:{lookup[key]}}}}}"
+        return match.group(0)
+
+    return _replacer
+
+
 def replace_resource_ids_with_names(
     prompt: str,
     resource_mappings: list["ResourceMapping"],
     flow_folder_name: str = None,
 ) -> str:
     """Replace resource IDs with names in the prompt string."""
-    # Build dict for O(1) lookups: (prefix, id) -> name
-    id_to_name: dict[tuple[str, str], str] = {}
-    for rm in resource_mappings:
-        if rm.flow_name and clean_name(rm.flow_name) not in (None, flow_folder_name):
-            continue
-        if rm.resource_prefix:
-            id_to_name[(rm.resource_prefix, rm.resource_id)] = rm.resource_name
-
-    def _replacer(match: re.Match) -> str:
-        key = (match.group(1), match.group(2))
-        if key in id_to_name:
-            return f"{{{{{key[0]}:{id_to_name[key]}}}}}"
-        return match.group(0)
-
-    return _REFERENCE_PATTERN.sub(_replacer, prompt)
+    replacer = _build_reference_replacer(resource_mappings, flow_folder_name, names_to_ids=False)
+    return _REFERENCE_PATTERN.sub(replacer, prompt)
 
 
 def replace_resource_names_with_ids(
@@ -308,21 +328,33 @@ def replace_resource_names_with_ids(
     flow_folder_name: str = None,
 ) -> str:
     """Replace resource names with IDs in the prompt string."""
-    # Build dict for O(1) lookups: (prefix, name) -> id
-    name_to_id: dict[tuple[str, str], str] = {}
-    for rm in resource_mappings:
-        if rm.flow_name and clean_name(rm.flow_name) not in (None, flow_folder_name):
-            continue
-        if rm.resource_prefix:
-            name_to_id[(rm.resource_prefix, rm.resource_name)] = rm.resource_id
+    replacer = _build_reference_replacer(resource_mappings, flow_folder_name, names_to_ids=True)
+    return _REFERENCE_PATTERN.sub(replacer, prompt)
 
-    def _replacer(match: re.Match) -> str:
-        key = (match.group(1), match.group(2))
-        if key in name_to_id:
-            return f"{{{{{key[0]}:{name_to_id[key]}}}}}"
-        return match.group(0)
 
-    return _REFERENCE_PATTERN.sub(_replacer, prompt)
+def replace_resource_names_with_ids_in_data(
+    data: object,
+    resource_mappings: list["ResourceMapping"],
+    flow_folder_name: str = None,
+) -> object:
+    """Replace resource names with IDs in every scalar string leaf of a parsed structure.
+
+    Recursively walks dicts and lists, rewriting {{prefix:name}} references in string
+    values; keys and non-string values are left unchanged. Returns freshly constructed
+    dict/list containers.
+    """
+    replacer = _build_reference_replacer(resource_mappings, flow_folder_name, names_to_ids=True)
+
+    def _walk(node: object) -> object:
+        if isinstance(node, dict):
+            return {k: _walk(v) for k, v in node.items()}
+        if isinstance(node, list):
+            return [_walk(item) for item in node]
+        if isinstance(node, str):
+            return _REFERENCE_PATTERN.sub(replacer, node)
+        return node
+
+    return _walk(data)
 
 
 def get_flow_id_from_flow_name(

--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -358,6 +358,9 @@ class TestCase(YamlResource):
         **kwargs,
     ) -> dict:
         """Replace resource names with IDs in a parsed YAML dict."""
+        yaml_dict = super().from_pretty_dict(
+            yaml_dict, resource_mappings=resource_mappings, **kwargs
+        )
         if variant_name := yaml_dict.get("variant"):
             variant_id = next(
                 (

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -266,6 +266,9 @@ class VariantAttribute(MultiResourceYamlResource):
         cls, yaml_dict: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
     ) -> dict:
         """Replace variant names with IDs in a parsed YAML dict."""
+        yaml_dict = super().from_pretty_dict(
+            yaml_dict, resource_mappings=resource_mappings, **kwargs
+        )
         variant_names_to_ids = {
             resource.resource_name: resource.resource_id
             for resource in resource_mappings or []

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -3,6 +3,7 @@
 Copyright PolyAI Limited
 """
 
+import copy
 import unittest
 
 import poly.resources.resource_utils as resource_utils
@@ -137,15 +138,17 @@ class MergeUtilsTests(unittest.TestCase):
         updated = "keep\nversion A\nkeep"
         incoming = "keep\nversion B\nkeep"
         result = utils.merge_strings(original, updated, incoming)
-        expected = "\n".join([
-            "keep",
-            "<<<<<<<",
-            "version A",
-            "=======",
-            "version B",
-            ">>>>>>>",
-            "keep",
-        ])
+        expected = "\n".join(
+            [
+                "keep",
+                "<<<<<<<",
+                "version A",
+                "=======",
+                "version B",
+                ">>>>>>>",
+                "keep",
+            ]
+        )
         self.assertEqual(result, expected)
 
     def test_merge_strings_with_trailing_newlines(self):
@@ -289,7 +292,6 @@ def test_code(
             restored_code,
         )
 
-
         with_docstring_code = """import random
 def test_code(
     conv: Conversation,
@@ -371,16 +373,8 @@ def test_code(
 
     def test_restore_function_def_line_comment_with_hash_in_body(self):
         """Test that a # inside the comment text is not double-spaced."""
-        code = (
-            "def test_code(\n"
-            "    conv: Conversation\n"
-            "):  # see issue #123\n"
-            "    pass\n"
-        )
-        expected = (
-            "def test_code(conv: Conversation):  # see issue #123\n"
-            "    pass\n"
-        )
+        code = "def test_code(\n    conv: Conversation\n):  # see issue #123\n    pass\n"
+        expected = "def test_code(conv: Conversation):  # see issue #123\n    pass\n"
         restored = resource_utils.restore_function_def_line(code, "test_code")
         self.assertEqual(restored, expected)
 
@@ -407,10 +401,14 @@ class StringUtilsTests(unittest.TestCase):
         self.assertEqual(cleaned_name, "this_is_a_test_name_with_special_chars")
 
         allow_uppercase = "ThisIsATestName"
-        self.assertEqual(resource_utils.clean_name(allow_uppercase, lowercase=False), "ThisIsATestName")
+        self.assertEqual(
+            resource_utils.clean_name(allow_uppercase, lowercase=False), "ThisIsATestName"
+        )
 
         allow_non_english = "こんにちは"
-        self.assertEqual(resource_utils.clean_name(allow_non_english, lowercase=False), "こんにちは")
+        self.assertEqual(
+            resource_utils.clean_name(allow_non_english, lowercase=False), "こんにちは"
+        )
 
     def test_to_snake_case(self):
         camel_case = "ThisIsATestName"
@@ -547,9 +545,7 @@ class ValidateReferencesTests(unittest.TestCase):
         self.assertTrue(valid)
         self.assertEqual(invalid, [])
 
-        valid, invalid = resource_utils.validate_references(
-            {"attributes": {}, "variables": {}}, []
-        )
+        valid, invalid = resource_utils.validate_references({"attributes": {}, "variables": {}}, [])
         self.assertTrue(valid)
         self.assertEqual(invalid, [])
 
@@ -867,6 +863,174 @@ class ResourceMappingTests(unittest.TestCase):
         )
         expected = "Hello {{vrbl:VAR-customer_name}}, order {{vrbl:VAR-order_id}}."
         self.assertEqual(updated, expected)
+
+
+class ReplaceResourceNamesWithIdsInDataTests(unittest.TestCase):
+    """Tests for replace_resource_names_with_ids_in_data (dict/list walking variant)."""
+
+    # Reuse the same mappings as the string-based reference tests.
+    TEST_RESOURCE_MAPPINGS = ResourceMappingTests.TEST_RESOURCE_MAPPINGS
+
+    def _nested_data(self) -> dict:
+        """A representative nested structure with references at multiple depths.
+
+        References appear inside dict values, list items, and deeply nested
+        dicts, interleaved with non-string values (int, bool, None).
+        """
+        return {
+            "prompt": "Call {{fn:Function 1}} then {{fn:Function 2}}.",
+            "enabled": True,
+            "retries": 3,
+            "fallback": None,
+            "steps": [
+                "First use {{fn:Function 1}}.",
+                42,
+                {
+                    "instruction": "Then {{entity:customer_name}} and {{ho:default}}.",
+                    "nested": {
+                        "deep": "Send {{twilio_sms:test_template}} now.",
+                        "count": 7,
+                    },
+                },
+            ],
+            "closing": "Finally {{attr:customer-name}}.",
+        }
+
+    def test_equivalence_with_string_path_over_serialized_yaml(self):
+        """In-data replacement matches the serialize -> string replace -> reparse path.
+
+        The equivalence holds because references only ever appear inside scalar
+        string values, never in keys or YAML structure.
+        """
+        data = self._nested_data()
+
+        # Baseline: run the existing string-based replacer over the serialized YAML.
+        yaml_string = resource_utils.dump_yaml(data)
+        replaced_yaml = resource_utils.replace_resource_names_with_ids(
+            yaml_string, self.TEST_RESOURCE_MAPPINGS
+        )
+        baseline = resource_utils.load_yaml(replaced_yaml)
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        self.assertEqual(result, baseline)
+
+    def test_scalar_string_references_are_replaced_at_all_depths(self):
+        """Every string leaf has its references swapped, keys untouched."""
+        data = self._nested_data()
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        self.assertEqual(result["prompt"], "Call {{fn:function-1}} then {{fn:function-2}}.")
+        self.assertEqual(result["steps"][0], "First use {{fn:function-1}}.")
+        self.assertEqual(
+            result["steps"][2]["instruction"],
+            "Then {{entity:ENTITY-customer_name}} and {{ho:handoff-1}}.",
+        )
+        self.assertEqual(
+            result["steps"][2]["nested"]["deep"],
+            "Send {{twilio_sms:SMS_TEMPLATE-123}} now.",
+        )
+        self.assertEqual(result["closing"], "Finally {{attr:attr-customer-name}}.")
+
+    def test_reference_shaped_keys_are_not_rewritten(self):
+        """Only scalar string values are rewritten; dict keys are left untouched."""
+        data = {"{{fn:Function 1}}": "Refers to {{fn:Function 2}}."}
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        # Key preserved verbatim, value rewritten.
+        self.assertEqual(result, {"{{fn:Function 1}}": "Refers to {{fn:function-2}}."})
+
+    def test_non_string_leaves_are_preserved(self):
+        """Ints, bools, and None pass through unchanged and keep their types."""
+        data = self._nested_data()
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        self.assertIs(result["enabled"], True)
+        self.assertEqual(result["retries"], 3)
+        self.assertIsNone(result["fallback"])
+        self.assertEqual(result["steps"][1], 42)
+        self.assertEqual(result["steps"][2]["nested"]["count"], 7)
+
+    def test_input_is_not_mutated(self):
+        """Calling the function leaves the original structure untouched."""
+        data = self._nested_data()
+        original = copy.deepcopy(data)
+
+        resource_utils.replace_resource_names_with_ids_in_data(data, self.TEST_RESOURCE_MAPPINGS)
+
+        self.assertEqual(data, original)
+
+    def test_result_containers_are_independent_of_input(self):
+        """Mutating the returned structure does not affect the input."""
+        data = self._nested_data()
+        original = copy.deepcopy(data)
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        # Mutate nested dict and list containers in the result.
+        result["steps"].append("new step")
+        result["steps"][2]["nested"]["count"] = 999
+
+        self.assertEqual(data, original)
+
+    def test_empty_containers_round_trip(self):
+        """Empty dicts and lists are returned as fresh empty containers."""
+        self.assertEqual(
+            resource_utils.replace_resource_names_with_ids_in_data({}, self.TEST_RESOURCE_MAPPINGS),
+            {},
+        )
+        self.assertEqual(
+            resource_utils.replace_resource_names_with_ids_in_data([], self.TEST_RESOURCE_MAPPINGS),
+            [],
+        )
+
+    def test_flow_scoped_mappings_only_apply_for_matching_flow(self):
+        """Flow-scoped references are swapped only when flow_folder_name matches."""
+        data = {
+            "prompt": "In the flow, call {{ft:Flow Function}} and {{fn:Function 1}}.",
+        }
+
+        flow_1_result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS, flow_folder_name="flow_1"
+        )
+        self.assertEqual(
+            flow_1_result["prompt"],
+            "In the flow, call {{ft:flow-function-1}} and {{fn:function-1}}.",
+        )
+
+        flow_2_result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS, flow_folder_name="flow_2"
+        )
+        self.assertEqual(
+            flow_2_result["prompt"],
+            "In the flow, call {{ft:flow-function-2}} and {{fn:function-1}}.",
+        )
+
+    def test_flow_scoped_mappings_not_applied_without_flow(self):
+        """Without a matching flow_folder_name, flow-scoped references are left as-is."""
+        data = {
+            "prompt": "Call {{ft:Flow Function}} and {{fn:Function 1}}.",
+        }
+
+        result = resource_utils.replace_resource_names_with_ids_in_data(
+            data, self.TEST_RESOURCE_MAPPINGS
+        )
+
+        # The flow-scoped {{ft:...}} reference is untouched; the global {{fn:...}} is swapped.
+        self.assertEqual(result["prompt"], "Call {{ft:Flow Function}} and {{fn:function-1}}.")
 
 
 class FlowUtilsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Removes a redundant YAML serialize→reparse roundtrip from the resource read path. Multi-resource reads now use the already-parsed cached dict directly, cutting `poly diff` on a large project from ~4.0s to ~1.8s (2.3×, measured with `time poly diff`).

## Motivation

Profiling `poly diff` on a large agent project showed the time dominated by ruamel.yaml (serialize + parse). The cause: `MultiResourceYamlResource` caches each file already parsed as a dict, but on every resource read it dumped the matching sub-dict back to a YAML string just so the string-based name→ID replacement could run, then immediately reparsed that string into a dict. The dict was squeezed through a string and reconstituted for no benefit (the loader is `typ="safe"`, so no comments/formatting are preserved).

## Changes

- `resource_utils.py`: add `replace_resource_names_with_ids_in_data`, a dict/list-walking equivalent of the existing string replacement; factor the shared lookup/replacer into `_build_reference_replacer` (behaviour of the two string functions is unchanged).
- `resource.py`: add a `_read_yaml_dict` read seam. `MultiResourceYamlResource` returns its cached sub-dict via a single `_get_matching` seam that both `read_from_file` (string) and `_read_yaml_dict` (dict) derive from. Move the generic name→ID replacement into the base `from_pretty_dict` (it now walks the dict and returns fresh containers), instead of a whole-string pass in `read_local_resource`.
- `flows.py`, `test_suite.py`, `phrase_filter.py`, `variant_attributes.py`: the four `from_pretty_dict` overrides now call `super().from_pretty_dict()` first so they keep the generic replacement.
- `languages.py`: `DefaultLanguage` / `AdditionalLanguage` override `_get_matching` (their on-disk form is a bare scalar) instead of `read_from_file`, removing the need for a special-case flag.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly diff` on a large project — output byte-identical, "No changes detected.")
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

New unit tests assert the dict-walking replacement matches the old string-path result on nested structures, preserves non-string leaves and keys, does not mutate its input, and honours flow-scoped mappings.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (946 passed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

`time poly diff` on a large project (median of 5 warm runs):

| | Before | After |
|---|---|---|
| Wall time | **3.97s** | **1.75s** |

~2.3× faster; output unchanged (`No changes detected.`).

_(Earlier drafts of this PR quoted cProfile totals, which inflate ruamel's per-call cost; the above are real `time poly diff` wall-clock numbers.)_
