### PR TITLE
fix: write empty object instead of null for unset RTC schema/variables

### DIFF
--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -607,8 +607,8 @@ class RTCCommand(BaseCommand):
             return {"success": False, "error": f"Failed to fetch RTC config: {e}"}
 
         baseline_last_updated = config.get("lastUpdated")
-        schema = config.get("schema", {})
-        variables = config.get("variables", {})
+        schema = config.get("schema") or {}
+        variables = config.get("variables") or {}
 
         if edit_schema:
             content = schema

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3248,8 +3248,8 @@ class AgentStudioProject:
         env_dir = self._rtc_env_dir(env)
         os.makedirs(env_dir, exist_ok=True)
 
-        schema = config.get("schema", {})
-        variables = config.get("variables", {})
+        schema = config.get("schema") or {}
+        variables = config.get("variables") or {}
 
         schema_path = os.path.join(env_dir, "schema.json")
         data_path = os.path.join(env_dir, "data.json")

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -7,6 +7,8 @@ Copyright PolyAI Limited
 
 import json
 import os
+import shutil
+import tempfile
 import unittest
 from copy import deepcopy
 from unittest.mock import MagicMock, patch
@@ -2386,7 +2388,9 @@ class ValidateProjectTest(unittest.TestCase):
             errors = project.validate_project()
         self.assertEqual(len(errors), 2)
         error_texts = "\n".join(errors)
-        self.assertIn("Invalid references: ['global_functions: FUNCTION-missing_function']", error_texts)
+        self.assertIn(
+            "Invalid references: ['global_functions: FUNCTION-missing_function']", error_texts
+        )
         self.assertIn("Start step 'missing_step' not found.", error_texts)
 
 
@@ -3982,6 +3986,86 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
 
         self.assertIsNone(current_name)
         self.assertEqual(len(branches), 1)
+
+
+class RtcPullEnvTest(unittest.TestCase):
+    """Tests for AgentStudioProject.rtc_pull_env writing RTC files to disk."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.project = AgentStudioProject.from_dict(deepcopy(EMPTY_PROJECT_DATA), self.temp_dir)
+        self.env_dir = os.path.join(self.temp_dir, "real_time_configuration", "draft_and_sandbox")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _read_json(self, file_name: str) -> object:
+        with open(os.path.join(self.env_dir, file_name), "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_pull_env_writes_schema_and_data_returned_by_api(self):
+        """Schema and variables from the API are written to schema.json and data.json."""
+        config = {
+            "schema": {"type": "object", "properties": {"flag": {"type": "boolean"}}},
+            "variables": {"flag": True},
+            "lastUpdated": "2026-01-01T00:00:00Z",
+        }
+
+        with patch.object(AgentStudioProject, "rtc_fetch_config", return_value=config):
+            result = self.project.rtc_pull_env("sandbox")
+
+        self.assertEqual(result["environment"], "sandbox")
+        self.assertEqual(self._read_json("schema.json"), config["schema"])
+        self.assertEqual(self._read_json("data.json"), config["variables"])
+
+    def test_pull_env_writes_empty_dicts_when_api_returns_null(self):
+        """A project with no RTC configured writes {} to disk, never literal null.
+
+        The API returns explicit JSON null (not a missing key) for schema/variables when
+        RTC has never been configured, and null is not valid content for these files.
+        """
+        config = {"schema": None, "variables": None, "lastUpdated": "2026-01-01T00:00:00Z"}
+
+        with patch.object(AgentStudioProject, "rtc_fetch_config", return_value=config):
+            self.project.rtc_pull_env("sandbox")
+
+        self.assertEqual(self._read_json("schema.json"), {})
+        self.assertEqual(self._read_json("data.json"), {})
+
+    def test_pull_env_metadata_records_empty_dicts_when_api_returns_null(self):
+        """The stored baseline metadata is {} rather than being left unset on null."""
+        config = {"schema": None, "variables": None, "lastUpdated": "2026-01-01T00:00:00Z"}
+
+        with patch.object(AgentStudioProject, "rtc_fetch_config", return_value=config):
+            self.project.rtc_pull_env("sandbox")
+
+        self.assertEqual(self.project.rtc_metadata["sandbox"]["base_schema"], {})
+        self.assertEqual(self.project.rtc_metadata["sandbox"]["base_data"], {})
+        self.assertEqual(
+            self.project.rtc_metadata["sandbox"]["last_updated"], "2026-01-01T00:00:00Z"
+        )
+
+    def test_pull_env_null_config_round_trips_through_rtc_load_local(self):
+        """Files written from a null API response can be read back as empty dicts."""
+        config = {"schema": None, "variables": None, "lastUpdated": "2026-01-01T00:00:00Z"}
+
+        with patch.object(AgentStudioProject, "rtc_fetch_config", return_value=config):
+            self.project.rtc_pull_env("sandbox")
+
+        loaded = self.project.rtc_load_local("sandbox")
+
+        self.assertEqual(loaded, {"schema": {}, "variables": {}})
+
+    def test_pull_env_schema_only_does_not_write_data_file(self):
+        """schema_only writes schema.json and leaves data.json absent."""
+        config = {"schema": {"type": "object"}, "variables": {"flag": True}, "lastUpdated": "T1"}
+
+        with patch.object(AgentStudioProject, "rtc_fetch_config", return_value=config):
+            result = self.project.rtc_pull_env("sandbox", schema_only=True)
+
+        self.assertNotIn("data_file", result)
+        self.assertTrue(os.path.exists(os.path.join(self.env_dir, "schema.json")))
+        self.assertFalse(os.path.exists(os.path.join(self.env_dir, "data.json")))
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -804,6 +804,68 @@ class TestRTCEdit(unittest.TestCase):
         self.assertIn("validation failed", result["error"])
         mock_project.rtc_push_to_api.assert_not_called()
 
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_edit_null_variables_opens_empty_object_in_editor(self, mock_load_project, mock_editor):
+        """The editor gets {} when the API returns null variables, not literal null.
+
+        Projects with no RTC configured get explicit JSON null back from the API, and
+        editing "null" is not a usable starting point.
+        """
+        mock_project = MagicMock()
+        mock_project.rtc_fetch_config.return_value = {
+            "schema": None,
+            "variables": None,
+            "lastUpdated": "T1",
+        }
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
+        mock_editor.return_value = '{"flag": true}'
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        editor_content = mock_editor.call_args[0][0]
+        self.assertEqual(editor_content, "{}\n")
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_edit_schema_null_opens_empty_object_in_editor(self, mock_load_project, mock_editor):
+        """--schema gets {} in the editor when the API returns null schema."""
+        mock_project = MagicMock()
+        mock_project.rtc_fetch_config.return_value = {
+            "schema": None,
+            "variables": None,
+            "lastUpdated": "T1",
+        }
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
+        mock_editor.return_value = '{"type": "object"}'
+
+        RTCCommand.rtc_edit(self.temp_dir, env="sandbox", edit_schema=True)
+
+        editor_content = mock_editor.call_args[0][0]
+        self.assertEqual(editor_content, "{}\n")
+
+    @patch("poly.cli_commands.rtc.edit_in_editor")
+    @patch("poly.cli_commands.rtc.load_project")
+    def test_edit_null_schema_skips_data_validation(self, mock_load_project, mock_editor):
+        """With a null schema there is nothing to validate against, so the edit pushes."""
+        mock_project = MagicMock()
+        mock_project.rtc_fetch_config.return_value = {
+            "schema": None,
+            "variables": None,
+            "lastUpdated": "T1",
+        }
+        mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "sandbox"}
+        mock_load_project.return_value = mock_project
+        mock_editor.return_value = '{"flag": true}'
+
+        result = RTCCommand.rtc_edit(self.temp_dir, env="sandbox")
+
+        self.assertTrue(result["success"])
+        call_kwargs = mock_project.rtc_push_to_api.call_args[1]
+        self.assertEqual(call_kwargs["variables"], {"flag": True})
+
 
 class TestRTCDiff(unittest.TestCase):
     """Test suite for poly rtc diff command."""


### PR DESCRIPTION
## Summary

`poly rtc pull` wrote literal `null` into `schema.json`/`data.json` when a project had no RTC configured. This now correctly writes `{}`.

## Motivation

The RTC API returns `schema`/`variables` as explicit JSON `null` (not omitted) when a project has no RTC configured. `dict.get(key, {})` only substitutes the default when the key is *absent* — since the key is present with value `null`, the code got `None` through, which was then written straight to disk via `json.dump`, producing literal `null` instead of `{}`.


## Changes

- `src/poly/project.py`: `rtc_pull_env` now uses `config.get("schema") or {}` / `config.get("variables") or {}`
- `src/poly/cli_commands/rtc.py`: same fix applied to the `rtc_edit` command path
- Added regression tests in `src/poly/tests/project_test.py` (`RtcPullEnvTest`) and `src/poly/tests/rtc_test.py`

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly rtc pull`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

<img width="568" height="135" alt="image" src="https://github.com/user-attachments/assets/fd561b64-e419-4406-8073-b7bf64b51960" />