### PR TITLE
perf: defer heavy CLI imports to speed up startup

### DIFF
--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -8,9 +8,6 @@ import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
 from typing import Optional
 
-import questionary
-import requests
-
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project
 from poly.output.console import edit_in_editor, error, info, success, warning
@@ -77,6 +74,8 @@ def _resolve_rtc_conflict_interactively(
     Returns:
         Resolved dict, or None if the user cancelled.
     """
+    import questionary
+
     while True:
         choices = [
             questionary.Choice("Use local version (yours)", value="local"),
@@ -387,6 +386,8 @@ class RTCCommand(BaseCommand):
         Returns:
             dict: Result with success status and files_written list.
         """
+        import requests
+
         project = load_project(base_path, output_json=output_json)
 
         if env == "all":
@@ -424,6 +425,9 @@ class RTCCommand(BaseCommand):
         Returns:
             dict with success status, or None if the user cancelled interactively.
         """
+        import questionary
+        import requests
+
         project = load_project(base_path, output_json=output_json)
 
         # Load local files
@@ -599,6 +603,9 @@ class RTCCommand(BaseCommand):
         Returns:
             dict with success status, or None if cancelled/no changes.
         """
+        import questionary
+        import requests
+
         project = load_project(base_path)
 
         try:
@@ -688,6 +695,8 @@ class RTCCommand(BaseCommand):
         Returns:
             dict with success status and per-environment diffs.
         """
+        import requests
+
         project = load_project(base_path, output_json=output_json)
 
         if env == "all":

--- a/src/poly/resources/experimental_config.py
+++ b/src/poly/resources/experimental_config.py
@@ -7,8 +7,6 @@ import json
 import os
 from dataclasses import dataclass, field
 
-import jsonschema
-
 import poly.resources.resource_utils as utils
 from poly.handlers.protobuf.experimental_config_pb2 import ExperimentalConfig_UpdateConfig
 from poly.resources.resource import Resource, register_resource
@@ -84,6 +82,8 @@ class ExperimentalConfig(Resource):
         return NotImplementedError("ExperimentalConfig does not support creation.")
 
     def validate(self, **kwargs):
+        import jsonschema
+
         # Validate against schema
         schema_path = os.environ.get("ADK_EXPERIMENTAL_CONFIG_SCHEMA_PATH") or os.path.join(
             os.path.dirname(__file__), "experimental_config_schema.yaml"

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -21,7 +21,6 @@ from enum import Enum
 from io import StringIO
 from typing import TYPE_CHECKING, Optional, Union
 
-import langcodes
 import ruamel.yaml as yaml
 
 logger = logging.getLogger(__name__)
@@ -564,6 +563,8 @@ def convert_keys_to_snake_case(dict_obj: dict) -> dict:
 
 def is_valid_language_code(code: str) -> bool:
     """Check if the given code is a valid BCP 47 language code."""
+    import langcodes
+
     return langcodes.tag_is_valid(code)
 
 

--- a/src/poly/tests/rtc_test.py
+++ b/src/poly/tests/rtc_test.py
@@ -196,9 +196,9 @@ class TestRTC(unittest.TestCase):
         self.assertTrue(result["success"])
         mock_project.rtc_push_to_api.assert_called_once()
 
-    @patch("poly.cli_commands.rtc.questionary")
+    @patch("questionary.confirm")
     @patch("poly.cli_commands.rtc.load_project")
-    def test_rtc_push_live_interactive_confirm(self, mock_load_project, mock_questionary):
+    def test_rtc_push_live_interactive_confirm(self, mock_load_project, mock_confirm):
         """Verify interactive live push proceeds when user confirms."""
         mock_project = MagicMock()
         mock_project.rtc_load_local.return_value = {
@@ -207,17 +207,17 @@ class TestRTC(unittest.TestCase):
         }
         mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
         mock_project.rtc_push_to_api.return_value = {"success": True, "environment": "live"}
-        mock_questionary.confirm.return_value.ask.return_value = True
+        mock_confirm.return_value.ask.return_value = True
         mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
 
-        mock_questionary.confirm.assert_called_once()
+        mock_confirm.assert_called_once()
         mock_project.rtc_push_to_api.assert_called_once()
 
-    @patch("poly.cli_commands.rtc.questionary")
+    @patch("questionary.confirm")
     @patch("poly.cli_commands.rtc.load_project")
-    def test_rtc_push_live_interactive_decline(self, mock_load_project, mock_questionary):
+    def test_rtc_push_live_interactive_decline(self, mock_load_project, mock_confirm):
         """Verify interactive live push is cancelled when user declines."""
         mock_project = MagicMock()
         mock_project.rtc_load_local.return_value = {
@@ -225,12 +225,12 @@ class TestRTC(unittest.TestCase):
             "variables": {"key": "val"},
         }
         mock_project.check_rtc_drift.return_value = {"status": "no_metadata"}
-        mock_questionary.confirm.return_value.ask.return_value = False
+        mock_confirm.return_value.ask.return_value = False
         mock_load_project.return_value = mock_project
 
         RTCCommand.rtc_push(self.temp_dir, env="live", force=False, output_json=False)
 
-        mock_questionary.confirm.assert_called_once()
+        mock_confirm.assert_called_once()
         mock_project.rtc_push_to_api.assert_not_called()
 
 
@@ -747,10 +747,10 @@ class TestRTCEdit(unittest.TestCase):
         self.assertIn("modified while you were editing", result["error"])
         mock_project.rtc_push_to_api.assert_not_called()
 
-    @patch("poly.cli_commands.rtc.questionary")
+    @patch("questionary.confirm")
     @patch("poly.cli_commands.rtc.edit_in_editor")
     @patch("poly.cli_commands.rtc.load_project")
-    def test_edit_live_declined(self, mock_load_project, mock_editor, mock_questionary):
+    def test_edit_live_declined(self, mock_load_project, mock_editor, mock_confirm):
         """Verify live edit cancelled when user declines confirmation."""
         mock_project = MagicMock()
         mock_project.rtc_fetch_config.return_value = {
@@ -759,7 +759,7 @@ class TestRTCEdit(unittest.TestCase):
             "lastUpdated": "T1",
         }
         mock_load_project.return_value = mock_project
-        mock_questionary.confirm.return_value.ask.return_value = False
+        mock_confirm.return_value.ask.return_value = False
         mock_editor.return_value = '{"flag": true}'
 
         RTCCommand.rtc_edit(self.temp_dir, env="live")


### PR DESCRIPTION
## Summary

Defers heavy third-party imports out of CLI module load so `poly` commands don't pay for dependencies they don't use. Cuts `import poly.cli` from ~284ms to ~180ms (~37%).

## Motivation

`poly`'s entrypoint imports every command module up front (to register argparse subcommands), so a few heavy deps were loaded on *every* invocation regardless of the command:
- `prompt_toolkit` + `questionary` (~55ms) — interactive prompts, only used by `poly rtc`
- `langcodes` (~16ms, compiles regex/data tables at import) — language validation only
- `jsonschema` (~20ms) — experimental-config validation only

A `poly diff`/`status`/`pull` never touches any of these, but paid ~90ms of import cost for them.

## Changes

Moved each import to point-of-use inside the function that needs it:
- `resources/resource_utils.py`: `langcodes` → inside `is_valid_language_code`.
- `resources/experimental_config.py`: `jsonschema` → inside `ExperimentalConfig.validate`.
- `cli_commands/rtc.py`: `questionary`/`requests` → local imports in the five methods that use them.
- `tests/rtc_test.py`: re-point three mock patches from `poly.cli_commands.rtc.questionary` (no longer a module attribute) to `questionary.confirm`.

No behavior change — purely where the imports happen.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly --help`, `poly diff` — verified `prompt_toolkit`/`questionary`/`langcodes`/`jsonschema` no longer load at startup via `python -X importtime`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (937 passed)
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

## Screenshots / Logs

`python -X importtime -c "import poly.cli"`:

| | Before | After |
|---|---|---|
| `import poly.cli` cumulative | ~284ms | ~180ms |
| `prompt_toolkit`/`questionary` | loaded | not loaded |
| `langcodes` | loaded | not loaded |
| `jsonschema` | loaded | not loaded |
