### PR TITLE
feat: add poly audio-cache CLI commands (DEVP-377)

### DIFF
--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -546,6 +546,139 @@ poly conversations get-audio <conversation_id> --json
 | `--path` | Base path to the project. Defaults to the current working directory. |
 | `--json` | Print a JSON summary on stdout instead of the success message (audio is still written to disk). |
 
+### `poly audio-cache`
+
+Manage an agent's cached TTS audio entries using the public Audio Cache API.
+
+`poly audio-cache` requires a subcommand: `list`, `get-file`, `update-file`, `update-details`, `delete`, `bulk-delete`, or `synthesize`.
+
+Examples:
+
+~~~bash
+poly audio-cache list
+poly audio-cache get-file <entry_id> -o cached.wav
+poly audio-cache update-file <entry_id> --file replacement.wav
+poly audio-cache synthesize <entry_id> --text "Hello there" -o preview.wav
+poly audio-cache delete <entry_id>
+poly audio-cache bulk-delete --ids id1,id2,id3
+~~~
+
+#### `poly audio-cache list`
+
+List cached TTS audio entries with metadata (transcript, provider, voice, duration, hit count).
+
+~~~bash
+poly audio-cache list
+poly audio-cache list --limit 20 --offset 10
+poly audio-cache list --sort hit_count:desc
+~~~
+
+| Flag | Description |
+|---|---|
+| `--limit` | Max number of entries to return (1-200). Defaults to `50`. |
+| `--offset` | Number of entries to skip. Defaults to `0`. |
+| `--sort` | Sort expression, e.g. `hit_count:desc` or `duration:asc`. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a single JSON object on stdout (machine-readable). |
+
+#### `poly audio-cache get-file`
+
+Download the cached WAV audio file for a cache entry.
+
+~~~bash
+poly audio-cache get-file <entry_id>
+poly audio-cache get-file <entry_id> -o cached.wav
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `entry_id` | The audio cache entry ID. Required. |
+| `-o`, `--output` | Output file path. Defaults to `<entry_id>.wav`. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a JSON summary on stdout instead of the success message (audio is still written to disk). |
+
+#### `poly audio-cache update-file`
+
+Replace the audio file for an existing cache entry. Maximum file size is 6MB.
+
+~~~bash
+poly audio-cache update-file <entry_id> --file replacement.wav
+poly audio-cache update-file <entry_id> --file replacement.wav --filename clip.wav
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `entry_id` | The audio cache entry ID. Required. |
+| `--file` | Path to the local replacement WAV file. Required. |
+| `--filename` | Filename to record for the uploaded audio. Defaults to the local file's basename. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a single JSON object on stdout (machine-readable). |
+
+#### `poly audio-cache update-details`
+
+Replace both the audio file and voice tuning settings for a cache entry in one call. Maximum file size is 6MB.
+
+~~~bash
+poly audio-cache update-details <entry_id> --file replacement.wav --text "Hi there"
+poly audio-cache update-details <entry_id> --file replacement.wav --text "Hi" --config '{"stability": 0.5}'
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `entry_id` | The audio cache entry ID. Required. |
+| `--file` | Path to the local replacement WAV file. Required. |
+| `--text` | Transcript text associated with the audio. Required. |
+| `--config` | JSON object of provider-specific voice tuning settings (e.g. `stability`, `speed`, `model_id`). Defaults to `{}`. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a single JSON object on stdout (machine-readable). |
+
+#### `poly audio-cache delete`
+
+Permanently delete a cached audio entry and its audio file.
+
+~~~bash
+poly audio-cache delete <entry_id>
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `entry_id` | The audio cache entry ID. Required. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a single JSON object on stdout (machine-readable). |
+
+#### `poly audio-cache bulk-delete`
+
+Delete multiple audio cache entries in a single request. Best-effort — reports which IDs succeeded and which failed, so partial failures can be retried. Maximum 20 IDs per request.
+
+~~~bash
+poly audio-cache bulk-delete --ids id1,id2,id3
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `--ids` | Comma-separated list of audio cache entry IDs to delete (max 20). Required. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a single JSON object on stdout (machine-readable). |
+
+#### `poly audio-cache synthesize`
+
+Generate a TTS audio preview using an existing cache entry's voice and provider configuration, without saving it to the cache.
+
+~~~bash
+poly audio-cache synthesize <entry_id> --text "Hello there"
+poly audio-cache synthesize <entry_id> --text "Hi" --language en-US -o out.wav
+~~~
+
+| Argument / Flag | Description |
+|---|---|
+| `entry_id` | The audio cache entry ID whose voice/provider config to preview with. Required. |
+| `--text` | Text to synthesize. Required. |
+| `--config` | JSON object of provider-specific voice tuning settings. Defaults to `{}`. |
+| `--language` | BCP-47 language tag, e.g. `en-US`. |
+| `-o`, `--output` | Output file path. Defaults to `<entry_id>-preview.wav`. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+| `--json` | Print a JSON summary on stdout instead of the success message (audio is still written to disk). |
+
 ### `poly docs`
 
 Output resource documentation.
@@ -705,6 +838,12 @@ poly deployments rollback --to <id> --force --json
 poly conversations list --json
 poly conversations get <conversation_id> --json
 poly conversations get-audio <conversation_id> --json
+poly audio-cache list --json
+poly audio-cache get-file <entry_id> --json
+poly audio-cache update-file <entry_id> --file replacement.wav --json
+poly audio-cache delete <entry_id> --json
+poly audio-cache bulk-delete --ids id1,id2 --json
+poly audio-cache synthesize <entry_id> --text "Hello" --json
 ~~~
 
 When `--json` is used:
@@ -749,6 +888,13 @@ The exact fields vary by command. Common fields include:
 | `poly conversations list --json` | `conversations`, `count`, `limit`, `offset` |
 | `poly conversations get --json` | full conversation detail object |
 | `poly conversations get-audio --json` | `success`, `conversation_id`, `direction`, `redacted`, `output_path`, `size_bytes` |
+| `poly audio-cache list --json` | `entries`, `total_count` |
+| `poly audio-cache get-file --json` | `success`, `entry_id`, `output_path`, `size_bytes` |
+| `poly audio-cache update-file --json` | `success`, `entry_id`, `size_bytes` |
+| `poly audio-cache update-details --json` | `success`, `entry_id`, `size_bytes` |
+| `poly audio-cache delete --json` | `success` |
+| `poly audio-cache bulk-delete --json` | `deleted`, `failed` |
+| `poly audio-cache synthesize --json` | `success`, `entry_id`, `output_path`, `size_bytes` |
 
 For `poly branch delete --json`, when a branch that was the current branch is deleted, the response also includes `"switched_to": "main"`.
 

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -12,6 +12,7 @@ from importlib.metadata import version as get_package_version
 
 import argcomplete
 
+from poly.cli_commands.audio_cache import AudioCacheCommand
 from poly.cli_commands.auth import LoginCommand, StartCommand
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.branch import BranchCommand
@@ -53,6 +54,7 @@ COMMANDS = [
     BranchCommand,
     DeploymentsCommand,
     ConversationsCommand,
+    AudioCacheCommand,
     TestingCommand,
     RTCCommand,
     ChatCommand,

--- a/src/poly/cli_commands/audio_cache.py
+++ b/src/poly/cli_commands/audio_cache.py
@@ -1,0 +1,592 @@
+"""Audio cache command family: manage an agent's cached TTS audio via the
+public Audio Cache API.
+
+Copyright PolyAI Limited
+"""
+
+import json
+import os
+import sys
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+from typing import Optional
+
+from poly.cli_commands.base import BaseCommand, Parents
+from poly.cli_commands.shared import load_project
+from poly.handlers.interface import AgentStudioInterface
+from poly.output.json_output import json_print
+
+
+class AudioCacheCommand(BaseCommand):
+    """Manage an agent's cached TTS audio entries."""
+
+    command = "audio-cache"
+
+    @classmethod
+    def add_arguments(cls, subparsers: _SubParsersAction[ArgumentParser], parents: Parents) -> None:
+        """Register the ``audio-cache`` subcommand tree."""
+        audio_cache_parser = subparsers.add_parser(
+            "audio-cache",
+            parents=[parents.verbose],
+            help="Manage cached TTS audio via the Audio Cache API.",
+            description=(
+                "Manage an agent's cached TTS audio entries.\n\n"
+                "Examples:\n"
+                "  poly audio-cache list\n"
+                "  poly audio-cache get-file <entry_id> -o cached.wav\n"
+                "  poly audio-cache update-file <entry_id> --file replacement.wav\n"
+                "  poly audio-cache synthesize <entry_id> --text 'Hello there' -o preview.wav\n"
+                "  poly audio-cache delete <entry_id>\n"
+                "  poly audio-cache bulk-delete --ids id1,id2,id3\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        audio_cache_subparsers = audio_cache_parser.add_subparsers(
+            dest="audio_cache_subcommand", required=True
+        )
+
+        list_parser = audio_cache_subparsers.add_parser(
+            "list",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="List cached audio entries for the agent.",
+            description=(
+                "List cached TTS audio entries with metadata (transcript, provider,\n"
+                "voice, duration, hit count).\n\n"
+                "Examples:\n"
+                "  poly audio-cache list\n"
+                "  poly audio-cache list --limit 20 --offset 10\n"
+                "  poly audio-cache list --sort hit_count:desc\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        list_parser.add_argument(
+            "--limit",
+            type=int,
+            default=50,
+            help="Max number of entries to return (1-200). Defaults to 50.",
+        )
+        list_parser.add_argument(
+            "--offset",
+            type=int,
+            default=0,
+            help="Number of entries to skip. Defaults to 0.",
+        )
+        list_parser.add_argument(
+            "--sort",
+            type=str,
+            default=None,
+            help="Sort expression, e.g. 'hit_count:desc' or 'duration:asc'.",
+        )
+
+        get_file_parser = audio_cache_subparsers.add_parser(
+            "get-file",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Download the cached audio file for an entry.",
+            description=(
+                "Download the cached WAV audio file for a cache entry.\n\n"
+                "Examples:\n"
+                "  poly audio-cache get-file <entry_id>\n"
+                "  poly audio-cache get-file <entry_id> -o cached.wav\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        get_file_parser.add_argument("entry_id", type=str, help="The audio cache entry ID.")
+        get_file_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            default=None,
+            help="Output file path. Defaults to <entry_id>.wav.",
+        )
+
+        update_file_parser = audio_cache_subparsers.add_parser(
+            "update-file",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Replace the audio file for a cache entry.",
+            description=(
+                "Replace the audio file for an existing cache entry. Maximum file\n"
+                "size is 6MB.\n\n"
+                "Examples:\n"
+                "  poly audio-cache update-file <entry_id> --file replacement.wav\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        update_file_parser.add_argument("entry_id", type=str, help="The audio cache entry ID.")
+        update_file_parser.add_argument(
+            "--file",
+            type=str,
+            required=True,
+            metavar="FILE",
+            dest="file_path",
+            help="Path to the replacement WAV file.",
+        )
+        update_file_parser.add_argument(
+            "--filename",
+            type=str,
+            default=None,
+            help="Filename to record for the uploaded audio. Defaults to <entry_id>.wav.",
+        )
+
+        update_details_parser = audio_cache_subparsers.add_parser(
+            "update-details",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Replace the audio file and voice tuning settings for a cache entry.",
+            description=(
+                "Replace both the audio file and voice tuning settings for a cache\n"
+                "entry. Maximum file size is 6MB.\n\n"
+                "Examples:\n"
+                "  poly audio-cache update-details <entry_id> --file r.wav --text 'Hi there'\n"
+                "  poly audio-cache update-details <entry_id> --file r.wav --text 'Hi'"
+                " --config '{\"stability\": 0.5}'\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        update_details_parser.add_argument("entry_id", type=str, help="The audio cache entry ID.")
+        update_details_parser.add_argument(
+            "--file",
+            type=str,
+            required=True,
+            metavar="FILE",
+            dest="file_path",
+            help="Path to the replacement WAV file.",
+        )
+        update_details_parser.add_argument(
+            "--text",
+            type=str,
+            required=True,
+            help="Transcript text associated with the audio.",
+        )
+        update_details_parser.add_argument(
+            "--config",
+            type=str,
+            default="{}",
+            help="JSON object of provider-specific voice tuning settings.",
+        )
+
+        delete_parser = audio_cache_subparsers.add_parser(
+            "delete",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Delete a cached audio entry.",
+            description=(
+                "Permanently delete a cached audio entry and its audio file.\n\n"
+                "Examples:\n"
+                "  poly audio-cache delete <entry_id>\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        delete_parser.add_argument("entry_id", type=str, help="The audio cache entry ID.")
+
+        bulk_delete_parser = audio_cache_subparsers.add_parser(
+            "bulk-delete",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Delete multiple cached audio entries by ID.",
+            description=(
+                "Delete multiple audio cache entries in a single request. Best-effort:\n"
+                "reports which IDs succeeded and which failed. Maximum 20 IDs.\n\n"
+                "Examples:\n"
+                "  poly audio-cache bulk-delete --ids id1,id2,id3\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        bulk_delete_parser.add_argument(
+            "--ids",
+            type=str,
+            required=True,
+            help="Comma-separated list of audio cache entry IDs to delete (max 20).",
+        )
+
+        synthesize_parser = audio_cache_subparsers.add_parser(
+            "synthesize",
+            parents=[parents.path, parents.json, parents.verbose],
+            help="Preview TTS audio using an existing cache entry's voice config.",
+            description=(
+                "Generate a TTS audio preview using an existing cache entry's voice\n"
+                "and provider configuration, without saving it to the cache.\n\n"
+                "Examples:\n"
+                "  poly audio-cache synthesize <entry_id> --text 'Hello there'\n"
+                "  poly audio-cache synthesize <entry_id> --text 'Hi' --language en-US -o out.wav\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        synthesize_parser.add_argument("entry_id", type=str, help="The audio cache entry ID.")
+        synthesize_parser.add_argument(
+            "--text",
+            type=str,
+            required=True,
+            help="Text to synthesize.",
+        )
+        synthesize_parser.add_argument(
+            "--config",
+            type=str,
+            default="{}",
+            help="JSON object of provider-specific voice tuning settings.",
+        )
+        synthesize_parser.add_argument(
+            "--language",
+            type=str,
+            default=None,
+            help="BCP-47 language tag, e.g. 'en-US'.",
+        )
+        synthesize_parser.add_argument(
+            "-o",
+            "--output",
+            type=str,
+            default=None,
+            help="Output file path. Defaults to <entry_id>-preview.wav.",
+        )
+
+    @classmethod
+    def run(cls, args: Namespace) -> None:
+        """Dispatch to the matching audio-cache sub-handler."""
+        if args.audio_cache_subcommand == "list":
+            cls.audio_cache_list(
+                args.path,
+                limit=args.limit,
+                offset=args.offset,
+                sort=args.sort,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "get-file":
+            cls.audio_cache_get_file(
+                args.path,
+                args.entry_id,
+                output_path=args.output,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "update-file":
+            cls.audio_cache_update_file(
+                args.path,
+                args.entry_id,
+                args.file_path,
+                filename=args.filename,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "update-details":
+            cls.audio_cache_update_details(
+                args.path,
+                args.entry_id,
+                args.file_path,
+                args.text,
+                args.config,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "delete":
+            cls.audio_cache_delete(
+                args.path,
+                args.entry_id,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "bulk-delete":
+            cls.audio_cache_bulk_delete(
+                args.path,
+                args.ids,
+                output_json=args.json,
+            )
+        elif args.audio_cache_subcommand == "synthesize":
+            cls.audio_cache_synthesize(
+                args.path,
+                args.entry_id,
+                args.text,
+                args.config,
+                language=args.language,
+                output_path=args.output,
+                output_json=args.json,
+            )
+
+    @classmethod
+    def audio_cache_list(
+        cls,
+        base_path: str,
+        limit: int = 50,
+        offset: int = 0,
+        sort: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """List cached audio entries for the agent.
+
+        Args:
+            base_path: Base path for the project.
+            limit: Max number of entries to return.
+            offset: Number of entries to skip.
+            sort: Optional sort expression, e.g. "hit_count:desc".
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import info, print_audio_cache_entries
+
+        project = load_project(base_path, output_json=output_json)
+        result = AgentStudioInterface.list_audio_cache(
+            region=project.region,
+            project_id=project.project_id,
+            limit=limit,
+            offset=offset,
+            sort=sort,
+        )
+        entries = result.get("entries", [])
+
+        if output_json:
+            json_print(result)
+        else:
+            if not entries:
+                info("No audio cache entries found.")
+                return
+            print_audio_cache_entries(entries)
+
+    @classmethod
+    def audio_cache_get_file(
+        cls,
+        base_path: str,
+        entry_id: str,
+        output_path: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """Download the cached audio file for an entry.
+
+        Args:
+            base_path: Base path for the project.
+            entry_id: The audio cache entry ID.
+            output_path: Output file path. Defaults to <entry_id>.wav.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import success
+
+        project = load_project(base_path, output_json=output_json)
+        audio_data = AgentStudioInterface.get_audio_cache_file(
+            region=project.region,
+            project_id=project.project_id,
+            entry_id=entry_id,
+        )
+
+        if output_path is None:
+            output_path = f"{entry_id}.wav"
+
+        with open(output_path, "wb") as f:
+            f.write(audio_data)
+
+        size_bytes = len(audio_data)
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "entry_id": entry_id,
+                    "output_path": output_path,
+                    "size_bytes": size_bytes,
+                }
+            )
+        else:
+            size_mb = size_bytes / 1_000_000
+            success(f"Audio saved to {output_path} ({size_mb:.1f} MB)")
+
+    @classmethod
+    def audio_cache_update_file(
+        cls,
+        base_path: str,
+        entry_id: str,
+        file_path: str,
+        filename: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """Replace the audio file for a cache entry.
+
+        Args:
+            base_path: Base path for the project.
+            entry_id: The audio cache entry ID.
+            file_path: Local path to the replacement WAV file.
+            filename: Optional filename to record for the uploaded audio.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import success
+
+        project = load_project(base_path, output_json=output_json)
+        with open(file_path, "rb") as f:
+            audio_bytes = f.read()
+
+        AgentStudioInterface.update_audio_cache_file(
+            region=project.region,
+            project_id=project.project_id,
+            entry_id=entry_id,
+            audio_bytes=audio_bytes,
+            filename=filename or os.path.basename(file_path),
+        )
+
+        if output_json:
+            json_print({"success": True, "entry_id": entry_id, "size_bytes": len(audio_bytes)})
+        else:
+            success(f"Updated audio file for entry {entry_id}.")
+
+    @classmethod
+    def audio_cache_update_details(
+        cls,
+        base_path: str,
+        entry_id: str,
+        file_path: str,
+        text: str,
+        config: str,
+        output_json: bool = False,
+    ) -> None:
+        """Replace the audio file and voice tuning settings for a cache entry.
+
+        Args:
+            base_path: Base path for the project.
+            entry_id: The audio cache entry ID.
+            file_path: Local path to the replacement WAV file.
+            text: Transcript text associated with the audio.
+            config: JSON string of provider-specific voice tuning settings.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError as e:
+            msg = f"Invalid JSON in --config: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        with open(file_path, "rb") as f:
+            audio_bytes = f.read()
+
+        AgentStudioInterface.update_audio_cache_details(
+            region=project.region,
+            project_id=project.project_id,
+            entry_id=entry_id,
+            audio_bytes=audio_bytes,
+            settings={"text": text, "config": parsed_config},
+            filename=os.path.basename(file_path),
+        )
+
+        if output_json:
+            json_print({"success": True, "entry_id": entry_id, "size_bytes": len(audio_bytes)})
+        else:
+            success(f"Updated audio and details for entry {entry_id}.")
+
+    @classmethod
+    def audio_cache_delete(
+        cls,
+        base_path: str,
+        entry_id: str,
+        output_json: bool = False,
+    ) -> None:
+        """Delete a cached audio entry.
+
+        Args:
+            base_path: Base path for the project.
+            entry_id: The audio cache entry ID.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import success
+
+        project = load_project(base_path, output_json=output_json)
+        result = AgentStudioInterface.delete_audio_cache_entry(
+            region=project.region,
+            project_id=project.project_id,
+            entry_id=entry_id,
+        )
+
+        if output_json:
+            json_print(result)
+        else:
+            success(f"Deleted audio cache entry {entry_id}.")
+
+    @classmethod
+    def audio_cache_bulk_delete(
+        cls,
+        base_path: str,
+        ids: str,
+        output_json: bool = False,
+    ) -> None:
+        """Delete multiple cached audio entries by ID.
+
+        Args:
+            base_path: Base path for the project.
+            ids: Comma-separated list of audio cache entry IDs.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+        id_list = [i.strip() for i in ids.split(",") if i.strip()]
+
+        result = AgentStudioInterface.bulk_delete_audio_cache(
+            region=project.region,
+            project_id=project.project_id,
+            ids=id_list,
+        )
+
+        if output_json:
+            json_print(result)
+            return
+
+        deleted = result.get("deleted", [])
+        failed = result.get("failed", [])
+        if deleted:
+            success(f"Deleted {len(deleted)} entries: {', '.join(deleted)}")
+        if failed:
+            error(f"Failed to delete {len(failed)} entries: {', '.join(failed)}")
+
+    @classmethod
+    def audio_cache_synthesize(
+        cls,
+        base_path: str,
+        entry_id: str,
+        text: str,
+        config: str,
+        language: Optional[str] = None,
+        output_path: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """Generate a TTS audio preview using an existing cache entry's voice config.
+
+        Args:
+            base_path: Base path for the project.
+            entry_id: The audio cache entry ID whose voice/provider config to use.
+            text: Text to synthesize.
+            config: JSON string of provider-specific voice tuning settings.
+            language: Optional BCP-47 language tag.
+            output_path: Output file path. Defaults to <entry_id>-preview.wav.
+            output_json: If True, emit machine-readable JSON.
+        """
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+        try:
+            parsed_config = json.loads(config)
+        except json.JSONDecodeError as e:
+            msg = f"Invalid JSON in --config: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        audio_data = AgentStudioInterface.synthesize_audio_cache(
+            region=project.region,
+            project_id=project.project_id,
+            entry_id=entry_id,
+            text=text,
+            config=parsed_config,
+            language=language,
+        )
+
+        if output_path is None:
+            output_path = f"{entry_id}-preview.wav"
+
+        with open(output_path, "wb") as f:
+            f.write(audio_data)
+
+        size_bytes = len(audio_data)
+        if output_json:
+            json_print(
+                {
+                    "success": True,
+                    "entry_id": entry_id,
+                    "output_path": output_path,
+                    "size_bytes": size_bytes,
+                }
+            )
+        else:
+            size_mb = size_bytes / 1_000_000
+            success(f"Preview audio saved to {output_path} ({size_mb:.1f} MB)")

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1028,6 +1028,140 @@ class AgentStudioInterface:
         )
 
     @staticmethod
+    def list_audio_cache(
+        region: str,
+        project_id: str,
+        limit: int = 50,
+        offset: int = 0,
+        sort: Optional[str] = None,
+    ) -> dict:
+        """List cached TTS audio entries for an agent.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max entries to return (1-200).
+            offset: Pagination offset.
+            sort: Optional sort expression, e.g. "hit_count:desc".
+
+        Returns:
+            dict: The API response with entries and total_count.
+        """
+        return PlatformAPIHandler.list_audio_cache(region, project_id, limit, offset, sort)
+
+    @staticmethod
+    def get_audio_cache_file(region: str, project_id: str, entry_id: str) -> bytes:
+        """Download the cached audio file for an audio cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+
+        Returns:
+            bytes: The raw WAV audio data.
+        """
+        return PlatformAPIHandler.get_audio_cache_file(region, project_id, entry_id)
+
+    @staticmethod
+    def update_audio_cache_file(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        audio_bytes: bytes,
+        filename: Optional[str] = None,
+    ) -> None:
+        """Replace the audio file for an existing cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+            audio_bytes: Raw WAV audio bytes (max 6MB).
+            filename: Optional filename, sent via the X-Filename header.
+        """
+        PlatformAPIHandler.update_audio_cache_file(
+            region, project_id, entry_id, audio_bytes, filename
+        )
+
+    @staticmethod
+    def update_audio_cache_details(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        audio_bytes: bytes,
+        settings: dict,
+        filename: str = "audio.wav",
+    ) -> None:
+        """Replace both the audio file and voice tuning settings for a cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+            audio_bytes: Raw WAV audio bytes (max 6MB).
+            settings: Dict with "text" and "config" keys (voice tuning settings).
+            filename: Filename to use for the multipart file part.
+        """
+        PlatformAPIHandler.update_audio_cache_details(
+            region, project_id, entry_id, audio_bytes, settings, filename
+        )
+
+    @staticmethod
+    def delete_audio_cache_entry(region: str, project_id: str, entry_id: str) -> dict:
+        """Delete a cached audio entry and its associated audio file.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+
+        Returns:
+            dict: The API response, e.g. {"success": True}.
+        """
+        return PlatformAPIHandler.delete_audio_cache_entry(region, project_id, entry_id)
+
+    @staticmethod
+    def bulk_delete_audio_cache(region: str, project_id: str, ids: list[str]) -> dict:
+        """Delete multiple audio cache entries by ID in a single request.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            ids: List of audio cache entry IDs to delete (max 20).
+
+        Returns:
+            dict: The API response with "deleted" and "failed" ID lists.
+        """
+        return PlatformAPIHandler.bulk_delete_audio_cache(region, project_id, ids)
+
+    @staticmethod
+    def synthesize_audio_cache(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        text: str,
+        config: dict,
+        language: Optional[str] = None,
+    ) -> bytes:
+        """Generate a TTS audio preview using an existing cache entry's voice config.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID whose voice/provider config to use.
+            text: Text to synthesize.
+            config: Provider-specific voice tuning settings.
+            language: Optional BCP-47 language tag, e.g. "en-US".
+
+        Returns:
+            bytes: The raw WAV audio data (preview only, not saved to cache).
+        """
+        return PlatformAPIHandler.synthesize_audio_cache(
+            region, project_id, entry_id, text, config, language
+        )
+
+    @staticmethod
     def list_test_runs(
         region: str,
         project_id: str,

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -35,6 +35,12 @@ ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/rollback"
 CONVERSATIONS_URL = "/v1/agents/{project_id}/conversations"
 CONVERSATION_URL = "/v1/agents/{project_id}/conversations/{conversation_id}"
 CONVERSATION_AUDIO_URL = "/v1/agents/{project_id}/conversations/{conversation_id}/audio"
+AUDIO_CACHE_URL = "/v1/agents/{project_id}/audio-cache"
+AUDIO_CACHE_ENTRY_URL = "/v1/agents/{project_id}/audio-cache/{entry_id}"
+AUDIO_CACHE_FILE_URL = "/v1/agents/{project_id}/audio-cache/{entry_id}/file"
+AUDIO_CACHE_DETAILS_URL = "/v1/agents/{project_id}/audio-cache/{entry_id}/details"
+AUDIO_CACHE_SYNTHESIZE_URL = "/v1/agents/{project_id}/audio-cache/{entry_id}/synthesize"
+AUDIO_CACHE_BULK_DELETE_URL = "/v1/agents/{project_id}/audio-cache/bulk-delete"
 LIST_AGENTS_URL = "/v1/accounts/{account_id}/agents"
 DELETE_AGENT_URL = "/v1/agents/{project_id}"
 DUPLICATE_AGENT_URL = "/v1/agents/{project_id}/duplicate"
@@ -929,6 +935,254 @@ class PlatformAPIHandler:
 
         logger.info(f"Making GET request to {url}")
         response = requests.get(url, headers=headers, params=params, allow_redirects=False)
+
+        logger.debug(
+            f"Request/response url={url!r}"
+            f" status_code={response.status_code!r} content_length={len(response.content)}"
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request status_code={response.status_code!r} response={response.text!r}"
+            )
+            raise
+
+        return response.content
+
+    @staticmethod
+    def list_audio_cache(
+        region: str,
+        project_id: str,
+        limit: int = 50,
+        offset: int = 0,
+        sort: ty.Optional[str] = None,
+    ) -> dict:
+        """List cached TTS audio entries for an agent.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            limit: Max entries to return (1-200).
+            offset: Pagination offset.
+            sort: Optional sort expression, e.g. "hit_count:desc".
+
+        Returns:
+            dict: The API response with entries and total_count.
+        """
+        endpoint = AUDIO_CACHE_URL.format(project_id=project_id)
+        params: dict = {"limit": limit, "offset": offset}
+        if sort:
+            params["sort"] = sort
+        return PlatformAPIHandler.make_request(region, endpoint, "GET", params=params)
+
+    @staticmethod
+    def get_audio_cache_file(region: str, project_id: str, entry_id: str) -> bytes:
+        """Download the cached audio file for an audio cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+
+        Returns:
+            bytes: The raw WAV audio data.
+        """
+        endpoint = AUDIO_CACHE_FILE_URL.format(project_id=project_id, entry_id=entry_id)
+        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "X-API-KEY": retrieve_api_key(region),
+            "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
+        }
+
+        logger.info(f"Making GET request to {url}")
+        response = requests.get(url, headers=headers, allow_redirects=False)
+
+        logger.debug(
+            f"Request/response url={url!r}"
+            f" status_code={response.status_code!r} content_length={len(response.content)}"
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request status_code={response.status_code!r} response={response.text!r}"
+            )
+            raise
+
+        return response.content
+
+    @staticmethod
+    def update_audio_cache_file(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        audio_bytes: bytes,
+        filename: ty.Optional[str] = None,
+    ) -> None:
+        """Replace the audio file for an existing cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+            audio_bytes: Raw WAV audio bytes (max 6MB).
+            filename: Optional filename, sent via the X-Filename header.
+        """
+        endpoint = AUDIO_CACHE_FILE_URL.format(project_id=project_id, entry_id=entry_id)
+        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "X-API-KEY": retrieve_api_key(region),
+            "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
+            "Content-Type": "audio/wav",
+        }
+        if filename:
+            headers["X-Filename"] = filename
+
+        logger.info(f"Making PATCH request to {url}")
+        response = requests.request(
+            method="PATCH", url=url, headers=headers, data=audio_bytes, allow_redirects=False
+        )
+
+        logger.debug(
+            f"Request/response url={url!r}"
+            f" status_code={response.status_code!r} response={response.text!r}"
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request status_code={response.status_code!r} response={response.text!r}"
+            )
+            raise
+
+    @staticmethod
+    def update_audio_cache_details(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        audio_bytes: bytes,
+        settings: dict,
+        filename: str = "audio.wav",
+    ) -> None:
+        """Replace both the audio file and voice tuning settings for a cache entry.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+            audio_bytes: Raw WAV audio bytes (max 6MB).
+            settings: Dict with "text" and "config" keys (voice tuning settings).
+            filename: Filename to use for the multipart file part.
+        """
+        endpoint = AUDIO_CACHE_DETAILS_URL.format(project_id=project_id, entry_id=entry_id)
+        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "X-API-KEY": retrieve_api_key(region),
+            "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
+        }
+
+        logger.info(f"Making PUT request to {url}")
+        response = requests.request(
+            method="PUT",
+            url=url,
+            headers=headers,
+            files={"file": (filename, audio_bytes, "audio/wav")},
+            data={"settings": json.dumps(settings)},
+            allow_redirects=False,
+        )
+
+        logger.debug(
+            f"Request/response url={url!r}"
+            f" status_code={response.status_code!r} response={response.text!r}"
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.debug(
+                f"Error in request status_code={response.status_code!r} response={response.text!r}"
+            )
+            raise
+
+    @staticmethod
+    def delete_audio_cache_entry(region: str, project_id: str, entry_id: str) -> dict:
+        """Delete a cached audio entry and its associated audio file.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID.
+
+        Returns:
+            dict: The API response, e.g. {"success": True}.
+        """
+        endpoint = AUDIO_CACHE_ENTRY_URL.format(project_id=project_id, entry_id=entry_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "DELETE")
+
+    @staticmethod
+    def bulk_delete_audio_cache(region: str, project_id: str, ids: list[str]) -> dict:
+        """Delete multiple audio cache entries by ID in a single request.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            ids: List of audio cache entry IDs to delete (max 20).
+
+        Returns:
+            dict: The API response with "deleted" and "failed" ID lists.
+        """
+        endpoint = AUDIO_CACHE_BULK_DELETE_URL.format(project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data={"ids": ids})
+
+    @staticmethod
+    def synthesize_audio_cache(
+        region: str,
+        project_id: str,
+        entry_id: str,
+        text: str,
+        config: dict,
+        language: ty.Optional[str] = None,
+    ) -> bytes:
+        """Generate a TTS audio preview using an existing cache entry's voice config.
+
+        Args:
+            region: The region name.
+            project_id: The project ID (agent ID).
+            entry_id: The audio cache entry ID whose voice/provider config to use.
+            text: Text to synthesize.
+            config: Provider-specific voice tuning settings.
+            language: Optional BCP-47 language tag, e.g. "en-US".
+
+        Returns:
+            bytes: The raw WAV audio data (preview only, not saved to cache).
+        """
+        endpoint = AUDIO_CACHE_SYNTHESIZE_URL.format(project_id=project_id, entry_id=entry_id)
+        url = PlatformAPIHandler.get_base_url(region) + endpoint
+        correlation_id = f"adk-{uuid.uuid4()}"
+        headers = {
+            "X-API-KEY": retrieve_api_key(region),
+            "X-PolyAI-Correlation-Id": correlation_id,
+            "X-Poly-Source": "adk",
+            "Content-Type": "application/json",
+        }
+        body: dict = {"text": text, "config": config}
+        if language:
+            body["language"] = language
+
+        logger.info(f"Making POST request to {url}")
+        response = requests.request(
+            method="POST", url=url, headers=headers, data=json.dumps(body), allow_redirects=False
+        )
 
         logger.debug(
             f"Request/response url={url!r}"

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -854,6 +854,40 @@ def print_conversations(
     console.print(table)
 
 
+def print_audio_cache_entries(entries: list[dict[str, Any]]) -> None:
+    """Print a table of audio cache entry summaries.
+
+    Args:
+        entries: List of audio cache entry dicts (as returned by the
+            audio cache list API).
+    """
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("ID", style="bold yellow", no_wrap=True)
+    table.add_column("Transcript", overflow="fold")
+    table.add_column("Provider", no_wrap=True)
+    table.add_column("Voice", no_wrap=True)
+    table.add_column("Duration", no_wrap=True, justify="right")
+    table.add_column("Hits", no_wrap=True, justify="right")
+    table.add_column("Cached At", no_wrap=True)
+
+    for e in entries:
+        cached_at = e.get("cached_at") or "—"
+        if cached_at != "—":
+            cached_at = _format_iso_timestamp(cached_at)
+        duration = f"{e.get('duration', 0):.1f}s"
+        table.add_row(
+            str(e.get("id", "—")),
+            e.get("transcript", "—"),
+            e.get("provider", "—"),
+            e.get("provider_voice_id", "—"),
+            duration,
+            str(e.get("hit_count", 0)),
+            cached_at,
+        )
+
+    console.print(table)
+
+
 def print_conversation_detail(conversation: dict[str, Any], studio_url: str | None = None) -> None:
     """Print detailed conversation information including turns.
 

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -220,5 +220,208 @@ class GetConversationAudio(unittest.TestCase):
             PlatformAPIHandler.get_conversation_audio("studio", "agent-1", "conv-1")
 
 
+class ListAudioCache(unittest.TestCase):
+    """Tests for PlatformAPIHandler.list_audio_cache."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_sends_limit_offset_and_sort_params(self, mock_request, _mock_key):
+        """limit/offset/sort are forwarded as query params when provided."""
+        mock_request.return_value = make_mock_response(
+            200, json_body={"entries": [], "total_count": 0}
+        )
+
+        PlatformAPIHandler.list_audio_cache(
+            "studio", "agent-1", limit=20, offset=5, sort="hit_count:desc"
+        )
+
+        params = mock_request.call_args.kwargs["params"]
+        self.assertEqual(params, {"limit": 20, "offset": 5, "sort": "hit_count:desc"})
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_omits_sort_when_not_provided(self, mock_request, _mock_key):
+        """sort is left out of the query params entirely when None."""
+        mock_request.return_value = make_mock_response(
+            200, json_body={"entries": [], "total_count": 0}
+        )
+
+        PlatformAPIHandler.list_audio_cache("studio", "agent-1")
+
+        params = mock_request.call_args.kwargs["params"]
+        self.assertNotIn("sort", params)
+
+
+class GetAudioCacheFile(unittest.TestCase):
+    """Tests for PlatformAPIHandler.get_audio_cache_file."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.get")
+    def test_returns_raw_audio_bytes(self, mock_get, _mock_key):
+        """The raw response content is returned as bytes."""
+        mock_get.return_value = make_mock_response(200, content=b"RIFF-audio-data")
+
+        audio = PlatformAPIHandler.get_audio_cache_file("studio", "agent-1", "entry-1")
+
+        self.assertEqual(audio, b"RIFF-audio-data")
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.get")
+    def test_error_status_raises_http_error(self, mock_get, _mock_key):
+        """A failing file request propagates as requests.HTTPError."""
+        mock_get.return_value = make_mock_response(404, content=b"not found")
+
+        with self.assertRaises(requests.HTTPError):
+            PlatformAPIHandler.get_audio_cache_file("studio", "agent-1", "entry-1")
+
+
+class UpdateAudioCacheFile(unittest.TestCase):
+    """Tests for PlatformAPIHandler.update_audio_cache_file."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_sends_raw_bytes_with_wav_content_type(self, mock_request, _mock_key):
+        """The raw audio bytes are sent as the body with a WAV content type."""
+        mock_request.return_value = make_mock_response(204)
+
+        PlatformAPIHandler.update_audio_cache_file(
+            "studio", "agent-1", "entry-1", b"RIFF-new-audio", filename="clip.wav"
+        )
+
+        call = mock_request.call_args
+        self.assertEqual(call.kwargs["method"], "PATCH")
+        self.assertEqual(call.kwargs["data"], b"RIFF-new-audio")
+        self.assertEqual(call.kwargs["headers"]["Content-Type"], "audio/wav")
+        self.assertEqual(call.kwargs["headers"]["X-Filename"], "clip.wav")
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_omits_filename_header_when_not_provided(self, mock_request, _mock_key):
+        """X-Filename is left out of headers entirely when no filename is given."""
+        mock_request.return_value = make_mock_response(204)
+
+        PlatformAPIHandler.update_audio_cache_file("studio", "agent-1", "entry-1", b"data")
+
+        self.assertNotIn("X-Filename", mock_request.call_args.kwargs["headers"])
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_error_status_raises_http_error(self, mock_request, _mock_key):
+        """A failing update propagates as requests.HTTPError."""
+        mock_request.return_value = make_mock_response(400, json_body={"error": "too big"})
+
+        with self.assertRaises(requests.HTTPError):
+            PlatformAPIHandler.update_audio_cache_file("studio", "agent-1", "entry-1", b"data")
+
+
+class UpdateAudioCacheDetails(unittest.TestCase):
+    """Tests for PlatformAPIHandler.update_audio_cache_details."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_sends_multipart_file_and_settings(self, mock_request, _mock_key):
+        """The audio bytes and JSON-encoded settings are sent as multipart form data."""
+        mock_request.return_value = make_mock_response(204)
+
+        PlatformAPIHandler.update_audio_cache_details(
+            "studio",
+            "agent-1",
+            "entry-1",
+            b"RIFF-new-audio",
+            {"text": "hello", "config": {"stability": 0.5}},
+            filename="clip.wav",
+        )
+
+        call = mock_request.call_args
+        self.assertEqual(call.kwargs["method"], "PUT")
+        self.assertEqual(call.kwargs["files"]["file"][0], "clip.wav")
+        self.assertEqual(call.kwargs["files"]["file"][1], b"RIFF-new-audio")
+        sent_settings = json.loads(call.kwargs["data"]["settings"])
+        self.assertEqual(sent_settings, {"text": "hello", "config": {"stability": 0.5}})
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_error_status_raises_http_error(self, mock_request, _mock_key):
+        """A failing update propagates as requests.HTTPError."""
+        mock_request.return_value = make_mock_response(400, json_body={"error": "bad settings"})
+
+        with self.assertRaises(requests.HTTPError):
+            PlatformAPIHandler.update_audio_cache_details(
+                "studio", "agent-1", "entry-1", b"data", {"text": "hi", "config": {}}
+            )
+
+
+class DeleteAudioCacheEntry(unittest.TestCase):
+    """Tests for PlatformAPIHandler.delete_audio_cache_entry."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_sends_delete_to_entry_endpoint(self, mock_request, _mock_key):
+        """DELETE is sent to the entry-specific endpoint."""
+        mock_request.return_value = make_mock_response(200, json_body={"success": True})
+
+        result = PlatformAPIHandler.delete_audio_cache_entry("studio", "agent-1", "entry-1")
+
+        self.assertEqual(mock_request.call_args.kwargs["method"], "DELETE")
+        self.assertIn("/agents/agent-1/audio-cache/entry-1", mock_request.call_args.kwargs["url"])
+        self.assertEqual(result, {"success": True})
+
+
+class BulkDeleteAudioCache(unittest.TestCase):
+    """Tests for PlatformAPIHandler.bulk_delete_audio_cache."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_sends_ids_in_body(self, mock_request, _mock_key):
+        """The list of IDs is JSON-encoded into the request body."""
+        mock_request.return_value = make_mock_response(
+            200, json_body={"deleted": ["1", "2"], "failed": []}
+        )
+
+        result = PlatformAPIHandler.bulk_delete_audio_cache("studio", "agent-1", ["1", "2"])
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent, {"ids": ["1", "2"]})
+        self.assertEqual(result, {"deleted": ["1", "2"], "failed": []})
+
+
+class SynthesizeAudioCache(unittest.TestCase):
+    """Tests for PlatformAPIHandler.synthesize_audio_cache."""
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_returns_raw_audio_bytes(self, mock_request, _mock_key):
+        """The raw response content is returned as bytes."""
+        mock_request.return_value = make_mock_response(200, content=b"RIFF-preview-audio")
+
+        audio = PlatformAPIHandler.synthesize_audio_cache(
+            "studio", "agent-1", "entry-1", "hello there", {"stability": 0.5}
+        )
+
+        self.assertEqual(audio, b"RIFF-preview-audio")
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_includes_language_when_provided(self, mock_request, _mock_key):
+        """language is included in the JSON body only when provided."""
+        mock_request.return_value = make_mock_response(200, content=b"audio")
+
+        PlatformAPIHandler.synthesize_audio_cache(
+            "studio", "agent-1", "entry-1", "hi", {}, language="en-US"
+        )
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent["language"], "en-US")
+
+    @patch("poly.handlers.platform_api.retrieve_api_key", return_value="secret-key")
+    @patch("poly.handlers.platform_api.requests.request")
+    def test_error_status_raises_http_error(self, mock_request, _mock_key):
+        """A failing synthesis request propagates as requests.HTTPError."""
+        mock_request.return_value = make_mock_response(422, json_body={"error": "bad text"})
+
+        with self.assertRaises(requests.HTTPError):
+            PlatformAPIHandler.synthesize_audio_cache("studio", "agent-1", "entry-1", "hi", {})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -9,6 +9,7 @@ from io import StringIO
 from unittest.mock import MagicMock, patch
 
 from poly.cli import AgentStudioCLI
+from poly.cli_commands.audio_cache import AudioCacheCommand
 from poly.cli_commands.branch import BranchCommand
 from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
@@ -2886,3 +2887,201 @@ class ConversationsCommandTest(unittest.TestCase):
         )
         mock_success.assert_called_once()
         self.assertIn("2.0 MB", mock_success.call_args[0][0])
+
+
+class AudioCacheCommandTest(unittest.TestCase):
+    """Tests for the audio-cache CLI commands."""
+
+    SAMPLE_LIST = {
+        "entries": [
+            {
+                "id": "1",
+                "transcript": "Hello there",
+                "cached_at": "2026-05-26T10:00:00+00:00",
+                "hit_count": 3,
+                "duration": 1.2,
+                "regenerated": False,
+                "provider": "eleven_labs",
+                "provider_voice_id": "21m00Tcm4TlvDq8ikWAM",
+                "audio_filename": "1.wav",
+                "imported": False,
+                "language_code": "en-US",
+            }
+        ],
+        "total_count": 1,
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.audio_cache.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.region = "us-1"
+        self.proj.project_id = "test-project"
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.list_audio_cache")
+    @patch("poly.output.console.print_audio_cache_entries")
+    def test_list_calls_api_with_params(self, mock_print, mock_api):
+        """audio-cache list passes limit/offset/sort to the API."""
+        mock_api.return_value = self.SAMPLE_LIST
+
+        AudioCacheCommand.audio_cache_list(TEST_DIR, limit=20, offset=5, sort="hit_count:desc")
+
+        mock_api.assert_called_once_with(
+            region="us-1", project_id="test-project", limit=20, offset=5, sort="hit_count:desc"
+        )
+        mock_print.assert_called_once()
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.list_audio_cache")
+    @patch("poly.cli_commands.audio_cache.json_print")
+    def test_list_json_outputs_raw_response(self, mock_json, mock_api):
+        """audio-cache list --json outputs the full API response."""
+        mock_api.return_value = self.SAMPLE_LIST
+
+        AudioCacheCommand.audio_cache_list(TEST_DIR, output_json=True)
+
+        mock_json.assert_called_once_with(self.SAMPLE_LIST)
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.list_audio_cache")
+    @patch("poly.output.console.info")
+    def test_list_empty_shows_info(self, mock_info, mock_api):
+        """audio-cache list with no results shows info message."""
+        mock_api.return_value = {"entries": [], "total_count": 0}
+
+        AudioCacheCommand.audio_cache_list(TEST_DIR)
+
+        mock_info.assert_called_once()
+
+    @patch("builtins.open", create=True)
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.get_audio_cache_file")
+    @patch("poly.output.console.success")
+    def test_get_file_writes_file(self, mock_success, mock_api, mock_open):
+        """audio-cache get-file downloads and writes a WAV file."""
+        mock_open.return_value.__enter__ = MagicMock()
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        mock_api.return_value = b"\x00" * 2_000_000
+
+        AudioCacheCommand.audio_cache_get_file(TEST_DIR, "entry-1", output_path="/tmp/test.wav")
+
+        mock_api.assert_called_once_with(
+            region="us-1", project_id="test-project", entry_id="entry-1"
+        )
+        mock_success.assert_called_once()
+        self.assertIn("2.0 MB", mock_success.call_args[0][0])
+
+    @patch("builtins.open", create=True)
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.update_audio_cache_file")
+    @patch("poly.output.console.success")
+    def test_update_file_reads_and_sends_bytes(self, mock_success, mock_api, mock_open):
+        """audio-cache update-file reads the local file and sends its bytes."""
+        mock_open.return_value.__enter__.return_value.read.return_value = b"RIFF-data"
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+        AudioCacheCommand.audio_cache_update_file(
+            TEST_DIR, "entry-1", "/tmp/replacement.wav", filename="clip.wav"
+        )
+
+        mock_api.assert_called_once_with(
+            region="us-1",
+            project_id="test-project",
+            entry_id="entry-1",
+            audio_bytes=b"RIFF-data",
+            filename="clip.wav",
+        )
+        mock_success.assert_called_once()
+
+    @patch("builtins.open", create=True)
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.update_audio_cache_details")
+    @patch("poly.output.console.success")
+    def test_update_details_parses_config_and_sends_settings(
+        self, mock_success, mock_api, mock_open
+    ):
+        """audio-cache update-details parses --config JSON into the settings payload."""
+        mock_open.return_value.__enter__.return_value.read.return_value = b"RIFF-data"
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+
+        AudioCacheCommand.audio_cache_update_details(
+            TEST_DIR, "entry-1", "/tmp/replacement.wav", "hello", '{"stability": 0.5}'
+        )
+
+        mock_api.assert_called_once_with(
+            region="us-1",
+            project_id="test-project",
+            entry_id="entry-1",
+            audio_bytes=b"RIFF-data",
+            settings={"text": "hello", "config": {"stability": 0.5}},
+            filename="replacement.wav",
+        )
+        mock_success.assert_called_once()
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.update_audio_cache_details")
+    @patch("poly.cli_commands.audio_cache.json_print")
+    def test_update_details_invalid_config_json_exits(self, mock_json, mock_api):
+        """An invalid --config JSON string exits with an error instead of calling the API."""
+        with self.assertRaises(SystemExit):
+            AudioCacheCommand.audio_cache_update_details(
+                TEST_DIR, "entry-1", "/tmp/replacement.wav", "hello", "{not json", output_json=True
+            )
+
+        mock_api.assert_not_called()
+        mock_json.assert_called_once()
+        self.assertFalse(mock_json.call_args[0][0]["success"])
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.delete_audio_cache_entry")
+    @patch("poly.output.console.success")
+    def test_delete_calls_api(self, mock_success, mock_api):
+        """audio-cache delete calls the API with the entry ID."""
+        mock_api.return_value = {"success": True}
+
+        AudioCacheCommand.audio_cache_delete(TEST_DIR, "entry-1")
+
+        mock_api.assert_called_once_with(
+            region="us-1", project_id="test-project", entry_id="entry-1"
+        )
+        mock_success.assert_called_once()
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.bulk_delete_audio_cache")
+    @patch("poly.output.console.success")
+    def test_bulk_delete_splits_comma_separated_ids(self, mock_success, mock_api):
+        """audio-cache bulk-delete parses the --ids flag into a list."""
+        mock_api.return_value = {"deleted": ["1", "2"], "failed": []}
+
+        AudioCacheCommand.audio_cache_bulk_delete(TEST_DIR, "1, 2")
+
+        mock_api.assert_called_once_with(region="us-1", project_id="test-project", ids=["1", "2"])
+        mock_success.assert_called_once()
+
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.bulk_delete_audio_cache")
+    @patch("poly.output.console.error")
+    def test_bulk_delete_reports_failures(self, mock_error, mock_api):
+        """audio-cache bulk-delete reports IDs that failed to delete."""
+        mock_api.return_value = {"deleted": [], "failed": ["9"]}
+
+        AudioCacheCommand.audio_cache_bulk_delete(TEST_DIR, "9")
+
+        mock_error.assert_called_once()
+
+    @patch("builtins.open", create=True)
+    @patch("poly.cli_commands.audio_cache.AgentStudioInterface.synthesize_audio_cache")
+    @patch("poly.output.console.success")
+    def test_synthesize_writes_preview_file(self, mock_success, mock_api, mock_open):
+        """audio-cache synthesize downloads and writes a preview WAV file."""
+        mock_open.return_value.__enter__ = MagicMock()
+        mock_open.return_value.__exit__ = MagicMock(return_value=False)
+        mock_api.return_value = b"\x00" * 1_000_000
+
+        AudioCacheCommand.audio_cache_synthesize(TEST_DIR, "entry-1", "hello", "{}")
+
+        mock_api.assert_called_once_with(
+            region="us-1",
+            project_id="test-project",
+            entry_id="entry-1",
+            text="hello",
+            config={},
+            language=None,
+        )
+        mock_success.assert_called_once()
+        self.assertIn("entry-1-preview.wav", mock_success.call_args[0][0])


### PR DESCRIPTION
## Summary

Adds `poly audio-cache` CLI commands wrapping the Audio Cache public API (poly_core PR #42487) so developers can manage an agent's cached TTS audio without hand-rolled HTTP calls.

## Motivation

[DEVP-377: Create ADK CLI commands for voice cache API](https://linear.app/poly-ai/issue/DEVP-377/create-adk-cli-commands-for-voice-cache-api)

Closes DEVP-377

## Changes

- `poly audio-cache list` — list cached entries with pagination/sorting
- `poly audio-cache get-file` — download the cached WAV file
- `poly audio-cache update-file` — replace the audio file for an entry
- `poly audio-cache update-details` — replace audio + voice tuning settings together
- `poly audio-cache delete` / `bulk-delete` — remove one or many entries
- `poly audio-cache synthesize` — preview TTS audio without saving to cache
- New `PlatformAPIHandler`/`AgentStudioInterface` methods for the above, following the existing `conversations` command pattern (including binary upload/download support, which is new)
- `print_audio_cache_entries` table helper in `console.py`
- Unit tests for the handler layer (`platform_api_test.py`) and CLI layer (`cli_test.py`)
- `cli.md` reference docs for the new command family

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly audio-cache --help` and all subcommand `--help` variants, plus a local file-read/write smoke test)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (974 passed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)