### PR TITLE
feat: branch sync, history, rename, tag/untag, and archive/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,12 +143,29 @@ poly revert file1.yaml file2.yaml  # revert specific files
 Manage branches (default branch is `main`):
 
 ```bash
-poly branch list
+poly branch list                       # active branches
+poly branch list --archived            # soft-deleted branches
 poly branch current
 poly branch create my-feature
 poly branch switch my-feature
 poly branch switch my-feature --force  # discard uncommitted changes
+poly branch rename my-feature-v2       # rename the current branch
+poly branch merge 'Merge my-feature'   # merge into the parent branch
+poly branch sync                       # pull the parent branch's changes in
+poly branch history                    # merge history for the current branch
+poly branch delete                     # soft-delete, restorable for 30 days
+poly branch restore my-feature         # restore a soft-deleted branch
 ```
+
+Projects using simplified deployments can also stage a branch:
+
+```bash
+poly branch tag                        # tag the current branch, deploying it to staging
+poly branch untag                      # remove the tag
+```
+
+`poly branch sync`, `tag`, and `untag` are only available on projects with simplified deployments
+enabled; they exit with an error otherwise.
 
 ### `poly format`
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ poly branch list                       # active branches
 poly branch list --archived            # soft-deleted branches
 poly branch current
 poly branch create my-feature
+poly branch create my-hotfix --from my-feature  # branch from another branch instead of the current one
 poly branch switch my-feature
 poly branch switch my-feature --force  # discard uncommitted changes
 poly branch rename my-feature-v2       # rename the current branch

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ poly branch merge 'Merge my-feature'   # merge into the parent branch
 poly branch sync                       # pull the parent branch's changes in
 poly branch history                    # merge history for the current branch
 poly branch delete                     # soft-delete, restorable for 30 days
-poly branch restore my-feature         # restore a soft-deleted branch
+poly branch restore my-feature-id      # restore a soft-deleted branch
 ```
 
 Projects using simplified deployments can also stage a branch:

--- a/licenses.json
+++ b/licenses.json
@@ -31,6 +31,11 @@
   },
   {
     "License": "MIT License",
+    "Name": "backoff",
+    "URL": "https://github.com/litl/backoff"
+  },
+  {
+    "License": "MIT License",
     "Name": "cattrs",
     "URL": "https://catt.rs"
   },
@@ -58,6 +63,11 @@
     "License": "Python Software Foundation License",
     "Name": "distlib",
     "URL": "https://github.com/pypa/distlib"
+  },
+  {
+    "License": "Apache Software License",
+    "Name": "distro",
+    "URL": "https://github.com/python-distro/distro"
   },
   {
     "License": "MIT License",
@@ -138,6 +148,11 @@
     "License": "MIT License",
     "Name": "pluggy",
     "URL": "UNKNOWN"
+  },
+  {
+    "License": "MIT",
+    "Name": "posthog",
+    "URL": "https://github.com/posthog/posthog-python"
   },
   {
     "License": "MIT",
@@ -238,6 +253,11 @@
     "License": "MIT License",
     "Name": "ty",
     "URL": "https://github.com/astral-sh/ty/"
+  },
+  {
+    "License": "PSF-2.0",
+    "Name": "typing_extensions",
+    "URL": "https://github.com/python/typing_extensions"
   },
   {
     "License": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,8 @@ dependencies = [
     "ruff>=0.14.0",
     "ty",
     "argcomplete>=3.0.0",
-    "langcodes==3.5.1"
+    "langcodes==3.5.1",
+    "posthog==7.35.4"
 ]
 
 [project.license]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ ignore_packages = [
     "rpds-py",
     "urllib3",
     "wcwidth",
+    "posthog",
+    "typing_extensions"
 ]
 
 [tool.semantic_release]

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -663,26 +663,44 @@ class BranchCommand(BaseCommand):
 
     @classmethod
     def get_current_branch(cls, base_path: str, output_json: bool = False) -> None:
-        """Get the current branch of the Agent Studio project."""
+        """Get the current branch of the Agent Studio project, and its parent if it has one."""
         from poly.output.console import plain, warning
 
         project = load_project(base_path, output_json=output_json)
 
-        current_branch = project.get_current_branch()
-        if output_json:
-            json_output = {
-                "current_branch": current_branch,
-            }
-            json_print(json_output)
-            return
+        current_branch, branches = project.get_branches()
 
         if current_branch is None:
-            warning(
-                "Current local branch does not exist in Agent Studio. "
-                "It may have been deleted or merged."
-            )
+            if output_json:
+                json_print({"current_branch": None, "parent_branch": None})
+            else:
+                warning(
+                    "Current local branch does not exist in Agent Studio. "
+                    "It may have been deleted or merged."
+                )
             return
+
+        parent_branch_id = branches.get(current_branch, {}).get("parentBranchId")
+        parent_branch = (
+            next(
+                (
+                    name
+                    for name, meta in branches.items()
+                    if meta.get("branchId") == parent_branch_id
+                ),
+                parent_branch_id,
+            )
+            if parent_branch_id
+            else None
+        )
+
+        if output_json:
+            json_print({"current_branch": current_branch, "parent_branch": parent_branch})
+            return
+
         plain(f"Current branch: [bold]{current_branch}[/bold]")
+        if parent_branch:
+            plain(f"Parent branch: [bold]{parent_branch}[/bold]")
 
     @classmethod
     def branch_delete(

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -1387,6 +1387,18 @@ class BranchCommand(BaseCommand):
 
         project = load_project(base_path, output_json=output_json)
 
+        if not project.using_simplified_deployments:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "Branch sync is only available for projects using simplified deployments.",
+                    }
+                )
+            else:
+                error("Branch sync is only available for projects using simplified deployments.")
+            sys.exit(1)
+
         branch_name = project.get_current_branch()
         ctx = console.status("[info]Syncing branch...[/info]") if not output_json else nullcontext()
         with ctx:

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -370,57 +370,6 @@ class BranchCommand(BaseCommand):
         ).completer = cls._branch_name_completer
         branch_status_parser.set_defaults(branch_subcommand="status")
 
-        # -- history ──
-        branch_history_parser = branch_subparsers.add_parser(
-            "history",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Show the history of a branch.",
-        )
-
-        branch_history_parser.add_argument(
-            "--branch-name",
-            "-b",
-            type=str,
-            default=None,
-            help="Name of the branch to show history for. Defaults to the current branch.",
-        )
-        branch_history_parser.add_argument(
-            "--limit",
-            type=int,
-            default=10,
-            help="Number of history entries to show. Defaults to 10.",
-        )
-
-        branch_history_parser.set_defaults(branch_subcommand="history")
-
-        branch_rename_parser = branch_subparsers.add_parser(
-            "rename",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Rename a current branch.",
-        )
-        branch_rename_parser.add_argument(
-            "new_branch_name",
-            type=str,
-            nargs="?",
-            default=None,
-            help="New name for the current branch.",
-        )
-        branch_rename_parser.set_defaults(branch_subcommand="rename")
-
-        branch_restore_parser = branch_subparsers.add_parser(
-            "restore",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Restore a soft-deleted branch from the archive.",
-        )
-        branch_restore_parser.add_argument(
-            "branch_name",
-            type=str,
-            nargs="?",
-            default=None,
-            help="Name of the archived branch to restore.",
-        )
-        branch_restore_parser.set_defaults(branch_subcommand="restore")
-
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching branch sub-handler."""

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -297,7 +297,7 @@ class BranchCommand(BaseCommand):
             "message",
             nargs="?",
             default=None,
-            help="Message for the merge.",
+            help="Message for the merge. Required when merging into main.",
         )
         branch_merge_parser.add_argument(
             "--interactive",
@@ -1065,13 +1065,6 @@ class BranchCommand(BaseCommand):
             warning,
         )
 
-        if message is None or (isinstance(message, str) and not message.strip()):
-            if output_json:
-                json_print({"success": False, "error": "Merge message is required."})
-            else:
-                error("Merge message is required.")
-            sys.exit(1)
-
         if interactive and output_json:
             json_print(
                 {
@@ -1109,6 +1102,17 @@ class BranchCommand(BaseCommand):
             (name for name, meta in branches.items() if meta.get("branchId") == parent_branch_id),
             "main",
         )
+
+        if parent_branch_name == "main" and (
+            message is None or (isinstance(message, str) and not message.strip())
+        ):
+            if output_json:
+                json_print(
+                    {"success": False, "error": "Merge message is required when merging into main."}
+                )
+            else:
+                error("Merge message is required when merging into main.")
+            sys.exit(1)
 
         is_live_deploy = parent_branch_name == "main" and project.using_simplified_deployments
 

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -1370,6 +1370,7 @@ class BranchCommand(BaseCommand):
         resolutions_file: str = None,
     ):
         """Synch the current branch with it's parent, with optional conflict resolutions."""
+        from poly.cli_commands.shared import require_deployment_simplification
         from poly.output.console import (
             console,
             error,
@@ -1409,17 +1410,7 @@ class BranchCommand(BaseCommand):
 
         project = load_project(base_path, output_json=output_json)
 
-        if not project.using_simplified_deployments:
-            if output_json:
-                json_print(
-                    {
-                        "success": False,
-                        "error": "Branch sync is only available for projects using simplified deployments.",
-                    }
-                )
-            else:
-                error("Branch sync is only available for projects using simplified deployments.")
-            sys.exit(1)
+        require_deployment_simplification(project, output_json=output_json)
 
         branch_name = project.get_current_branch()
         ctx = console.status("[info]Syncing branch...[/info]") if not output_json else nullcontext()
@@ -1711,9 +1702,11 @@ class BranchCommand(BaseCommand):
         output_json: bool = False,
     ) -> None:
         """Tag the current branch with a new tag."""
+        from poly.cli_commands.shared import require_deployment_simplification
         from poly.output.console import error, success
 
         project = load_project(base_path, output_json=output_json)
+        require_deployment_simplification(project, output_json=output_json)
 
         tagged = project.tag_branch()
 
@@ -1732,9 +1725,11 @@ class BranchCommand(BaseCommand):
         output_json: bool = False,
     ) -> None:
         """Remove a tag from the current branch."""
+        from poly.cli_commands.shared import require_deployment_simplification
         from poly.output.console import error, success
 
         project = load_project(base_path, output_json=output_json)
+        require_deployment_simplification(project, output_json=output_json)
 
         untagged = project.untag_branch()
 

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -282,6 +282,23 @@ class BranchCommand(BaseCommand):
         ).completer = cls._branch_name_completer
         branch_status_parser.set_defaults(branch_subcommand="status")
 
+        # -- history ──
+        branch_history_parser = branch_subparsers.add_parser(
+            "history",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Show the history of a branch.",
+        )
+
+        branch_history_parser.add_argument(
+            "--branch-name",
+            "-b",
+            type=str,
+            default=None,
+            help="Name of the branch to show history for. Defaults to the current branch.",
+        )
+
+        branch_history_parser.set_defaults(branch_subcommand="history")
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching branch sub-handler."""
@@ -325,6 +342,9 @@ class BranchCommand(BaseCommand):
 
         elif args.branch_subcommand == "status":
             cls.branch_status(args.path, args.branch_name, args.json)
+
+        elif args.branch_subcommand == "history":
+            cls.branch_history(args.path, args.branch_name, args.json)
 
     @classmethod
     def branch_list(cls, base_path: str, output_json: bool = False) -> None:
@@ -1140,3 +1160,45 @@ class BranchCommand(BaseCommand):
 
         if not new_files and not modified_files and not deleted_files:
             plain("\n[muted]No changes on this branch.[/muted]")
+
+    @classmethod
+    def branch_history(
+        cls, base_path: str, branch_name: Optional[str] = None, output_json: bool = False
+    ) -> None:
+        """Show the history of a branch in the Agent Studio project."""
+        from poly.output.console import plain, print_branch_history, warning
+
+        project = load_project(base_path, output_json=output_json)
+
+        current_branch, branches = project.get_branches()
+        if not branch_name:
+            branch_name = current_branch
+
+        if not branch_name:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "No current branch found. Please specify a branch name.",
+                    }
+                )
+            else:
+                warning("No current branch found. Please specify a branch name.")
+
+        branch_id = branches.get(branch_name)
+        if not branch_id:
+            warning(f"Branch '{branch_name}' does not exist.")
+            return
+
+        history = project.get_branch_history(branch_id)
+
+        if output_json:
+            json_print({"branch_name": branch_name, "branch_id": branch_id, "history": history})
+            return
+
+        if not history:
+            plain(f"[muted]No history found for branch '{branch_name}'.[/muted]")
+            return
+
+        plain(f"History for branch '{branch_name}':")
+        print_branch_history(history)

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -142,6 +142,7 @@ class BranchCommand(BaseCommand):
                 "  poly branch list\n"
                 "  poly branch list --archived\n"
                 "  poly branch create new-branch\n"
+                "  poly branch create new-branch --from other-branch\n"
                 "  poly branch switch existing-branch\n"
                 "  poly branch rename new-name\n"
                 "  poly branch merge 'Merge branch'\n"
@@ -188,6 +189,14 @@ class BranchCommand(BaseCommand):
             dest="environment",
             help="Initiate the new branch from this environment instead of sandbox (main).",
         )
+        branch_create_parser.add_argument(
+            "--from",
+            type=str,
+            default=None,
+            dest="source_branch",
+            metavar="BRANCH",
+            help="Create the new branch from this branch instead of the current branch.",
+        ).completer = cls._branch_name_completer
         branch_create_parser.add_argument(
             "--force",
             "-f",
@@ -453,6 +462,7 @@ class BranchCommand(BaseCommand):
                 args.json,
                 getattr(args, "environment", None),
                 getattr(args, "force", False),
+                getattr(args, "source_branch", None),
             )
 
         elif args.branch_subcommand == "switch":
@@ -561,6 +571,7 @@ class BranchCommand(BaseCommand):
         output_json: bool = False,
         env: str = None,
         force: bool = False,
+        source_branch: str = None,
     ) -> None:
         """Create a new branch in the Agent Studio project."""
         from poly.output.console import error, success, warning
@@ -587,10 +598,15 @@ class BranchCommand(BaseCommand):
                 warning("No branch name provided. Exiting.")
                 return
 
-        base_branch_id = project.branch_id
-        base_branch_name = project.get_current_branch()
+        if source_branch:
+            base_branch_name = source_branch
+            _, branches = project.get_branches()
+            base_branch_id = branches.get(source_branch, {}).get("branchId")
+        else:
+            base_branch_id = project.branch_id
+            base_branch_name = project.get_current_branch()
         try:
-            new_branch_id = project.create_branch(branch_name)
+            new_branch_id = project.create_branch(branch_name, source_branch_name=source_branch)
         except ValueError as e:
             if output_json:
                 json_print({"success": False, "error": str(e)})

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -301,6 +301,12 @@ class BranchCommand(BaseCommand):
             default=None,
             help="Name of the branch to show history for. Defaults to the current branch.",
         )
+        branch_history_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of history entries to show. Defaults to 10.",
+        )
 
         branch_history_parser.set_defaults(branch_subcommand="history")
 
@@ -377,7 +383,7 @@ class BranchCommand(BaseCommand):
             cls.branch_status(args.path, args.branch_name, args.json)
 
         elif args.branch_subcommand == "history":
-            cls.branch_history(args.path, args.branch_name, args.json)
+            cls.branch_history(args.path, args.branch_name, args.json, args.limit)
 
         elif args.branch_subcommand == "rename":
             cls.branch_rename(args.path, args.new_branch_name, args.json)
@@ -1213,7 +1219,11 @@ class BranchCommand(BaseCommand):
 
     @classmethod
     def branch_history(
-        cls, base_path: str, branch_name: Optional[str] = None, output_json: bool = False
+        cls,
+        base_path: str,
+        branch_name: Optional[str] = None,
+        output_json: bool = False,
+        limit: int = 10,
     ) -> None:
         """Show the history of a branch in the Agent Studio project."""
         from poly.output.console import plain, print_branch_history, warning
@@ -1241,6 +1251,7 @@ class BranchCommand(BaseCommand):
             return
 
         history = project.get_branch_history(branch_id)
+        history = history[:limit]
 
         if output_json:
             json_print({"branch_name": branch_name, "branch_id": branch_id, "history": history})

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -68,6 +68,42 @@ def _auto_merge_resolution(path: list[str], merged_value: str) -> dict[str, Any]
     return {"path": path, "value": merged_value, "strategy": "theirs"}
 
 
+def _build_branch_name_lookup(project: Any, archived: list[dict[str, Any]]) -> dict[str, str]:
+    """Map branch ids to branch names, for displaying archived branches' parents.
+
+    Archived entries reference their parent by id only, which means nothing to a
+    user. A parent is normally archived alongside its children, so the archive
+    resolves most ids on its own; the active branches are fetched only when an id
+    is still unresolved (a child archived while its parent stayed live).
+    """
+    names = {
+        branch["branchId"]: branch.get("name") or branch["branchId"]
+        for branch in archived
+        if branch.get("branchId")
+    }
+
+    unresolved = {
+        branch.get("parentBranchId")
+        for branch in archived
+        if branch.get("parentBranchId") and branch.get("parentBranchId") != "main"
+    } - names.keys()
+    if not unresolved:
+        return names
+
+    try:
+        _, active = project.get_branches()
+    except ValueError:
+        # The parent column is cosmetic — degrade to showing raw ids rather than
+        # failing the whole listing.
+        return names
+
+    for name, meta in active.items():
+        branch_id = meta.get("branchId")
+        if branch_id and branch_id not in names:
+            names[branch_id] = name
+    return names
+
+
 class BranchCommand(BaseCommand):
     """Manage branches in the Agent Studio project."""
 
@@ -239,11 +275,15 @@ class BranchCommand(BaseCommand):
             help="Restore a soft-deleted branch from the archive.",
         )
         branch_restore_parser.add_argument(
-            "branch_name",
+            "branch_id",
             type=str,
+            metavar="BRANCH",
             nargs="?",
             default=None,
-            help="Name of the archived branch to restore.",
+            help=(
+                "Branch id of the archived branch to restore. Archived names are not "
+                "unique, so ids are required — find them with 'poly branch list --archived'."
+            ),
         )
         branch_restore_parser.set_defaults(branch_subcommand="restore")
 
@@ -447,7 +487,7 @@ class BranchCommand(BaseCommand):
             cls.branch_rename(args.path, args.new_branch_name, args.json)
 
         elif args.branch_subcommand == "restore":
-            cls.branch_restore(args.path, args.branch_name, args.json)
+            cls.branch_restore(args.path, args.branch_id, args.json)
 
         elif args.branch_subcommand == "tag":
             cls.branch_tag(args.path, args.json)
@@ -485,7 +525,7 @@ class BranchCommand(BaseCommand):
             if not branches:
                 plain("[muted]No archived branches found.[/muted]")
                 return
-            print_archived_branches(branches)
+            print_archived_branches(branches, _build_branch_name_lookup(project, branches))
             return
 
         current_branch, branches = project.get_branches()
@@ -1627,22 +1667,28 @@ class BranchCommand(BaseCommand):
     def branch_restore(
         cls,
         base_path: str,
-        branch_name: Optional[str] = None,
+        branch_id: Optional[str] = None,
         output_json: bool = False,
     ) -> None:
-        """Restore a soft-deleted branch from the archive."""
+        """Restore a soft-deleted branch from the archive, by branch id or name."""
         import questionary
 
-        from poly.output.console import error, plain, success, warning
+        from poly.output.console import (
+            error,
+            plain,
+            resolve_parent_branch_label,
+            success,
+            warning,
+        )
 
         project = load_project(base_path, output_json=output_json)
 
-        if not branch_name:
+        if not branch_id:
             if output_json:
                 json_print(
                     {
                         "success": False,
-                        "error": "branch restore with --json requires a branch name argument.",
+                        "error": "branch restore with --json requires a branch id argument.",
                     }
                 )
                 sys.exit(1)
@@ -1652,14 +1698,19 @@ class BranchCommand(BaseCommand):
                 plain("[muted]No archived branches to restore.[/muted]")
                 return
 
+            name_by_branch_id = _build_branch_name_lookup(project, archived)
+            archived_branch_ids = {b["branchId"] for b in archived if b.get("branchId")}
             choices = []
-            branch_id_map: dict[str, str] = {}
+            branch_by_label: dict[str, dict[str, Any]] = {}
             for b in archived:
                 name = b.get("name", "—")
-                branch_id = b.get("branchId", "")
-                label = f"{name} ({branch_id})"
+                archived_branch_id = b.get("branchId", "")
+                parent = resolve_parent_branch_label(b, name_by_branch_id, archived_branch_ids)
+                # Names repeat across the archive, so the id and parent are what
+                # actually let the user tell two same-named entries apart.
+                label = f"{name} ({archived_branch_id}) — parent: {parent}"
                 choices.append(label)
-                branch_id_map[label] = branch_id
+                branch_by_label[label] = b
 
             selected = questionary.select(
                 "Select branch to restore",
@@ -1671,21 +1722,20 @@ class BranchCommand(BaseCommand):
                 warning("No branch selected. Exiting.")
                 return
 
-            selected_branch_id = branch_id_map[selected]
+            selected_branch = branch_by_label[selected]
             try:
-                restored = project.api_handler.restore_branch(selected_branch_id)
+                restored = project.restore_branch(selected_branch["branchId"])
             except (ValueError, Exception) as e:
                 error(str(e))
                 return
             if restored:
-                branch_name = selected.split(" (")[0]
-                success(f"Branch '{branch_name}' restored.")
+                success(f"Branch '{selected_branch.get('name', '—')}' restored.")
             else:
                 error("Failed to restore selected branch.")
             return
 
         try:
-            restored = project.restore_branch(branch_name)
+            restored = project.restore_branch(branch_id)
         except (ValueError, Exception) as e:
             if output_json:
                 json_print({"success": False, "error": str(e)})
@@ -1694,12 +1744,12 @@ class BranchCommand(BaseCommand):
             return
 
         if output_json:
-            json_print({"success": restored, "branch_name": branch_name})
+            json_print({"success": restored, "branch_id": branch_id})
         else:
             if restored:
-                success(f"Branch '{branch_name}' restored.")
+                success(f"Branch '{branch_id}' restored.")
             else:
-                error(f"Failed to restore branch '{branch_name}'.")
+                error(f"Failed to restore branch '{branch_id}'.")
 
     @classmethod
     def branch_tag(

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -104,12 +104,18 @@ class BranchCommand(BaseCommand):
                 "Manage branches in the Agent Studio project.\n\n"
                 "Examples:\n"
                 "  poly branch list\n"
+                "  poly branch list --archived\n"
                 "  poly branch create new-branch\n"
                 "  poly branch switch existing-branch\n"
+                "  poly branch rename new-name\n"
                 "  poly branch merge 'Merge branch'\n"
                 "  poly branch sync\n"
+                "  poly branch history\n"
                 "  poly branch current\n"
                 "  poly branch delete\n"
+                "  poly branch restore archived-branch\n"
+                "  poly branch tag\n"
+                "  poly branch untag\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -240,6 +240,13 @@ class BranchCommand(BaseCommand):
                 '- value: Optional custom value (use "theirs" strategy)'
             ),
         )
+        branch_merge_parser.add_argument(
+            "--force",
+            "-f",
+            action="store_true",
+            help="Skip the confirmation prompt when merging into main deploys to a live environment.",
+        )
+
         branch_merge_parser.set_defaults(branch_subcommand="merge")
 
         branch_merge_parser = branch_subparsers.add_parser(
@@ -264,6 +271,13 @@ class BranchCommand(BaseCommand):
                 '- strategy: Resolution strategy - "ours", "theirs", or "base"\n'
                 '- value: Optional custom value (use "theirs" strategy)'
             ),
+        )
+        branch_merge_parser.add_argument(
+            "--force",
+            "-f",
+            action="store_true",
+            default=False,
+            help="Deploy to main without confirmation prompt when it will deploy to live",
         )
         branch_merge_parser.set_defaults(branch_subcommand="sync")
 
@@ -319,6 +333,7 @@ class BranchCommand(BaseCommand):
             help="Name of the archived branch to restore.",
         )
         branch_restore_parser.set_defaults(branch_subcommand="restore")
+
         # ── diff ──
         branch_diff_parser = branch_subparsers.add_parser(
             "diff",
@@ -404,7 +419,9 @@ class BranchCommand(BaseCommand):
             cls.branch_delete(args.path, args.branch_name, args.json)
 
         elif args.branch_subcommand == "merge":
-            cls.branch_merge(args.path, args.message, args.json, args.interactive, args.resolutions)
+            cls.branch_merge(
+                args.path, args.message, args.json, args.interactive, args.resolutions, args.force
+            )
 
         elif args.branch_subcommand == "sync":
             cls.branch_sync(args.path, args.json, args.interactive, args.resolutions)
@@ -959,8 +976,11 @@ class BranchCommand(BaseCommand):
         output_json: bool = False,
         interactive: bool = False,
         resolutions_file: str = None,
+        force: bool = False,
     ):
         """Merge the current branch into main, with optional conflict resolutions."""
+        import questionary
+
         from poly.output.console import (
             console,
             error,
@@ -1008,8 +1028,30 @@ class BranchCommand(BaseCommand):
 
         project = load_project(base_path, output_json=output_json)
 
-        branch_name = project.get_current_branch()
-        ctx = console.status("[info]Merging branch...[/info]") if not output_json else nullcontext()
+        current_branch_name, branches = project.get_branches()
+        current_branch_meta = branches.get(current_branch_name, {})
+        parent_branch_id = current_branch_meta.get("parentBranchId") or None
+        parent_branch_name = next(
+            (name for name, meta in branches.items() if meta.get("branchId") == parent_branch_id),
+            "main",
+        )
+
+        if parent_branch_name == "main" and project.using_simplified_deployments:
+            if not output_json and not force:
+                warning("Merging into 'main' will deploy changes into live environment")
+                if not questionary.confirm(
+                    "Confirm Deployment?", default=False, auto_enter=False
+                ).ask():
+                    warning("Aborted.")
+                    sys.exit(0)
+
+        ctx = (
+            console.status(
+                f"[info]Merging branch '{current_branch_name}' into '{parent_branch_name}'...[/info]"
+            )
+            if not output_json
+            else nullcontext()
+        )
         with ctx:
             merge_success, conflicts, errors = project.merge_branch(
                 message=message, conflict_resolutions=file_resolutions
@@ -1026,12 +1068,12 @@ class BranchCommand(BaseCommand):
             return
 
         if merge_success:
-            success(f"Branch '{branch_name}' merged successfully.")
-            info('Switched to "main" branch after merge.')
+            success(f"Branch '{current_branch_name}' merged successfully.")
+            info(f"Switched to '{parent_branch_name}' branch after merge.")
             return
 
         # Failed branch merge
-        error(f"Failed to merge branch '{branch_name}'.")
+        error(f"Failed to merge branch '{current_branch_name}'.")
         if errors:
             plain("\n[red]Errors:[/red]")
             for err in errors:
@@ -1062,7 +1104,9 @@ class BranchCommand(BaseCommand):
             os.sep.join(r["path"]): r for r in (file_resolutions or []) if "path" in r
         }
         while True:
-            resolutions = cls._merge_interactively(enriched, existing_resolutions, branch_name)
+            resolutions = cls._merge_interactively(
+                enriched, existing_resolutions, current_branch_name
+            )
             if not resolutions:
                 warning("No resolutions provided. Exiting.")
                 sys.exit(1)
@@ -1076,18 +1120,18 @@ class BranchCommand(BaseCommand):
                     message=message, conflict_resolutions=resolutions
                 )
             if merge_success:
-                success(f"Branch '{branch_name}' merged successfully.")
-                info('Switched to "main" branch after merge.')
+                success(f"Branch '{current_branch_name}' merged successfully.")
+                info(f"Switched to '{parent_branch_name}' branch after merge.")
                 break
             if errors:
-                error(f"Failed to merge branch '{branch_name}' after conflict resolution.")
+                error(f"Failed to merge branch '{current_branch_name}' after conflict resolution.")
                 plain("\n[red]Errors:[/red]")
                 for err in errors:
                     error(f"- {err['path']}: {err['message']}")
                 sys.exit(1)
             if not conflicts:
                 error(
-                    f"Failed to merge branch '{branch_name}' after conflict resolution "
+                    f"Failed to merge branch '{current_branch_name}' after conflict resolution "
                     "(no conflicts or errors returned)."
                 )
                 sys.exit(1)

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -299,6 +299,20 @@ class BranchCommand(BaseCommand):
 
         branch_history_parser.set_defaults(branch_subcommand="history")
 
+        branch_rename_parser = branch_subparsers.add_parser(
+            "rename",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Rename a current branch.",
+        )
+        branch_rename_parser.add_argument(
+            "new_branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="New name for the current branch.",
+        )
+        branch_rename_parser.set_defaults(branch_subcommand="rename")
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching branch sub-handler."""
@@ -345,6 +359,9 @@ class BranchCommand(BaseCommand):
 
         elif args.branch_subcommand == "history":
             cls.branch_history(args.path, args.branch_name, args.json)
+
+        elif args.branch_subcommand == "rename":
+            cls.branch_rename(args.path, args.new_branch_name, args.json)
 
     @classmethod
     def branch_list(cls, base_path: str, output_json: bool = False) -> None:
@@ -1202,3 +1219,64 @@ class BranchCommand(BaseCommand):
 
         plain(f"History for branch '{branch_name}':")
         print_branch_history(history)
+
+    @classmethod
+    def branch_rename(
+        cls, base_path: str, new_branch_name: Optional[str] = None, output_json: bool = False
+    ) -> None:
+        """Rename the current branch in the Agent Studio project."""
+        from poly.output.console import error, success, warning
+
+        project = load_project(base_path, output_json=output_json)
+
+        current_branch = project.get_current_branch()
+        if not current_branch:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "Current branch doesn't exist. Create a new branch before renaming.",
+                    }
+                )
+            else:
+                warning("Current branch doesn't exist. Create a new branch before renaming.")
+            return
+
+        if current_branch == "main":
+            if output_json:
+                json_print({"success": False, "error": "Cannot rename the main branch."})
+            else:
+                error("Cannot rename the main branch.")
+            return
+
+        if not new_branch_name:
+            if output_json:
+                json_print({"success": False, "error": "No new branch name provided."})
+            else:
+                new_branch_name = input("Enter the new name for the current branch: ").strip()
+                if not new_branch_name:
+                    warning("No new branch name provided. Exiting.")
+                    return
+
+        try:
+            renamed = project.rename_branch(new_branch_name)
+        except (ValueError, Exception) as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            return
+
+        if output_json:
+            json_print(
+                {
+                    "success": renamed,
+                    "old_branch_name": current_branch,
+                    "new_branch_name": new_branch_name,
+                }
+            )
+        else:
+            if renamed:
+                success(f"Renamed branch '{current_branch}' to '{new_branch_name}'.")
+            else:
+                error(f"Failed to rename branch '{current_branch}' to '{new_branch_name}'.")

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -249,18 +249,18 @@ class BranchCommand(BaseCommand):
 
         branch_merge_parser.set_defaults(branch_subcommand="merge")
 
-        branch_merge_parser = branch_subparsers.add_parser(
+        branch_sync_parser = branch_subparsers.add_parser(
             "sync",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
             help="Sync branch with parent",
         )
-        branch_merge_parser.add_argument(
+        branch_sync_parser.add_argument(
             "--interactive",
             "-i",
             action="store_true",
             help="Enable interactive mode for resolving any merge conflicts. Set $EDITOR or $VISUAL to your preferred editor for editing merge conflict values if needed.",
         )
-        branch_merge_parser.add_argument(
+        branch_sync_parser.add_argument(
             "--resolutions",
             type=str,
             default=None,
@@ -272,14 +272,7 @@ class BranchCommand(BaseCommand):
                 '- value: Optional custom value (use "theirs" strategy)'
             ),
         )
-        branch_merge_parser.add_argument(
-            "--force",
-            "-f",
-            action="store_true",
-            default=False,
-            help="Deploy to main without confirmation prompt when it will deploy to live",
-        )
-        branch_merge_parser.set_defaults(branch_subcommand="sync")
+        branch_sync_parser.set_defaults(branch_subcommand="sync")
 
         # -- history --
         branch_history_parser = branch_subparsers.add_parser(
@@ -443,15 +436,6 @@ class BranchCommand(BaseCommand):
 
         elif args.branch_subcommand == "status":
             cls.branch_status(args.path, args.branch_name, args.json)
-
-        elif args.branch_subcommand == "history":
-            cls.branch_history(args.path, args.branch_name, args.json, args.limit)
-
-        elif args.branch_subcommand == "rename":
-            cls.branch_rename(args.path, args.new_branch_name, args.json)
-
-        elif args.branch_subcommand == "restore":
-            cls.branch_restore(args.path, args.branch_name, args.json)
 
     @classmethod
     def branch_list(cls, base_path: str, output_json: bool = False, archived: bool = False) -> None:
@@ -1506,10 +1490,14 @@ class BranchCommand(BaseCommand):
                 )
             else:
                 warning("No current branch found. Please specify a branch name.")
+            return
 
-        branch_id = branches.get(branch_name)
+        branch_id = branches.get(branch_name, {}).get("branchId")
         if not branch_id:
-            warning(f"Branch '{branch_name}' does not exist.")
+            if output_json:
+                json_print({"success": False, "error": f"Branch '{branch_name}' does not exist."})
+            else:
+                warning(f"Branch '{branch_name}' does not exist.")
             return
 
         history = project.get_branch_history(branch_id)

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -1720,7 +1720,9 @@ class BranchCommand(BaseCommand):
             json_print({"success": tagged})
         else:
             if tagged:
-                success(f"Current branch '{project.get_current_branch()}' tagged successfully.")
+                success(
+                    f"Current branch '{project.get_current_branch()}' tagged and deployed to staging."
+                )
             else:
                 error("Failed to tag the current branch.")
 
@@ -1743,6 +1745,8 @@ class BranchCommand(BaseCommand):
             json_print({"success": untagged})
         else:
             if untagged:
-                success(f"Tag removed from current branch '{project.get_current_branch()}'.")
+                success(
+                    f"Staging tag removed from current branch '{project.get_current_branch()}'."
+                )
             else:
                 error("Failed to remove tag from the current branch.")

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -806,12 +806,12 @@ class BranchCommand(BaseCommand):
                     return
             try:
                 deleted = project.delete_branch(branch_name)
-            except (ValueError, Exception) as e:
+            except ValueError as e:
                 if output_json:
                     json_print({"success": False, "message": str(e)})
                 else:
                     error(str(e))
-                return
+                sys.exit(1)
             if output_json:
                 result = {"success": deleted}
                 if deleted and branch_name == current_branch:
@@ -877,7 +877,7 @@ class BranchCommand(BaseCommand):
                 else:
                     if not output_json:
                         error(f"Failed to delete branch '{name}'.")
-            except (ValueError, Exception) as e:
+            except ValueError as e:
                 if not output_json:
                     error(str(e))
 
@@ -1640,12 +1640,12 @@ class BranchCommand(BaseCommand):
 
         try:
             renamed = project.rename_branch(new_branch_name)
-        except (ValueError, Exception) as e:
+        except ValueError as e:
             if output_json:
                 json_print({"success": False, "error": str(e)})
             else:
                 error(str(e))
-            return
+            sys.exit(1)
 
         if output_json:
             json_print(
@@ -1723,9 +1723,9 @@ class BranchCommand(BaseCommand):
             selected_branch = branch_by_label[selected]
             try:
                 restored = project.restore_branch(selected_branch["branchId"])
-            except (ValueError, Exception) as e:
+            except ValueError as e:
                 error(str(e))
-                return
+                sys.exit(1)
             if restored:
                 success(f"Branch '{selected_branch.get('name', '—')}' restored.")
             else:
@@ -1734,12 +1734,12 @@ class BranchCommand(BaseCommand):
 
         try:
             restored = project.restore_branch(branch_id)
-        except (ValueError, Exception) as e:
+        except ValueError as e:
             if output_json:
                 json_print({"success": False, "error": str(e)})
             else:
                 error(str(e))
-            return
+            sys.exit(1)
 
         if output_json:
             json_print({"success": restored, "branch_id": branch_id})

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -571,7 +571,7 @@ class BranchCommand(BaseCommand):
         """Switch to a different branch in the Agent Studio project."""
         import questionary
 
-        from poly.output.console import console, error, plain, success, warning
+        from poly.output.console import console, error, flatten_branch_tree, plain, success, warning
 
         project = load_project(base_path, output_json=output_json)
 
@@ -590,24 +590,27 @@ class BranchCommand(BaseCommand):
                 plain("[muted]No branches found.[/muted]")
                 return
 
-            # Create menu options from branch names
-            menu_options = []
-            for name in branches.keys():
-                if name == current_branch:
-                    menu_options.append(f"{name} (current)")
-                else:
-                    menu_options.append(name)
+            if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+                # Show branch-from-branch lineage via indentation/connectors.
+                choices = [
+                    questionary.Choice(title=title, value=value)
+                    for title, value in flatten_branch_tree(branches, current_branch)
+                ]
+            else:
+                choices = [
+                    questionary.Choice(
+                        title=f"{name} (current)" if name == current_branch else name,
+                        value=name,
+                    )
+                    for name in branches.keys()
+                ]
 
-            branch_menu = questionary.select(
-                "Select Branch", choices=menu_options, use_search_filter=True, use_jk_keys=False
+            branch_name = questionary.select(
+                "Select Branch", choices=choices, use_search_filter=True, use_jk_keys=False
             ).ask()
-            if not branch_menu:
+            if not branch_name:
                 warning("No branch selected. Exiting.")
                 return
-
-            # Get the selected branch name (remove "(current)" suffix if present)
-            selected_option = branch_menu
-            branch_name = selected_option.replace(" (current)", "")
 
         projection_json = parse_from_projection_json(
             from_projection,
@@ -687,7 +690,7 @@ class BranchCommand(BaseCommand):
         """
         import questionary
 
-        from poly.output.console import error, info, plain, success, warning
+        from poly.output.console import error, flatten_branch_tree, info, plain, success, warning
 
         project = load_project(base_path, output_json=output_json)
         current_branch, branches = project.get_branches()
@@ -736,17 +739,31 @@ class BranchCommand(BaseCommand):
             plain("[muted]No deletable branches found.[/muted]")
             return
 
-        choices = []
-        for name in deletable:
-            label = f"{name} (current)" if name == current_branch else name
-            choices.append(label)
+        if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            # Show 'main' as disabled tree context so lineage is visible, but not selectable.
+            choices = [
+                questionary.Choice(
+                    title=title,
+                    value=value,
+                    disabled="cannot delete main" if value == "main" else None,
+                )
+                for title, value in flatten_branch_tree(branches, current_branch)
+            ]
+        else:
+            choices = [
+                questionary.Choice(
+                    title=f"{name} (current)" if name == current_branch else name,
+                    value=name,
+                )
+                for name in deletable
+            ]
 
         selected = questionary.checkbox("Select branches to delete", choices=choices).ask()
         if not selected:
             warning("No branches selected. Exiting.")
             return
 
-        branch_names = [label.replace(" (current)", "") for label in selected]
+        branch_names = selected
         confirm_msg = f"Delete {len(branch_names)} branch(es): {', '.join(branch_names)}?"
         confirmed = questionary.confirm(confirm_msg, default=False).ask()
         if not confirmed:
@@ -755,8 +772,7 @@ class BranchCommand(BaseCommand):
 
         deleted_count = 0
         current_branch_deleted = False
-        for label in selected:
-            name = label.replace(" (current)", "")
+        for name in selected:
             try:
                 deleted = project.delete_branch(name)
                 if deleted:

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -305,6 +305,22 @@ class BranchCommand(BaseCommand):
         )
         branch_sync_parser.set_defaults(branch_subcommand="sync")
 
+        # -- tag --
+        branch_tag_parser = branch_subparsers.add_parser(
+            "tag",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Tag the current branch and deploy to staging environment. Tagging 'main' branch is not supported.",
+        )
+        branch_tag_parser.set_defaults(branch_subcommand="tag")
+
+        # -- untag --
+        branch_untag_parser = branch_subparsers.add_parser(
+            "untag",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Remove a tag from the current branch. Untagging 'main' branch is not supported.",
+        )
+        branch_untag_parser.set_defaults(branch_subcommand="untag")
+
         # -- diff --
         branch_diff_parser = branch_subparsers.add_parser(
             "diff",
@@ -426,6 +442,12 @@ class BranchCommand(BaseCommand):
 
         elif args.branch_subcommand == "restore":
             cls.branch_restore(args.path, args.branch_name, args.json)
+
+        elif args.branch_subcommand == "tag":
+            cls.branch_tag(args.path, args.json)
+
+        elif args.branch_subcommand == "untag":
+            cls.branch_untag(args.path, args.json)
 
         elif args.branch_subcommand == "diff":
             cls.branch_diff(args.path, args.branch_name, getattr(args, "files", None), args.json)
@@ -1681,3 +1703,45 @@ class BranchCommand(BaseCommand):
                 success(f"Branch '{branch_name}' restored.")
             else:
                 error(f"Failed to restore branch '{branch_name}'.")
+
+    @classmethod
+    def branch_tag(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+    ) -> None:
+        """Tag the current branch with a new tag."""
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+
+        tagged = project.tag_branch()
+
+        if output_json:
+            json_print({"success": tagged})
+        else:
+            if tagged:
+                success(f"Current branch '{project.get_current_branch()}' tagged successfully.")
+            else:
+                error("Failed to tag the current branch.")
+
+    @classmethod
+    def branch_untag(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+    ) -> None:
+        """Remove a tag from the current branch."""
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+
+        untagged = project.untag_branch()
+
+        if output_json:
+            json_print({"success": untagged})
+        else:
+            if untagged:
+                success(f"Tag removed from current branch '{project.get_current_branch()}'.")
+            else:
+                error("Failed to remove tag from the current branch.")

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -699,7 +699,7 @@ class BranchCommand(BaseCommand):
             return
 
         plain(f"Current branch: [bold]{current_branch}[/bold]")
-        if parent_branch:
+        if parent_branch and parent_branch != "main":
             plain(f"Parent branch: [bold]{parent_branch}[/bold]")
 
     @classmethod

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -571,11 +571,7 @@ class BranchCommand(BaseCommand):
             # Checks for any local changes on main before creating env branch.
             if diffs := project.get_diffs():
                 if not force:
-                    raise ValueError(
-                        f"Uncommitted changes on main branch, diffs: {list(diffs.keys())}"
-                    )
-            project.pull_project_from_env(env=env, format=False)
-            success(f"Pulled {project.account_id}/{project.project_id}")
+                    raise ValueError(f"Uncommitted changes on main, diffs: {list(diffs.keys())}")
 
         if not branch_name:
             if output_json:
@@ -625,6 +621,8 @@ class BranchCommand(BaseCommand):
 
         # Pushes existing state of env to provide clean slate for hotfixes.
         if env in ["pre-release", "live"]:
+            project.pull_project_from_env(env=env, format=False)
+            success(f"Pulled {project.account_id}/{project.project_id}")
             project.push_project(
                 force=True,
                 skip_validation=True,
@@ -1415,7 +1413,7 @@ class BranchCommand(BaseCommand):
         interactive: bool = False,
         resolutions_file: str = None,
     ):
-        """Synch the current branch with it's parent, with optional conflict resolutions."""
+        """Sync the current branch with it's parent, with optional conflict resolutions."""
         from poly.cli_commands.shared import require_deployment_simplification
         from poly.output.console import (
             console,

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -489,21 +489,6 @@ class BranchCommand(BaseCommand):
 
         project = load_project(base_path, output_json=output_json)
 
-        if project.branch_id != "main":
-            if output_json:
-                json_print(
-                    {
-                        "success": False,
-                        "error": "Branches can only be created from the main branch (sandbox).",
-                    }
-                )
-            else:
-                error(
-                    "Branches can only be created from the [bold]main[/bold] branch (sandbox). "
-                    "Please switch and try again."
-                )
-            sys.exit(1)
-
         if env in ["pre-release", "live"]:
             # Checks for any local changes on main before creating env branch.
             if diffs := project.get_diffs():
@@ -528,11 +513,15 @@ class BranchCommand(BaseCommand):
                 warning("No branch name provided. Exiting.")
                 return
 
+        base_branch_id = project.branch_id
+        base_branch_name = project.get_current_branch()
         new_branch_id = project.create_branch(branch_name)
         if output_json:
             json_print(
                 {
                     "success": bool(new_branch_id),
+                    "base_branch_id": base_branch_id,
+                    "base_branch_name": base_branch_name,
                     "new_branch_id": new_branch_id,
                     "branch_name": branch_name,
                 }
@@ -542,7 +531,9 @@ class BranchCommand(BaseCommand):
             return
 
         if new_branch_id:
-            success(f"Branch '{branch_name}' created (ID: {new_branch_id})")
+            success(
+                f"Created new branch '{branch_name}' (ID: {new_branch_id}) from '{base_branch_name}'"
+            )
         else:
             error("Failed to create the branch.")
             sys.exit(1)

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -113,6 +113,7 @@ class BranchCommand(BaseCommand):
         )
         branch_subparsers = branches_parser.add_subparsers(dest="branch_subcommand", required=True)
 
+        # -- list --
         branch_list_parser = branch_subparsers.add_parser(
             "list",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -125,6 +126,7 @@ class BranchCommand(BaseCommand):
         )
         branch_list_parser.set_defaults(branch_subcommand="list")
 
+        # -- create --
         branch_create_parser = branch_subparsers.add_parser(
             "create",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -150,6 +152,7 @@ class BranchCommand(BaseCommand):
         )
         branch_create_parser.set_defaults(branch_subcommand="create")
 
+        # -- switch --
         branch_switch_parser = branch_subparsers.add_parser(
             "switch",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -184,6 +187,7 @@ class BranchCommand(BaseCommand):
         )
         branch_switch_parser.set_defaults(branch_subcommand="switch")
 
+        # -- current --
         branch_current_parser = branch_subparsers.add_parser(
             "current",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -191,6 +195,7 @@ class BranchCommand(BaseCommand):
         )
         branch_current_parser.set_defaults(branch_subcommand="current")
 
+        # -- delete --
         branch_delete_parser = branch_subparsers.add_parser(
             "delete",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -204,6 +209,7 @@ class BranchCommand(BaseCommand):
         ).completer = cls._branch_name_completer
         branch_delete_parser.set_defaults(branch_subcommand="delete")
 
+        # -- merge --
         branch_merge_parser = branch_subparsers.add_parser(
             "merge",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -235,6 +241,83 @@ class BranchCommand(BaseCommand):
         )
         branch_merge_parser.set_defaults(branch_subcommand="merge")
 
+        branch_merge_parser = branch_subparsers.add_parser(
+            "sync",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Sync branch with parent",
+        )
+        branch_merge_parser.add_argument(
+            "--interactive",
+            "-i",
+            action="store_true",
+            help="Enable interactive mode for resolving any merge conflicts. Set $EDITOR or $VISUAL to your preferred editor for editing merge conflict values if needed.",
+        )
+        branch_merge_parser.add_argument(
+            "--resolutions",
+            type=str,
+            default=None,
+            help=(
+                "Conflict resolutions as a JSON file path, inline JSON string, or '-' for stdin. "
+                "JSON should be an array of objects, each representing a conflict resolution:\n"
+                '- path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])\n'
+                '- strategy: Resolution strategy - "ours", "theirs", or "base"\n'
+                '- value: Optional custom value (use "theirs" strategy)'
+            ),
+        )
+        branch_merge_parser.set_defaults(branch_subcommand="sync")
+
+        # -- history --
+        branch_history_parser = branch_subparsers.add_parser(
+            "history",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Show the history of a branch.",
+        )
+
+        branch_history_parser.add_argument(
+            "--branch-name",
+            "-b",
+            type=str,
+            default=None,
+            help="Name of the branch to show history for. Defaults to the current branch.",
+        )
+        branch_history_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of history entries to show. Defaults to 10.",
+        )
+
+        branch_history_parser.set_defaults(branch_subcommand="history")
+
+        # -- rename --
+        branch_rename_parser = branch_subparsers.add_parser(
+            "rename",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Rename a current branch.",
+        )
+        branch_rename_parser.add_argument(
+            "new_branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="New name for the current branch.",
+        )
+        branch_rename_parser.set_defaults(branch_subcommand="rename")
+
+        # -- restore --
+        branch_restore_parser = branch_subparsers.add_parser(
+            "restore",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Restore a soft-deleted branch from the archive.",
+        )
+        branch_restore_parser.add_argument(
+            "branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Name of the archived branch to restore.",
+        )
+        branch_restore_parser.set_defaults(branch_subcommand="restore")
         # ── diff ──
         branch_diff_parser = branch_subparsers.add_parser(
             "diff",
@@ -372,6 +455,18 @@ class BranchCommand(BaseCommand):
 
         elif args.branch_subcommand == "merge":
             cls.branch_merge(args.path, args.message, args.json, args.interactive, args.resolutions)
+
+        elif args.branch_subcommand == "sync":
+            cls.branch_sync(args.path, args.json, args.interactive, args.resolutions)
+
+        elif args.branch_subcommand == "history":
+            cls.branch_history(args.path, args.branch_name, args.json, args.limit)
+
+        elif args.branch_subcommand == "rename":
+            cls.branch_rename(args.path, args.new_branch_name, args.json)
+
+        elif args.branch_subcommand == "restore":
+            cls.branch_restore(args.path, args.branch_name, args.json)
 
         elif args.branch_subcommand == "diff":
             cls.branch_diff(args.path, args.branch_name, getattr(args, "files", None), args.json)
@@ -1216,6 +1311,147 @@ class BranchCommand(BaseCommand):
 
         if not new_files and not modified_files and not deleted_files:
             plain("\n[muted]No changes on this branch.[/muted]")
+
+    @classmethod
+    def branch_sync(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+        interactive: bool = False,
+        resolutions_file: str = None,
+    ):
+        """Synch the current branch with it's parent, with optional conflict resolutions."""
+        from poly.output.console import (
+            console,
+            error,
+            output_merge_conflict_table,
+            plain,
+            success,
+            warning,
+        )
+
+        if interactive and output_json:
+            json_print(
+                {
+                    "success": False,
+                    "error": "--interactive and --json cannot be used together.",
+                }
+            )
+            sys.exit(1)
+
+        file_resolutions: list[dict[str, Any]] | None = None
+        if resolutions_file:
+            try:
+                if resolutions_file == "-":
+                    file_resolutions = json.load(sys.stdin)
+                elif resolutions_file.lstrip().startswith("["):
+                    file_resolutions = json.loads(resolutions_file)
+                else:
+                    with open(resolutions_file, encoding="utf-8") as f:
+                        file_resolutions = json.load(f)
+                if not isinstance(file_resolutions, list):
+                    raise ValueError("Resolutions must be a JSON array.")
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                if output_json:
+                    json_print({"success": False, "error": f"Failed to parse resolutions: {exc}"})
+                else:
+                    error(f"Failed to parse resolutions: {exc}")
+                sys.exit(1)
+
+        project = load_project(base_path, output_json=output_json)
+
+        branch_name = project.get_current_branch()
+        ctx = console.status("[info]Syncing branch...[/info]") if not output_json else nullcontext()
+        with ctx:
+            merge_success, conflicts, errors = project.sync_branch(
+                conflict_resolutions=file_resolutions
+            )
+
+        if output_json:
+            output = {"success": merge_success}
+            if conflicts or errors:
+                output["conflicts"] = conflicts
+                output["errors"] = errors
+            json_print(output)
+            if not merge_success:
+                sys.exit(1)
+            return
+
+        if merge_success:
+            success(f"Branch '{branch_name}' synced successfully.")
+            return
+
+        # Failed branch sync
+        error(f"Failed to sync branch '{branch_name}'.")
+        if errors:
+            plain("\n[red]Errors:[/red]")
+            for err in errors:
+                error(f"- {err['path']}: {err['message']}")
+
+        enriched = enrich_branch_merge_conflicts(conflicts) if conflicts else []
+        display_conflict = [
+            c for c in enriched if c.get("path") and c["path"][-1] not in {"updatedAt", "createdAt"}
+        ]
+        if display_conflict:
+            output_merge_conflict_table(
+                display_conflict, show_type=True, resolutions=file_resolutions
+            )
+
+        if errors:
+            sys.exit(1)
+
+        if not interactive:
+            plain(
+                "Merge conflicts detected. To resolve:\n"
+                "- Use 'poly branch sync -i' to resolve conflicts interactively\n"
+                "- Use 'poly branch sync --resolutions <file.json>' to provide pre-defined resolutions\n"
+                "- Merge manually on Agent Studio"
+            )
+            sys.exit(1)
+
+        existing_resolutions = {
+            os.sep.join(r["path"]): r for r in (file_resolutions or []) if "path" in r
+        }
+        while True:
+            resolutions = cls._merge_interactively(enriched, existing_resolutions, branch_name)
+            if not resolutions:
+                warning("No resolutions provided. Exiting.")
+                sys.exit(1)
+            ctx2 = (
+                console.status("[info]Sync branch...[/info]") if not output_json else nullcontext()
+            )
+            with ctx2:
+                merge_success, conflicts, errors = project.sync_branch(
+                    conflict_resolutions=resolutions
+                )
+            if merge_success:
+                success(f"Branch '{branch_name}' synced successfully.")
+                break
+            if errors:
+                error(f"Failed to sync branch '{branch_name}' after conflict resolution.")
+                plain("\n[red]Errors:[/red]")
+                for err in errors:
+                    error(f"- {err['path']}: {err['message']}")
+                sys.exit(1)
+            if not conflicts:
+                error(
+                    f"Failed to sync branch '{branch_name}' after conflict resolution "
+                    "(no conflicts or errors returned)."
+                )
+                sys.exit(1)
+            warning("Sync still blocked; resolve the remaining conflicts below.")
+            enriched = enrich_branch_merge_conflicts(conflicts)
+            display_conflict = [
+                c
+                for c in enriched
+                if c.get("path") and c["path"][-1] not in {"updatedAt", "createdAt"}
+            ]
+            if display_conflict:
+                output_merge_conflict_table(
+                    display_conflict,
+                    show_type=True,
+                    panel_title="Remaining merge conflicts",
+                )
 
     @classmethod
     def branch_history(

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -542,7 +542,14 @@ class BranchCommand(BaseCommand):
 
         base_branch_id = project.branch_id
         base_branch_name = project.get_current_branch()
-        new_branch_id = project.create_branch(branch_name)
+        try:
+            new_branch_id = project.create_branch(branch_name)
+        except ValueError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            sys.exit(1)
         if output_json:
             json_print(
                 {
@@ -1036,7 +1043,18 @@ class BranchCommand(BaseCommand):
             "main",
         )
 
-        if parent_branch_name == "main" and project.using_simplified_deployments:
+        is_live_deploy = parent_branch_name == "main" and project.using_simplified_deployments
+
+        def _report_merge_success() -> None:
+            if is_live_deploy:
+                success(
+                    f"Branch '{current_branch_name}' merged into main — your changes are now live."
+                )
+            else:
+                success(f"Branch '{current_branch_name}' merged successfully.")
+            info(f"Switched to '{parent_branch_name}' branch after merge.")
+
+        if is_live_deploy:
             if not output_json and not force:
                 warning("Merging into 'main' will deploy changes into live environment")
                 if not questionary.confirm(
@@ -1068,8 +1086,7 @@ class BranchCommand(BaseCommand):
             return
 
         if merge_success:
-            success(f"Branch '{current_branch_name}' merged successfully.")
-            info(f"Switched to '{parent_branch_name}' branch after merge.")
+            _report_merge_success()
             return
 
         # Failed branch merge
@@ -1120,8 +1137,7 @@ class BranchCommand(BaseCommand):
                     message=message, conflict_resolutions=resolutions
                 )
             if merge_success:
-                success(f"Branch '{current_branch_name}' merged successfully.")
-                info(f"Switched to '{parent_branch_name}' branch after merge.")
+                _report_merge_success()
                 break
             if errors:
                 error(f"Failed to merge branch '{current_branch_name}' after conflict resolution.")

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -197,6 +197,21 @@ class BranchCommand(BaseCommand):
         )
         branch_current_parser.set_defaults(branch_subcommand="current")
 
+        # -- rename --
+        branch_rename_parser = branch_subparsers.add_parser(
+            "rename",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Rename the current branch.",
+        )
+        branch_rename_parser.add_argument(
+            "new_branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="New name for the current branch.",
+        )
+        branch_rename_parser.set_defaults(branch_subcommand="rename")
+
         # -- delete --
         branch_delete_parser = branch_subparsers.add_parser(
             "delete",
@@ -210,6 +225,21 @@ class BranchCommand(BaseCommand):
             help="Name of the branch to delete directly, skipping the interactive prompt.",
         ).completer = cls._branch_name_completer
         branch_delete_parser.set_defaults(branch_subcommand="delete")
+
+        # -- restore --
+        branch_restore_parser = branch_subparsers.add_parser(
+            "restore",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Restore a soft-deleted branch from the archive.",
+        )
+        branch_restore_parser.add_argument(
+            "branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Name of the archived branch to restore.",
+        )
+        branch_restore_parser.set_defaults(branch_subcommand="restore")
 
         # -- merge --
         branch_merge_parser = branch_subparsers.add_parser(
@@ -247,9 +277,9 @@ class BranchCommand(BaseCommand):
             action="store_true",
             help="Skip the confirmation prompt when merging into main deploys to a live environment.",
         )
-
         branch_merge_parser.set_defaults(branch_subcommand="merge")
 
+        # -- sync --
         branch_sync_parser = branch_subparsers.add_parser(
             "sync",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -275,60 +305,7 @@ class BranchCommand(BaseCommand):
         )
         branch_sync_parser.set_defaults(branch_subcommand="sync")
 
-        # -- history --
-        branch_history_parser = branch_subparsers.add_parser(
-            "history",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Show the history of a branch.",
-        )
-
-        branch_history_parser.add_argument(
-            "--branch-name",
-            "-b",
-            type=str,
-            default=None,
-            help="Name of the branch to show history for. Defaults to the current branch.",
-        )
-        branch_history_parser.add_argument(
-            "--limit",
-            type=int,
-            default=10,
-            help="Number of history entries to show. Defaults to 10.",
-        )
-
-        branch_history_parser.set_defaults(branch_subcommand="history")
-
-        # -- rename --
-        branch_rename_parser = branch_subparsers.add_parser(
-            "rename",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Rename the current branch.",
-        )
-        branch_rename_parser.add_argument(
-            "new_branch_name",
-            type=str,
-            nargs="?",
-            default=None,
-            help="New name for the current branch.",
-        )
-        branch_rename_parser.set_defaults(branch_subcommand="rename")
-
-        # -- restore --
-        branch_restore_parser = branch_subparsers.add_parser(
-            "restore",
-            parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Restore a soft-deleted branch from the archive.",
-        )
-        branch_restore_parser.add_argument(
-            "branch_name",
-            type=str,
-            nargs="?",
-            default=None,
-            help="Name of the archived branch to restore.",
-        )
-        branch_restore_parser.set_defaults(branch_subcommand="restore")
-
-        # ── diff ──
+        # -- diff --
         branch_diff_parser = branch_subparsers.add_parser(
             "diff",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -347,7 +324,7 @@ class BranchCommand(BaseCommand):
         )
         branch_diff_parser.set_defaults(branch_subcommand="diff")
 
-        # ── review ──
+        # -- review --
         branch_review_parser = branch_subparsers.add_parser(
             "review",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -366,7 +343,7 @@ class BranchCommand(BaseCommand):
         )
         branch_review_parser.set_defaults(branch_subcommand="review")
 
-        # ── status ──
+        # -- status --
         branch_status_parser = branch_subparsers.add_parser(
             "status",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -379,6 +356,27 @@ class BranchCommand(BaseCommand):
             help="Branch to check status for. Defaults to the current branch.",
         ).completer = cls._branch_name_completer
         branch_status_parser.set_defaults(branch_subcommand="status")
+
+        # -- history --
+        branch_history_parser = branch_subparsers.add_parser(
+            "history",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Show the history of a branch.",
+        )
+        branch_history_parser.add_argument(
+            "--branch-name",
+            "-b",
+            type=str,
+            default=None,
+            help="Name of the branch to show history for. Defaults to the current branch.",
+        )
+        branch_history_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of history entries to show. Defaults to 10.",
+        )
+        branch_history_parser.set_defaults(branch_subcommand="history")
 
     @classmethod
     def run(cls, args: Namespace) -> None:

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project, parse_from_projection_json, read_project_config
 from poly.output.json_output import json_print
+from poly.project import DeploymentMode
 from poly.resources.resource_utils import contains_merge_conflict
 from poly.utils import merge_strings
 
@@ -438,7 +439,13 @@ class BranchCommand(BaseCommand):
     @classmethod
     def branch_list(cls, base_path: str, output_json: bool = False, archived: bool = False) -> None:
         """List branches in the Agent Studio project."""
-        from poly.output.console import plain, print_archived_branches, print_branches, warning
+        from poly.output.console import (
+            plain,
+            print_archived_branches,
+            print_branches,
+            print_releases_branches,
+            warning,
+        )
 
         project = load_project(base_path, output_json=output_json)
 
@@ -467,7 +474,10 @@ class BranchCommand(BaseCommand):
             plain("[muted]No branches found.[/muted]")
             return
 
-        print_branches(branches, current_branch)
+        if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            print_releases_branches(branches, current_branch)
+        else:
+            print_branches(branches, current_branch)
 
         if current_branch is None:
             warning(

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -118,6 +118,11 @@ class BranchCommand(BaseCommand):
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
             help="List all branches in the project.",
         )
+        branch_list_parser.add_argument(
+            "--archived",
+            action="store_true",
+            help="Show soft-deleted (archived) branches instead of active ones.",
+        )
         branch_list_parser.set_defaults(branch_subcommand="list")
 
         branch_create_parser = branch_subparsers.add_parser(
@@ -313,11 +318,25 @@ class BranchCommand(BaseCommand):
         )
         branch_rename_parser.set_defaults(branch_subcommand="rename")
 
+        branch_restore_parser = branch_subparsers.add_parser(
+            "restore",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Restore a soft-deleted branch from the archive.",
+        )
+        branch_restore_parser.add_argument(
+            "branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="Name of the archived branch to restore.",
+        )
+        branch_restore_parser.set_defaults(branch_subcommand="restore")
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching branch sub-handler."""
         if args.branch_subcommand == "list":
-            cls.branch_list(args.path, args.json)
+            cls.branch_list(args.path, args.json, getattr(args, "archived", False))
 
         elif args.branch_subcommand == "create":
             cls.branch_create(
@@ -363,12 +382,26 @@ class BranchCommand(BaseCommand):
         elif args.branch_subcommand == "rename":
             cls.branch_rename(args.path, args.new_branch_name, args.json)
 
+        elif args.branch_subcommand == "restore":
+            cls.branch_restore(args.path, args.branch_name, args.json)
+
     @classmethod
-    def branch_list(cls, base_path: str, output_json: bool = False) -> None:
+    def branch_list(cls, base_path: str, output_json: bool = False, archived: bool = False) -> None:
         """List branches in the Agent Studio project."""
-        from poly.output.console import plain, print_branches, warning
+        from poly.output.console import plain, print_archived_branches, print_branches, warning
 
         project = load_project(base_path, output_json=output_json)
+
+        if archived:
+            branches = project.list_archived_branches()
+            if output_json:
+                json_print({"archived_branches": branches})
+                return
+            if not branches:
+                plain("[muted]No archived branches found.[/muted]")
+                return
+            print_archived_branches(branches)
+            return
 
         current_branch, branches = project.get_branches()
 
@@ -1280,3 +1313,81 @@ class BranchCommand(BaseCommand):
                 success(f"Renamed branch '{current_branch}' to '{new_branch_name}'.")
             else:
                 error(f"Failed to rename branch '{current_branch}' to '{new_branch_name}'.")
+
+    @classmethod
+    def branch_restore(
+        cls,
+        base_path: str,
+        branch_name: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """Restore a soft-deleted branch from the archive."""
+        import questionary
+
+        from poly.output.console import error, plain, success, warning
+
+        project = load_project(base_path, output_json=output_json)
+
+        if not branch_name:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "branch restore with --json requires a branch name argument.",
+                    }
+                )
+                sys.exit(1)
+
+            archived = project.list_archived_branches()
+            if not archived:
+                plain("[muted]No archived branches to restore.[/muted]")
+                return
+
+            choices = []
+            branch_id_map: dict[str, str] = {}
+            for b in archived:
+                name = b.get("name", "—")
+                branch_id = b.get("branchId", "")
+                label = f"{name} ({branch_id})"
+                choices.append(label)
+                branch_id_map[label] = branch_id
+
+            selected = questionary.select(
+                "Select branch to restore",
+                choices=choices,
+                use_search_filter=True,
+                use_jk_keys=False,
+            ).ask()
+            if not selected:
+                warning("No branch selected. Exiting.")
+                return
+
+            selected_branch_id = branch_id_map[selected]
+            try:
+                restored = project.api_handler.restore_branch(selected_branch_id)
+            except (ValueError, Exception) as e:
+                error(str(e))
+                return
+            if restored:
+                branch_name = selected.split(" (")[0]
+                success(f"Branch '{branch_name}' restored.")
+            else:
+                error("Failed to restore selected branch.")
+            return
+
+        try:
+            restored = project.restore_branch(branch_name)
+        except (ValueError, Exception) as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            return
+
+        if output_json:
+            json_print({"success": restored, "branch_name": branch_name})
+        else:
+            if restored:
+                success(f"Branch '{branch_name}' restored.")
+            else:
+                error(f"Failed to restore branch '{branch_name}'.")

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -106,7 +106,8 @@ class BranchCommand(BaseCommand):
                 "  poly branch list\n"
                 "  poly branch create new-branch\n"
                 "  poly branch switch existing-branch\n"
-                "  poly branch merge 'Merge branch'"
+                "  poly branch merge 'Merge branch'\n"
+                "  poly branch sync\n"
                 "  poly branch current\n"
                 "  poly branch delete\n"
             ),
@@ -214,7 +215,7 @@ class BranchCommand(BaseCommand):
         branch_merge_parser = branch_subparsers.add_parser(
             "merge",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Merge branch into main",
+            help="Merge branch into its parent branch",
         )
         branch_merge_parser.add_argument(
             "message",
@@ -301,7 +302,7 @@ class BranchCommand(BaseCommand):
         branch_rename_parser = branch_subparsers.add_parser(
             "rename",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Rename a current branch.",
+            help="Rename the current branch.",
         )
         branch_rename_parser.add_argument(
             "new_branch_name",

--- a/src/poly/cli_commands/deployments.py
+++ b/src/poly/cli_commands/deployments.py
@@ -55,9 +55,12 @@ class DeploymentsCommand(BaseCommand):
             "--env",
             "-e",
             type=str,
-            default="sandbox",
+            default=None,
             choices=["sandbox", "pre-release", "live"],
-            help="Environment to list deployments for. Defaults to sandbox.",
+            help=(
+                "Environment to list deployments for. Defaults to live for projects using"
+                " simplified deployments, otherwise sandbox."
+            ),
         )
         deployment_list_parser.add_argument(
             "--limit",
@@ -104,9 +107,12 @@ class DeploymentsCommand(BaseCommand):
             "--env",
             "-e",
             type=str,
-            default="sandbox",
+            default=None,
             choices=["sandbox", "pre-release", "live"],
-            help="Environment to query. Defaults to sandbox.",
+            help=(
+                "Environment to query. Defaults to live for projects using simplified"
+                " deployments, otherwise sandbox."
+            ),
         )
 
         deployment_promote_parser = deployments_subparsers.add_parser(
@@ -154,9 +160,11 @@ class DeploymentsCommand(BaseCommand):
         deployment_rollback_parser = deployments_subparsers.add_parser(
             "rollback",
             parents=[parents.path, parents.json, parents.verbose, parents.debug],
-            help="Rollback sandbox/main to a previous version.",
+            help="Rollback main to a previous version.",
             description=(
-                "Rollback a deployment to a previous version.\n\nExamples:\n  poly deployments rollback --to <deployment_id>\n"
+                "Rollback a deployment to a previous version.\n\n"
+                "Targets live for projects using simplified deployments, otherwise"
+                " sandbox.\n\nExamples:\n  poly deployments rollback --to <deployment_id>\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -478,7 +486,7 @@ class DeploymentsCommand(BaseCommand):
     def deployments_list(
         cls,
         base_path: str,
-        environment: str = "sandbox",
+        environment: Optional[str] = None,
         limit: int = 10,
         offset: int = 0,
         version_hash: str = None,
@@ -487,13 +495,14 @@ class DeploymentsCommand(BaseCommand):
     ) -> None:
         """List deployment history for the project.
 
-        By default shows the 10 most recent deployments for the sandbox environment.
-        Pass version_hash to start the listing from a specific version. Use details for
-        full per-deployment metadata.
+        By default shows the 10 most recent deployments for live on projects using
+        simplified deployments, and for sandbox otherwise. Pass version_hash to start
+        the listing from a specific version. Use details for full per-deployment metadata.
 
         Args:
             base_path: Base path for the project.
-            environment: Environment to query — sandbox, pre-release, or live.
+            environment: Environment to query — sandbox, pre-release, or live. Defaults
+                to the environment holding the project's deployments.
             limit: Maximum number of versions to show.
             offset: Number of versions to skip before showing results.
             version_hash: Start listing from this version hash (overrides offset).
@@ -502,7 +511,9 @@ class DeploymentsCommand(BaseCommand):
         """
         from poly.output.console import error, print_deployments
 
-        project = load_project(base_path)
+        project = load_project(base_path, output_json=output_json)
+        if environment is None:
+            environment = "live" if project.using_simplified_deployments else "sandbox"
         versions, active_deployment_hashes = project.get_deployments(client_env=environment)
 
         if not versions:
@@ -539,25 +550,30 @@ class DeploymentsCommand(BaseCommand):
         cls,
         base_path: str,
         version_hash: str,
-        environment: str = "sandbox",
+        environment: Optional[str] = None,
         output_json: bool = False,
     ) -> None:
         """Show detailed metadata and included deployments for a single deployment.
 
-        Displays the deployment record and the sandbox deployments included since
-        the previous version in the given environment. Sandbox is always the source
-        of truth for the linear version history — pre-release/live only contain
-        promotions that reference the same version hashes.
+        Displays the deployment record and the sandbox deployments included since the
+        previous version in the given environment. Sandbox remains the source of truth
+        for the linear version history — pre-release/live promotions carry the same
+        version hashes forward. Deployments made under simplified deployments never
+        reached sandbox, so nothing is bundled into them and the included list is empty;
+        a project's older pre-migration promotions still resolve normally.
 
         Args:
             base_path: Base path for the project.
             version_hash: Full or prefix hash of the target deployment.
-            environment: Environment to query (sandbox, pre-release, live).
+            environment: Environment to query (sandbox, pre-release, live). Defaults to
+                the environment holding the project's deployments.
             output_json: If True, emit machine-readable JSON.
         """
         from poly.output.console import error, print_deployment_show
 
         project = load_project(base_path, output_json=output_json)
+        if environment is None:
+            environment = "live" if project.using_simplified_deployments else "sandbox"
         env_versions, active_deployment_hashes = project.get_deployments(client_env=environment)
 
         if not env_versions:
@@ -585,14 +601,14 @@ class DeploymentsCommand(BaseCommand):
         if version_idx < len(env_versions) - 1:
             predecessor_full_hash = env_versions[version_idx + 1].get("version_hash", "")
 
-        # Resolve included deployments from sandbox (the linear history)
+        # Resolve included deployments from the environment holding the linear history
         if environment == "sandbox":
-            sandbox_versions = env_versions
+            history_versions = env_versions
         else:
-            sandbox_versions, _ = project.get_deployments(client_env="sandbox")
+            history_versions, _ = project.get_deployments(client_env="sandbox")
 
         included, is_rollback = cls._resolve_included_deployments(
-            sandbox_versions, target_full_hash, predecessor_full_hash
+            history_versions, target_full_hash, predecessor_full_hash
         )
 
         if output_json:
@@ -639,6 +655,21 @@ class DeploymentsCommand(BaseCommand):
 
         result: dict = {"success": False, "to_env": to_env}
         deployment_hash = None
+
+        # Under simplified deployments the sandbox -> pre-release -> live ladder no
+        # longer exists: merging to main deploys straight to live, and sandbox is
+        # frozen at its pre-migration state. The platform does not reject promotions,
+        # so without this guard promoting would republish stale content to production.
+        if project.using_simplified_deployments:
+            msg = (
+                "'poly deployments promote' is not available for projects using simplified"
+                " deployments. Merging to main deploys directly to live."
+            )
+            if output_json:
+                json_print({**result, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
 
         if to_env not in ["pre-release", "live"]:
             msg = f"Invalid target environment '{to_env}'. Must be 'pre-release' or 'live'."
@@ -747,14 +778,19 @@ class DeploymentsCommand(BaseCommand):
         output_json: bool = False,
         dry_run: bool = False,
     ) -> None:
-        """Rollback sandbox/main to a previous deployment."""
+        """Rollback main to a previous deployment.
+
+        Targets live for projects using simplified deployments — where main tracks live
+        and the platform only accepts live rollback targets — and sandbox otherwise.
+        """
         import questionary
 
         from poly.output.console import error, plain, print_deployments, success, warning
 
         project = load_project(base_path, output_json=output_json)
 
-        versions, active_deployment_hashes = project.get_deployments("sandbox")
+        environment = "live" if project.using_simplified_deployments else "sandbox"
+        versions, active_deployment_hashes = project.get_deployments(environment)
 
         # Resolve deployment to full version hash
         if deployment in active_deployment_hashes:
@@ -768,7 +804,7 @@ class DeploymentsCommand(BaseCommand):
         )
 
         if not deployment_version:
-            msg = f"Deployment '{deployment}' not found in sandbox."
+            msg = f"Deployment '{deployment}' not found in {environment}."
             if output_json:
                 json_print({"success": False, "error": msg})
             else:
@@ -778,12 +814,10 @@ class DeploymentsCommand(BaseCommand):
         deployment_metadata = deployment_version.get("deployment_metadata", {})
         deployment_message = deployment_metadata.get("deployment_message")
 
-        # Resolve reverted deployments (current sandbox -> target)
+        # Resolve reverted deployments (current deployment -> target)
         target_full_hash = deployment_version.get("version_hash", "")
-        current_sandbox_hash = active_deployment_hashes.get("sandbox")
-        reverted, _ = cls._resolve_included_deployments(
-            versions, current_sandbox_hash, target_full_hash
-        )
+        current_hash = active_deployment_hashes.get(environment)
+        reverted, _ = cls._resolve_included_deployments(versions, current_hash, target_full_hash)
 
         result = {
             "success": False,
@@ -794,7 +828,7 @@ class DeploymentsCommand(BaseCommand):
 
         if not output_json:
             plain(
-                f"Rolling back sandbox to deployment "
+                f"Rolling back {environment} to deployment "
                 f"'[bold]{target_full_hash[:9]}[/bold]: {deployment_message or '-'}'"
             )
             if reverted:
@@ -820,7 +854,7 @@ class DeploymentsCommand(BaseCommand):
             if output_json:
                 json_print({**result, "success": True})
             else:
-                success(f"Sandbox rolled back to deployment {deployment}.")
+                success(f"{environment.capitalize()} rolled back to deployment {deployment}.")
         except Exception as e:
             if output_json:
                 json_print({**result, "error": str(e)})

--- a/src/poly/cli_commands/shared.py
+++ b/src/poly/cli_commands/shared.py
@@ -243,3 +243,27 @@ def print_project_file_changes(
 
     if not modified_files and not new_files and not deleted_files and not files_with_conflicts:
         plain("\n[muted]No changes detected.[/muted]")
+
+
+def require_deployment_simplification(
+    project: AgentStudioProject, output_json: bool = False
+) -> None:
+    """Check if the project is using deployment simplification and exit if not.
+
+    Args:
+        project: The loaded project.
+        output_json: If True, output JSON and exit on failure.
+    """
+    from poly.output.console import error
+
+    if not project.using_simplified_deployments:
+        if output_json:
+            json_print(
+                {
+                    "success": False,
+                    "error": "Command is only available for projects using simplified deployments.",
+                }
+            )
+        else:
+            error("Command is only available for projects using simplified deployments.")
+        sys.exit(1)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1218,3 +1218,28 @@ class AgentStudioInterface:
             return self.sync_client.rename_branch(new_branch_name)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of archived branch entries.
+        """
+        try:
+            return self.sync_client.list_archived_branches()
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def restore_branch(self, branch_id: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id (str): The ID of the branch to restore.
+
+        Returns:
+            bool: True if the branch was restored successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.restore_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1204,3 +1204,17 @@ class AgentStudioInterface:
             return self.sync_client.get_branch_history(branch_name)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch to a new name.
+
+        Args:
+            new_branch_name (str): The new name for the current branch
+
+        Returns:
+            bool: True if the branch was renamed successfully, False otherwise
+        """
+        try:
+            return self.sync_client.rename_branch(new_branch_name)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1230,17 +1230,17 @@ class AgentStudioInterface:
         """
         return PlatformAPIHandler.patch_rtc_variables(region, project_id, client_env, variables)
 
-    def get_branch_history(self, branch_name: str) -> list[dict[str, Any]]:
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
         """Get the history of a specific branch.
 
         Args:
-            branch_name (str): The name of the branch
+            branch_id (str): The ID of the branch
 
         Returns:
             list[dict[str, Any]]: A list of commit history entries for the branch
         """
         try:
-            return self.sync_client.get_branch_history(branch_name)
+            return self.sync_client.get_branch_history(branch_id)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -559,13 +559,13 @@ class AgentStudioInterface:
             self._handle_api_error(e)
 
     def merge_branch(
-        self, message: str, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+        self, message: Optional[str], conflict_resolutions: Optional[list[dict[str, Any]]] = None
     ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
         """Merge the current branch into main.
 
         Args:
-            message (str): The merge commit message
-            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+            message (Optional[str]): The merge commit message
+            conflict_resolutions (Optional[list[dict[str, Any]]]): A list of conflict resolutions. Each resolution should have:
                 - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
                 - strategy: Resolution strategy - "ours", "theirs", or "base"
                 - value: Optional custom value (only used with custom strategy)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -137,6 +137,20 @@ class AgentStudioInterface:
         return PlatformAPIHandler.get_accounts(region)
 
     @staticmethod
+    def get_project(region: str, account_id: str, project_id: str) -> dict[str, Any]:
+        """Get the details of a specific project.
+
+        Args:
+            region (str): The region name
+            account_id (str): The account ID
+            project_id (str): The project ID
+
+        Returns:
+            dict[str, Any]: A dictionary containing the project's details
+        """
+        return PlatformAPIHandler.get_project(region, account_id, project_id)
+
+    @staticmethod
     def get_projects(region: str, account_id: str) -> dict[str, str]:
         """Get the projects for a given account.
 

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1283,6 +1283,34 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
+    def tag_branch(self, branch_id: str) -> bool:
+        """Tag the current branch with a specific tag name.
+
+        Args:
+            branch_id (str): The ID of the branch to tag.
+
+        Returns:
+            bool: True if the branch was tagged successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.tag_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def untag_branch(self, branch_id: str) -> bool:
+        """Remove a specific tag from the current branch.
+
+        Args:
+            branch_id (str): The ID of the branch to untag.
+
+        Returns:
+            bool: True if the branch was untagged successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.untag_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
     def feature_flag_enabled(
         self,
         key: str,

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -562,6 +562,27 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
+    def sync_branch(
+        self, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Sync the current branch with it's parent.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            success (bool): True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflict information if the merge failed, empty list if successful
+            list[dict[str, str]]: A list of error information if the merge failed, empty list if successful
+        """
+        try:
+            return self.sync_client.sync_branch(conflict_resolutions)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
     def delete_branch(self, branch_id: str) -> bool:
         """Delete a branch in the project.
 

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1190,3 +1190,17 @@ class AgentStudioInterface:
             dict: The updated RTC config.
         """
         return PlatformAPIHandler.patch_rtc_variables(region, project_id, client_env, variables)
+
+    def get_branch_history(self, branch_name: str) -> list[dict[str, Any]]:
+        """Get the history of a specific branch.
+
+        Args:
+            branch_name (str): The name of the branch
+
+        Returns:
+            list[dict[str, Any]]: A list of commit history entries for the branch
+        """
+        try:
+            return self.sync_client.get_branch_history(branch_name)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -10,6 +10,7 @@ import requests
 from google.protobuf.message import Message
 
 from poly.handlers.platform_api import PlatformAPIHandler
+from poly.handlers.posthog import PosthogHandler
 from poly.handlers.protobuf.commands_pb2 import Command
 from poly.handlers.protobuf.handoff_pb2 import Handoff_SetDefault
 from poly.handlers.sdk import SourcererAPIError
@@ -1281,3 +1282,30 @@ class AgentStudioInterface:
             return self.sync_client.restore_branch(branch_id)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
+
+    def feature_flag_enabled(
+        self,
+        key: str,
+        identity: Optional[str] = None,
+        region: Optional[str] = None,
+        project_id: Optional[str] = None,
+        default: bool = False,
+    ) -> bool:
+        """Check if a feature flag is enabled for a given identity.
+
+        Args:
+            key (str): The feature flag key to check.
+            identity (Optional[str]): The unique identifier for the user or entity.
+            region (Optional[str]): The region name for grouping.
+            project_id (Optional[str]): The project ID for grouping.
+            default (bool): The default value to return if the flag cannot be evaluated.
+
+        Returns:
+            bool: True if the feature flag is enabled, False otherwise.
+        """
+        return PosthogHandler.is_feature_enabled(
+            region=region,
+            key=key,
+            default=default,
+            project_id=project_id,
+        )

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -526,17 +526,20 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
-    def create_branch(self, branch_name: Optional[str] = None) -> str:
+    def create_branch(
+        self, branch_name: Optional[str] = None, source_branch_id: Optional[str] = None
+    ) -> str:
         """Create a new branch in the project.
 
         Args:
             branch_name (str): The name of the new branch
+            source_branch_id (str): The ID of the source branch to create the new branch from. Defaults to 'main' if not provided.
 
         Returns:
             str: The ID of the newly created branch
         """
         try:
-            return self.sync_client.create_branch(branch_name)
+            return self.sync_client.create_branch(branch_name, source_branch_id=source_branch_id)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -17,6 +17,7 @@ from poly.utils import any_credentials_exist, retrieve_api_key
 logger = logging.getLogger(__name__)
 ACCOUNTS_URL = "/adk/v1/accounts"
 PROJECTS_URL = "/adk/v1/accounts/{account_id}/projects"
+PROJECT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}"
 DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments"
 ACTIVE_DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments/active"
 CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat"
@@ -218,6 +219,21 @@ class PlatformAPIHandler:
                 accounts[account.get("id")] = account.get("name")
 
         return accounts
+
+    @staticmethod
+    def get_project(region: str, account_id: str, project_id: str) -> dict:
+        """Get a specific project for a given account.
+
+        Args:
+            region (str): The region name
+            account_id (str): The account ID
+            project_id (str): The project ID
+
+        Returns:
+            dict: The project details
+        """
+        endpoint = PROJECT_URL.format(account_id=account_id, project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
 
     @staticmethod
     def get_projects(region: str, account_id: str) -> dict[str, str]:

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -1,0 +1,103 @@
+"""Client for the PolyAI Posthog tenant, used for feature flags in the PolyAI ADK CLI.
+
+Copyright PolyAI Limited
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+POSTHOG_HOST = "https://eu.i.posthog.com"
+POSTHOG_KEY = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
+FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from posthog import Posthog
+
+_client: Posthog | None = None
+
+region_to_posthog_cluster = {
+    "dev": "apollo",
+}
+
+
+def get_posthog_client() -> Posthog:
+    """Get a Posthog client instance.
+
+    Returns:
+        A Posthog client instance.
+    """
+    from posthog import Posthog
+
+    global _client
+
+    if _client is not None:
+        return _client
+    _client = Posthog(
+        project_api_key=POSTHOG_KEY,
+        host=POSTHOG_HOST,
+        feature_flags_request_timeout_seconds=FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS,
+    )
+    return _client
+
+
+def get_user_identity() -> str:
+    """Get the user identity for Posthog feature flag evaluation.
+
+    Returns:
+        The user identity (distinct_id) for Posthog.
+    """
+    import getpass
+
+    return getpass.getuser()
+
+
+class PosthogHandler:
+    """Handler for feature flags with the PolyAI Posthog tenant."""
+
+    @staticmethod
+    def is_feature_enabled(
+        region: str,
+        key: str,
+        *,
+        default: bool,
+        project_id: str | None = None,
+    ) -> bool:
+        """Evaluate a boolean feature flag against PostHog.
+
+        Args:
+            key: The PostHog feature flag key.
+            default: Returned whenever the flag cannot be evaluated. Pick the
+                safe state for the gated code path.
+            email: The requesting user's email, used as the PostHog
+                distinct_id. Required — without it, percentage rollouts
+                would bucket all reads together, so reads with no email
+                return `default` without evaluating.
+            project_id: The project ID (`project` group key). Workspace
+                targeting goes through the `project` group — the workspace id
+                lives on it as a group property in PostHog.
+
+        Returns:
+            The flag value, or `default` if it cannot be evaluated.
+        """
+        client = get_posthog_client()
+        if not client:
+            return default
+
+        groups = {"cluster": region_to_posthog_cluster.get(region, region)}
+        if project_id:
+            groups["project"] = project_id
+
+        try:
+            result = client.feature_enabled(
+                key,
+                distinct_id=get_user_identity(),
+                groups=groups,
+                send_feature_flag_events=False,
+            )
+        except Exception as exc:
+            logger.warning(f"PostHog flag evaluation failed key={key}", exc_info=exc)
+            return default
+
+        return default if result is None else result

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -67,13 +67,10 @@ class PosthogHandler:
         """Evaluate a boolean feature flag against PostHog.
 
         Args:
+            region: The region the user is in, used to determine the PostHog cluster.
             key: The PostHog feature flag key.
             default: Returned whenever the flag cannot be evaluated. Pick the
                 safe state for the gated code path.
-            email: The requesting user's email, used as the PostHog
-                distinct_id. Required — without it, percentage rollouts
-                would bucket all reads together, so reads with no email
-                return `default` without evaluating.
             project_id: The project ID (`project` group key). Workspace
                 targeting goes through the `project` group — the workspace id
                 lives on it as a group property in PostHog.
@@ -81,15 +78,14 @@ class PosthogHandler:
         Returns:
             The flag value, or `default` if it cannot be evaluated.
         """
-        client = get_posthog_client()
-        if not client:
-            return default
-
-        groups = {"cluster": region_to_posthog_cluster.get(region, region)}
-        if project_id:
-            groups["project"] = project_id
-
         try:
+            client = get_posthog_client()
+            if not client:
+                return default
+
+            groups = {"cluster": region_to_posthog_cluster.get(region, region)}
+            if project_id:
+                groups["project"] = project_id
             result = client.feature_enabled(
                 key,
                 distinct_id=get_user_identity(),

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -439,7 +439,7 @@ class SourcererSDK:
             response.raise_for_status()
 
             response_data = response.json()
-            logger.info(f"Branch merged successfully, sequence: {response_data.get('sequence')}")
+            logger.info(f"Branch synced successfully, sequence: {response_data.get('sequence')}")
 
             return response_data
 

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -729,6 +729,59 @@ class SourcererSDK:
                 error_msg = f"Request failed: {e}"
             raise SourcererAPIError(error_msg) from e
 
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            A list of dictionaries containing archived branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/archive"
+            response = self.session.get(url)
+            response.raise_for_status()
+            return response.json().get("branches", [])
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def restore_branch(self, branch_id: str) -> dict[str, Any]:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id: The ID of the branch to restore.
+
+        Returns:
+            A dictionary containing the restored branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/restore"
+            response = self.session.post(url)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
     def rename_branch(self, new_branch_name: str) -> dict[str, Any]:
         """Rename the current branch.
 

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -701,3 +701,30 @@ class SourcererSDK:
             "projection": self._projection_cache,
             "last_known_sequence": self._last_known_sequence,
         }
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of commands for a specific branch.
+
+        Args:
+            branch_id: The branch ID to fetch history for.
+
+        Returns:
+            A list of dictionaries containing commit information for the branch.
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/merge-history"
+            response = self.session.get(url)
+            response.raise_for_status()
+            return response.json().get("merges", [])
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -152,7 +152,7 @@ class SourcererSDK:
         return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/merge"
 
     def _get_branch_sync_url(self) -> str:
-        """Get the branch merge endpoint URL"""
+        """Get the branch sync endpoint URL"""
         return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/sync"
 
     def _initialize_branch(self) -> str:
@@ -356,7 +356,7 @@ class SourcererSDK:
         self,
         conflict_resolutions: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
-        """Merge the parent branch into the current branch
+        """Sync the current branch with its parent
 
         This method merges changes from the current branch's parent into the current branch.
         If conflicts are detected, they will be returned in the response for manual resolution.
@@ -387,14 +387,14 @@ class SourcererSDK:
             SourcererAPIError: If the API request fails or sequence mismatch occurs
 
         Example:
-            # Simple merge without conflicts
-            result = sdk.merge_branch()
+            # Simple sync without conflicts
+            result = sdk.sync_branch()
             if "hasConflicts" in result and result["hasConflicts"]:
                 print("Conflicts detected:", result["conflicts"])
             else:
-                print("Merge successful, sequence:", result["sequence"])
+                print("Sync successful, sequence:", result["sequence"])
 
-            # Merge with conflict resolution
+            # Sync with conflict resolution
             resolutions = [
                 {
                     "path": ["users", "1", "name"],
@@ -405,7 +405,7 @@ class SourcererSDK:
                     "strategy": "theirs",
                 }
             ]
-            result = sdk.merge_branch(
+            result = sdk.sync_branch(
                 conflict_resolutions=resolutions
             )
         """

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -925,3 +925,61 @@ class SourcererSDK:
             else:
                 error_msg = f"Request failed: {e}"
             raise SourcererAPIError(error_msg) from e
+
+    def tag_branch(self, branch_id: str) -> dict[str, Any]:
+        """Tag a branch for staging
+
+        Args:
+            branch_id: The ID of the branch to tag.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/tag"
+            payload = {"tag": "staging"}
+            response = self.session.put(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def untag_branch(self, branch_id: str) -> dict[str, Any]:
+        """Untag a branch for staging
+
+        Args:
+            branch_id: The ID of the branch to untag.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/tag"
+            response = self.session.delete(url)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -728,3 +728,35 @@ class SourcererSDK:
             else:
                 error_msg = f"Request failed: {e}"
             raise SourcererAPIError(error_msg) from e
+
+    def rename_branch(self, new_branch_name: str) -> dict[str, Any]:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name: The new name for the current branch.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+        if not self.branch_id:
+            raise SourcererAPIError("No current branch found. Cannot rename.")
+
+        try:
+            url = f"{self._get_branches_url()}/{self.branch_id}"
+            payload = {"name": new_branch_name}
+            response = self.session.patch(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -203,12 +203,14 @@ class SourcererSDK:
         self,
         expected_main_last_known_sequence: int = 0,
         branch_name: Optional[str] = None,
+        source_branch_id: Optional[str] = None,
     ) -> str:
         """Create a new branch for the project
 
         Args:
             expected_main_last_known_sequence: The expected sequence number from main branch
             branch_name: Optional name for the branch. If not provided, will generate a default name
+            source_branch_id: Optional source branch ID to create the new branch from. Defaults to main if not provided.
 
         Returns:
             The ID of the created branch
@@ -225,6 +227,10 @@ class SourcererSDK:
                 "expectedMainLastKnownSequence": expected_main_last_known_sequence,
                 "branchName": branch_name or f"sdk-branch-{os.urandom(4).hex()}",
             }
+
+            if source_branch_id is not None and source_branch_id != "main":
+                payload["sourceBranchId"] = source_branch_id
+
             response = self.session.post(self._get_branches_url(), json=payload)
             response.raise_for_status()
             branch_data = response.json()

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -309,8 +309,10 @@ class SourcererSDK:
         try:
             payload = {
                 "expectedBranchLastKnownSequence": self.get_last_known_sequence() or 0,
-                "deploymentMessage": deployment_message,
             }
+
+            if deployment_message:
+                payload["deploymentMessage"] = deployment_message
 
             if conflict_resolutions is not None:
                 payload["conflictResolutions"] = conflict_resolutions

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -151,6 +151,10 @@ class SourcererSDK:
         """Get the branch merge endpoint URL"""
         return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/merge"
 
+    def _get_branch_sync_url(self) -> str:
+        """Get the branch merge endpoint URL"""
+        return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/sync"
+
     def _initialize_branch(self) -> str:
         """Initialize branch_id by fetching existing branches or creating a new one"""
         try:
@@ -241,9 +245,9 @@ class SourcererSDK:
         deployment_message: str = "",
         conflict_resolutions: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
-        """Merge the current branch into the main branch
+        """Merge the current branch into the parent branch
 
-        This method merges changes from the current branch into the main branch.
+        This method merges changes from the current branch into it's parent branch.
         If conflicts are detected, they will be returned in the response for manual resolution.
         Once conflicts are resolved, call this method again with the conflict_resolutions parameter.
 
@@ -309,6 +313,108 @@ class SourcererSDK:
             logger.debug(f"Merge payload: {payload}")
 
             response = self.session.post(self._get_branch_merge_url(), json=payload)
+
+            # Handle conflict response (400 status with conflicts data)
+            if response.status_code == 400:
+                try:
+                    response_data = response.json()
+                    # Check if this is a conflict response
+                    if "conflicts" in response_data or "hasConflicts" in response_data:
+                        return response_data
+                    # Otherwise, it's a different error
+                    error_msg = f"API Error 400: {response_data}"
+                    raise SourcererAPIError(error_msg)
+                except (ValueError, KeyError):
+                    error_msg = f"API Error 400: {response.text}"
+                    raise SourcererAPIError(error_msg)
+
+            response.raise_for_status()
+
+            response_data = response.json()
+            logger.info(f"Branch merged successfully, sequence: {response_data.get('sequence')}")
+
+            return response_data
+
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def sync_branch(
+        self,
+        conflict_resolutions: Optional[list[dict[str, Any]]] = None,
+    ) -> dict[str, Any]:
+        """Merge the parent branch into the current branch
+
+        This method merges changes from the current branch's parent into the current branch.
+        If conflicts are detected, they will be returned in the response for manual resolution.
+        Once conflicts are resolved, call this method again with the conflict_resolutions parameter.
+
+        Args:
+            conflict_resolutions: Optional list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            Dictionary containing:
+            - If successful:
+                - sequence: The new sequence number after merge (as string)
+                - message: Success message
+                - testRunIds: List of test run IDs that were triggered
+            - If conflicts detected:
+                - hasConflicts: True
+                - conflicts: List of conflict objects, each containing:
+                    - path: Path to the conflicted field
+                    - baseValue: Original value from base
+                    - oursValue: Value from main branch
+                    - theirsValue: Value from the branch being merged
+                    - type: Type of conflict ("add", "modify", or "delete")
+
+        Raises:
+            SourcererAPIError: If the API request fails or sequence mismatch occurs
+
+        Example:
+            # Simple merge without conflicts
+            result = sdk.merge_branch()
+            if "hasConflicts" in result and result["hasConflicts"]:
+                print("Conflicts detected:", result["conflicts"])
+            else:
+                print("Merge successful, sequence:", result["sequence"])
+
+            # Merge with conflict resolution
+            resolutions = [
+                {
+                    "path": ["users", "1", "name"],
+                    "strategy": "ours",
+                },
+                {
+                    "path": ["settings", "theme"],
+                    "strategy": "theirs",
+                }
+            ]
+            result = sdk.merge_branch(
+                conflict_resolutions=resolutions
+            )
+        """
+        try:
+            payload = {
+                "expectedBranchSequence": self.get_last_known_sequence() or 0,
+            }
+
+            if conflict_resolutions is not None:
+                payload["conflictResolutions"] = conflict_resolutions
+
+            logger.info(f"Sync branch {self.branch_id} with parent")
+            logger.debug(f"Sync payload: {payload}")
+
+            response = self.session.post(self._get_branch_sync_url(), json=payload)
 
             # Handle conflict response (400 status with conflicts data)
             if response.status_code == 400:

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -373,3 +373,34 @@ class SyncClientHandler:
 
         logger.info(f"Successfully renamed branch ID:'{self.sdk.branch_id}' to '{new_branch_name}'")
         return True
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of dictionaries containing archived branch information.
+        """
+        logger.info("Fetching archived branches")
+        branches = self.sdk.list_archived_branches()
+        logger.info(f"Fetched {len(branches)} archived branches")
+        return branches
+
+    def restore_branch(self, branch_id: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id (str): The ID of the branch to restore.
+
+        Returns:
+            bool: True if the restore was successful, False otherwise.
+        """
+        logger.info(f"Restoring branch ID:'{branch_id}'")
+
+        try:
+            self.sdk.restore_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to restore branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully restored branch ID:'{branch_id}'")
+        return True

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -291,13 +291,13 @@ class SyncClientHandler:
         return True
 
     def merge_branch(
-        self, message: str, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+        self, message: Optional[str], conflict_resolutions: Optional[list[dict[str, Any]]] = None
     ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
         """Merge the current branch into its parent branch.
 
         Args:
-            message (str): The merge commit message
-            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+            message (Optional[str]): The merge commit message
+            conflict_resolutions (Optional[list[dict[str, Any]]]): A list of conflict resolutions. Each resolution should have:
                 - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
                 - strategy: Resolution strategy - "ours", "theirs", or "base"
                 - value: Optional custom value (only used with custom strategy)

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -329,6 +329,49 @@ class SyncClientHandler:
         logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into 'main'")
         return True, [], []
 
+    def sync_branch(
+        self, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Merge the parent branch into the current branch.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            success (bool): True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflict information if the merge failed, empty list if successful
+            list[dict[str, str]]: A list of error information if the merge failed, empty list if successful
+        """
+        self.assert_branch_exists()
+
+        if self.sdk.branch_id == "main":
+            logger.error("Cannot sync 'main' branch into")
+            return False, [], []
+
+        logger.info(f"Merging parent into '{self.sdk.branch_id}'")
+
+        try:
+            result = self.sdk.sync_branch(
+                conflict_resolutions=conflict_resolutions,
+            )
+        except SourcererAPIError as e:
+            logger.error(f"Failed to sync branch '{self.sdk.branch_id}': {e}")
+            return False, [], []
+
+        if result.get("hasConflicts", False) or result.get("errors", []):
+            logger.info(
+                f"Failed to sync branch '{self.sdk.branch_id}' to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
+            )
+            conflicts = result.get("conflicts", [])
+            errors = result.get("errors", [])
+            return False, conflicts, errors
+
+        logger.info(f"Successfully synced branch '{self.sdk.branch_id}'")
+        return True, [], []
+
     def get_branch_chat_info(self, branch_id: str) -> dict[str, Any]:
         """Get deployment info needed to start a draft chat on a branch."""
         self.assert_branch_exists()

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -347,3 +347,29 @@ class SyncClientHandler:
         history = self.sdk.get_branch_history(branch_id)
         logger.info(f"Fetched {len(history)} commits for branch ID:'{branch_id}'")
         return history
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name (str): The new name for the current branch.
+
+        Returns:
+            bool: True if the rename was successful, False otherwise.
+        """
+        self.assert_branch_exists()
+
+        if self.sdk.branch_id == "main":
+            logger.error("Cannot rename 'main' branch.")
+            return False
+
+        logger.info(f"Renaming branch ID:'{self.sdk.branch_id}' to '{new_branch_name}'")
+
+        try:
+            self.sdk.rename_branch(new_branch_name=new_branch_name)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to rename branch ID:'{self.sdk.branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully renamed branch ID:'{self.sdk.branch_id}' to '{new_branch_name}'")
+        return True

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -356,7 +356,7 @@ class SyncClientHandler:
         self.assert_branch_exists()
 
         if self.sdk.branch_id == "main":
-            logger.error("Cannot sync 'main' branch into")
+            logger.error("Cannot sync 'main' branch — it has no parent to sync from.")
             return False, [], []
 
         logger.info(f"Merging parent into '{self.sdk.branch_id}'")

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -293,7 +293,7 @@ class SyncClientHandler:
     def merge_branch(
         self, message: str, conflict_resolutions: Optional[list[dict[str, Any]]] = None
     ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
-        """Merge the current branch into main.
+        """Merge the current branch into its parent branch.
 
         Args:
             message (str): The merge commit message
@@ -313,7 +313,7 @@ class SyncClientHandler:
             logger.error("Cannot merge 'main' branch into itself.")
             return False, [], []
 
-        logger.info(f"Merging branch '{self.sdk.branch_id}' into 'main'")
+        logger.info(f"Merging branch '{self.sdk.branch_id}' into its parent branch")
 
         try:
             result = self.sdk.merge_branch(
@@ -321,18 +321,20 @@ class SyncClientHandler:
                 conflict_resolutions=conflict_resolutions,
             )
         except SourcererAPIError as e:
-            logger.error(f"Failed to merge branch '{self.sdk.branch_id}' into 'main': {e}")
+            logger.error(
+                f"Failed to merge branch '{self.sdk.branch_id}' into its parent branch: {e}"
+            )
             return False, [], []
 
         if result.get("hasConflicts", False) or result.get("errors", []):
             logger.info(
-                f"Failed to merge branch '{self.sdk.branch_id}' into 'main' due to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
+                f"Failed to merge branch '{self.sdk.branch_id}' into its parent branch due to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
             )
             conflicts = result.get("conflicts", [])
             errors = result.get("errors", [])
             return False, conflicts, errors
 
-        logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into 'main'")
+        logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into its parent branch")
         return True, [], []
 
     def sync_branch(

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -455,3 +455,41 @@ class SyncClientHandler:
 
         logger.info(f"Successfully restored branch ID:'{branch_id}'")
         return True
+
+    def tag_branch(self, branch_id: str) -> bool:
+        """Tag a branch with staging tag
+
+        Args:
+            branch_id (str): The ID of the branch to tag.
+        Returns:
+            bool: True if the tagging was successful, False otherwise.
+        """
+        logger.info(f"Tagging branch ID:'{branch_id}' with staging tag")
+
+        try:
+            self.sdk.tag_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to tag branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully tagged branch ID:'{branch_id}' with staging tag")
+        return True
+
+    def untag_branch(self, branch_id: str) -> bool:
+        """Remove staging tag from a branch
+
+        Args:
+            branch_id (str): The ID of the branch to untag.
+        Returns:
+            bool: True if the untagging was successful, False otherwise.
+        """
+        logger.info(f"Removing staging tag from branch ID:'{branch_id}'")
+
+        try:
+            self.sdk.untag_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to remove staging tag from branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully removed staging tag from branch ID:'{branch_id}'")
+        return True

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -333,3 +333,17 @@ class SyncClientHandler:
         """Get deployment info needed to start a draft chat on a branch."""
         self.assert_branch_exists()
         return self.sdk.get_branch_chat_info(branch_id)
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of a specific branch.
+
+        Args:
+            branch_id (str): The ID of the branch to retrieve history for.
+
+        Returns:
+            list[dict[str, Any]]: A list of dictionaries containing commit information for the branch.
+        """
+        logger.info(f"Fetching history for branch ID:'{branch_id}'")
+        history = self.sdk.get_branch_history(branch_id)
+        logger.info(f"Fetched {len(history)} commits for branch ID:'{branch_id}'")
+        return history

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -209,7 +209,9 @@ class SyncClientHandler:
                 return False
         return False
 
-    def create_branch(self, branch_name: Optional[str] = None) -> str:
+    def create_branch(
+        self, branch_name: Optional[str] = None, source_branch_id: Optional[str] = None
+    ) -> str:
         """Create a new branch for the project
 
         Args:
@@ -218,8 +220,9 @@ class SyncClientHandler:
         Returns:
             The ID of the created branch
         """
-        self.sdk.branch_id = "main"
-        self.sdk.get_project_data()
+        sequence_number = self.sdk.fetch_last_known_sequence_number(
+            branch_id=source_branch_id or "main"
+        )
 
         if branch_name is None:
             metadata = self.sdk.create_metadata()
@@ -228,11 +231,14 @@ class SyncClientHandler:
             suffix = f"{time_suffix}-{random_suffix}"  # to avoid duplicate names
             branch_name = f"ADK-{suffix}"
 
-        logger.info(f"Creating new branch '{branch_name}' from 'main' branch")
+        logger.info(
+            f"Creating new branch '{branch_name}' from branch '{source_branch_id or 'main'}'"
+        )
 
         self.sdk.branch_id = self.sdk.create_branch(
-            expected_main_last_known_sequence=self.sdk._last_known_sequence,
+            expected_main_last_known_sequence=sequence_number,
             branch_name=branch_name,
+            source_branch_id=source_branch_id,
         )
         logger.info(
             f"Created and switched to new branch. Name:'{branch_name}' ID:'{self.sdk.branch_id}'"

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -158,6 +158,29 @@ def print_branches(branches: dict[str, Any] | list[str], current_branch: str | N
             console.print(f"    {name}")
 
 
+# {'merges': [{'branchId': 'BRANCH-RLX9GX78', 'branchName': 'Ruari Phipps / Release', 'mergedBy': 'ruari@poly-ai.com', 'mergedAt': '2026-07-21T14:07:06.909Z', 'source': None}], 'count': 1}
+def print_branch_history(commits: list[dict[str, Any]]) -> None:
+    """Print a table of branch history commits."""
+    if not commits:
+        console.print("[muted]No commits found for this branch.[/muted]")
+        return
+
+    table = Table(box=None, show_header=False, header_style="bold", padding=(0, 1))
+    table.add_column("Merged At", no_wrap=True)
+    table.add_column("Branch", no_wrap=True)
+    table.add_column("Merged By", no_wrap=True)
+
+    for commit in commits:
+        merged_at = _format_iso_timestamp(commit.get("mergedAt", ""))
+        table.add_row(
+            merged_at,
+            commit.get("branchName", "—"),
+            commit.get("mergedBy", "—"),
+        )
+
+    console.print(table)
+
+
 def print_validation_errors(errors: list[str]) -> None:
     """Print validation errors in a styled list."""
     console.print("[error]Project configuration is invalid.[/error]")

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -805,9 +805,7 @@ def print_deployment_show(
     console.print(f"Message: {deployment_message}")
     console.print()
 
-    if not included_deployments:
-        console.print("[muted]No intermediate deployments.[/muted]")
-    else:
+    if included_deployments:
         count = len(included_deployments)
         label = "Reverted deployments" if is_rollback else "Included deployments"
         console.print(f"[label]{label} ({count}):[/label]")

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -159,6 +159,28 @@ def print_branches(branches: dict[str, Any] | list[str], current_branch: str | N
 
 
 # {'merges': [{'branchId': 'BRANCH-RLX9GX78', 'branchName': 'Ruari Phipps / Release', 'mergedBy': 'ruari@poly-ai.com', 'mergedAt': '2026-07-21T14:07:06.909Z', 'source': None}], 'count': 1}
+def print_archived_branches(branches: list[dict[str, Any]]) -> None:
+    """Print a table of archived (soft-deleted) branches."""
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("Branch", no_wrap=True)
+    table.add_column("ID", style="muted", no_wrap=True)
+    table.add_column("Archived", no_wrap=True)
+    table.add_column("Expires", no_wrap=True)
+
+    for branch in branches:
+        archived_at = _format_iso_timestamp(branch.get("archivedAt", ""))
+        days_left = branch.get("daysLeft")
+        expires = f"{days_left} days left" if days_left is not None else "—"
+        table.add_row(
+            branch.get("name", "—"),
+            branch.get("branchId", "—"),
+            archived_at,
+            expires,
+        )
+
+    console.print(table)
+
+
 def print_branch_history(commits: list[dict[str, Any]]) -> None:
     """Print a table of branch history commits."""
     if not commits:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -236,13 +236,55 @@ def print_branches(branches: dict[str, Any] | list[str], current_branch: str | N
             console.print(f"    {name}")
 
 
-def print_archived_branches(branches: list[dict[str, Any]]) -> None:
-    """Print a table of archived (soft-deleted) branches."""
+def resolve_parent_branch_label(
+    branch: dict[str, Any],
+    name_by_branch_id: dict[str, str] | None = None,
+    archived_branch_ids: set[str] | None = None,
+) -> str:
+    """Describe an archived branch's parent for display.
+
+    Archived branches carry only a ``parentBranchId``, which is meaningless to a
+    user. Resolve it to a name where possible: ``main`` stands for itself, other
+    ids are looked up in ``name_by_branch_id`` (built from the archive itself and,
+    where needed, the active branches). An id with no known name falls back to the
+    id so the row is never silently blank.
+
+    A parent that is itself archived is marked ``(archived)`` — restoring a child
+    does not bring its parent back, so that distinction is load-bearing.
+
+    Returns plain text, not markup: this also labels the interactive restore
+    picker, which renders literally.
+    """
+    parent_branch_id = branch.get("parentBranchId")
+    if not parent_branch_id:
+        return "—"
+    if parent_branch_id == "main":
+        return "main"
+
+    label = (name_by_branch_id or {}).get(parent_branch_id, parent_branch_id)
+    if parent_branch_id in (archived_branch_ids or set()):
+        return f"{label} (archived)"
+    return label
+
+
+def print_archived_branches(
+    branches: list[dict[str, Any]], name_by_branch_id: dict[str, str] | None = None
+) -> None:
+    """Print a table of archived (soft-deleted) branches.
+
+    Args:
+        branches: Archived branch entries as returned by the platform.
+        name_by_branch_id: Branch id to name, used to render each row's parent.
+    """
     table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
     table.add_column("Branch", no_wrap=True)
     table.add_column("ID", style="muted", no_wrap=True)
+    table.add_column("Parent", no_wrap=True)
     table.add_column("Archived", no_wrap=True)
     table.add_column("Expires", no_wrap=True)
+
+    # Derived here rather than passed in so it cannot drift from the rows shown.
+    archived_branch_ids = {b["branchId"] for b in branches if b.get("branchId")}
 
     for branch in branches:
         archived_at = _format_iso_timestamp(branch.get("archivedAt", ""))
@@ -251,6 +293,7 @@ def print_archived_branches(branches: list[dict[str, Any]]) -> None:
         table.add_row(
             branch.get("name", "—"),
             branch.get("branchId", "—"),
+            resolve_parent_branch_label(branch, name_by_branch_id, archived_branch_ids),
             archived_at,
             expires,
         )

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -188,6 +188,37 @@ def print_releases_branches(branches: dict[str, Any], current_branch: str | None
     console.print(tree)
 
 
+def flatten_branch_tree(
+    branches: dict[str, Any], current_branch: str | None
+) -> list[tuple[str, str]]:
+    """Flatten the parent/child branch tree into (display_title, branch_name) pairs.
+
+    For use in flat pickers (e.g. questionary) that have no native tree rendering —
+    hierarchy is conveyed via indentation and connector characters in the title,
+    while the value stays the plain branch name.
+    """
+
+    def label(name: str) -> str:
+        return f"{name} (current)" if name == current_branch else name
+
+    def walk(nodes: list[dict[str, Any]], indent: str) -> list[tuple[str, str]]:
+        lines = []
+        nodes = sorted(nodes, key=lambda n: n["name"])
+        for i, node in enumerate(nodes):
+            is_last = i == len(nodes) - 1
+            connector = "└─ " if is_last else "├─ "
+            lines.append((indent + connector + label(node["name"]), node["name"]))
+            extension = "   " if is_last else "│  "
+            lines.extend(walk(node["children"], indent + extension))
+        return lines
+
+    lines = []
+    for root in sorted(_convert_flat_branches_to_tree(branches), key=lambda n: n["name"]):
+        lines.append((label(root["name"]), root["name"]))
+        lines.extend(walk(root["children"], ""))
+    return lines
+
+
 def print_branches(branches: dict[str, Any] | list[str], current_branch: str | None) -> None:
     """Print branch list with current branch highlighted."""
     console.print("[label]Branches:[/label]")

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -172,9 +172,12 @@ def print_releases_branches(branches: dict[str, Any], current_branch: str | None
 
     def label(node: dict[str, Any]) -> str:
         name = node["name"]
+        text = f"[success]{name}[/success]" if name == current_branch else name
+        if tag := node["meta"].get("tag"):
+            text += f" [info]({tag})[/info]"
         if name == current_branch:
-            return f"[success]{name}[/success] [muted](current)[/muted]"
-        return name
+            text += " [muted](current)[/muted]"
+        return text
 
     def add(parent_tree: Tree, node: dict[str, Any]) -> None:
         branch_tree = parent_tree.add(label(node))

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -22,6 +22,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
+from rich.tree import Tree
 
 # Global verbose flag — set by CLI before commands run
 _verbose = False
@@ -147,6 +148,46 @@ def print_agents(agents: list[dict[str, Any]]) -> None:
     console.print(table)
 
 
+def _convert_flat_branches_to_tree(branches: dict[str, Any]) -> list[dict[str, Any]]:
+    """Group a flat branches dict into a forest of nodes linked by parentBranchId.
+
+    Two passes are required: branches can be listed in any order — including a
+    child appearing before its own parent — so every node must exist before any
+    parent lookup runs.
+    """
+    nodes = {
+        meta.get("branchId"): {"name": name, "meta": meta, "children": []}
+        for name, meta in branches.items()
+    }
+
+    roots = []
+    for node in nodes.values():
+        parent = nodes.get(node["meta"].get("parentBranchId"))
+        (parent["children"] if parent is not None else roots).append(node)
+    return roots
+
+
+def print_releases_branches(branches: dict[str, Any], current_branch: str | None) -> None:
+    """Print branches as a tree reflecting parent/child (branch-from-branch) relationships."""
+
+    def label(node: dict[str, Any]) -> str:
+        name = node["name"]
+        if name == current_branch:
+            return f"[success]{name}[/success] [muted](current)[/muted]"
+        return name
+
+    def add(parent_tree: Tree, node: dict[str, Any]) -> None:
+        branch_tree = parent_tree.add(label(node))
+        for child in sorted(node["children"], key=lambda n: n["name"]):
+            add(branch_tree, child)
+
+    console.print("[label]Branches:[/label]")
+    tree = Tree("", hide_root=True, guide_style="dim")
+    for root in sorted(_convert_flat_branches_to_tree(branches), key=lambda n: n["name"]):
+        add(tree, root)
+    console.print(tree)
+
+
 def print_branches(branches: dict[str, Any] | list[str], current_branch: str | None) -> None:
     """Print branch list with current branch highlighted."""
     console.print("[label]Branches:[/label]")
@@ -158,7 +199,6 @@ def print_branches(branches: dict[str, Any] | list[str], current_branch: str | N
             console.print(f"    {name}")
 
 
-# {'merges': [{'branchId': 'BRANCH-RLX9GX78', 'branchName': 'Ruari Phipps / Release', 'mergedBy': 'ruari@poly-ai.com', 'mergedAt': '2026-07-21T14:07:06.909Z', 'source': None}], 'count': 1}
 def print_archived_branches(branches: list[dict[str, Any]]) -> None:
     """Print a table of archived (soft-deleted) branches."""
     table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2730,12 +2730,12 @@ class AgentStudioProject:
         return validation_errors
 
     def merge_branch(
-        self, message: str, conflict_resolutions: list[dict[str, Any]] = None
+        self, message: Optional[str], conflict_resolutions: list[dict[str, Any]] = None
     ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
         """Merge the current branch into main in the project.
 
         Args:
-            message (str): The merge commit message.
+            message (Optional[str]): The merge commit message.
             conflict_resolutions (list[dict[str, Any]]): A list of conflict
                 resolutions. Each resolution should have:
                 - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3568,34 +3568,30 @@ class AgentStudioProject:
         """
         return self.api_handler.list_archived_branches()
 
-    def restore_branch(self, branch_name: str) -> bool:
+    def restore_branch(self, branch_id: str) -> bool:
         """Restore a soft-deleted branch from the archive.
 
+        Identified by id rather than name because archived names are not unique —
+        the same branch name can be archived repeatedly. Use
+        ``list_archived_branches`` to find the id.
+
         Args:
-            branch_name (str): The name of the branch to restore.
+            branch_id (str): The branch id of the archived branch to restore.
 
         Returns:
             bool: True if the branch was restored successfully, False otherwise.
         """
-        if not branch_name:
-            raise ValueError("Branch name must be provided.")
+        if not branch_id:
+            raise ValueError("Branch id must be provided.")
 
         archived = self.api_handler.list_archived_branches()
-        matches = [b for b in archived if b.get("name") == branch_name]
-        if not matches:
+        if not any(branch.get("branchId") == branch_id for branch in archived):
             raise ValueError(
-                f"Branch '{branch_name}' not found in archive. "
+                f"Branch '{branch_id}' not found in archive. "
                 "Use 'poly branch list --archived' to see available branches."
             )
 
-        if len(matches) > 1:
-            branch_ids = ", ".join(b["branchId"] for b in matches)
-            raise ValueError(
-                f"Multiple archived branches named '{branch_name}' found ({branch_ids}). "
-                "Use the interactive picker (poly branch restore) to select the correct one."
-            )
-
-        return self.api_handler.restore_branch(matches[0]["branchId"])
+        return self.api_handler.restore_branch(branch_id)
 
     def tag_branch(self, branch_name: str = None) -> bool:
         """Tag the current branch with a new tag.

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -113,7 +113,7 @@ class AgentStudioProject:
     file_structure_info: dict[str, dict[str, str]] = None
     _migration_flags: set[MigrationFlag] = None
     rtc_metadata: Optional[dict[str, dict]] = None
-    __deployment_mode: Optional[DeploymentMode] = None
+    _deployment_mode: Optional[DeploymentMode] = None
 
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
@@ -2747,11 +2747,15 @@ class AgentStudioProject:
             message=message, conflict_resolutions=conflict_resolutions
         )
         if success:
-            parent_branch_id = current_branch_meta.get("parentBranchId") or "main"
+            parent_branch_id = current_branch_meta.get("parentBranchId")
             parent_branch_meta = branch_meta.get(parent_branch_id) or {}
-            parent_branch_name = parent_branch_meta.get("name") or "main"
-            self.switch_branch(parent_branch_name, force=True)
-            return True, [], []
+            parent_branch_name = parent_branch_meta.get("name")
+            if not parent_branch_name:
+                raise ValueError(
+                    f"Could not find parent branch name for branch ID {parent_branch_id}."
+                )
+            success, _ = self.switch_branch(parent_branch_name, force=True)
+            return success, [], []
 
         return False, conflicts, errors
 
@@ -3657,10 +3661,10 @@ class AgentStudioProject:
 
     @property
     def deployment_mode(self) -> DeploymentMode:
-        if self.__deployment_mode is None:
+        if self._deployment_mode is None:
             cfg = self.get_project_info().get("config") or {}
-            self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
-        return self.__deployment_mode
+            self._deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
+        return self._deployment_mode
 
     @cached_property
     def using_simplified_deployments(self) -> bool:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2274,43 +2274,61 @@ class AgentStudioProject:
         )
         return current_branch, branches
 
-    def create_branch(self, branch_name: str = None) -> str:
+    def create_branch(
+        self, branch_name: str = None, source_branch_name: Optional[str] = None
+    ) -> str:
         """Create a new branch in the project.
 
         Args:
             branch_name (str): The name of the new branch
+            source_branch_name (str): Name of the branch to create the new branch from.
+                Defaults to the current branch.
 
         Returns:
             str: The ID of the newly created branch
 
         Raises:
-            ValueError: If the branch cannot be created due to deployment mode restrictions
+            ValueError: If the branch cannot be created due to deployment mode restrictions,
+                or source_branch_name does not exist.
         """
-        if self.deployment_mode == DeploymentMode.SIMPLE:
+        branches = None
+        if source_branch_name is not None or self.deployment_mode in (
+            DeploymentMode.SIMPLE,
+            DeploymentMode.RELEASES_BRANCHES,
+        ):
             branches = self.api_handler.get_branches()
+
+        if source_branch_name is not None:
+            if source_branch_name not in branches:
+                raise ValueError(f"Branch '{source_branch_name}' does not exist.")
+            source_branch_id = branches[source_branch_name]["branchId"]
+        else:
+            source_branch_id = self.branch_id
+
+        if self.deployment_mode == DeploymentMode.SIMPLE:
             if len(branches) >= 2:
                 raise ValueError(
                     "Cannot create branch. Only one branch is allowed in simple deployment mode. Please delete/merge existing branches before creating a new one."
                 )
         if self.deployment_mode == DeploymentMode.RELEASES:
-            if self.branch_id != "main":
+            if source_branch_id != "main":
                 raise ValueError(
                     "Cannot create branch. Branches can only be created from the main branch in releases deployment mode."
                 )
         if self.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
-            branches = self.api_handler.get_branches()
-            current_branch_meta = next(
-                (meta for meta in branches.values() if meta["branchId"] == self.branch_id),
+            source_branch_meta = next(
+                (meta for meta in branches.values() if meta["branchId"] == source_branch_id),
                 None,
             )
-            if current_branch_meta is None or (
-                not self.branch_id == "main" and current_branch_meta.get("parentBranchId") != "main"
+            if source_branch_meta is None or (
+                not source_branch_id == "main"
+                and source_branch_meta.get("parentBranchId") != "main"
             ):
                 raise ValueError(
                     "Cannot create branch. Branches with depth above 2 are not allowed in releases-branches deployment mode."
                 )
 
-        branch_id = self.api_handler.create_branch(branch_name, self.branch_id)
+        branch_id = self.api_handler.create_branch(branch_name, source_branch_id)
         self.branch_id = branch_id
         self.save_config()
         return branch_id
@@ -3694,7 +3712,13 @@ class AgentStudioProject:
         """Get the deployment mode for the project."""
         if self._deployment_mode is None:
             cfg = self.get_project_info().get("config") or {}
-            self._deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
+            deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
+            if (
+                deployment_mode == DeploymentMode.RELEASES_BRANCHES
+                and not self.using_simplified_deployments
+            ):
+                deployment_mode = DeploymentMode.RELEASES
+            self._deployment_mode = deployment_mode
         return self._deployment_mode
 
     @cached_property

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3470,3 +3470,40 @@ class AgentStudioProject:
 
         success = self.api_handler.rename_branch(new_branch_name=new_branch_name)
         return success
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of archived branch entries.
+        """
+        return self.api_handler.list_archived_branches()
+
+    def restore_branch(self, branch_name: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_name (str): The name of the branch to restore.
+
+        Returns:
+            bool: True if the branch was restored successfully, False otherwise.
+        """
+        if not branch_name:
+            raise ValueError("Branch name must be provided.")
+
+        archived = self.api_handler.list_archived_branches()
+        matches = [b for b in archived if b.get("name") == branch_name]
+        if not matches:
+            raise ValueError(
+                f"Branch '{branch_name}' not found in archive. "
+                "Use 'poly branch list --archived' to see available branches."
+            )
+
+        if len(matches) > 1:
+            branch_ids = ", ".join(b["branchId"] for b in matches)
+            raise ValueError(
+                f"Multiple archived branches named '{branch_name}' found ({branch_ids}). "
+                "Use the interactive picker (poly branch restore) to select the correct one."
+            )
+
+        return self.api_handler.restore_branch(matches[0]["branchId"])

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, fields
 from datetime import datetime
 from enum import Enum
+from functools import cached_property
 from typing import Any, Optional, TypeAlias
 
 from google.protobuf.message import Message
@@ -3611,7 +3612,11 @@ class AgentStudioProject:
             self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
         return self.__deployment_mode
 
-    @property
+    @cached_property
     def using_simplified_deployments(self) -> bool:
-        # TODO: Hook up to FF
-        return False
+        return self.api_handler.feature_flag_enabled(
+            key="deployment_simplification",
+            region=self.region,
+            project_id=self.project_id,
+            default=False,
+        )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3700,9 +3700,35 @@ class AgentStudioProject:
     @cached_property
     def using_simplified_deployments(self) -> bool:
         """Check if the project is using simplified deployments."""
-        return self.api_handler.feature_flag_enabled(
+        flag_enabled = self.api_handler.feature_flag_enabled(
             key="deployment-simplification",
             region=self.region,
             project_id=self.project_id,
             default=False,
+        )
+        if not flag_enabled:
+            return False
+
+        # A project is converged if the main == live
+        # Once a project is converged, all deployments will go to live
+        # To check, look at most recent deployment in sandbox and live. If it is the same as live, then the project is converged
+        live_deployments = self.api_handler.get_deployments(
+            self.region, self.account_id, self.project_id, client_env="live"
+        )
+        sandbox_deployments = self.api_handler.get_deployments(
+            self.region, self.account_id, self.project_id, client_env="sandbox"
+        )
+
+        live_head = next((d for d in live_deployments if not d.get("deleted", False)), None)
+        sandbox_head = next((d for d in sandbox_deployments if not d.get("deleted", False)), None)
+
+        def _parse_created_at(deployment: dict) -> datetime:
+            return datetime.strptime(deployment["created_at"], "%a, %d %b %Y %H:%M:%S %Z")
+
+        if live_head is None and sandbox_head is None:
+            # No deployments in either environment, consider converged
+            return True
+
+        return live_head is not None and (
+            sandbox_head is None or _parse_created_at(live_head) >= _parse_created_at(sandbox_head)
         )

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3447,3 +3447,26 @@ class AgentStudioProject:
             list[dict[str, Any]]: A list of commit history entries for the branch.
         """
         return self.api_handler.get_branch_history(branch_id)
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name (str): The new name for the current branch.
+
+        Returns:
+            bool: True if the rename was successful, False otherwise.
+        """
+        if not new_branch_name:
+            raise ValueError("New branch name must be provided.")
+
+        if self.branch_id == "main":
+            raise ValueError("Renaming 'main' branch is not supported.")
+
+        branches = self.api_handler.get_branches()
+
+        if new_branch_name in branches:
+            raise ValueError(f"Branch {new_branch_name} already exists.")
+
+        success = self.api_handler.rename_branch(new_branch_name=new_branch_name)
+        return success

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2716,8 +2716,10 @@ class AgentStudioProject:
             list[dict[str, str]]: A list of errors
         """
         branches = self.api_handler.get_branches()
-        branch_ids = {meta["branchId"] for meta in branches.values()}
-        if self.branch_id not in branch_ids:
+        branch_meta = {meta["branchId"]: meta for meta in branches.values()}
+        current_branch_meta = branch_meta.get(self.branch_id)
+
+        if not current_branch_meta:
             raise ValueError(f"Branch {self.branch_id} does not exist.")
 
         if self.branch_id == "main":
@@ -2741,7 +2743,10 @@ class AgentStudioProject:
             message=message, conflict_resolutions=conflict_resolutions
         )
         if success:
-            self.switch_branch("main", force=True)
+            parent_branch_id = current_branch_meta.get("parentBranchId") or "main"
+            parent_branch_meta = branch_meta.get(parent_branch_id) or {}
+            parent_branch_name = parent_branch_meta.get("name") or "main"
+            self.switch_branch(parent_branch_name, force=True)
             return True, [], []
 
         return False, conflicts, errors
@@ -3602,3 +3607,8 @@ class AgentStudioProject:
             cfg = self.get_project_info().get("config") or {}
             self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
         return self.__deployment_mode
+
+    @property
+    def using_simplified_deployments(self) -> bool:
+        # TODO: Hook up to FF
+        return True

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2714,6 +2714,54 @@ class AgentStudioProject:
 
         return False, conflicts, errors
 
+    def sync_branch(
+        self, conflict_resolutions: list[dict[str, Any]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Sync the current branch with its parent in the project.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict
+                resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value
+
+        Returns:
+            bool: True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflicts
+            list[dict[str, str]]: A list of errors
+        """
+        branches = self.api_handler.get_branches()
+        branch_ids = {meta["branchId"] for meta in branches.values()}
+        if self.branch_id not in branch_ids:
+            raise ValueError(f"Branch {self.branch_id} does not exist.")
+
+        if self.branch_id == "main":
+            raise ValueError("Syncing 'main' branch is not supported.")
+
+        if diffs := self.get_diffs():
+            raise ValueError(
+                f"Cannot sync branch with uncommitted changes, diffs: {list(diffs.keys())}"
+            )
+
+        for resolution in conflict_resolutions or []:
+            if "path" not in resolution or "strategy" not in resolution:
+                raise ValueError(f"Resolution must include 'path' and 'strategy': {resolution}")
+            if resolution["strategy"] not in {"ours", "theirs", "base"}:
+                raise ValueError(
+                    f"Invalid conflict resolution strategy: {resolution['strategy']} for path {resolution['path']}. "
+                    f"Must be one of 'ours', 'theirs', or 'base'."
+                )
+
+        success, conflicts, errors = self.api_handler.sync_branch(
+            conflict_resolutions=conflict_resolutions
+        )
+        if success:
+            self.pull_project(force=True)
+            return True, [], []
+
+        return False, conflicts, errors
+
     def delete_branch(self, branch_name: str) -> bool:
         """Delete a branch in the project.
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3597,6 +3597,60 @@ class AgentStudioProject:
 
         return self.api_handler.restore_branch(matches[0]["branchId"])
 
+    def tag_branch(self, branch_name: str = None) -> bool:
+        """Tag the current branch with a new tag.
+
+        Args:
+            branch_name (str): The name of the branch to tag. If None, tags the current branch.
+        Returns:
+            bool: True if the tagging was successful, False otherwise.
+        """
+        branches = self.api_handler.get_branches()
+        if branch_name is None:
+            branch_id = self.branch_id
+            branch_name = next(
+                (name for name, meta in branches.items() if meta["branchId"] == branch_id), None
+            )
+            if branch_name is None:
+                raise ValueError(f"Current branch ID {branch_id} does not exist.")
+        else:
+            if branch_name not in branches:
+                raise ValueError(f"Branch {branch_name} does not exist.")
+            branch_id = branches[branch_name]["branchId"]
+
+        if branch_id == "main":
+            raise ValueError("Tagging 'main' branch is not supported.")
+
+        success = self.api_handler.tag_branch(branch_id)
+        return success
+
+    def untag_branch(self, branch_name: str = None) -> bool:
+        """Remove a tag from a branch.
+
+        Args:
+            branch_name (str): The name of the branch to untag. If None, untags the current branch.
+        Returns:
+            bool: True if the untagging was successful, False otherwise.
+        """
+        branches = self.api_handler.get_branches()
+        if branch_name is None:
+            branch_id = self.branch_id
+            branch_name = next(
+                (name for name, meta in branches.items() if meta["branchId"] == branch_id), None
+            )
+            if branch_name is None:
+                raise ValueError(f"Current branch ID {branch_id} does not exist.")
+        else:
+            if branch_name not in branches:
+                raise ValueError(f"Branch {branch_name} does not exist.")
+            branch_id = branches[branch_name]["branchId"]
+
+        if branch_id == "main":
+            raise ValueError("Untagging 'main' branch is not supported.")
+
+        success = self.api_handler.untag_branch(branch_id)
+        return success
+
     def get_project_info(self) -> dict[str, Any]:
         """Get basic information about the project from the API.
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -12,6 +12,7 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, fields
 from datetime import datetime
+from enum import Enum
 from typing import Any, Optional, TypeAlias
 
 from google.protobuf.message import Message
@@ -86,6 +87,14 @@ class PushPhaseChangeSet:
     post: ResourceChangeSet
 
 
+class DeploymentMode(Enum):
+    """Deployment mode for the project"""
+
+    SIMPLE = "simple"
+    RELEASES = "releases"
+    RELEASES_BRANCHES = "release_branches"
+
+
 @dataclass
 class AgentStudioProject:
     """Dataclass representing an Agent Studio Project"""
@@ -103,6 +112,7 @@ class AgentStudioProject:
     file_structure_info: dict[str, dict[str, str]] = None
     _migration_flags: set[MigrationFlag] = None
     rtc_metadata: Optional[dict[str, dict]] = None
+    __deployment_mode: Optional[DeploymentMode] = None
 
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
@@ -3563,3 +3573,9 @@ class AgentStudioProject:
             dict[str, Any]: A dictionary containing project information.
         """
         return self.api_handler.get_project(self.region, self.account_id, self.project_id)
+
+    def get_deployment_mode(self) -> DeploymentMode:
+        if self.__deployment_mode is None:
+            cfg = self.get_project_info().get("config") or {}
+            self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
+        return self.__deployment_mode

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3614,4 +3614,4 @@ class AgentStudioProject:
     @property
     def using_simplified_deployments(self) -> bool:
         # TODO: Hook up to FF
-        return True
+        return False

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2256,6 +2256,9 @@ class AgentStudioProject:
 
         Returns:
             str: The ID of the newly created branch
+
+        Raises:
+            ValueError: If the branch cannot be created due to deployment mode restrictions
         """
         if self.deployment_mode == DeploymentMode.SIMPLE:
             branches = self.api_handler.get_branches()
@@ -2275,8 +2278,7 @@ class AgentStudioProject:
                 None,
             )
             if current_branch_meta is None or (
-                not current_branch_meta.get("branchId") == "main"
-                and current_branch_meta.get("parentBranchId") != "main"
+                not self.branch_id == "main" and current_branch_meta.get("parentBranchId") != "main"
             ):
                 raise ValueError(
                     "Cannot create branch. Branches with depth above 2 are not allowed in releases-branches deployment mode."
@@ -3661,6 +3663,7 @@ class AgentStudioProject:
 
     @property
     def deployment_mode(self) -> DeploymentMode:
+        """Get the deployment mode for the project."""
         if self._deployment_mode is None:
             cfg = self.get_project_info().get("config") or {}
             self._deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
@@ -3668,6 +3671,7 @@ class AgentStudioProject:
 
     @cached_property
     def using_simplified_deployments(self) -> bool:
+        """Check if the project is using simplified deployments."""
         return self.api_handler.feature_flag_enabled(
             key="deployment-simplification",
             region=self.region,

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -92,7 +92,7 @@ class DeploymentMode(Enum):
 
     SIMPLE = "simple"
     RELEASES = "releases"
-    RELEASES_BRANCHES = "release_branches"
+    RELEASES_BRANCHES = "releases_branches"
 
 
 @dataclass
@@ -2256,7 +2256,29 @@ class AgentStudioProject:
         Returns:
             str: The ID of the newly created branch
         """
-        branch_id = self.api_handler.create_branch(branch_name)
+        if self.deployment_mode == DeploymentMode.SIMPLE:
+            branches = self.api_handler.get_branches()
+            if len(branches) >= 2:
+                raise ValueError(
+                    "Cannot create more than one branch in simple deployment mode. Please delete/merge existing branches before creating a new one."
+                )
+        if self.deployment_mode == DeploymentMode.RELEASES:
+            if self.branch_id != "main":
+                raise ValueError(
+                    "Cannot create a new branch from a non-main branch in releases deployment mode."
+                )
+        if self.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            branches = self.api_handler.get_branches()
+            current_branch_meta = next(
+                (meta for meta in branches.values() if meta["branchId"] == self.branch_id),
+                None,
+            )
+            if current_branch_meta is None or current_branch_meta.get("parentBranchId") != "main":
+                raise ValueError(
+                    "Cannot create a branch with depth above 2 in releases-branches deployment mode."
+                )
+
+        branch_id = self.api_handler.create_branch(branch_name, self.branch_id)
         self.branch_id = branch_id
         self.save_config()
         return branch_id
@@ -3574,7 +3596,8 @@ class AgentStudioProject:
         """
         return self.api_handler.get_project(self.region, self.account_id, self.project_id)
 
-    def get_deployment_mode(self) -> DeploymentMode:
+    @property
+    def deployment_mode(self) -> DeploymentMode:
         if self.__deployment_mode is None:
             cfg = self.get_project_info().get("config") or {}
             self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3061,7 +3061,6 @@ class AgentStudioProject:
         )
 
     # ── RTC (Real-Time Configuration) ──
-
     RTC_ENV_TO_DIR = {
         "sandbox": "draft_and_sandbox",
         "pre-release": "pre_release",
@@ -3437,3 +3436,14 @@ class AgentStudioProject:
             ]
         except (jsonschema.SchemaError, jsonschema.exceptions.UnknownType) as e:
             return [f"Invalid schema: {e}"]
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of a branch.
+
+        Args:
+            branch_id (str): The ID of the branch to get history for.
+
+        Returns:
+            list[dict[str, Any]]: A list of commit history entries for the branch.
+        """
+        return self.api_handler.get_branch_history(branch_id)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2261,12 +2261,12 @@ class AgentStudioProject:
             branches = self.api_handler.get_branches()
             if len(branches) >= 2:
                 raise ValueError(
-                    "Cannot create more than one branch in simple deployment mode. Please delete/merge existing branches before creating a new one."
+                    "Cannot create branch. Only one branch is allowed in simple deployment mode. Please delete/merge existing branches before creating a new one."
                 )
         if self.deployment_mode == DeploymentMode.RELEASES:
             if self.branch_id != "main":
                 raise ValueError(
-                    "Cannot create a new branch from a non-main branch in releases deployment mode."
+                    "Cannot create branch. Branches can only be created from the main branch in releases deployment mode."
                 )
         if self.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
             branches = self.api_handler.get_branches()
@@ -2279,7 +2279,7 @@ class AgentStudioProject:
                 and current_branch_meta.get("parentBranchId") != "main"
             ):
                 raise ValueError(
-                    "Cannot create a branch with depth above 2 in releases-branches deployment mode."
+                    "Cannot create branch. Branches with depth above 2 are not allowed in releases-branches deployment mode."
                 )
 
         branch_id = self.api_handler.create_branch(branch_name, self.branch_id)
@@ -3615,7 +3615,7 @@ class AgentStudioProject:
     @cached_property
     def using_simplified_deployments(self) -> bool:
         return self.api_handler.feature_flag_enabled(
-            key="deployment_simplification",
+            key="deployment-simplification",
             region=self.region,
             project_id=self.project_id,
             default=False,

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2753,9 +2753,11 @@ class AgentStudioProject:
             parent_branch_meta = branch_meta.get(parent_branch_id) or {}
             parent_branch_name = parent_branch_meta.get("name")
             if not parent_branch_name:
-                raise ValueError(
-                    f"Could not find parent branch name for branch ID {parent_branch_id}."
+                logger.warning(
+                    f"Could not resolve parent branch for '{self.branch_id}' "
+                    f"(parentBranchId={parent_branch_id!r}); defaulting to 'main'."
                 )
+                parent_branch_name = "main"
             success, _ = self.switch_branch(parent_branch_name, force=True)
             return success, [], []
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3555,3 +3555,11 @@ class AgentStudioProject:
             )
 
         return self.api_handler.restore_branch(matches[0]["branchId"])
+
+    def get_project_info(self) -> dict[str, Any]:
+        """Get basic information about the project from the API.
+
+        Returns:
+            dict[str, Any]: A dictionary containing project information.
+        """
+        return self.api_handler.get_project(self.region, self.account_id, self.project_id)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2273,7 +2273,10 @@ class AgentStudioProject:
                 (meta for meta in branches.values() if meta["branchId"] == self.branch_id),
                 None,
             )
-            if current_branch_meta is None or current_branch_meta.get("parentBranchId") != "main":
+            if current_branch_meta is None or (
+                not current_branch_meta.get("branchId") == "main"
+                and current_branch_meta.get("parentBranchId") != "main"
+            ):
                 raise ValueError(
                     "Cannot create a branch with depth above 2 in releases-branches deployment mode."
                 )

--- a/src/poly/tests/api/interface_test.py
+++ b/src/poly/tests/api/interface_test.py
@@ -201,5 +201,139 @@ class QueueResources(unittest.TestCase):
         self.assertLess(types.index("variable_delete"), types.index("delete_topic"))
 
 
+class GetBranchHistoryInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.get_branch_history."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_history_from_sync_client(self):
+        """The interface delegates to sync_client and returns the result."""
+        expected = [{"commit_id": "c1", "message": "first commit"}]
+        self.interface.sync_client.get_branch_history.return_value = expected
+
+        result = self.interface.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        self.interface.sync_client.get_branch_history.assert_called_once_with("branch-1")
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.get_branch_history.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.get_branch_history("branch-1")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.get_branch_history.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.get_branch_history("branch-1")
+
+
+class RenameBranchInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.rename_branch."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns True on success."""
+        self.interface.sync_client.rename_branch.return_value = True
+
+        result = self.interface.rename_branch("new-name")
+
+        self.assertTrue(result)
+        self.interface.sync_client.rename_branch.assert_called_once_with("new-name")
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.rename_branch.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.rename_branch("new-name")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.rename_branch.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.rename_branch("new-name")
+
+
+class ListArchivedBranchesInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.list_archived_branches."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns the result."""
+        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
+        self.interface.sync_client.list_archived_branches.return_value = expected
+
+        result = self.interface.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        self.interface.sync_client.list_archived_branches.assert_called_once()
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.list_archived_branches.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.list_archived_branches()
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError is translated into a ValueError."""
+        self.interface.sync_client.list_archived_branches.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.list_archived_branches()
+
+
+class RestoreBranchInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.restore_branch."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns True on success."""
+        self.interface.sync_client.restore_branch.return_value = True
+
+        result = self.interface.restore_branch("branch-1")
+
+        self.assertTrue(result)
+        self.interface.sync_client.restore_branch.assert_called_once_with("branch-1")
+
+    def test_returns_false_from_sync_client(self):
+        """The interface returns False when sync_client returns False."""
+        self.interface.sync_client.restore_branch.return_value = False
+
+        result = self.interface.restore_branch("branch-1")
+
+        self.assertFalse(result)
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.restore_branch.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.restore_branch("branch-1")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError is translated into a ValueError."""
+        self.interface.sync_client.restore_branch.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.restore_branch("branch-1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -1,0 +1,159 @@
+"""Tests for the PostHog feature-flag handler.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from poly.handlers import posthog as posthog_module
+from poly.handlers.posthog import PosthogHandler, get_posthog_client, get_user_identity
+
+
+class IsFeatureEnabledTest(unittest.TestCase):
+    """Tests for PosthogHandler.is_feature_enabled."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.client_patcher = patch(
+            "poly.handlers.posthog.get_posthog_client", return_value=self.client
+        )
+        self.client_patcher.start()
+        self.identity_patcher = patch(
+            "poly.handlers.posthog.get_user_identity", return_value="test-user"
+        )
+        self.identity_patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_returns_flag_value_when_evaluated(self):
+        """A resolved flag is returned as-is, for both True and False."""
+        for value in (True, False):
+            with self.subTest(value=value):
+                self.client.feature_enabled.return_value = value
+
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=not value
+                )
+
+                self.assertEqual(result, value)
+
+    def test_returns_default_when_flag_is_unresolved(self):
+        """A None result means PostHog could not evaluate the flag, so default wins."""
+        self.client.feature_enabled.return_value = None
+
+        for default in (True, False):
+            with self.subTest(default=default):
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=default
+                )
+
+                self.assertEqual(result, default)
+
+    def test_returns_default_when_evaluation_raises(self):
+        """Any exception from the client is swallowed and the default returned.
+
+        The 1s request timeout means a slow or unreachable PostHog must never
+        take down a gated CLI command.
+        """
+        self.client.feature_enabled.side_effect = RuntimeError("connection reset")
+
+        for default in (True, False):
+            with self.subTest(default=default):
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=default
+                )
+
+                self.assertEqual(result, default)
+
+    def test_returns_default_when_client_is_unavailable(self):
+        """A falsy client short-circuits to the default without evaluating."""
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=None):
+            result = PosthogHandler.is_feature_enabled(
+                region="studio", key="some-flag", default=True
+            )
+
+        self.assertTrue(result)
+
+    def test_passes_key_identity_and_project_group(self):
+        """The flag key, distinct_id and project group are forwarded to PostHog."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(
+            region="studio",
+            key="deployment-simplification",
+            default=False,
+            project_id="proj-1",
+        )
+
+        self.client.feature_enabled.assert_called_once_with(
+            "deployment-simplification",
+            distinct_id="test-user",
+            groups={"cluster": "studio", "project": "proj-1"},
+            send_feature_flag_events=False,
+        )
+
+    def test_omits_project_group_when_no_project_id(self):
+        """Without a project id only the cluster group is sent."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(region="studio", key="some-flag", default=False)
+
+        self.assertEqual(
+            self.client.feature_enabled.call_args.kwargs["groups"], {"cluster": "studio"}
+        )
+
+    def test_region_is_mapped_to_posthog_cluster(self):
+        """Regions with a cluster alias are translated; others pass through unchanged."""
+        self.client.feature_enabled.return_value = True
+
+        for region, expected_cluster in (("dev", "apollo"), ("studio", "studio")):
+            with self.subTest(region=region):
+                PosthogHandler.is_feature_enabled(region=region, key="some-flag", default=False)
+
+                self.assertEqual(
+                    self.client.feature_enabled.call_args.kwargs["groups"]["cluster"],
+                    expected_cluster,
+                )
+
+
+class GetPosthogClientTest(unittest.TestCase):
+    """Tests for the module-level PostHog client singleton."""
+
+    def setUp(self):
+        self.original_client = posthog_module._client
+        posthog_module._client = None
+
+    def tearDown(self):
+        posthog_module._client = self.original_client
+
+    def test_client_is_constructed_once_and_reused(self):
+        """The client is built on first use and cached for subsequent calls."""
+        with patch("posthog.Posthog") as mock_posthog_cls:
+            first = get_posthog_client()
+            second = get_posthog_client()
+
+        self.assertIs(first, second)
+        mock_posthog_cls.assert_called_once()
+
+    def test_client_is_configured_with_a_request_timeout(self):
+        """A feature-flag read is bounded so the CLI cannot hang on PostHog."""
+        with patch("posthog.Posthog") as mock_posthog_cls:
+            get_posthog_client()
+
+        timeout = mock_posthog_cls.call_args.kwargs["feature_flags_request_timeout_seconds"]
+        self.assertEqual(timeout, posthog_module.FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS)
+
+
+class GetUserIdentityTest(unittest.TestCase):
+    """Tests for get_user_identity, the PostHog distinct_id source."""
+
+    def test_identity_is_the_local_username(self):
+        """The distinct_id is the OS username, so rollouts bucket per developer."""
+        with patch("getpass.getuser", return_value="ada"):
+            self.assertEqual(get_user_identity(), "ada")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/api/sdk_test.py
+++ b/src/poly/tests/api/sdk_test.py
@@ -104,6 +104,61 @@ class FetchProjection(unittest.TestCase):
             sdk.fetch_projection()
 
 
+class CreateBranch(unittest.TestCase):
+    """Tests for the payload SourcererSDK.create_branch posts."""
+
+    def setUp(self):
+        self.sdk = build_sdk()
+        self.session = MagicMock()
+        self.session.post.return_value = make_mock_response(
+            200, json_body={"branchId": "new-branch-id"}
+        )
+        self.sdk._session = self.session
+
+    def _posted_payload(self):
+        """The JSON body sent to the branches endpoint."""
+        return self.session.post.call_args.kwargs["json"]
+
+    def test_returns_new_branch_id_from_response(self):
+        """The branchId from the API response is returned."""
+        branch_id = self.sdk.create_branch(branch_name="my-feature")
+
+        self.assertEqual(branch_id, "new-branch-id")
+
+    def test_payload_carries_branch_name_and_expected_sequence(self):
+        """The branch name and expected sequence number are always sent."""
+        self.sdk.create_branch(expected_main_last_known_sequence=12, branch_name="my-feature")
+
+        payload = self._posted_payload()
+        self.assertEqual(payload["branchName"], "my-feature")
+        self.assertEqual(payload["expectedMainLastKnownSequence"], 12)
+
+    def test_non_main_source_branch_is_sent(self):
+        """A source branch other than main is sent as sourceBranchId."""
+        self.sdk.create_branch(branch_name="my-feature", source_branch_id="branch-parent")
+
+        self.assertEqual(self._posted_payload()["sourceBranchId"], "branch-parent")
+
+    def test_source_branch_omitted_when_not_specified(self):
+        """With no source branch the payload has no sourceBranchId key at all."""
+        self.sdk.create_branch(branch_name="my-feature")
+
+        self.assertNotIn("sourceBranchId", self._posted_payload())
+
+    def test_source_branch_omitted_when_source_is_main(self):
+        """Main is the server-side default, so it is not sent explicitly."""
+        self.sdk.create_branch(branch_name="my-feature", source_branch_id="main")
+
+        self.assertNotIn("sourceBranchId", self._posted_payload())
+
+    def test_request_failure_raises_sourcerer_error(self):
+        """A failing create request raises SourcererAPIError."""
+        self.session.post.return_value = make_mock_response(409, json_body={"error": "conflict"})
+
+        with self.assertRaises(SourcererAPIError):
+            self.sdk.create_branch(branch_name="my-feature")
+
+
 class SendCommandBatch(unittest.TestCase):
     """Tests for SourcererSDK.send_command_batch serialization and lifecycle."""
 

--- a/src/poly/tests/api/sync_client_test.py
+++ b/src/poly/tests/api/sync_client_test.py
@@ -171,5 +171,49 @@ class RestoreBranch(unittest.TestCase):
         self.assertFalse(result)
 
 
+class TagBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.tag_branch."""
+
+    def test_successful_tag_returns_true(self):
+        """A successful SDK tag call returns True."""
+        handler = build_handler()
+
+        result = handler.tag_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.tag_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during tagging returns False rather than propagating."""
+        handler = build_handler()
+        handler._sdk.tag_branch.side_effect = SourcererAPIError("tag failed")
+
+        result = handler.tag_branch("branch-1")
+
+        self.assertFalse(result)
+
+
+class UntagBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.untag_branch."""
+
+    def test_successful_untag_returns_true(self):
+        """A successful SDK untag call returns True."""
+        handler = build_handler()
+
+        result = handler.untag_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.untag_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during untagging returns False rather than propagating."""
+        handler = build_handler()
+        handler._sdk.untag_branch.side_effect = SourcererAPIError("untag failed")
+
+        result = handler.untag_branch("branch-1")
+
+        self.assertFalse(result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/api/sync_client_test.py
+++ b/src/poly/tests/api/sync_client_test.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from poly.handlers.protobuf.commands_pb2 import Command
-from poly.handlers.sdk import SourcererSDK
+from poly.handlers.sdk import SourcererAPIError, SourcererSDK
 from poly.handlers.sync_client import SyncClientHandler
 
 
@@ -62,6 +62,113 @@ class SendQueuedCommands(unittest.TestCase):
 
         self.assertTrue(handler.send_queued_commands())
         handler._sdk.send_command_batch.assert_called_once()
+
+
+class GetBranchHistory(unittest.TestCase):
+    """Tests for SyncClientHandler.get_branch_history."""
+
+    def test_returns_history_from_sdk(self):
+        """The handler delegates to sdk.get_branch_history and returns its result."""
+        handler = build_handler()
+        expected = [{"commit_id": "c1", "message": "initial"}]
+        handler._sdk.get_branch_history.return_value = expected
+
+        result = handler.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        handler._sdk.get_branch_history.assert_called_once_with("branch-1")
+
+    def test_returns_empty_list_when_no_history(self):
+        """An empty history list is returned as-is."""
+        handler = build_handler()
+        handler._sdk.get_branch_history.return_value = []
+
+        result = handler.get_branch_history("branch-1")
+
+        self.assertEqual(result, [])
+
+
+class RenameBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.rename_branch."""
+
+    def test_successful_rename_returns_true(self):
+        """A successful SDK rename call returns True."""
+        handler = build_handler()
+        handler._sdk.branch_id = "branch-1"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "branch-1"}]}
+
+        result = handler.rename_branch("new-name")
+
+        self.assertTrue(result)
+        handler._sdk.rename_branch.assert_called_once_with(new_branch_name="new-name")
+
+    def test_main_branch_returns_false(self):
+        """Renaming the main branch returns False without calling the SDK."""
+        handler = build_handler()
+        handler._sdk.branch_id = "main"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "main"}]}
+
+        result = handler.rename_branch("new-name")
+
+        self.assertFalse(result)
+        handler._sdk.rename_branch.assert_not_called()
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during rename returns False."""
+        handler = build_handler()
+        handler._sdk.branch_id = "branch-1"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "branch-1"}]}
+        handler._sdk.rename_branch.side_effect = SourcererAPIError("rename failed")
+
+        result = handler.rename_branch("new-name")
+
+        self.assertFalse(result)
+
+
+class ListArchivedBranches(unittest.TestCase):
+    """Tests for SyncClientHandler.list_archived_branches."""
+
+    def test_returns_archived_branches_from_sdk(self):
+        """The handler delegates to sdk.list_archived_branches and returns its result."""
+        handler = build_handler()
+        expected = [{"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"}]
+        handler._sdk.list_archived_branches.return_value = expected
+
+        result = handler.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        handler._sdk.list_archived_branches.assert_called_once()
+
+    def test_returns_empty_list_when_no_archived_branches(self):
+        """An empty list is returned as-is."""
+        handler = build_handler()
+        handler._sdk.list_archived_branches.return_value = []
+
+        result = handler.list_archived_branches()
+
+        self.assertEqual(result, [])
+
+
+class RestoreBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.restore_branch."""
+
+    def test_successful_restore_returns_true(self):
+        """A successful SDK restore call returns True."""
+        handler = build_handler()
+
+        result = handler.restore_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.restore_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during restore returns False."""
+        handler = build_handler()
+        handler._sdk.restore_branch.side_effect = SourcererAPIError("restore failed")
+
+        result = handler.restore_branch("branch-1")
+
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -3025,7 +3025,10 @@ class ConversationsCommandTest(unittest.TestCase):
 class BranchHistoryTest(unittest.TestCase):
     """Tests for BranchCommand.branch_history CLI handler."""
 
-    SAMPLE_BRANCHES = {"main": "main-id", "feature-a": "branch-a-id"}
+    SAMPLE_BRANCHES = {
+        "main": {"branchId": "main-id"},
+        "feature-a": {"branchId": "branch-a-id"},
+    }
 
     def setUp(self):
         self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -14,7 +14,7 @@ from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand
-from poly.cli_commands.shared import compute_diff
+from poly.cli_commands.shared import compute_diff, require_deployment_simplification
 from poly.cli_commands.sync import FormatCommand, RevertCommand
 from poly.cli_commands.utils import CompletionCommand
 from poly.project import DeploymentMode
@@ -871,12 +871,38 @@ class BranchSyncTest(unittest.TestCase):
         self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
         self.mock_load = self.mock_load_patcher.start()
         self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
         self.proj.get_current_branch.return_value = "feature-a"
         self.proj.sync_branch.return_value = (True, [], [])
         self.mock_load.return_value = self.proj
 
     def tearDown(self):
         patch.stopall()
+
+    @patch("poly.output.console.error")
+    def test_sync_blocked_without_simplified_deployments(self, mock_error):
+        """Sync is refused locally rather than surfacing the platform's 404."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.sync_branch.assert_not_called()
+        self.proj.get_current_branch.assert_not_called()
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_sync_blocked_without_simplified_deployments_json(self, mock_json_print):
+        """The refusal is reported as JSON when --json is set."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(mock_json_print.call_args[0][0]["success"])
+        self.proj.sync_branch.assert_not_called()
 
     @patch("poly.output.console.success")
     def test_sync_success_reports_branch_name(self, mock_success):
@@ -3666,3 +3692,138 @@ class BranchRestoreTest(unittest.TestCase):
 
         mock_error.assert_called_once()
         self.assertIn("Failed to restore", mock_error.call_args[0][0])
+
+
+class RequireDeploymentSimplificationTest(unittest.TestCase):
+    """Tests for the require_deployment_simplification CLI gate."""
+
+    def setUp(self):
+        self.proj = MagicMock()
+
+    @patch("poly.output.console.error")
+    def test_returns_silently_when_enabled(self, mock_error):
+        """An enabled project passes through without output or exit."""
+        self.proj.using_simplified_deployments = True
+
+        require_deployment_simplification(self.proj)
+
+        mock_error.assert_not_called()
+
+    @patch("poly.output.console.error")
+    def test_exits_with_error_when_disabled(self, mock_error):
+        """A disabled project is refused on stderr with exit code 1."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            require_deployment_simplification(self.proj)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_reports_failure_as_json(self, mock_json_print):
+        """In JSON mode the refusal is a machine-readable payload, not stderr text."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            require_deployment_simplification(self.proj, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json_print.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("simplified deployments", payload["error"])
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_json_payload_carries_no_rich_markup(self, mock_json_print):
+        """The JSON error stays markup-free so consumers get plain text."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit):
+            require_deployment_simplification(self.proj, output_json=True)
+
+        self.assertNotIn("[bold]", mock_json_print.call_args[0][0]["error"])
+
+
+class BranchTagTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_tag and branch_untag."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.tag_branch.return_value = True
+        self.proj.untag_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_tag_success_reports_branch_name(self, mock_success):
+        """A successful tag names the branch that was staged."""
+        BranchCommand.branch_tag(TEST_DIR)
+
+        self.proj.tag_branch.assert_called_once_with()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("poly.output.console.success")
+    def test_untag_success_reports_branch_name(self, mock_success):
+        """A successful untag names the branch whose tag was removed."""
+        BranchCommand.branch_untag(TEST_DIR)
+
+        self.proj.untag_branch.assert_called_once_with()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_tag_failure_is_reported(self, mock_error):
+        """A False from the project layer surfaces as an error."""
+        self.proj.tag_branch.return_value = False
+
+        BranchCommand.branch_tag(TEST_DIR)
+
+        self.assertIn("Failed to tag", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_untag_failure_is_reported(self, mock_error):
+        """A False from the project layer surfaces as an error."""
+        self.proj.untag_branch.return_value = False
+
+        BranchCommand.branch_untag(TEST_DIR)
+
+        self.assertIn("Failed to remove tag", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_outcome(self, mock_json_print):
+        """JSON mode reports the boolean outcome for both commands."""
+        BranchCommand.branch_tag(TEST_DIR, output_json=True)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+        self.proj.untag_branch.return_value = False
+        BranchCommand.branch_untag(TEST_DIR, output_json=True)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": False})
+
+    @patch("poly.output.console.error")
+    def test_tag_blocked_without_simplified_deployments(self, mock_error):
+        """Staging tags only exist under simplified deployments, so tag is gated."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_tag(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.tag_branch.assert_not_called()
+
+    @patch("poly.output.console.error")
+    def test_untag_blocked_without_simplified_deployments(self, mock_error):
+        """Untag is gated on the same flag as tag."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_untag(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.untag_branch.assert_not_called()

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -210,6 +210,24 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.create_branch.assert_not_called()
         self.proj.push_project.assert_not_called()
 
+    def test_branch_create_env_creates_branch_before_pulling(self):
+        """The branch must exist before env state is pulled into it.
+
+        Regression test pinning the call order explicitly: the branch is created
+        first, then env resources are pulled into it, then pushed. Checking call
+        counts/args alone wouldn't catch a reorder of these two calls.
+        """
+        manager = MagicMock()
+        manager.attach_mock(self.proj.create_branch, "create_branch")
+        manager.attach_mock(self.proj.pull_project_from_env, "pull_project_from_env")
+
+        BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
+
+        self.assertEqual(
+            [call[0] for call in manager.mock_calls],
+            ["create_branch", "pull_project_from_env"],
+        )
+
     def test_branch_create_env_force_bypasses_check(self):
         """branch create --env live --force proceeds despite local changes."""
         self.proj.get_diffs.return_value = {"file.py": "example diff"}
@@ -247,7 +265,11 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         )
 
     def test_branch_create_env_raises_when_live_deployment_missing(self):
-        """If live (or pre-release) has no active deployment, pull_project_from_env raises."""
+        """If live (or pre-release) has no active deployment, pull_project_from_env raises.
+
+        The branch has already been created by this point (pull happens after
+        creation), so the raise leaves a branch behind with no env state pushed.
+        """
         self.proj.get_diffs.return_value = {}
         self.proj.pull_project_from_env.side_effect = ValueError(
             "No resources returned from environment 'live'."
@@ -257,11 +279,11 @@ class BranchCreateFromEnvTest(unittest.TestCase):
             BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
 
         self.assertIn("No resources returned from environment 'live'", str(ctx.exception))
+        self.proj.create_branch.assert_called_once_with("my-branch")
         self.proj.pull_project_from_env.assert_called_once()
         pull_kwargs = self.proj.pull_project_from_env.call_args[1]
         self.assertEqual(pull_kwargs["env"], "live")
         self.assertIs(pull_kwargs["format"], False)
-        self.proj.create_branch.assert_not_called()
         self.proj.push_project.assert_not_called()
 
     def test_branch_create_env_sandbox_skips_env_pull(self):
@@ -359,7 +381,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.push_project.assert_not_called()
 
     def test_branch_create_env_does_not_push_when_create_branch_fails(self):
-        """After failed branch creation, push_project is not called and process exits."""
+        """After failed branch creation, neither the env pull nor push happen."""
         self.proj.get_diffs.return_value = {}
         self.proj.create_branch.return_value = None
 
@@ -367,9 +389,8 @@ class BranchCreateFromEnvTest(unittest.TestCase):
             BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
 
         self.assertEqual(ctx.exception.code, 1)
-        self.proj.pull_project_from_env.assert_called_once()
-        self.assertIs(self.proj.pull_project_from_env.call_args[1]["format"], False)
         self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.pull_project_from_env.assert_not_called()
         self.proj.push_project.assert_not_called()
 
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2761,3 +2761,200 @@ class ConversationsCommandTest(unittest.TestCase):
         )
         mock_success.assert_called_once()
         self.assertIn("2.0 MB", mock_success.call_args[0][0])
+
+
+class BranchHistoryTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_history CLI handler."""
+
+    SAMPLE_BRANCHES = {"main": "main-id", "feature-a": "branch-a-id"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_branches.return_value = ("feature-a", dict(self.SAMPLE_BRANCHES))
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_defaults_to_current_branch(self, mock_plain, mock_print_history):
+        """When no branch_name is given, history uses the current branch."""
+        self.proj.get_branch_history.return_value = [{"mergedAt": "2026-07-01", "branchName": "x"}]
+
+        BranchCommand.branch_history(TEST_DIR)
+
+        self.proj.get_branch_history.assert_called_once_with("branch-a-id")
+        mock_print_history.assert_called_once()
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_explicit_branch_name(self, mock_plain, mock_print_history):
+        """An explicit branch_name looks up its ID and fetches history."""
+        self.proj.get_branch_history.return_value = [{"mergedAt": "2026-07-01"}]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="main")
+
+        self.proj.get_branch_history.assert_called_once_with("main-id")
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_output(self, mock_json):
+        """JSON mode outputs branch_name, branch_id, and history."""
+        history = [{"mergedAt": "2026-07-01", "branchName": "feat"}]
+        self.proj.get_branch_history.return_value = history
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["branch_name"], "feature-a")
+        self.assertEqual(payload["branch_id"], "branch-a-id")
+        self.assertEqual(payload["history"], history)
+
+    @patch("poly.output.console.plain")
+    def test_empty_history_shows_message(self, mock_plain):
+        """When history is empty, a 'no history found' message is shown."""
+        self.proj.get_branch_history.return_value = []
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a")
+
+        mock_plain.assert_called_once()
+        self.assertIn("No history found", mock_plain.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_nonexistent_branch_shows_warning(self, mock_warning):
+        """A branch name not in the branches dict shows a warning."""
+        BranchCommand.branch_history(TEST_DIR, branch_name="no-such-branch")
+
+        self.proj.get_branch_history.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("does not exist", mock_warning.call_args[0][0])
+
+
+class BranchRenameTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_rename CLI handler."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.rename_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_successful_rename(self, mock_success):
+        """A successful rename prints a success message."""
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_called_once_with("new-name")
+        mock_success.assert_called_once()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+        self.assertIn("new-name", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_successful_rename_json(self, mock_json):
+        """JSON mode outputs old_branch_name, new_branch_name, and success."""
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["old_branch_name"], "feature-a")
+        self.assertEqual(payload["new_branch_name"], "new-name")
+
+    @patch("poly.output.console.error")
+    def test_rename_failure_shows_error(self, mock_error):
+        """When rename_branch returns False, a failure message is shown."""
+        self.proj.rename_branch.return_value = False
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to rename", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_no_current_branch_shows_warning(self, mock_warning):
+        """When current branch is None, a warning is shown."""
+        self.proj.get_current_branch.return_value = None
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("doesn't exist", mock_warning.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_current_branch_json(self, mock_json):
+        """JSON mode outputs error when no current branch exists."""
+        self.proj.get_current_branch.return_value = None
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("doesn't exist", payload["error"])
+
+    @patch("poly.output.console.error")
+    def test_main_branch_shows_error(self, mock_error):
+        """Renaming main branch shows an error."""
+        self.proj.get_current_branch.return_value = "main"
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_not_called()
+        mock_error.assert_called_once()
+        self.assertIn("Cannot rename the main branch", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_main_branch_json(self, mock_json):
+        """JSON mode outputs error when trying to rename main."""
+        self.proj.get_current_branch.return_value = "main"
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("Cannot rename the main branch", payload["error"])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_name_json_mode(self, mock_json):
+        """JSON mode outputs error when no name is provided."""
+        self.proj.rename_branch.side_effect = ValueError("New branch name must be provided.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name=None, output_json=True)
+
+        calls = mock_json.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertFalse(calls[0][0][0]["success"])
+        self.assertIn("No new branch name provided", calls[0][0][0]["error"])
+        self.assertFalse(calls[1][0][0]["success"])
+
+    @patch("poly.output.console.error")
+    def test_rename_exception_shows_error(self, mock_error):
+        """When rename_branch raises, the error message is shown."""
+        self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing")
+
+        mock_error.assert_called_once()
+        self.assertIn("Branch already exists", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_rename_exception_json(self, mock_json):
+        """JSON mode outputs the error when rename_branch raises."""
+        self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("Branch already exists", payload["error"])

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -598,6 +598,7 @@ class BranchCurrentTest(unittest.TestCase):
     BRANCH_TREE = {
         "main": {"branchId": "main"},
         "feature-a": {"branchId": "id-a", "parentBranchId": "main"},
+        "feature-b": {"branchId": "id-b", "parentBranchId": "feature-a"},
     }
 
     def setUp(self):
@@ -613,7 +614,7 @@ class BranchCurrentTest(unittest.TestCase):
         self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
 
     @patch("poly.output.console.plain")
-    def test_shows_parent_branch_when_present(self, mock_plain):
+    def test_does_not_show_parent_branch_when_parent_is_main(self, mock_plain):
         """A branch with a parent shows both the current and parent branch."""
         self._set_current_branch("feature-a")
 
@@ -621,7 +622,18 @@ class BranchCurrentTest(unittest.TestCase):
 
         lines = [call.args[0] for call in mock_plain.call_args_list]
         self.assertTrue(any("feature-a" in line for line in lines))
-        self.assertTrue(any("main" in line for line in lines))
+        self.assertFalse(any("main" in line for line in lines))
+
+    @patch("poly.output.console.plain")
+    def test_shows_parent_branch_when_present_and_not_main(self, mock_plain):
+        """A branch with a parent shows both the current and parent branch."""
+        self._set_current_branch("feature-b")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        lines = [call.args[0] for call in mock_plain.call_args_list]
+        self.assertTrue(any("feature-b" in line for line in lines))
+        self.assertTrue(any("feature-a" in line for line in lines))
 
     @patch("poly.output.console.plain")
     def test_main_has_no_parent_branch_line(self, mock_plain):

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2834,6 +2834,48 @@ class BranchHistoryTest(unittest.TestCase):
         mock_warning.assert_called_once()
         self.assertIn("does not exist", mock_warning.call_args[0][0])
 
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_limit_truncates_history(self, mock_plain, mock_print_history):
+        """--limit truncates history to the given number of entries."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", limit=5)
+
+        mock_print_history.assert_called_once()
+        printed = mock_print_history.call_args[0][0]
+        self.assertEqual(len(printed), 5)
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_default_limit_is_10(self, mock_plain, mock_print_history):
+        """Without --limit, history is capped at 10 entries."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a")
+
+        mock_print_history.assert_called_once()
+        printed = mock_print_history.call_args[0][0]
+        self.assertEqual(len(printed), 10)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_limit_applies_to_json_output(self, mock_json):
+        """--limit also truncates history in JSON mode."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(
+            TEST_DIR, branch_name="feature-a", output_json=True, limit=3
+        )
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(len(payload["history"]), 3)
+
 
 class BranchRenameTest(unittest.TestCase):
     """Tests for BranchCommand.branch_rename CLI handler."""

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -781,6 +781,107 @@ class BranchMergeTest(unittest.TestCase):
         self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
 
 
+class BranchSyncTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_sync."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.sync_branch.return_value = (True, [], [])
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_sync_success_reports_branch_name(self, mock_success):
+        """A successful sync reports the current branch name."""
+        BranchCommand.branch_sync(TEST_DIR)
+
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=None)
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+        self.assertIn("synced successfully", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_success(self, mock_json_print):
+        """JSON mode reports success without conflicts/errors keys."""
+        BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_failure_and_exits(self, mock_json_print):
+        """JSON mode reports conflicts/errors and exits non-zero on failure."""
+        conflicts = [{"path": ["a"], "type": "modify"}]
+        self.proj.sync_branch.return_value = (False, conflicts, [])
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        output = mock_json_print.call_args[0][0]
+        self.assertEqual(output["success"], False)
+        self.assertEqual(output["conflicts"], conflicts)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_interactive_and_json_together_is_rejected(self, mock_json_print):
+        """--interactive and --json cannot be combined."""
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True, interactive=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_not_called()
+        self.assertFalse(mock_json_print.call_args[0][0]["success"])
+
+    @patch("poly.output.console.error")
+    def test_non_interactive_conflicts_exit_with_guidance(self, mock_error):
+        """Non-interactive conflicts print guidance and exit non-zero, without merging further."""
+        conflicts = [{"path": ["a"], "type": "modify"}]
+        self.proj.sync_branch.return_value = (False, conflicts, [])
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=None)
+        mock_error.assert_any_call("Failed to sync branch 'feature-a'.")
+
+    @patch("poly.output.console.error")
+    def test_errors_exit_before_conflict_prompt(self, mock_error):
+        """A hard error (not just conflicts) exits immediately, even without --interactive."""
+        self.proj.sync_branch.return_value = (
+            False,
+            [],
+            [{"path": "x", "message": "boom"}],
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_any_call("- x: boom")
+
+    def test_invalid_resolutions_json_exits(self):
+        """An unparseable --resolutions value exits with an error before syncing."""
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, resolutions_file="not-json")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_not_called()
+
+    @patch("poly.output.console.success")
+    def test_inline_resolutions_json_is_parsed_and_forwarded(self, mock_success):
+        """An inline JSON array passed via --resolutions is forwarded to project.sync_branch."""
+        resolutions = [{"path": ["a"], "strategy": "ours"}]
+
+        BranchCommand.branch_sync(TEST_DIR, resolutions_file=str(resolutions).replace("'", '"'))
+
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=resolutions)
+        mock_success.assert_called_once()
+
+
 class BranchMergeConflictHelpersTest(unittest.TestCase):
     """Branch merge conflict enrichment, resolution payload, and conflict table layout."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2282,7 +2282,9 @@ class CreateProjectTest(unittest.TestCase):
     @patch("poly.cli_commands.project.AgentStudioInterface")
     @patch("questionary.text")
     @patch("questionary.select")
-    def test_user_cancels_project_name_entry(self, mock_select, mock_text, mock_iface_cls, mock_init):
+    def test_user_cancels_project_name_entry(
+        self, mock_select, mock_text, mock_iface_cls, mock_init
+    ):
         """create project returns early when user enters empty project name."""
         mock_iface = mock_iface_cls.return_value
         mock_iface.get_accessible_regions.return_value = ["us-1", "euw-1"]
@@ -2958,3 +2960,225 @@ class BranchRenameTest(unittest.TestCase):
         payload = mock_json.call_args[0][0]
         self.assertFalse(payload["success"])
         self.assertIn("Branch already exists", payload["error"])
+
+
+class BranchListArchivedTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_list with --archived flag."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.print_archived_branches")
+    def test_archived_flag_calls_list_archived(self, mock_print):
+        """--archived delegates to list_archived_branches and prints the table."""
+        archived = [
+            {
+                "branchId": "BRANCH-1",
+                "name": "old-prompts",
+                "archivedAt": "2026-07-05",
+                "daysLeft": 15,
+            },
+        ]
+        self.proj.list_archived_branches.return_value = archived
+
+        BranchCommand.branch_list(TEST_DIR, archived=True)
+
+        self.proj.list_archived_branches.assert_called_once()
+        mock_print.assert_called_once_with(archived)
+
+    @patch("poly.output.console.plain")
+    def test_archived_empty_shows_message(self, mock_plain):
+        """When no archived branches exist, a 'no archived' message is shown."""
+        self.proj.list_archived_branches.return_value = []
+
+        BranchCommand.branch_list(TEST_DIR, archived=True)
+
+        mock_plain.assert_called_once()
+        self.assertIn("No archived branches", mock_plain.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_archived_json_output(self, mock_json):
+        """JSON mode with --archived outputs archived_branches."""
+        archived = [{"branchId": "BRANCH-1", "name": "old", "daysLeft": 30}]
+        self.proj.list_archived_branches.return_value = archived
+
+        BranchCommand.branch_list(TEST_DIR, output_json=True, archived=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["archived_branches"], archived)
+
+    @patch("poly.output.console.print_branches")
+    def test_no_archived_flag_uses_normal_list(self, mock_print):
+        """Without --archived, branch_list uses the normal get_branches flow."""
+        self.proj.get_branches.return_value = ("main", {"main": "main-id"})
+
+        BranchCommand.branch_list(TEST_DIR, archived=False)
+
+        self.proj.list_archived_branches.assert_not_called()
+        self.proj.get_branches.assert_called_once()
+
+
+class BranchRestoreTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_restore CLI handler."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.restore_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_successful_restore(self, mock_success):
+        """A successful restore prints a success message."""
+        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch")
+
+        self.proj.restore_branch.assert_called_once_with("old-branch")
+        mock_success.assert_called_once()
+        self.assertIn("old-branch", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_successful_restore_json(self, mock_json):
+        """JSON mode outputs success and the branch name."""
+        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["branch_name"], "old-branch")
+
+    @patch("poly.output.console.error")
+    def test_restore_failure(self, mock_error):
+        """When restore_branch returns False, a failure message is shown."""
+        self.proj.restore_branch.return_value = False
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch")
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to restore", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_restore_not_found_shows_error(self, mock_error):
+        """When the branch isn't in the archive, the ValueError is shown."""
+        self.proj.restore_branch.side_effect = ValueError("not found in archive")
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name="no-such-branch")
+
+        mock_error.assert_called_once()
+        self.assertIn("not found in archive", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_restore_not_found_json(self, mock_json):
+        """JSON mode outputs the error when restore_branch raises."""
+        self.proj.restore_branch.side_effect = ValueError("not found in archive")
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name="no-such-branch", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found in archive", payload["error"])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_duplicate_name_json(self, mock_json):
+        """JSON mode outputs the error when restore_branch raises for duplicate names."""
+        self.proj.restore_branch.side_effect = ValueError(
+            "Multiple archived branches named 'release' found"
+        )
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name="release", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("Multiple archived branches", payload["error"])
+
+    @patch("poly.output.console.error")
+    def test_duplicate_name_shows_error(self, mock_error):
+        """When multiple archived branches share a name, the error is shown."""
+        self.proj.restore_branch.side_effect = ValueError(
+            "Multiple archived branches named 'release' found"
+        )
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name="release")
+
+        mock_error.assert_called_once()
+        self.assertIn("Multiple archived branches", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_name_json_mode_exits(self, mock_json):
+        """JSON mode without a branch name prints error and exits."""
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_restore(TEST_DIR, branch_name=None, output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("requires a branch name", payload["error"])
+
+    @patch("poly.output.console.plain")
+    def test_no_name_empty_archive_shows_message(self, mock_plain):
+        """Interactive mode with no archived branches shows a message."""
+        self.proj.list_archived_branches.return_value = []
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+
+        mock_plain.assert_called_once()
+        self.assertIn("No archived branches", mock_plain.call_args[0][0])
+        self.proj.restore_branch.assert_not_called()
+
+    @patch("questionary.select")
+    @patch("poly.output.console.warning")
+    def test_no_name_user_cancels_shows_warning(self, mock_warning, mock_select):
+        """Interactive mode where user cancels shows a warning."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch"}
+        ]
+        mock_select.return_value.ask.return_value = None
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+
+        mock_warning.assert_called_once()
+        self.assertIn("No branch selected", mock_warning.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_no_name_interactive_success(self, mock_success, mock_select):
+        """Interactive mode selects a branch and restores it."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch"},
+            {"branchId": "BRANCH-2", "name": "old-branch"},
+        ]
+        mock_select.return_value.ask.return_value = "old-branch (BRANCH-2)"
+        self.proj.api_handler.restore_branch.return_value = True
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+
+        self.proj.api_handler.restore_branch.assert_called_once_with("BRANCH-2")
+        mock_success.assert_called_once()
+        self.assertIn("old-branch", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.error")
+    def test_no_name_interactive_restore_fails(self, mock_error, mock_select):
+        """Interactive mode shows error when restore returns False."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch"},
+        ]
+        mock_select.return_value.ask.return_value = "old-branch (BRANCH-1)"
+        self.proj.api_handler.restore_branch.return_value = False
+
+        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to restore", mock_error.call_args[0][0])

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -3614,6 +3614,7 @@ class BranchListArchivedTest(unittest.TestCase):
             {
                 "branchId": "BRANCH-1",
                 "name": "old-prompts",
+                "parentBranchId": "main",
                 "archivedAt": "2026-07-05",
                 "daysLeft": 15,
             },
@@ -3623,7 +3624,7 @@ class BranchListArchivedTest(unittest.TestCase):
         BranchCommand.branch_list(TEST_DIR, archived=True)
 
         self.proj.list_archived_branches.assert_called_once()
-        mock_print.assert_called_once_with(archived)
+        mock_print.assert_called_once_with(archived, {"BRANCH-1": "old-prompts"})
 
     @patch("poly.output.console.plain")
     def test_archived_empty_shows_message(self, mock_plain):
@@ -3674,7 +3675,7 @@ class BranchRestoreTest(unittest.TestCase):
     @patch("poly.output.console.success")
     def test_successful_restore(self, mock_success):
         """A successful restore prints a success message."""
-        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch")
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch")
 
         self.proj.restore_branch.assert_called_once_with("old-branch")
         mock_success.assert_called_once()
@@ -3683,19 +3684,19 @@ class BranchRestoreTest(unittest.TestCase):
     @patch("poly.cli_commands.branch.json_print")
     def test_successful_restore_json(self, mock_json):
         """JSON mode outputs success and the branch name."""
-        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch", output_json=True)
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch", output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]
         self.assertTrue(payload["success"])
-        self.assertEqual(payload["branch_name"], "old-branch")
+        self.assertEqual(payload["branch_id"], "old-branch")
 
     @patch("poly.output.console.error")
     def test_restore_failure(self, mock_error):
         """When restore_branch returns False, a failure message is shown."""
         self.proj.restore_branch.return_value = False
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name="old-branch")
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch")
 
         mock_error.assert_called_once()
         self.assertIn("Failed to restore", mock_error.call_args[0][0])
@@ -3705,7 +3706,7 @@ class BranchRestoreTest(unittest.TestCase):
         """When the branch isn't in the archive, the ValueError is shown."""
         self.proj.restore_branch.side_effect = ValueError("not found in archive")
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name="no-such-branch")
+        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch")
 
         mock_error.assert_called_once()
         self.assertIn("not found in archive", mock_error.call_args[0][0])
@@ -3715,7 +3716,7 @@ class BranchRestoreTest(unittest.TestCase):
         """JSON mode outputs the error when restore_branch raises."""
         self.proj.restore_branch.side_effect = ValueError("not found in archive")
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name="no-such-branch", output_json=True)
+        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch", output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]
@@ -3723,48 +3724,22 @@ class BranchRestoreTest(unittest.TestCase):
         self.assertIn("not found in archive", payload["error"])
 
     @patch("poly.cli_commands.branch.json_print")
-    def test_duplicate_name_json(self, mock_json):
-        """JSON mode outputs the error when restore_branch raises for duplicate names."""
-        self.proj.restore_branch.side_effect = ValueError(
-            "Multiple archived branches named 'release' found"
-        )
-
-        BranchCommand.branch_restore(TEST_DIR, branch_name="release", output_json=True)
-
-        mock_json.assert_called_once()
-        payload = mock_json.call_args[0][0]
-        self.assertFalse(payload["success"])
-        self.assertIn("Multiple archived branches", payload["error"])
-
-    @patch("poly.output.console.error")
-    def test_duplicate_name_shows_error(self, mock_error):
-        """When multiple archived branches share a name, the error is shown."""
-        self.proj.restore_branch.side_effect = ValueError(
-            "Multiple archived branches named 'release' found"
-        )
-
-        BranchCommand.branch_restore(TEST_DIR, branch_name="release")
-
-        mock_error.assert_called_once()
-        self.assertIn("Multiple archived branches", mock_error.call_args[0][0])
-
-    @patch("poly.cli_commands.branch.json_print")
     def test_no_name_json_mode_exits(self, mock_json):
         """JSON mode without a branch name prints error and exits."""
         with self.assertRaises(SystemExit):
-            BranchCommand.branch_restore(TEST_DIR, branch_name=None, output_json=True)
+            BranchCommand.branch_restore(TEST_DIR, branch_id=None, output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]
         self.assertFalse(payload["success"])
-        self.assertIn("requires a branch name", payload["error"])
+        self.assertIn("requires a branch id", payload["error"])
 
     @patch("poly.output.console.plain")
     def test_no_name_empty_archive_shows_message(self, mock_plain):
         """Interactive mode with no archived branches shows a message."""
         self.proj.list_archived_branches.return_value = []
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
 
         mock_plain.assert_called_once()
         self.assertIn("No archived branches", mock_plain.call_args[0][0])
@@ -3779,7 +3754,7 @@ class BranchRestoreTest(unittest.TestCase):
         ]
         mock_select.return_value.ask.return_value = None
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
 
         mock_warning.assert_called_once()
         self.assertIn("No branch selected", mock_warning.call_args[0][0])
@@ -3789,15 +3764,18 @@ class BranchRestoreTest(unittest.TestCase):
     def test_no_name_interactive_success(self, mock_success, mock_select):
         """Interactive mode selects a branch and restores it."""
         self.proj.list_archived_branches.return_value = [
-            {"branchId": "BRANCH-1", "name": "old-branch"},
-            {"branchId": "BRANCH-2", "name": "old-branch"},
+            {"branchId": "BRANCH-1", "name": "old-branch", "parentBranchId": "main"},
+            {"branchId": "BRANCH-2", "name": "old-branch", "parentBranchId": "BRANCH-1"},
         ]
-        mock_select.return_value.ask.return_value = "old-branch (BRANCH-2)"
-        self.proj.api_handler.restore_branch.return_value = True
+        # BRANCH-1 is the parent and is itself archived, so the label marks it.
+        mock_select.return_value.ask.return_value = (
+            "old-branch (BRANCH-2) — parent: old-branch (archived)"
+        )
+        self.proj.restore_branch.return_value = True
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
 
-        self.proj.api_handler.restore_branch.assert_called_once_with("BRANCH-2")
+        self.proj.restore_branch.assert_called_once_with("BRANCH-2")
         mock_success.assert_called_once()
         self.assertIn("old-branch", mock_success.call_args[0][0])
 
@@ -3806,12 +3784,12 @@ class BranchRestoreTest(unittest.TestCase):
     def test_no_name_interactive_restore_fails(self, mock_error, mock_select):
         """Interactive mode shows error when restore returns False."""
         self.proj.list_archived_branches.return_value = [
-            {"branchId": "BRANCH-1", "name": "old-branch"},
+            {"branchId": "BRANCH-1", "name": "old-branch", "parentBranchId": "main"},
         ]
-        mock_select.return_value.ask.return_value = "old-branch (BRANCH-1)"
-        self.proj.api_handler.restore_branch.return_value = False
+        mock_select.return_value.ask.return_value = "old-branch (BRANCH-1) — parent: main"
+        self.proj.restore_branch.return_value = False
 
-        BranchCommand.branch_restore(TEST_DIR, branch_name=None)
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
 
         mock_error.assert_called_once()
         self.assertIn("Failed to restore", mock_error.call_args[0][0])

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -442,21 +442,23 @@ class BranchDeleteTest(unittest.TestCase):
     @patch("questionary.confirm")
     @patch("poly.output.console.error")
     def test_direct_delete_when_project_raises_shows_error(self, mock_error, mock_confirm):
-        """If project.delete_branch raises, the error is shown to the user."""
+        """If project.delete_branch raises, the error is shown to the user and the command exits 1."""
         mock_confirm.return_value.ask.return_value = True
         self.proj.delete_branch.side_effect = ValueError("API failure")
 
-        BranchCommand.branch_delete(TEST_DIR, branch_name="feature-a")
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_delete(TEST_DIR, branch_name="feature-a")
 
         mock_error.assert_called_once()
         self.assertIn("API failure", mock_error.call_args[0][0])
 
     @patch("poly.cli_commands.branch.json_print")
     def test_direct_delete_when_project_raises_json_mode(self, mock_json):
-        """If project.delete_branch raises in JSON mode, error is printed as JSON."""
+        """If project.delete_branch raises in JSON mode, error is printed as JSON and exits 1."""
         self.proj.delete_branch.side_effect = ValueError("API failure")
 
-        BranchCommand.branch_delete(TEST_DIR, branch_name="feature-a", output_json=True)
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_delete(TEST_DIR, branch_name="feature-a", output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]
@@ -3564,7 +3566,8 @@ class BranchRenameTest(unittest.TestCase):
         """JSON mode outputs error when no name is provided."""
         self.proj.rename_branch.side_effect = ValueError("New branch name must be provided.")
 
-        BranchCommand.branch_rename(TEST_DIR, new_branch_name=None, output_json=True)
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_rename(TEST_DIR, new_branch_name=None, output_json=True)
 
         calls = mock_json.call_args_list
         self.assertEqual(len(calls), 2)
@@ -3574,20 +3577,22 @@ class BranchRenameTest(unittest.TestCase):
 
     @patch("poly.output.console.error")
     def test_rename_exception_shows_error(self, mock_error):
-        """When rename_branch raises, the error message is shown."""
+        """When rename_branch raises, the error message is shown and the command exits 1."""
         self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
 
-        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing")
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing")
 
         mock_error.assert_called_once()
         self.assertIn("Branch already exists", mock_error.call_args[0][0])
 
     @patch("poly.cli_commands.branch.json_print")
     def test_rename_exception_json(self, mock_json):
-        """JSON mode outputs the error when rename_branch raises."""
+        """JSON mode outputs the error when rename_branch raises, and exits 1."""
         self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
 
-        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing", output_json=True)
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing", output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]
@@ -3703,20 +3708,22 @@ class BranchRestoreTest(unittest.TestCase):
 
     @patch("poly.output.console.error")
     def test_restore_not_found_shows_error(self, mock_error):
-        """When the branch isn't in the archive, the ValueError is shown."""
+        """When the branch isn't in the archive, the ValueError is shown and the command exits 1."""
         self.proj.restore_branch.side_effect = ValueError("not found in archive")
 
-        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch")
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch")
 
         mock_error.assert_called_once()
         self.assertIn("not found in archive", mock_error.call_args[0][0])
 
     @patch("poly.cli_commands.branch.json_print")
     def test_restore_not_found_json(self, mock_json):
-        """JSON mode outputs the error when restore_branch raises."""
+        """JSON mode outputs the error when restore_branch raises, and exits 1."""
         self.proj.restore_branch.side_effect = ValueError("not found in archive")
 
-        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch", output_json=True)
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch", output_json=True)
 
         mock_json.assert_called_once()
         payload = mock_json.call_args[0][0]

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -17,6 +17,7 @@ from poly.cli_commands.project import InitCommand, ProjectCommand
 from poly.cli_commands.shared import compute_diff
 from poly.cli_commands.sync import FormatCommand, RevertCommand
 from poly.cli_commands.utils import CompletionCommand
+from poly.project import DeploymentMode
 from poly.tests.project_test import TEST_DIR
 
 
@@ -520,12 +521,13 @@ class BranchDeleteTest(unittest.TestCase):
     @patch("questionary.confirm")
     @patch("questionary.checkbox")
     @patch("poly.output.console.success")
-    def test_interactive_current_branch_label_stripped(
+    def test_interactive_current_branch_uses_choice_value(
         self, mock_success, mock_checkbox, mock_confirm
     ):
-        """The ' (current)' suffix is stripped from labels before calling delete_branch."""
+        """Selecting the current branch calls delete_branch with the plain Choice value."""
         self.proj.get_branches.return_value = ("feature-a", dict(self.SAMPLE_BRANCHES))
-        mock_checkbox.return_value.ask.return_value = ["feature-a (current)"]
+        # questionary.checkbox resolves selected Choices to their .value — mocked directly here.
+        mock_checkbox.return_value.ask.return_value = ["feature-a"]
         mock_confirm.return_value.ask.return_value = True
 
         BranchCommand.branch_delete(TEST_DIR)
@@ -567,6 +569,94 @@ class BranchDeleteTest(unittest.TestCase):
         mock_error.assert_called_once()
         mock_success.assert_called_once()
         self.assertIn("1 branch(es)", mock_success.call_args[0][0])
+
+
+class BranchSwitchInteractiveTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_switch's interactive picker (no branch_name given)."""
+
+    # Branch metadata as returned by the platform: 'feature-a' was branched off 'main'.
+    BRANCH_TREE = {
+        "main": {"branchId": "id-main", "parentBranchId": None},
+        "feature-a": {"branchId": "id-a", "parentBranchId": "id-main"},
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_branches.return_value = ("main", dict(self.BRANCH_TREE))
+        self.proj.switch_branch.return_value = (True, None)
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _choices(self, mock_select) -> list[tuple[str, str]]:
+        """Return the (title, value) pairs of the choices passed to questionary.select."""
+        choices = mock_select.call_args.kwargs["choices"]
+        return [(choice.title, choice.value) for choice in choices]
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_releases_branches_mode_offers_tree_indented_choices(self, mock_success, mock_select):
+        """In releases_branches mode, choices show branch lineage but keep plain name values."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        mock_select.return_value.ask.return_value = "feature-a"
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.assertEqual(
+            self._choices(mock_select),
+            [("main (current)", "main"), ("└─ feature-a", "feature-a")],
+        )
+        self.proj.switch_branch.assert_called_once()
+        self.assertEqual(self.proj.switch_branch.call_args[0][0], "feature-a")
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_simple_mode_offers_flat_choices(self, mock_success, mock_select):
+        """Outside releases_branches mode, choices are a flat list with no tree connectors."""
+        self.proj.deployment_mode = DeploymentMode.SIMPLE
+        self.proj.get_branches.return_value = (
+            "main",
+            {"main": "id-main", "feature-a": "id-a"},
+        )
+        mock_select.return_value.ask.return_value = "feature-a"
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.assertEqual(
+            self._choices(mock_select),
+            [("main (current)", "main"), ("feature-a", "feature-a")],
+        )
+        self.proj.switch_branch.assert_called_once()
+        self.assertEqual(self.proj.switch_branch.call_args[0][0], "feature-a")
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.warning")
+    def test_nothing_selected_shows_warning_and_does_not_switch(self, mock_warning, mock_select):
+        """Cancelling the picker warns the user and leaves the current branch alone."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        mock_select.return_value.ask.return_value = None
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.proj.switch_branch.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("No branch selected", mock_warning.call_args[0][0])
+
+    @patch("poly.output.console.plain")
+    def test_no_branches_shows_message_and_does_not_switch(self, mock_plain):
+        """When the project has no branches, a message is shown instead of a picker."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        self.proj.get_branches.return_value = (None, {})
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.proj.switch_branch.assert_not_called()
+        self.assertIn("No branches found", mock_plain.call_args[0][0])
 
 
 class BranchMergeConflictHelpersTest(unittest.TestCase):

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -238,7 +238,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         call_kwargs = self.proj.pull_project_from_env.call_args[1]
         self.assertEqual(call_kwargs["env"], "live")
         self.assertIs(call_kwargs["format"], False)
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.push_project.assert_called_once_with(
             force=True,
             skip_validation=True,
@@ -256,7 +256,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         call_kwargs = self.proj.pull_project_from_env.call_args[1]
         self.assertEqual(call_kwargs["env"], "pre-release")
         self.assertIs(call_kwargs["format"], False)
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.push_project.assert_called_once_with(
             force=True,
             skip_validation=True,
@@ -279,7 +279,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
             BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
 
         self.assertIn("No resources returned from environment 'live'", str(ctx.exception))
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.pull_project_from_env.assert_called_once()
         pull_kwargs = self.proj.pull_project_from_env.call_args[1]
         self.assertEqual(pull_kwargs["env"], "live")
@@ -291,7 +291,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         BranchCommand.branch_create(TEST_DIR, "my-branch", env="sandbox", force=False)
 
         self.proj.pull_project_from_env.assert_not_called()
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.push_project.assert_not_called()
 
     @patch("poly.output.console.error")
@@ -342,7 +342,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
 
         # No source branch is passed: the CLI relies on the project's own branch state.
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         message = mock_success.call_args[0][0]
         self.assertIn("my-branch", message)
         self.assertIn("feature-a", message)
@@ -353,7 +353,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.branch_id = "branch-a-id"
         self.proj.get_current_branch.return_value = "feature-a"
 
-        def create_and_switch(_branch_name):
+        def create_and_switch(_branch_name, source_branch_name=None):
             self.proj.branch_id = "new-branch-id"
             return "new-branch-id"
 
@@ -377,7 +377,7 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
 
         self.proj.pull_project_from_env.assert_not_called()
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.push_project.assert_not_called()
 
     def test_branch_create_env_does_not_push_when_create_branch_fails(self):
@@ -389,9 +389,82 @@ class BranchCreateFromEnvTest(unittest.TestCase):
             BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
 
         self.assertEqual(ctx.exception.code, 1)
-        self.proj.create_branch.assert_called_once_with("my-branch")
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name=None)
         self.proj.pull_project_from_env.assert_not_called()
         self.proj.push_project.assert_not_called()
+
+
+class BranchCreateFromSourceBranchTest(unittest.TestCase):
+    """Tests for ``poly branch create --from <branch>``."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        # The user is on feature-a, but creates from feature-b via --from.
+        self.proj.branch_id = "branch-feature-a"
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.get_diffs.return_value = {}
+        self.proj.create_branch.return_value = "new-branch-id"
+        self.proj.get_branches.return_value = (
+            "feature-a",
+            {
+                "main": {"branchId": "main"},
+                "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+                "feature-b": {"branchId": "branch-feature-b", "parentBranchId": "main"},
+            },
+        )
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_from_flag_is_parsed_and_forwarded_as_the_source_branch(self, _mock_success):
+        """'branch create <name> --from <branch>' reaches create_branch as source_branch_name."""
+        cli = AgentStudioCLI()
+        cli.register_commands()
+        args = cli._create_parser().parse_args(
+            ["branch", "create", "my-branch", "--from", "feature-b"]
+        )
+
+        BranchCommand.run(args)
+
+        self.proj.create_branch.assert_called_once_with("my-branch", source_branch_name="feature-b")
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_output_reports_the_source_branch_as_the_base(self, mock_json):
+        """JSON base_branch_name/base_branch_id describe the --from branch, not the current one."""
+        BranchCommand.branch_create(
+            TEST_DIR, "my-branch", output_json=True, source_branch="feature-b"
+        )
+
+        self.assertEqual(
+            mock_json.call_args[0][0],
+            {
+                "success": True,
+                "base_branch_id": "branch-feature-b",
+                "base_branch_name": "feature-b",
+                "new_branch_id": "new-branch-id",
+                "branch_name": "my-branch",
+            },
+        )
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_unknown_source_branch_is_reported_as_a_json_error(self, mock_json):
+        """An unknown --from branch is rejected by the project and reported as an error."""
+        self.proj.create_branch.side_effect = ValueError("Branch 'ghost' does not exist.")
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_create(
+                TEST_DIR, "my-branch", output_json=True, source_branch="ghost"
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(
+            mock_json.call_args[0][0],
+            {"success": False, "error": "Branch 'ghost' does not exist."},
+        )
 
 
 class BranchDeleteTest(unittest.TestCase):

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1955,6 +1955,7 @@ class DeploymentsShowTest(unittest.TestCase):
         self.mock_load_patcher = patch("poly.cli_commands.deployments.load_project")
         self.mock_load = self.mock_load_patcher.start()
         self.proj = MagicMock()
+        self.proj.using_simplified_deployments = False
         self.mock_load.return_value = self.proj
 
         # Sandbox versions: [v0(newest), v1, v2, v3, v4(oldest)]
@@ -2205,6 +2206,7 @@ class DeploymentsPromoteTest(unittest.TestCase):
         self.mock_load_patcher = patch("poly.cli_commands.deployments.load_project")
         self.mock_load = self.mock_load_patcher.start()
         self.proj = MagicMock()
+        self.proj.using_simplified_deployments = False
         self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
         self.proj.promote_deployment.return_value = True
         self.mock_load.return_value = self.proj
@@ -2455,6 +2457,7 @@ class DeploymentsRollbackTest(unittest.TestCase):
         self.mock_load_patcher = patch("poly.cli_commands.deployments.load_project")
         self.mock_load = self.mock_load_patcher.start()
         self.proj = MagicMock()
+        self.proj.using_simplified_deployments = False
         self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
         self.proj.rollback_deployment.return_value = True
         self.mock_load.return_value = self.proj
@@ -4155,3 +4158,172 @@ class AudioCacheCommandTest(unittest.TestCase):
         )
         mock_success.assert_called_once()
         self.assertIn("entry-1-preview.wav", mock_success.call_args[0][0])
+
+
+class DeploymentsSimplifiedModeTest(unittest.TestCase):
+    """Deployment-mode awareness across the deployments command family.
+
+    Under simplified deployments main deploys straight to live and sandbox is frozen
+    at its pre-migration state, so these commands must target live rather than reading
+    or writing the stale sandbox history. Legacy-mode behaviour is covered by the
+    DeploymentsShowTest/PromoteTest/RollbackTest classes above.
+    """
+
+    VERSIONS = [
+        {
+            "id": "dep-1",
+            "version_hash": "abc123456xyz",
+            "deployment_metadata": {"deployment_message": "initial release"},
+        },
+        {
+            "id": "dep-2",
+            "version_hash": "def789012xyz",
+            "deployment_metadata": {"deployment_message": "hotfix"},
+        },
+    ]
+    ACTIVE_HASHES = {"sandbox": "abc123456xyz", "live": "abc123456xyz"}
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.deployments.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_deployments.return_value = (list(self.VERSIONS), dict(self.ACTIVE_HASHES))
+        self.proj.rollback_deployment.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _client_envs_queried(self):
+        """Every client_env passed to get_deployments, positional or keyword."""
+        return [
+            call.kwargs.get("client_env", call.args[0] if call.args else None)
+            for call in self.proj.get_deployments.call_args_list
+        ]
+
+    # ── list ─────────────────────────────────────────────────────────
+
+    @patch("poly.output.console.print_deployments")
+    def test_list_defaults_to_live_when_simplified(self, _mock_print):
+        """With no --env, a converged project lists live rather than frozen sandbox."""
+        self.proj.using_simplified_deployments = True
+
+        DeploymentsCommand.deployments_list(TEST_DIR)
+
+        self.assertEqual(self._client_envs_queried(), ["live"])
+
+    @patch("poly.output.console.print_deployments")
+    def test_list_defaults_to_sandbox_when_not_simplified(self, _mock_print):
+        """An unmigrated project keeps the legacy sandbox default."""
+        self.proj.using_simplified_deployments = False
+
+        DeploymentsCommand.deployments_list(TEST_DIR)
+
+        self.assertEqual(self._client_envs_queried(), ["sandbox"])
+
+    @patch("poly.output.console.print_deployments")
+    def test_list_explicit_env_wins_when_simplified(self, _mock_print):
+        """--env sandbox still reads the frozen pre-migration history."""
+        self.proj.using_simplified_deployments = True
+
+        DeploymentsCommand.deployments_list(TEST_DIR, environment="sandbox")
+
+        self.assertEqual(self._client_envs_queried(), ["sandbox"])
+
+    # ── show ─────────────────────────────────────────────────────────
+
+    @patch("poly.output.console.print_deployment_show")
+    def test_show_defaults_to_live_when_simplified(self, _mock_print):
+        """show defaults to live, then reads sandbox for the included-deployment history."""
+        self.proj.using_simplified_deployments = True
+
+        DeploymentsCommand.deployments_show(TEST_DIR, version_hash="abc123456")
+
+        self.assertEqual(self._client_envs_queried(), ["live", "sandbox"])
+
+    @patch("poly.cli_commands.deployments.json_print")
+    def test_show_reports_no_included_deployments_for_a_post_migration_deploy(self, mock_json):
+        """A live-only hash is absent from frozen sandbox, so nothing is bundled into it."""
+        self.proj.using_simplified_deployments = True
+        live_only = [
+            {
+                "id": "dep-live",
+                "version_hash": "live99999xyz",
+                "deployment_metadata": {"deployment_message": "merge to main"},
+            }
+        ]
+        # live holds the merge; sandbox is frozen and never saw this hash
+        self.proj.get_deployments.side_effect = [
+            (live_only, {"live": "live99999xyz"}),
+            (list(self.VERSIONS), dict(self.ACTIVE_HASHES)),
+        ]
+
+        DeploymentsCommand.deployments_show(TEST_DIR, version_hash="live99999", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["included_deployments"], [])
+        self.assertFalse(payload["is_rollback"])
+
+    @patch("poly.cli_commands.deployments.json_print")
+    def test_show_still_resolves_included_for_a_pre_migration_deploy(self, mock_json):
+        """A pre-migration promotion kept its sandbox hash, so its bundle still resolves."""
+        self.proj.using_simplified_deployments = True
+        promoted = [{**self.VERSIONS[0]}]
+        self.proj.get_deployments.side_effect = [
+            (promoted, {"live": "abc123456xyz"}),
+            (list(self.VERSIONS), dict(self.ACTIVE_HASHES)),
+        ]
+
+        DeploymentsCommand.deployments_show(TEST_DIR, version_hash="abc123456", output_json=True)
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(
+            [d["version_hash"] for d in payload["included_deployments"]],
+            ["abc123456xyz", "def789012xyz"],
+        )
+
+    # ── promote ──────────────────────────────────────────────────────
+
+    @patch("poly.output.console.error")
+    def test_promote_blocked_when_simplified(self, mock_error):
+        """Promote is refused before any API call — the platform does not reject it."""
+        self.proj.using_simplified_deployments = True
+
+        with self.assertRaises(SystemExit) as ctx:
+            DeploymentsCommand.deployments_promote(
+                TEST_DIR, from_deployment="abc123456", to_env="live", force=True
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.promote_deployment.assert_not_called()
+        self.proj.get_deployments.assert_not_called()
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.deployments.json_print")
+    def test_promote_blocked_when_simplified_json(self, mock_json):
+        """The refusal is machine-readable in --json mode."""
+        self.proj.using_simplified_deployments = True
+
+        with self.assertRaises(SystemExit) as ctx:
+            DeploymentsCommand.deployments_promote(
+                TEST_DIR, from_deployment="abc123456", to_env="live", output_json=True
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.promote_deployment.assert_not_called()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("simplified deployments", payload["error"])
+
+    # ── rollback ─────────────────────────────────────────────────────
+
+    @patch("poly.output.console.success")
+    def test_rollback_targets_live_when_simplified(self, mock_success):
+        """Rollback reads live candidates — the only target the platform accepts."""
+        self.proj.using_simplified_deployments = True
+
+        DeploymentsCommand.deployments_rollback(TEST_DIR, deployment="abc123456", force=True)
+
+        self.assertEqual(self._client_envs_queried(), ["live"])
+        self.proj.rollback_deployment.assert_called_once_with("dep-1", message="initial release")
+        self.assertIn("Live", mock_success.call_args[0][0])

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -592,6 +592,77 @@ class BranchDeleteTest(unittest.TestCase):
         self.assertIn("1 branch(es)", mock_success.call_args[0][0])
 
 
+class BranchCurrentTest(unittest.TestCase):
+    """Tests for BranchCommand.get_current_branch."""
+
+    BRANCH_TREE = {
+        "main": {"branchId": "main"},
+        "feature-a": {"branchId": "id-a", "parentBranchId": "main"},
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_name: str | None) -> None:
+        self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
+
+    @patch("poly.output.console.plain")
+    def test_shows_parent_branch_when_present(self, mock_plain):
+        """A branch with a parent shows both the current and parent branch."""
+        self._set_current_branch("feature-a")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        lines = [call.args[0] for call in mock_plain.call_args_list]
+        self.assertTrue(any("feature-a" in line for line in lines))
+        self.assertTrue(any("main" in line for line in lines))
+
+    @patch("poly.output.console.plain")
+    def test_main_has_no_parent_branch_line(self, mock_plain):
+        """main has no parent, so only the current branch is shown."""
+        self._set_current_branch("main")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        mock_plain.assert_called_once()
+        self.assertIn("main", mock_plain.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_no_current_branch_shows_warning(self, mock_warning):
+        """When the local branch no longer exists remotely, a warning is shown."""
+        self._set_current_branch(None)
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        mock_warning.assert_called_once()
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_includes_parent_branch(self, mock_json_print):
+        """JSON mode includes both current_branch and parent_branch."""
+        self._set_current_branch("feature-a")
+
+        BranchCommand.get_current_branch(TEST_DIR, output_json=True)
+
+        mock_json_print.assert_called_once_with(
+            {"current_branch": "feature-a", "parent_branch": "main"}
+        )
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_main_has_null_parent(self, mock_json_print):
+        """JSON mode for main reports a null parent_branch."""
+        self._set_current_branch("main")
+
+        BranchCommand.get_current_branch(TEST_DIR, output_json=True)
+
+        mock_json_print.assert_called_once_with({"current_branch": "main", "parent_branch": None})
+
+
 class BranchSwitchInteractiveTest(unittest.TestCase):
     """Tests for BranchCommand.branch_switch's interactive picker (no branch_name given)."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -659,6 +659,107 @@ class BranchSwitchInteractiveTest(unittest.TestCase):
         self.assertIn("No branches found", mock_plain.call_args[0][0])
 
 
+class BranchMergeTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_merge's deploy confirmation and success messaging."""
+
+    # 'feature-a' sits directly under main; 'feature-a-child' sits under the 'Release 1' branch.
+    BRANCH_TREE = {
+        "main": {"branchId": "main", "name": "main"},
+        "Release 1": {"branchId": "id-release-1", "name": "Release 1", "parentBranchId": "main"},
+        "feature-a": {"branchId": "id-a", "name": "feature-a", "parentBranchId": "main"},
+        "feature-a-child": {
+            "branchId": "id-a-child",
+            "name": "feature-a-child",
+            "parentBranchId": "id-release-1",
+        },
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
+        self.proj.merge_branch.return_value = (True, [], [])
+        self._set_current_branch("feature-a")
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_name: str) -> None:
+        """Make the project report the given branch as checked out."""
+        self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_merging_into_main_merges_after_deploy_confirmation(self, mock_info, mock_confirm):
+        """Merging into main warns about live deployment and proceeds once confirmed."""
+        mock_confirm.return_value.ask.return_value = True
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_called_once()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("main", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    def test_declining_deploy_confirmation_aborts_without_merging(self, mock_confirm):
+        """Answering no to the deployment prompt exits cleanly and leaves the branch unmerged."""
+        mock_confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.proj.merge_branch.assert_not_called()
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_force_skips_deploy_confirmation(self, mock_info, mock_confirm):
+        """--force merges into main without asking for deployment confirmation."""
+        BranchCommand.branch_merge(TEST_DIR, message="ship it", force=True)
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("main", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_simplified_deployments_off_skips_confirmation_for_main(self, mock_info, mock_confirm):
+        """With simplified deployments off, merging into main skips the deploy prompt too."""
+        self.proj.using_simplified_deployments = False
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("main", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_merging_into_non_main_parent_skips_confirmation_and_names_parent(
+        self, mock_info, mock_confirm
+    ):
+        """Merging into a release branch deploys nothing live, so no prompt is shown."""
+        self._set_current_branch("feature-a-child")
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("Release 1", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_merges_without_confirmation(self, mock_json_print, mock_confirm):
+        """JSON mode is non-interactive, so it merges without prompting and reports success."""
+        BranchCommand.branch_merge(TEST_DIR, message="ship it", output_json=True)
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+
 class BranchMergeConflictHelpersTest(unittest.TestCase):
     """Branch merge conflict enrichment, resolution payload, and conflict table layout."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -271,23 +271,44 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.create_branch.assert_called_once_with("my-branch")
         self.proj.push_project.assert_not_called()
 
-    def test_branch_create_surfaces_deployment_mode_rejection(self):
-        """A deployment-mode guard failure raised by the project reaches the caller.
+    @patch("poly.output.console.error")
+    def test_branch_create_surfaces_deployment_mode_rejection(self, mock_error):
+        """A deployment-mode guard failure raised by the project is shown cleanly, not crashed.
 
         The "which branches may be created from where" rules live in
         AgentStudioProject.create_branch (they depend on the project's deployment
-        mode), so the CLI must let that ValueError propagate rather than swallow it.
+        mode); the CLI catches that ValueError and reports it via error()/exit(1)
+        instead of letting it propagate as an unhandled exception.
         """
         self.proj.branch_id = "example-feature-branch"
         self.proj.create_branch.side_effect = ValueError(
             "Cannot create a new branch from a non-main branch in releases deployment mode."
         )
 
-        with self.assertRaises(ValueError) as ctx:
+        with self.assertRaises(SystemExit) as ctx:
             BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
 
-        self.assertIn("non-main branch", str(ctx.exception))
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("non-main branch", mock_error.call_args[0][0])
         self.proj.push_project.assert_not_called()
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_branch_create_json_mode_surfaces_deployment_mode_rejection(self, mock_json):
+        """In --json mode, a deployment-mode guard failure is reported as JSON, not a crash."""
+        self.proj.branch_id = "example-feature-branch"
+        self.proj.create_branch.side_effect = ValueError(
+            "Cannot create a new branch from a non-main branch in releases deployment mode."
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_create(
+                TEST_DIR, "my-branch", output_json=True, env=None, force=False
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("non-main branch", payload["error"])
 
     @patch("poly.output.console.success")
     def test_branch_create_reports_branch_it_was_created_from(self, mock_success):
@@ -691,8 +712,8 @@ class BranchMergeTest(unittest.TestCase):
         self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
 
     @patch("questionary.confirm")
-    @patch("poly.output.console.info")
-    def test_merging_into_main_merges_after_deploy_confirmation(self, mock_info, mock_confirm):
+    @patch("poly.output.console.success")
+    def test_merging_into_main_merges_after_deploy_confirmation(self, mock_success, mock_confirm):
         """Merging into main warns about live deployment and proceeds once confirmed."""
         mock_confirm.return_value.ask.return_value = True
 
@@ -700,7 +721,7 @@ class BranchMergeTest(unittest.TestCase):
 
         mock_confirm.assert_called_once()
         self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
-        self.assertIn("main", mock_info.call_args[0][0])
+        self.assertIn("now live", mock_success.call_args[0][0])
 
     @patch("questionary.confirm")
     def test_declining_deploy_confirmation_aborts_without_merging(self, mock_confirm):
@@ -714,14 +735,14 @@ class BranchMergeTest(unittest.TestCase):
         self.proj.merge_branch.assert_not_called()
 
     @patch("questionary.confirm")
-    @patch("poly.output.console.info")
-    def test_force_skips_deploy_confirmation(self, mock_info, mock_confirm):
+    @patch("poly.output.console.success")
+    def test_force_skips_deploy_confirmation(self, mock_success, mock_confirm):
         """--force merges into main without asking for deployment confirmation."""
         BranchCommand.branch_merge(TEST_DIR, message="ship it", force=True)
 
         mock_confirm.assert_not_called()
         self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
-        self.assertIn("main", mock_info.call_args[0][0])
+        self.assertIn("now live", mock_success.call_args[0][0])
 
     @patch("questionary.confirm")
     @patch("poly.output.console.info")

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -270,17 +270,62 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.create_branch.assert_called_once_with("my-branch")
         self.proj.push_project.assert_not_called()
 
-    def test_branch_create_blocked_when_not_on_main(self):
-        """branch create from non-main branch exits with an error."""
+    def test_branch_create_surfaces_deployment_mode_rejection(self):
+        """A deployment-mode guard failure raised by the project reaches the caller.
+
+        The "which branches may be created from where" rules live in
+        AgentStudioProject.create_branch (they depend on the project's deployment
+        mode), so the CLI must let that ValueError propagate rather than swallow it.
+        """
         self.proj.branch_id = "example-feature-branch"
+        self.proj.create_branch.side_effect = ValueError(
+            "Cannot create a new branch from a non-main branch in releases deployment mode."
+        )
 
-        with self.assertRaises(SystemExit) as ctx:
-            BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
+        with self.assertRaises(ValueError) as ctx:
+            BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
 
-        self.assertEqual(ctx.exception.code, 1)
-        self.proj.pull_project_from_env.assert_not_called()
-        self.proj.create_branch.assert_not_called()
+        self.assertIn("non-main branch", str(ctx.exception))
         self.proj.push_project.assert_not_called()
+
+    @patch("poly.output.console.success")
+    def test_branch_create_reports_branch_it_was_created_from(self, mock_success):
+        """The success message names the branch that was current before creation."""
+        self.proj.branch_id = "branch-a-id"
+        self.proj.get_current_branch.return_value = "feature-a"
+
+        BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
+
+        # No source branch is passed: the CLI relies on the project's own branch state.
+        self.proj.create_branch.assert_called_once_with("my-branch")
+        message = mock_success.call_args[0][0]
+        self.assertIn("my-branch", message)
+        self.assertIn("feature-a", message)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_branch_create_json_reports_base_branch_from_before_the_switch(self, mock_json):
+        """JSON output describes the base branch as it was before create_branch switched."""
+        self.proj.branch_id = "branch-a-id"
+        self.proj.get_current_branch.return_value = "feature-a"
+
+        def create_and_switch(_branch_name):
+            self.proj.branch_id = "new-branch-id"
+            return "new-branch-id"
+
+        self.proj.create_branch.side_effect = create_and_switch
+
+        BranchCommand.branch_create(TEST_DIR, "my-branch", output_json=True)
+
+        self.assertEqual(
+            mock_json.call_args[0][0],
+            {
+                "success": True,
+                "base_branch_id": "branch-a-id",
+                "base_branch_name": "feature-a",
+                "new_branch_id": "new-branch-id",
+                "branch_name": "my-branch",
+            },
+        )
 
     def test_branch_create_env_none_behaves_like_normal(self):
         """branch create with env=None skips env pull (default behavior)."""
@@ -2869,9 +2914,7 @@ class BranchHistoryTest(unittest.TestCase):
             {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
         ]
 
-        BranchCommand.branch_history(
-            TEST_DIR, branch_name="feature-a", output_json=True, limit=3
-        )
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", output_json=True, limit=3)
 
         payload = mock_json.call_args[0][0]
         self.assertEqual(len(payload["history"]), 3)

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -5,12 +5,14 @@ Copyright PolyAI Limited
 
 import unittest
 
-from poly.output.console import flatten_branch_tree
+from poly.output.console import console, flatten_branch_tree, print_releases_branches
 
 
-def _branch(branch_id: str, parent_branch_id: str | None = None) -> dict[str, str | None]:
+def _branch(
+    branch_id: str, parent_branch_id: str | None = None, tag: str | None = None
+) -> dict[str, str | None]:
     """Build the branch metadata shape returned by the platform for one branch."""
-    return {"branchId": branch_id, "parentBranchId": parent_branch_id}
+    return {"branchId": branch_id, "parentBranchId": parent_branch_id, "tag": tag}
 
 
 class FlattenBranchTreeTest(unittest.TestCase):
@@ -121,3 +123,46 @@ class FlattenBranchTreeTest(unittest.TestCase):
         values = [value for _, value in flatten_branch_tree(branches, current_branch="sub-a")]
 
         self.assertEqual(sorted(values), ["feature-a", "main", "sub-a"])
+
+
+class PrintReleasesBranchesTest(unittest.TestCase):
+    """Tests for print_releases_branches, the tree renderer used by `branch list`."""
+
+    def _render(self, branches: dict, current_branch: str | None = None) -> str:
+        with console.capture() as capture:
+            print_releases_branches(branches, current_branch)
+        return capture.get()
+
+    def test_tagged_branch_shows_tag_alongside_name(self):
+        """A branch with a tag renders '(tag)' after its name."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main", tag="staging"),
+        }
+
+        output = self._render(branches)
+
+        self.assertIn("Release 1 (staging)", output)
+
+    def test_untagged_branch_shows_no_tag_suffix(self):
+        """A branch with no tag renders its name with no trailing parenthetical."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main"),
+        }
+
+        output = self._render(branches)
+
+        self.assertIn("Release 1\n", output)
+        self.assertNotIn("(", output)
+
+    def test_current_and_tagged_branch_shows_both_markers(self):
+        """A branch that is both current and tagged shows the tag and '(current)'."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main", tag="staging"),
+        }
+
+        output = self._render(branches, current_branch="Release 1")
+
+        self.assertIn("Release 1 (staging) (current)", output)

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -1,0 +1,123 @@
+"""Tests for poly/output/console.py display helpers.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+
+from poly.output.console import flatten_branch_tree
+
+
+def _branch(branch_id: str, parent_branch_id: str | None = None) -> dict[str, str | None]:
+    """Build the branch metadata shape returned by the platform for one branch."""
+    return {"branchId": branch_id, "parentBranchId": parent_branch_id}
+
+
+class FlattenBranchTreeTest(unittest.TestCase):
+    """Tests for flatten_branch_tree, which renders a branch forest for flat pickers."""
+
+    def test_single_root_branch_has_no_prefix(self):
+        """A lone root branch is rendered as its plain name with no connector."""
+        branches = {"main": _branch("id-main")}
+
+        self.assertEqual(flatten_branch_tree(branches, current_branch=None), [("main", "main")])
+
+    def test_multi_level_tree_uses_connectors_and_indentation(self):
+        """Children are prefixed with connectors and indented once per level of depth."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "feature-b": _branch("id-b", "id-main"),
+            "sub-a": _branch("id-sub-a", "id-a"),
+            "sub-b": _branch("id-sub-b", "id-a"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [
+                ("main", "main"),
+                ("├─ feature-a", "feature-a"),
+                ("│  ├─ sub-a", "sub-a"),
+                ("│  └─ sub-b", "sub-b"),
+                ("└─ feature-b", "feature-b"),
+            ],
+        )
+
+    def test_last_sibling_subtree_indents_with_blank_continuation(self):
+        """Descendants of a last sibling indent with spaces, not a vertical guide."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "feature-b": _branch("id-b", "id-main"),
+            "grandchild": _branch("id-grandchild", "id-b"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [
+                ("main", "main"),
+                ("├─ feature-a", "feature-a"),
+                ("└─ feature-b", "feature-b"),
+                ("   └─ grandchild", "grandchild"),
+            ],
+        )
+
+    def test_siblings_are_sorted_alphabetically_at_every_level(self):
+        """Roots and children are both emitted in alphabetical order, not insertion order."""
+        branches = {
+            "zebra": _branch("id-zebra"),
+            "apple": _branch("id-apple"),
+            "z-child": _branch("id-z-child", "id-apple"),
+            "a-child": _branch("id-a-child", "id-apple"),
+        }
+
+        titles = [title for title, _ in flatten_branch_tree(branches, current_branch=None)]
+
+        self.assertEqual(titles, ["apple", "├─ a-child", "└─ z-child", "zebra"])
+
+    def test_current_branch_title_is_suffixed_but_value_is_not(self):
+        """The current branch shows '(current)' in its title while its value stays plain."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+        }
+
+        result = flatten_branch_tree(branches, current_branch="feature-a")
+
+        self.assertEqual(result, [("main", "main"), ("└─ feature-a (current)", "feature-a")])
+
+    def test_current_root_branch_title_is_suffixed(self):
+        """A root branch that is current is also suffixed, with no connector added."""
+        branches = {"main": _branch("id-main")}
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch="main"), [("main (current)", "main")]
+        )
+
+    def test_branch_with_unknown_parent_is_treated_as_root(self):
+        """A branch whose parent is missing from the dict is rendered as a root branch."""
+        branches = {
+            "main": _branch("id-main"),
+            "orphan": _branch("id-orphan", "id-deleted-parent"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [("main", "main"), ("orphan", "orphan")],
+        )
+
+    def test_no_branches_returns_empty_list(self):
+        """An empty branches dict produces no rows."""
+        self.assertEqual(flatten_branch_tree({}, current_branch=None), [])
+
+    def test_values_are_always_raw_branch_names(self):
+        """Every value is the raw branch name, so callers can use it without stripping."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "sub-a": _branch("id-sub-a", "id-a"),
+        }
+
+        values = [value for _, value in flatten_branch_tree(branches, current_branch="sub-a")]
+
+        self.assertEqual(sorted(values), ["feature-a", "main", "sub-a"])

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -5,7 +5,13 @@ Copyright PolyAI Limited
 
 import unittest
 
-from poly.output.console import console, flatten_branch_tree, print_releases_branches
+from poly.output.console import (
+    console,
+    flatten_branch_tree,
+    print_archived_branches,
+    print_branch_history,
+    print_releases_branches,
+)
 
 
 def _branch(
@@ -166,3 +172,90 @@ class PrintReleasesBranchesTest(unittest.TestCase):
         output = self._render(branches, current_branch="Release 1")
 
         self.assertIn("Release 1 (staging) (current)", output)
+
+
+class PrintArchivedBranchesTest(unittest.TestCase):
+    """Tests for print_archived_branches, the table used by `branch list --archived`."""
+
+    def _render(self, branches: list[dict]) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches)
+        return capture.get()
+
+    def test_renders_a_row_per_archived_branch(self):
+        """Each archived branch contributes its name and id to the table."""
+        output = self._render(
+            [
+                {"name": "old-a", "branchId": "b-a", "archivedAt": "", "daysLeft": 30},
+                {"name": "old-b", "branchId": "b-b", "archivedAt": "", "daysLeft": 2},
+            ]
+        )
+
+        for expected in ("old-a", "b-a", "old-b", "b-b"):
+            self.assertIn(expected, output)
+
+    def test_shows_remaining_days_before_permanent_deletion(self):
+        """daysLeft is rendered so users know how long they have to restore."""
+        output = self._render([{"name": "old", "branchId": "b-1", "daysLeft": 7}])
+
+        self.assertIn("7 days left", output)
+
+    def test_missing_expiry_renders_a_placeholder(self):
+        """A branch with no daysLeft shows a dash rather than 'None'."""
+        output = self._render([{"name": "old", "branchId": "b-1"}])
+
+        self.assertNotIn("None", output)
+        self.assertIn("—", output)
+
+    def test_zero_days_left_is_rendered_not_treated_as_missing(self):
+        """daysLeft of 0 is a real value — the last day — and must still show."""
+        output = self._render([{"name": "old", "branchId": "b-1", "daysLeft": 0}])
+
+        self.assertIn("0 days left", output)
+
+    def test_missing_fields_render_placeholders(self):
+        """A row missing name and id degrades to dashes instead of raising."""
+        output = self._render([{}])
+
+        self.assertIn("—", output)
+
+    def test_empty_list_renders_headers_only(self):
+        """With nothing archived the table still renders its headers."""
+        output = self._render([])
+
+        self.assertIn("Branch", output)
+        self.assertIn("Expires", output)
+
+
+class PrintBranchHistoryTest(unittest.TestCase):
+    """Tests for print_branch_history, the table used by `branch history`."""
+
+    def _render(self, commits: list[dict]) -> str:
+        with console.capture() as capture:
+            print_branch_history(commits)
+        return capture.get()
+
+    def test_renders_a_row_per_merge(self):
+        """Each merge contributes its source branch and author to the table."""
+        output = self._render(
+            [
+                {"mergedAt": "", "branchName": "feature-a", "mergedBy": "ada@example.com"},
+                {"mergedAt": "", "branchName": "feature-b", "mergedBy": "grace@example.com"},
+            ]
+        )
+
+        for expected in ("feature-a", "ada@example.com", "feature-b", "grace@example.com"):
+            self.assertIn(expected, output)
+
+    def test_empty_history_reports_no_commits(self):
+        """An empty history is explained rather than rendered as a blank table."""
+        output = self._render([])
+
+        self.assertIn("No commits found for this branch.", output)
+
+    def test_missing_fields_render_placeholders(self):
+        """A merge record missing its branch or author degrades to dashes."""
+        output = self._render([{"mergedAt": ""}])
+
+        self.assertIn("—", output)
+        self.assertNotIn("None", output)

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -11,6 +11,7 @@ from poly.output.console import (
     print_archived_branches,
     print_branch_history,
     print_releases_branches,
+    resolve_parent_branch_label,
 )
 
 
@@ -259,3 +260,123 @@ class PrintBranchHistoryTest(unittest.TestCase):
 
         self.assertIn("—", output)
         self.assertNotIn("None", output)
+
+
+class ResolveParentBranchLabelTest(unittest.TestCase):
+    """Tests for resolve_parent_branch_label, which names an archived branch's parent."""
+
+    def test_main_parent_is_named_directly(self):
+        """A top-level branch reports main without needing a lookup."""
+        label = resolve_parent_branch_label({"parentBranchId": "main"})
+
+        self.assertEqual(label, "main")
+
+    def test_parent_id_is_resolved_to_a_name(self):
+        """A sub-branch's parent id is resolved through the lookup."""
+        label = resolve_parent_branch_label(
+            {"parentBranchId": "BRANCH-P"}, {"BRANCH-P": "Release 1"}
+        )
+
+        self.assertEqual(label, "Release 1")
+
+    def test_unknown_parent_id_falls_back_to_the_id(self):
+        """An unresolvable parent shows its id rather than going blank."""
+        label = resolve_parent_branch_label({"parentBranchId": "BRANCH-GONE"}, {})
+
+        self.assertEqual(label, "BRANCH-GONE")
+
+    def test_missing_parent_renders_a_placeholder(self):
+        """An entry with no parent at all renders a dash."""
+        for branch in ({}, {"parentBranchId": None}, {"parentBranchId": ""}):
+            with self.subTest(branch=branch):
+                self.assertEqual(resolve_parent_branch_label(branch), "—")
+
+
+class PrintArchivedBranchesParentColumnTest(unittest.TestCase):
+    """Tests for the parent column in print_archived_branches."""
+
+    def _render(self, branches: list[dict], name_by_branch_id: dict | None = None) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches, name_by_branch_id)
+        return capture.get()
+
+    def test_parent_column_is_shown(self):
+        """The table gains a Parent header so lineage is visible."""
+        output = self._render([{"name": "old", "branchId": "b-1", "parentBranchId": "main"}])
+
+        self.assertIn("Parent", output)
+        self.assertIn("main", output)
+
+    def test_sub_branch_shows_its_parent_name(self):
+        """A branch archived under another branch names that parent, not its id."""
+        output = self._render(
+            [{"name": "child", "branchId": "b-2", "parentBranchId": "b-1"}],
+            {"b-1": "Release 1"},
+        )
+
+        self.assertIn("Release 1", output)
+
+    def test_renders_without_a_lookup(self):
+        """Omitting the lookup still renders, falling back to raw parent ids."""
+        output = self._render([{"name": "child", "branchId": "b-2", "parentBranchId": "b-1"}])
+
+        self.assertIn("b-1", output)
+
+
+class ArchivedParentMarkerTest(unittest.TestCase):
+    """Tests for marking a parent that is itself archived."""
+
+    def _render(self, branches: list[dict], name_by_branch_id: dict | None = None) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches, name_by_branch_id)
+        return capture.get()
+
+    def test_archived_parent_is_marked(self):
+        """A parent that is also in the archive is flagged, since restoring a child
+        does not bring the parent back."""
+        label = resolve_parent_branch_label(
+            {"parentBranchId": "b-1"}, {"b-1": "Release 1"}, {"b-1"}
+        )
+
+        self.assertEqual(label, "Release 1 (archived)")
+
+    def test_live_parent_is_not_marked(self):
+        """A parent that is still active is left unmarked."""
+        label = resolve_parent_branch_label({"parentBranchId": "b-1"}, {"b-1": "Release 1"}, set())
+
+        self.assertEqual(label, "Release 1")
+
+    def test_main_is_never_marked_archived(self):
+        """Main cannot be archived, so it is never flagged even if ids are passed."""
+        label = resolve_parent_branch_label({"parentBranchId": "main"}, {}, {"main"})
+
+        self.assertEqual(label, "main")
+
+    def test_unresolved_archived_parent_marks_the_raw_id(self):
+        """An archived parent with no known name still gets the marker."""
+        label = resolve_parent_branch_label({"parentBranchId": "b-9"}, {}, {"b-9"})
+
+        self.assertEqual(label, "b-9 (archived)")
+
+    def test_table_marks_parents_present_in_the_same_listing(self):
+        """The table derives the archived set from its own rows, so a parent listed
+        alongside its child is marked without the caller passing anything extra."""
+        output = self._render(
+            [
+                {"name": "Release 1", "branchId": "b-1", "parentBranchId": "main"},
+                {"name": "child", "branchId": "b-2", "parentBranchId": "b-1"},
+            ],
+            {"b-1": "Release 1", "b-2": "child"},
+        )
+
+        self.assertIn("(archived)", output)
+
+    def test_table_does_not_mark_a_live_parent(self):
+        """A parent absent from the listing is still live, so it is not marked."""
+        output = self._render(
+            [{"name": "child", "branchId": "b-2", "parentBranchId": "b-live"}],
+            {"b-live": "Active Release"},
+        )
+
+        self.assertIn("Active Release", output)
+        self.assertNotIn("(archived)", output)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4067,6 +4067,76 @@ class RtcPullEnvTest(unittest.TestCase):
         self.assertTrue(os.path.exists(os.path.join(self.env_dir, "schema.json")))
         self.assertFalse(os.path.exists(os.path.join(self.env_dir, "data.json")))
 
+class GetBranchHistoryProject(unittest.TestCase):
+    """Tests for AgentStudioProject.get_branch_history."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """get_branch_history passes through to the api_handler and returns its result."""
+        expected = [{"commit_id": "c1"}, {"commit_id": "c2"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branch_history.return_value = expected
+
+            result = self.project.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        mock_api.get_branch_history.assert_called_once_with("branch-1")
+
+
+class RenameBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.rename_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_name_raises_value_error(self):
+        """An empty branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("")
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_none_name_raises_value_error(self):
+        """A None branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch(None)
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_main_branch_raises_value_error(self):
+        """Renaming the main branch raises ValueError."""
+        self.project.branch_id = "main"
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("new-name")
+
+        self.assertIn("main", str(ctx.exception))
+
+    def test_duplicate_name_raises_value_error(self):
+        """A name that already exists raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"new-name": "branch-id-123"}
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.rename_branch("new-name")
+
+        self.assertIn("already exists", str(ctx.exception))
+
+    def test_successful_rename_returns_true(self):
+        """A valid rename delegates to api_handler and returns its result."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"other-branch": "id-456"}
+            mock_api.rename_branch.return_value = True
+
+            result = self.project.rename_branch("new-name")
+
+        self.assertTrue(result)
+        mock_api.rename_branch.assert_called_once_with(new_branch_name="new-name")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4438,27 +4438,190 @@ class CreateBranchDeploymentModeTest(unittest.TestCase):
 
         self.mock_api.create_branch.assert_not_called()
 
-    def test_releases_branches_mode_currently_rejects_creating_from_main(self):
-        """LIKELY BUG, behavior pinned: branching from main is refused in this mode.
-
-        ``SyncClientHandler.get_branches`` injects a synthetic ``main`` entry that has
-        no ``parentBranchId`` key, so the depth check reads ``None``, compares it to
-        ``"main"``, and rejects the request. That blocks the ordinary case of creating
-        a branch from main in releases_branches mode; only branches that are already
-        direct children of main can be branched from today.
-
-        This test documents the current behavior so that fixing it has to be an
-        explicit, visible change rather than a silent one.
-        """
+    def test_releases_branches_mode_creates_branch_from_main(self):
+        """Main itself may be used as the source branch, even though it has no parent."""
         self._set_deployment_mode("releases_branches")
         self._set_current_branch("main")
         self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
 
-        with self.assertRaises(ValueError) as ctx:
-            self.project.create_branch("my-feature")
+        new_branch_id = self.project.create_branch("my-feature")
 
-        self.assertIn("depth", str(ctx.exception))
-        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+
+class MergeBranchTest(unittest.TestCase):
+    """Tests for AgentStudioProject.merge_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.merge_branch.return_value = (True, [], [])
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.mock_save_config = self.save_config_patcher.start()
+        # merge_branch refuses to run with uncommitted changes; default to a clean tree.
+        self.get_diffs_patcher = patch.object(AgentStudioProject, "get_diffs", return_value={})
+        self.mock_get_diffs = self.get_diffs_patcher.start()
+        # A successful merge switches to the parent branch; assert on the call, don't sync.
+        self.switch_branch_patcher = patch.object(
+            AgentStudioProject, "switch_branch", return_value=(True, {})
+        )
+        self.mock_switch_branch = self.switch_branch_patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch."""
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    def test_merging_direct_child_of_main_switches_to_main(self):
+        """A branch whose parent is main lands the user back on main after merging."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        result = self.project.merge_branch("ship it")
+
+        self.assertEqual(result, (True, [], []))
+        self.mock_api.merge_branch.assert_called_once_with(
+            message="ship it", conflict_resolutions=None
+        )
+        self.mock_switch_branch.assert_called_once_with("main", force=True)
+
+    def test_merging_grandchild_switches_to_its_parent_branch(self):
+        """A branch nested under a release branch lands on that release branch, not main."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "Release 1": {
+                "branchId": "branch-release-1",
+                "name": "Release 1",
+                "parentBranchId": "main",
+            },
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "branch-release-1",
+            },
+        }
+
+        result = self.project.merge_branch("ship it")
+
+        self.assertEqual(result, (True, [], []))
+        self.mock_switch_branch.assert_called_once_with("Release 1", force=True)
+
+    def test_failed_merge_returns_conflicts_and_stays_on_branch(self):
+        """When the platform reports a failure, conflicts pass through and no switch happens."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+        conflicts = [{"path": ["flows", "f1", "name"], "oursValue": "a", "theirsValue": "b"}]
+        errors = [{"path": ["flows", "f1"], "message": "boom"}]
+        self.mock_api.merge_branch.return_value = (False, conflicts, errors)
+
+        success, returned_conflicts, returned_errors = self.project.merge_branch("ship it")
+
+        self.assertFalse(success)
+        self.assertEqual(returned_conflicts, conflicts)
+        self.assertEqual(returned_errors, errors)
+        self.mock_switch_branch.assert_not_called()
+
+    def test_merging_from_main_is_rejected(self):
+        """Main has nothing to merge into, so merging from it is refused."""
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("main", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_merging_branch_missing_from_remote_is_rejected(self):
+        """A local branch that no longer exists remotely cannot be merged."""
+        self._set_current_branch("branch-deleted")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("branch-deleted", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_merging_with_uncommitted_changes_is_rejected(self):
+        """Local edits must be pushed before merging."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+        self.mock_get_diffs.return_value = {"flows/my_flow.yaml": "some diff"}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("uncommitted", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_conflict_resolution_without_strategy_is_rejected(self):
+        """Every conflict resolution must say how the conflict should be resolved."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it", conflict_resolutions=[{"path": ["flows", "f1"]}])
+
+        self.assertIn("strategy", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_conflict_resolution_with_unknown_strategy_is_rejected(self):
+        """Only 'ours', 'theirs', and 'base' are valid resolution strategies."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch(
+                "ship it",
+                conflict_resolutions=[{"path": ["flows", "f1"], "strategy": "mine"}],
+            )
+
+        self.assertIn("mine", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
 
 
 class RtcPullEnvTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4259,6 +4259,174 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
         self.assertEqual(len(branches), 1)
 
 
+class BranchTaggingTest(unittest.TestCase):
+    """Tests for AgentStudioProject.tag_branch and untag_branch."""
+
+    BRANCHES = {
+        "main": {"branchId": "main"},
+        "feature-a": {"branchId": "branch-a", "parentBranchId": "main"},
+    }
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.get_branches.return_value = deepcopy(self.BRANCHES)
+        self.mock_api.tag_branch.return_value = True
+        self.mock_api.untag_branch.return_value = True
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+        self._set_current_branch("branch-a")
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch.
+
+        The ``api_handler`` property re-reads ``branch_id`` from the handler on
+        every access, so both sides have to agree.
+        """
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    def test_tags_current_branch_by_default(self):
+        """With no branch name the current branch's id is tagged."""
+        self.assertTrue(self.project.tag_branch())
+
+        self.mock_api.tag_branch.assert_called_once_with("branch-a")
+
+    def test_untags_current_branch_by_default(self):
+        """With no branch name the current branch's id is untagged."""
+        self.assertTrue(self.project.untag_branch())
+
+        self.mock_api.untag_branch.assert_called_once_with("branch-a")
+
+    def test_named_branch_is_resolved_to_its_id(self):
+        """An explicit branch name is resolved to the branch id before the API call."""
+        self._set_current_branch("main")
+
+        self.project.tag_branch("feature-a")
+
+        self.mock_api.tag_branch.assert_called_once_with("branch-a")
+
+    def test_rejects_unknown_branch_name(self):
+        """A name that is not in the branch list is refused before any API call."""
+        for method in (self.project.tag_branch, self.project.untag_branch):
+            with self.subTest(method=method.__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    method("no-such-branch")
+
+                self.assertIn("no-such-branch", str(ctx.exception))
+
+        self.mock_api.tag_branch.assert_not_called()
+        self.mock_api.untag_branch.assert_not_called()
+
+    def test_rejects_current_branch_missing_from_branch_list(self):
+        """A local branch id with no remote counterpart is reported rather than tagged."""
+        self._set_current_branch("branch-gone")
+
+        for method in (self.project.tag_branch, self.project.untag_branch):
+            with self.subTest(method=method.__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    method()
+
+                self.assertIn("branch-gone", str(ctx.exception))
+
+    def test_rejects_main_branch(self):
+        """Main carries the live deployment, so it can be neither tagged nor untagged."""
+        self._set_current_branch("main")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.tag_branch()
+        self.assertIn("Tagging 'main' branch is not supported", str(ctx.exception))
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.untag_branch()
+        self.assertIn("Untagging 'main' branch is not supported", str(ctx.exception))
+
+        self.mock_api.tag_branch.assert_not_called()
+        self.mock_api.untag_branch.assert_not_called()
+
+    def test_rejects_main_when_named_explicitly(self):
+        """Naming main explicitly is refused the same way as being on it."""
+        self._set_current_branch("branch-a")
+
+        with self.assertRaises(ValueError):
+            self.project.tag_branch("main")
+
+        self.mock_api.tag_branch.assert_not_called()
+
+    def test_api_failure_is_returned_to_the_caller(self):
+        """A False from the API layer is passed through, not raised."""
+        self.mock_api.tag_branch.return_value = False
+        self.mock_api.untag_branch.return_value = False
+
+        self.assertFalse(self.project.tag_branch())
+        self.assertFalse(self.project.untag_branch())
+
+
+class UsingSimplifiedDeploymentsTest(unittest.TestCase):
+    """Tests for the AgentStudioProject.using_simplified_deployments property."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.branch_id = "main"
+        self.mock_api.feature_flag_enabled.return_value = True
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _build_project(self, flag_value: bool) -> AgentStudioProject:
+        """Build a fresh project whose flag resolves to the given value.
+
+        A fresh instance is required per value because the property is cached.
+        """
+        project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        api = MagicMock()
+        api.branch_id = "main"
+        api.feature_flag_enabled.return_value = flag_value
+        project._api_handler = api
+        return project
+
+    def test_reads_the_deployment_simplification_flag_for_this_project(self):
+        """The flag is looked up by key and scoped to the project's region and id."""
+        self.assertTrue(self.project.using_simplified_deployments)
+
+        self.mock_api.feature_flag_enabled.assert_called_once_with(
+            key="deployment-simplification",
+            region=self.project.region,
+            project_id=self.project.project_id,
+            default=False,
+        )
+
+    def test_defaults_to_disabled_when_the_flag_cannot_be_read(self):
+        """`default=False` is passed so an unreachable PostHog gates the new commands off."""
+        self.project.using_simplified_deployments
+
+        self.assertFalse(self.mock_api.feature_flag_enabled.call_args.kwargs["default"])
+
+    def test_returns_the_flag_value(self):
+        """Whatever the flag resolves to is what the property reports."""
+        for value in (True, False):
+            with self.subTest(value=value):
+                project = self._build_project(value)
+
+                self.assertEqual(project.using_simplified_deployments, value)
+
+    def test_flag_is_evaluated_once_and_cached(self):
+        """Repeated reads reuse the cached value instead of re-evaluating the flag."""
+        first = self.project.using_simplified_deployments
+        second = self.project.using_simplified_deployments
+
+        self.assertEqual(first, second)
+        self.mock_api.feature_flag_enabled.assert_called_once()
+
+
 class DeploymentModePropertyTest(unittest.TestCase):
     """Tests for the AgentStudioProject.deployment_mode property."""
 

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3712,6 +3712,277 @@ class MigrateFlowStepResourceIdsTest(unittest.TestCase):
         self.assertEqual(flow_steps["FLOW-abc_step-1"]["resource_id"], "FLOW-abc_step-1")
 
 
+class SyncBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.sync_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def _make_branches(self, *branch_ids):
+        """Build a branches dict with the given branch IDs."""
+        return {bid: {"branchId": bid, "name": f"name-{bid}"} for bid in branch_ids}
+
+    def test_branch_not_found_raises(self):
+        """A branch_id not present in any branch metadata raises ValueError."""
+        self.project.branch_id = "nonexistent-branch"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.sync_branch()
+
+        self.assertIn("nonexistent-branch", str(ctx.exception))
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_main_branch_raises(self):
+        """Syncing the main branch raises ValueError."""
+        self.project.branch_id = "main"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main")
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.sync_branch()
+
+        self.assertIn("main", str(ctx.exception))
+        self.assertIn("not supported", str(ctx.exception))
+
+    def test_uncommitted_changes_raises(self):
+        """Uncommitted changes (non-empty get_diffs) raises ValueError listing the diffs."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value={"topic/foo": "modified"}):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch()
+
+        self.assertIn("uncommitted changes", str(ctx.exception))
+        self.assertIn("topic/foo", str(ctx.exception))
+
+    def test_invalid_resolution_missing_path(self):
+        """A resolution dict missing 'path' raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(conflict_resolutions=[{"strategy": "ours"}])
+
+        self.assertIn("path", str(ctx.exception))
+        self.assertIn("strategy", str(ctx.exception))
+
+    def test_invalid_resolution_missing_strategy(self):
+        """A resolution dict missing 'strategy' raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(conflict_resolutions=[{"path": ["users", "name"]}])
+
+        self.assertIn("path", str(ctx.exception))
+        self.assertIn("strategy", str(ctx.exception))
+
+    def test_invalid_resolution_bad_strategy(self):
+        """A strategy not in {ours, theirs, base} raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(
+                        conflict_resolutions=[{"path": ["users", "name"], "strategy": "invalid"}]
+                    )
+
+        self.assertIn("Invalid conflict resolution strategy", str(ctx.exception))
+        self.assertIn("invalid", str(ctx.exception))
+
+    def test_successful_sync_pulls_and_returns_true(self):
+        """On success, pull_project(force=True) is called and (True, [], []) is returned."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (True, [], [])
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project") as mock_pull:
+                    result = self.project.sync_branch()
+
+        self.assertEqual(result, (True, [], []))
+        mock_pull.assert_called_once_with(force=True)
+        mock_api.sync_branch.assert_called_once_with(conflict_resolutions=None)
+
+    def test_sync_with_conflicts_returns_false(self):
+        """When the API reports conflicts, returns (False, conflicts, errors) without pulling."""
+        self.project.branch_id = "branch-1"
+        conflicts = [{"path": "topic/foo", "type": "content"}]
+        errors = [{"message": "merge error"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (False, conflicts, errors)
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project") as mock_pull:
+                    result = self.project.sync_branch()
+
+        self.assertEqual(result, (False, conflicts, errors))
+        mock_pull.assert_not_called()
+
+    def test_none_resolutions_accepted(self):
+        """Passing None for conflict_resolutions skips validation and works."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (True, [], [])
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project"):
+                    result = self.project.sync_branch(conflict_resolutions=None)
+
+        self.assertEqual(result, (True, [], []))
+        mock_api.sync_branch.assert_called_once_with(conflict_resolutions=None)
+
+
+class GetBranchHistoryProject(unittest.TestCase):
+    """Tests for AgentStudioProject.get_branch_history."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """get_branch_history passes through to the api_handler and returns its result."""
+        expected = [{"commit_id": "c1"}, {"commit_id": "c2"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branch_history.return_value = expected
+
+            result = self.project.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        mock_api.get_branch_history.assert_called_once_with("branch-1")
+
+
+class RenameBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.rename_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_name_raises_value_error(self):
+        """An empty branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("")
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_none_name_raises_value_error(self):
+        """A None branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch(None)
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_main_branch_raises_value_error(self):
+        """Renaming the main branch raises ValueError."""
+        self.project.branch_id = "main"
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("new-name")
+
+        self.assertIn("main", str(ctx.exception))
+
+    def test_duplicate_name_raises_value_error(self):
+        """A name that already exists raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"new-name": "branch-id-123"}
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.rename_branch("new-name")
+
+        self.assertIn("already exists", str(ctx.exception))
+
+    def test_successful_rename_returns_true(self):
+        """A valid rename delegates to api_handler and returns its result."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"other-branch": "id-456"}
+            mock_api.rename_branch.return_value = True
+
+            result = self.project.rename_branch("new-name")
+
+        self.assertTrue(result)
+        mock_api.rename_branch.assert_called_once_with(new_branch_name="new-name")
+
+
+class ListArchivedBranchesProject(unittest.TestCase):
+    """Tests for AgentStudioProject.list_archived_branches."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """list_archived_branches passes through to the api_handler."""
+        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = expected
+
+            result = self.project.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        mock_api.list_archived_branches.assert_called_once()
+
+
+class RestoreBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.restore_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_name_raises_value_error(self):
+        """An empty branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.restore_branch("")
+
+        self.assertIn("Branch name must be provided", str(ctx.exception))
+
+    def test_branch_not_in_archive_raises_value_error(self):
+        """A name not found in the archive raises ValueError."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "b-1", "name": "other-branch"}
+            ]
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("no-such-branch")
+
+        self.assertIn("not found in archive", str(ctx.exception))
+
+    def test_successful_restore_returns_true(self):
+        """A valid restore looks up the branch ID and delegates to api_handler."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"},
+            ]
+            mock_api.restore_branch.return_value = True
+
+            result = self.project.restore_branch("old-branch")
+
+        self.assertTrue(result)
+        mock_api.restore_branch.assert_called_once_with("b-1")
+
+    def test_duplicate_name_raises_value_error(self):
+        """Multiple archived branches with the same name raises ValueError."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "release"},
+                {"branchId": "BRANCH-2", "name": "release"},
+            ]
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("release")
+
+        self.assertIn("Multiple archived branches", str(ctx.exception))
+        self.assertIn("BRANCH-1", str(ctx.exception))
+        self.assertIn("BRANCH-2", str(ctx.exception))
+        mock_api.restore_branch.assert_not_called()
+
+
 class DiffBranchTest(unittest.TestCase):
     """Tests for the diff_branch method."""
 

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3934,53 +3934,62 @@ class RestoreBranchProject(unittest.TestCase):
     def setUp(self):
         self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
-    def test_empty_name_raises_value_error(self):
-        """An empty branch name raises ValueError."""
-        with self.assertRaises(ValueError) as ctx:
-            self.project.restore_branch("")
-
-        self.assertIn("Branch name must be provided", str(ctx.exception))
-
-    def test_branch_not_in_archive_raises_value_error(self):
-        """A name not found in the archive raises ValueError."""
+    def test_empty_branch_id_raises_value_error(self):
+        """An empty branch id raises ValueError before any API call."""
         with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.list_archived_branches.return_value = [
-                {"branchId": "b-1", "name": "other-branch"}
-            ]
-
             with self.assertRaises(ValueError) as ctx:
-                self.project.restore_branch("no-such-branch")
+                self.project.restore_branch("")
 
-        self.assertIn("not found in archive", str(ctx.exception))
+        self.assertIn("Branch id must be provided", str(ctx.exception))
+        mock_api.restore_branch.assert_not_called()
 
-    def test_successful_restore_returns_true(self):
-        """A valid restore looks up the branch ID and delegates to api_handler."""
+    def test_restore_delegates_the_branch_id_to_the_api(self):
+        """A branch id present in the archive is restored."""
         with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
             mock_api.list_archived_branches.return_value = [
-                {"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"},
+                {"branchId": "BRANCH-1", "name": "old-branch"},
             ]
             mock_api.restore_branch.return_value = True
 
-            result = self.project.restore_branch("old-branch")
+            result = self.project.restore_branch("BRANCH-1")
 
         self.assertTrue(result)
-        mock_api.restore_branch.assert_called_once_with("b-1")
+        mock_api.restore_branch.assert_called_once_with("BRANCH-1")
 
-    def test_duplicate_name_raises_value_error(self):
-        """Multiple archived branches with the same name raises ValueError."""
+    def test_branch_id_not_in_archive_raises_value_error(self):
+        """An id that is not archived is refused before any restore is attempted."""
         with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
             mock_api.list_archived_branches.return_value = [
-                {"branchId": "BRANCH-1", "name": "release"},
-                {"branchId": "BRANCH-2", "name": "release"},
+                {"branchId": "BRANCH-1", "name": "old-branch"},
             ]
 
             with self.assertRaises(ValueError) as ctx:
-                self.project.restore_branch("release")
+                self.project.restore_branch("BRANCH-NOPE")
 
-        self.assertIn("Multiple archived branches", str(ctx.exception))
-        self.assertIn("BRANCH-1", str(ctx.exception))
-        self.assertIn("BRANCH-2", str(ctx.exception))
+        self.assertIn("not found in archive", str(ctx.exception))
         mock_api.restore_branch.assert_not_called()
+
+    def test_matching_is_by_id_not_name(self):
+        """A branch name is not accepted, even when it is unique in the archive."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+
+            with self.assertRaises(ValueError):
+                self.project.restore_branch("old-branch")
+
+        mock_api.restore_branch.assert_not_called()
+
+    def test_api_failure_is_returned_to_the_caller(self):
+        """A False from the API layer is passed through rather than raised."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+            mock_api.restore_branch.return_value = False
+
+            self.assertFalse(self.project.restore_branch("BRANCH-1"))
 
 
 class DiffBranchTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4555,6 +4555,62 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
         self.assertEqual(first, second)
         self.mock_api.feature_flag_enabled.assert_called_once()
 
+    def test_does_not_query_deployments_when_flag_is_disabled(self):
+        """Deployments are only fetched once the feature flag is confirmed enabled."""
+        project = self._build_project(flag_value=False)
+
+        self.assertFalse(project.using_simplified_deployments)
+        project.api_handler.get_deployments.assert_not_called()
+
+    def _deployment(self, created_at: str, deleted: bool = False) -> dict:
+        """Build a minimal deployment dict for convergence checks."""
+        return {"created_at": created_at, "deleted": deleted}
+
+    def _set_deployments(self, api: MagicMock, live: list, sandbox: list) -> None:
+        """Stub get_deployments to return a different list per client_env."""
+        api.get_deployments.side_effect = (
+            lambda *args, **kwargs: live if kwargs["client_env"] == "live" else sandbox
+        )
+
+    def test_converges_when_no_deployments_exist_in_either_environment(self):
+        """With no deployments anywhere, there's nothing for live to lag behind."""
+        self._set_deployments(self.mock_api, live=[], sandbox=[])
+
+        self.assertTrue(self.project.using_simplified_deployments)
+
+    def test_convergence_depends_on_relative_head_timestamps(self):
+        """Live is converged once its head is at least as new as sandbox's."""
+        earlier, later = "Mon, 01 Jan 2026 10:00:00 GMT", "Mon, 01 Jan 2026 12:00:00 GMT"
+        cases = {
+            "live newer": ((later, earlier), True),
+            "equal": ((later, later), True),
+            "live older": ((earlier, later), False),
+            "only live has deployments": ((earlier, None), True),
+            "only sandbox has deployments": ((None, earlier), False),
+        }
+        for name, ((live_time, sandbox_time), expected) in cases.items():
+            with self.subTest(name):
+                live = [self._deployment(live_time)] if live_time else []
+                sandbox = [self._deployment(sandbox_time)] if sandbox_time else []
+                self._set_deployments(self.mock_api, live=live, sandbox=sandbox)
+                self.project.__dict__.pop("using_simplified_deployments", None)
+
+                self.assertEqual(self.project.using_simplified_deployments, expected)
+
+    def test_skips_deleted_deployments_to_find_the_head(self):
+        """A deleted deployment at the top of the list is not treated as the head."""
+        self._set_deployments(
+            self.mock_api,
+            live=[
+                self._deployment("Mon, 01 Jan 2026 14:00:00 GMT", deleted=True),
+                self._deployment("Mon, 01 Jan 2026 10:00:00 GMT"),
+            ],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT")],
+        )
+
+        # The live head (10:00, ignoring the deleted 14:00 entry) is older than sandbox's (12:00).
+        self.assertFalse(self.project.using_simplified_deployments)
+
 
 class DeploymentModePropertyTest(unittest.TestCase):
     """Tests for the AgentStudioProject.deployment_mode property."""

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4458,7 +4458,7 @@ class DeploymentModePropertyTest(unittest.TestCase):
             ("releases_branches", DeploymentMode.RELEASES_BRANCHES),
         ):
             with self.subTest(value=value):
-                self.project._AgentStudioProject__deployment_mode = None
+                self.project._AgentStudioProject_deployment_mode = None
                 self.mock_api.get_project.return_value = {"config": {"deployment_mode": value}}
 
                 self.assertEqual(self.project.deployment_mode, expected)
@@ -4471,7 +4471,7 @@ class DeploymentModePropertyTest(unittest.TestCase):
             {"config": None},
         ):
             with self.subTest(payload=payload):
-                self.project._AgentStudioProject__deployment_mode = None
+                self.project._AgentStudioProject_deployment_mode = None
                 self.mock_api.get_project.return_value = payload
 
                 self.assertEqual(self.project.deployment_mode, DeploymentMode.RELEASES)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4676,6 +4676,23 @@ class MergeBranchTest(unittest.TestCase):
         )
         self.mock_switch_branch.assert_called_once_with("main", force=True)
 
+    def test_merging_with_unresolvable_parent_falls_back_to_main(self):
+        """If parentBranchId is missing/unresolvable, the merge still succeeds and lands on main."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                # No parentBranchId — simulates a branch created before lineage tracking existed.
+            },
+        }
+
+        result = self.project.merge_branch("ship it")
+
+        self.assertEqual(result, (True, [], []))
+        self.mock_switch_branch.assert_called_once_with("main", force=True)
+
     def test_merging_grandchild_switches_to_its_parent_branch(self):
         """A branch nested under a release branch lands on that release branch, not main."""
         self._set_current_branch("branch-feature-a")

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import poly.resources.resource_utils as resource_utils
-from poly.project import AgentStudioProject
+from poly.project import AgentStudioProject, DeploymentMode
 from poly.resources import (
     AsrSettings,
     ChatGreeting,
@@ -4259,6 +4259,208 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
         self.assertEqual(len(branches), 1)
 
 
+class DeploymentModePropertyTest(unittest.TestCase):
+    """Tests for the AgentStudioProject.deployment_mode property."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.branch_id = "main"
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def test_reads_mode_from_remote_project_config(self):
+        """Each recognised config value maps to the matching enum member."""
+        for value, expected in (
+            ("simple", DeploymentMode.SIMPLE),
+            ("releases", DeploymentMode.RELEASES),
+            ("releases_branches", DeploymentMode.RELEASES_BRANCHES),
+        ):
+            with self.subTest(value=value):
+                self.project._AgentStudioProject__deployment_mode = None
+                self.mock_api.get_project.return_value = {"config": {"deployment_mode": value}}
+
+                self.assertEqual(self.project.deployment_mode, expected)
+
+    def test_defaults_to_releases_when_config_missing(self):
+        """A missing 'config', missing 'deployment_mode', or null config all default to releases."""
+        for payload in (
+            {"projectId": "test_project"},
+            {"config": {"other_setting": True}},
+            {"config": None},
+        ):
+            with self.subTest(payload=payload):
+                self.project._AgentStudioProject__deployment_mode = None
+                self.mock_api.get_project.return_value = payload
+
+                self.assertEqual(self.project.deployment_mode, DeploymentMode.RELEASES)
+
+    def test_mode_is_fetched_once_and_cached(self):
+        """Repeated reads reuse the cached mode instead of re-querying the API."""
+        self.mock_api.get_project.return_value = {"config": {"deployment_mode": "simple"}}
+
+        first = self.project.deployment_mode
+        second = self.project.deployment_mode
+
+        self.assertEqual(first, second)
+        self.mock_api.get_project.assert_called_once()
+
+
+class CreateBranchDeploymentModeTest(unittest.TestCase):
+    """Tests for the deployment-mode guards in AgentStudioProject.create_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.create_branch.return_value = "new-branch-id"
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.mock_save_config = self.save_config_patcher.start()
+        self._set_current_branch("main")
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _set_deployment_mode(self, mode: str) -> None:
+        """Make the remote project report the given deployment mode."""
+        self.mock_api.get_project.return_value = {"config": {"deployment_mode": mode}}
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch."""
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    # -- simple mode: at most one branch may exist at a time --
+
+    def test_simple_mode_creates_branch_when_only_main_exists(self):
+        """In simple mode a branch can be created while main is the only branch."""
+        self._set_deployment_mode("simple")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main"}}
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+    def test_simple_mode_rejects_second_branch(self):
+        """In simple mode a second branch is refused while another branch exists."""
+        self._set_deployment_mode("simple")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "existing": {"branchId": "branch-existing", "parentBranchId": "main"},
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("simple deployment mode", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(self.project.branch_id, "main")
+
+    # -- releases mode: branches may only be created from main --
+
+    def test_releases_mode_creates_branch_from_main(self):
+        """In releases mode main is a valid source branch."""
+        self._set_deployment_mode("releases")
+        self._set_current_branch("main")
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+
+    def test_releases_mode_rejects_non_main_source_branch(self):
+        """In releases mode creating a branch from another branch is refused."""
+        self._set_deployment_mode("releases")
+        self._set_current_branch("branch-feature-a")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("releases deployment mode", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(self.project.branch_id, "branch-feature-a")
+
+    # -- releases_branches mode: source branch must be a direct child of main --
+
+    def test_releases_branches_mode_creates_branch_from_direct_child_of_main(self):
+        """A branch whose parent is main may be used as the source branch."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+        }
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "branch-feature-a")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+    def test_releases_branches_mode_rejects_grandchild_of_main(self):
+        """A branch whose parent is not main is too deep to branch from again."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a-child")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+            "feature-a-child": {
+                "branchId": "branch-feature-a-child",
+                "parentBranchId": "branch-feature-a",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("depth", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+
+    def test_releases_branches_mode_rejects_branch_missing_from_remote(self):
+        """A local branch that no longer exists remotely cannot be branched from."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-deleted")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main"}}
+
+        with self.assertRaises(ValueError):
+            self.project.create_branch("my-feature")
+
+        self.mock_api.create_branch.assert_not_called()
+
+    def test_releases_branches_mode_currently_rejects_creating_from_main(self):
+        """LIKELY BUG, behavior pinned: branching from main is refused in this mode.
+
+        ``SyncClientHandler.get_branches`` injects a synthetic ``main`` entry that has
+        no ``parentBranchId`` key, so the depth check reads ``None``, compares it to
+        ``"main"``, and rejects the request. That blocks the ordinary case of creating
+        a branch from main in releases_branches mode; only branches that are already
+        direct children of main can be branched from today.
+
+        This test documents the current behavior so that fixing it has to be an
+        explicit, visible change rather than a silent one.
+        """
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("depth", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+
+
 class RtcPullEnvTest(unittest.TestCase):
     """Tests for AgentStudioProject.rtc_pull_env writing RTC files to disk."""
 
@@ -4337,149 +4539,6 @@ class RtcPullEnvTest(unittest.TestCase):
         self.assertNotIn("data_file", result)
         self.assertTrue(os.path.exists(os.path.join(self.env_dir, "schema.json")))
         self.assertFalse(os.path.exists(os.path.join(self.env_dir, "data.json")))
-
-class GetBranchHistoryProject(unittest.TestCase):
-    """Tests for AgentStudioProject.get_branch_history."""
-
-    def setUp(self):
-        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-
-    def test_delegates_to_api_handler(self):
-        """get_branch_history passes through to the api_handler and returns its result."""
-        expected = [{"commit_id": "c1"}, {"commit_id": "c2"}]
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.get_branch_history.return_value = expected
-
-            result = self.project.get_branch_history("branch-1")
-
-        self.assertEqual(result, expected)
-        mock_api.get_branch_history.assert_called_once_with("branch-1")
-
-
-class RenameBranchProject(unittest.TestCase):
-    """Tests for AgentStudioProject.rename_branch."""
-
-    def setUp(self):
-        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-
-    def test_empty_name_raises_value_error(self):
-        """An empty branch name raises ValueError."""
-        with self.assertRaises(ValueError) as ctx:
-            self.project.rename_branch("")
-
-        self.assertIn("New branch name must be provided", str(ctx.exception))
-
-    def test_none_name_raises_value_error(self):
-        """A None branch name raises ValueError."""
-        with self.assertRaises(ValueError) as ctx:
-            self.project.rename_branch(None)
-
-        self.assertIn("New branch name must be provided", str(ctx.exception))
-
-    def test_main_branch_raises_value_error(self):
-        """Renaming the main branch raises ValueError."""
-        self.project.branch_id = "main"
-
-        with self.assertRaises(ValueError) as ctx:
-            self.project.rename_branch("new-name")
-
-        self.assertIn("main", str(ctx.exception))
-
-    def test_duplicate_name_raises_value_error(self):
-        """A name that already exists raises ValueError."""
-        self.project.branch_id = "branch-1"
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.get_branches.return_value = {"new-name": "branch-id-123"}
-
-            with self.assertRaises(ValueError) as ctx:
-                self.project.rename_branch("new-name")
-
-        self.assertIn("already exists", str(ctx.exception))
-
-    def test_successful_rename_returns_true(self):
-        """A valid rename delegates to api_handler and returns its result."""
-        self.project.branch_id = "branch-1"
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.get_branches.return_value = {"other-branch": "id-456"}
-            mock_api.rename_branch.return_value = True
-
-            result = self.project.rename_branch("new-name")
-
-        self.assertTrue(result)
-        mock_api.rename_branch.assert_called_once_with(new_branch_name="new-name")
-
-
-class ListArchivedBranchesProject(unittest.TestCase):
-    """Tests for AgentStudioProject.list_archived_branches."""
-
-    def setUp(self):
-        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-
-    def test_delegates_to_api_handler(self):
-        """list_archived_branches passes through to the api_handler."""
-        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.list_archived_branches.return_value = expected
-
-            result = self.project.list_archived_branches()
-
-        self.assertEqual(result, expected)
-        mock_api.list_archived_branches.assert_called_once()
-
-
-class RestoreBranchProject(unittest.TestCase):
-    """Tests for AgentStudioProject.restore_branch."""
-
-    def setUp(self):
-        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-
-    def test_empty_name_raises_value_error(self):
-        """An empty branch name raises ValueError."""
-        with self.assertRaises(ValueError) as ctx:
-            self.project.restore_branch("")
-
-        self.assertIn("Branch name must be provided", str(ctx.exception))
-
-    def test_branch_not_in_archive_raises_value_error(self):
-        """A name not found in the archive raises ValueError."""
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.list_archived_branches.return_value = [
-                {"branchId": "b-1", "name": "other-branch"}
-            ]
-
-            with self.assertRaises(ValueError) as ctx:
-                self.project.restore_branch("no-such-branch")
-
-        self.assertIn("not found in archive", str(ctx.exception))
-
-    def test_successful_restore_returns_true(self):
-        """A valid restore looks up the branch ID and delegates to api_handler."""
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.list_archived_branches.return_value = [
-                {"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"},
-            ]
-            mock_api.restore_branch.return_value = True
-
-            result = self.project.restore_branch("old-branch")
-
-        self.assertTrue(result)
-        mock_api.restore_branch.assert_called_once_with("b-1")
-
-    def test_duplicate_name_raises_value_error(self):
-        """Multiple archived branches with the same name raises ValueError."""
-        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
-            mock_api.list_archived_branches.return_value = [
-                {"branchId": "BRANCH-1", "name": "release"},
-                {"branchId": "BRANCH-2", "name": "release"},
-            ]
-
-            with self.assertRaises(ValueError) as ctx:
-                self.project.restore_branch("release")
-
-        self.assertIn("Multiple archived branches", str(ctx.exception))
-        self.assertIn("BRANCH-1", str(ctx.exception))
-        self.assertIn("BRANCH-2", str(ctx.exception))
-        mock_api.restore_branch.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4804,6 +4804,81 @@ class CreateBranchDeploymentModeTest(unittest.TestCase):
         self.assertEqual(self.project.branch_id, "new-branch-id")
         self.mock_save_config.assert_called()
 
+    # -- source_branch_name: create from a branch other than the current one --
+
+    def test_named_source_branch_overrides_the_current_branch(self):
+        """Passing source_branch_name resolves that branch's id and validates against it,
+        not against whatever branch the user currently has checked out."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+            "feature-b": {"branchId": "branch-feature-b", "parentBranchId": "main"},
+        }
+
+        new_branch_id = self.project.create_branch("my-feature", source_branch_name="feature-b")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "branch-feature-b")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+
+    def test_unknown_source_branch_is_rejected_without_creating(self):
+        """Naming a branch that does not exist remotely fails before anything is created."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature", source_branch_name="no-such-branch")
+
+        self.assertEqual(str(ctx.exception), "Branch 'no-such-branch' does not exist.")
+        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(self.project.branch_id, "branch-feature-a")
+
+    def test_deployment_mode_guards_validate_the_named_source_not_the_current_branch(self):
+        """The same per-mode guards apply, but keyed off source_branch_name when given."""
+        branches = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+            "feature-b": {"branchId": "branch-feature-b", "parentBranchId": "main"},
+            "feature-b-child": {
+                "branchId": "branch-feature-b-child",
+                "parentBranchId": "branch-feature-b",
+            },
+        }
+        cases = {
+            "releases allows main by name from elsewhere": ("releases", "main", None),
+            "releases rejects a named non-main source": (
+                "releases",
+                "feature-b",
+                "releases deployment mode",
+            ),
+            "releases_branches rejects a named grandchild of main": (
+                "releases_branches",
+                "feature-b-child",
+                "depth",
+            ),
+        }
+        for description, (mode, source_branch_name, expected_error) in cases.items():
+            with self.subTest(description):
+                self.project._deployment_mode = None  # deployment_mode caches on first access
+                self._set_deployment_mode(mode)
+                self._set_current_branch("branch-feature-a")
+                self.mock_api.get_branches.return_value = branches
+                self.mock_api.create_branch.reset_mock()
+
+                if expected_error:
+                    with self.assertRaises(ValueError) as ctx:
+                        self.project.create_branch(
+                            "my-feature", source_branch_name=source_branch_name
+                        )
+                    self.assertIn(expected_error, str(ctx.exception))
+                    self.mock_api.create_branch.assert_not_called()
+                else:
+                    self.project.create_branch("my-feature", source_branch_name=source_branch_name)
+                    self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+
 
 class MergeBranchTest(unittest.TestCase):
     """Tests for AgentStudioProject.merge_branch."""

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4138,5 +4138,78 @@ class RenameBranchProject(unittest.TestCase):
         mock_api.rename_branch.assert_called_once_with(new_branch_name="new-name")
 
 
+class ListArchivedBranchesProject(unittest.TestCase):
+    """Tests for AgentStudioProject.list_archived_branches."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """list_archived_branches passes through to the api_handler."""
+        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = expected
+
+            result = self.project.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        mock_api.list_archived_branches.assert_called_once()
+
+
+class RestoreBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.restore_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_name_raises_value_error(self):
+        """An empty branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.restore_branch("")
+
+        self.assertIn("Branch name must be provided", str(ctx.exception))
+
+    def test_branch_not_in_archive_raises_value_error(self):
+        """A name not found in the archive raises ValueError."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "b-1", "name": "other-branch"}
+            ]
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("no-such-branch")
+
+        self.assertIn("not found in archive", str(ctx.exception))
+
+    def test_successful_restore_returns_true(self):
+        """A valid restore looks up the branch ID and delegates to api_handler."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"},
+            ]
+            mock_api.restore_branch.return_value = True
+
+            result = self.project.restore_branch("old-branch")
+
+        self.assertTrue(result)
+        mock_api.restore_branch.assert_called_once_with("b-1")
+
+    def test_duplicate_name_raises_value_error(self):
+        """Multiple archived branches with the same name raises ValueError."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "release"},
+                {"branchId": "BRANCH-2", "name": "release"},
+            ]
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("release")
+
+        self.assertIn("Multiple archived branches", str(ctx.exception))
+        self.assertIn("BRANCH-1", str(ctx.exception))
+        self.assertIn("BRANCH-2", str(ctx.exception))
+        mock_api.restore_branch.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -4578,7 +4578,7 @@ class DeploymentModePropertyTest(unittest.TestCase):
             ("releases_branches", DeploymentMode.RELEASES_BRANCHES),
         ):
             with self.subTest(value=value):
-                self.project._AgentStudioProject_deployment_mode = None
+                self.project._deployment_mode = None
                 self.mock_api.get_project.return_value = {"config": {"deployment_mode": value}}
 
                 self.assertEqual(self.project.deployment_mode, expected)
@@ -4591,7 +4591,7 @@ class DeploymentModePropertyTest(unittest.TestCase):
             {"config": None},
         ):
             with self.subTest(payload=payload):
-                self.project._AgentStudioProject_deployment_mode = None
+                self.project._deployment_mode = None
                 self.mock_api.get_project.return_value = payload
 
                 self.assertEqual(self.project.deployment_mode, DeploymentMode.RELEASES)

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.36.2"
+version = "0.36.3"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "cattrs"
 version = "24.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -139,6 +148,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -341,12 +359,13 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.34.5"
+version = "0.36.2"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
     { name = "jsonschema" },
     { name = "langcodes" },
+    { name = "posthog" },
     { name = "protobuf" },
     { name = "python-dateutil" },
     { name = "questionary" },
@@ -376,6 +395,7 @@ requires-dist = [
     { name = "langcodes", specifier = "==3.5.1" },
     { name = "licensecheck", marker = "extra == 'dev'", specifier = ">=2024.3" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.1" },
+    { name = "posthog", specifier = "==7.35.4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=4.21.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -390,6 +410,21 @@ requires-dist = [
     { name = "ty" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "posthog"
+version = "7.35.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/b9/9471861b836eed9be1da207792d8ad69b385e99a174029f13d52467493fa/posthog-7.35.4.tar.gz", hash = "sha256:b0342314599c25bd9d32877a9525f9632ed49037d3b25a920b01be641dd1b368", size = 395178, upload-time = "2026-07-31T11:15:39.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/94/4e63655fa86054459be1bb50497198efd27bb76db50da977643739fa1c25/posthog-7.35.4-py3-none-any.whl", hash = "sha256:79e3979e7a68b98d2ff2064916eed60b2ee3b2c687e73c41b77e4de00514ec74", size = 468387, upload-time = "2026-07-31T11:15:37.556Z" },
+]
 
 [[package]]
 name = "pre-commit"
@@ -744,6 +779,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/88/36c652c658fe96658043e4abc8ea97801de6fb6e63ab50aaa82807bff1d8/ty-0.0.20-py3-none-win32.whl", hash = "sha256:c7d32bfe93f8fcaa52b6eef3f1b930fd7da410c2c94e96f7412c30cfbabf1d17", size = 9744206, upload-time = "2026-03-02T15:51:54.183Z" },
     { url = "https://files.pythonhosted.org/packages/ff/a7/a4a13bed1d7fd9d97aaa3c5bb5e6d3e9a689e6984806cbca2ab4c9233cac/ty-0.0.20-py3-none-win_amd64.whl", hash = "sha256:a5e10f40fc4a0a1cbcb740a4aad5c7ce35d79f030836ea3183b7a28f43170248", size = 10711999, upload-time = "2026-03-02T15:51:29.212Z" },
     { url = "https://files.pythonhosted.org/packages/8d/7e/6bfd748a9f4ff9267ed3329b86a0f02cdf6ab49f87bc36c8a164852f99fc/ty-0.0.20-py3-none-win_arm64.whl", hash = "sha256:53f7a5c12c960e71f160b734f328eff9a35d578af4b67a36b0bb5990ac5cdc27", size = 10150143, upload-time = "2026-03-02T15:51:31.283Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds six `poly branch` subcommands — `sync`, `history`, `rename`, `restore`, `tag`, `untag` — plus `branch list --archived`, and teaches `branch create`/`merge`/`current`/`list` about branch lineage and the project's deployment mode. Commands the platform only exposes under simplified deployments are gated behind the `deployment_simplification` feature flag. Also makes `poly deployments list`/`show`/`promote`/`rollback` aware of that same deployment mode.

## Motivation

The platform's simplified deployment model introduces branch lineage (branches can be created from other branches), staging tags, and soft-archive/restore with a 30-day window. The ADK CLI had no support for any of it, and `poly branch merge` assumed every branch's parent was `main`. Once a project moves to simplified deployments, its old `sandbox` deployment history is also frozen in place — merges to main go straight to `live` — so the existing `deployments` commands needed to stop defaulting to `sandbox`.

## Changes

**New commands**

- `poly branch sync` — merge the parent branch's changes into the current branch, reusing the existing merge-conflict UX (`-i`/`--interactive`, `--resolutions`)
- `poly branch history [--branch-name] [--limit]` — merge history for a branch, 10 entries by default
- `poly branch rename [new_name]` — rename the current branch
- `poly branch restore [branch]` — restore a soft-deleted branch from the archive
- `poly branch tag` / `poly branch untag` — tag the current branch to deploy it to staging, or remove the tag
- `poly branch list --archived` — list soft-deleted branches instead of active ones

**Changed behaviour**

- `branch create` now respects the project's deployment mode: one active branch in `simple`, main-only in `releases`, and branching off a direct child of main (max depth 2) in `releases_branches`. This replaces the previous unconditional "branches can only be created from main" guard. A new `--from <branch>` flag lets the source branch be named explicitly instead of always defaulting to whatever branch is currently checked out; the deployment-mode guards validate against the named source, not the current branch.
- `branch merge` merges into the branch's actual parent instead of always `main`, switches to that parent afterwards, and shows a confirmation plus "now live" messaging when merging into main under simplified deployments. Merges into a branch other than `main` no longer require a merge message.
- `branch current` also prints the parent branch, suppressed when the parent is `main` to avoid noise in the common case. `--json` always includes `parent_branch`.
- `branch list` and the `switch`/`delete` interactive pickers render lineage as an indented tree in `releases_branches` mode, and show staging tags.
- `branch` subcommands are regrouped into lifecycle and inspection groups in `--help`, and stale help text/epilogs are corrected.
- `deployments list`/`show` default to the `live` environment instead of `sandbox` for projects using simplified deployments (`--env` still overrides). `show` no longer prints a "No intermediate deployments" placeholder when the included list is empty, since post-migration deployments legitimately have none.
- `deployments promote` is refused outright for projects using simplified deployments — merging to main deploys straight to live, so there is no sandbox → pre-release → live ladder left to promote along, and the platform does not reject the call itself.
- `deployments rollback` targets `live` rather than `sandbox` for projects using simplified deployments, since that's the only environment the platform accepts a rollback target for.

**Feature-flag gating**

- New `PosthogHandler` and `AgentStudioInterface.feature_flag_enabled`, backing `AgentStudioProject.using_simplified_deployments`.
- `using_simplified_deployments` now also checks convergence: even with the feature flag on, it only reports `True` once the project's `live` deployment head is at least as recent as its `sandbox` head (i.e. `live` has caught up and sandbox is no longer receiving new deployments). This avoids treating a project as simplified mid-migration, while it still has newer sandbox deployments that haven't reached live.
- New `require_deployment_simplification` helper gates `sync`, `tag`, and `untag` — the three endpoints the platform 404s when the flag is off. Previously these surfaced a bare `API error: 404 Client Error`; they now exit 1 with an explanatory message in both human and `--json` modes.
- New `DeploymentMode` enum and `AgentStudioProject.deployment_mode`, read from the project's `config.deployment_mode` and defaulting to `releases`.

**Supporting API surface**

`sync_branch`, `get_branch_history`, `rename_branch`, `list_archived_branches`, `restore_branch`, `tag_branch`, `untag_branch`, `get_project`, and `create_branch(..., source_branch_id)` across the SDK, sync client, and interface. New console renderers for branch trees, archived branches, and merge history.

**Other**

- Adds `posthog==7.35.4`.
- README `poly branch` section and `poly branch --help` examples updated to cover the new commands, including `--from`.

## Follow-ups (tracked separately, not silently dropped)

- The `sandbox` environment does not exist under simplified deployments, but it is still the hardcoded default for `diff`, `chat`, and the `rtc` commands, so those return empty results rather than an explanation. Fixing that also means introducing a shared environment constant — the three-environment literal is currently duplicated at 15+ sites — and renaming `sandbox`/`pre-release` to the branches/staging vocabulary the product now uses.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1208 passed, 61 subtests)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
