### PR TITLE
ci: add TruffleHog secret scanning on PRs and pushes to main

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,52 @@
+name: Secret Scanning
+
+on:
+  pull_request:
+  push:
+    branches:
+    - main
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  trufflehog:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Scan for secrets
+      uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
+      with:
+        extra_args: --results=verified,unknown
+
+    # Direct pushes to main skip PR review entirely, so the Actions tab may be
+    # the only signal. Open an issue and assign the pusher so it can't be missed.
+    - name: Notify pusher on direct push to main
+      if: failure() && github.event_name == 'push'
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const author = context.payload.head_commit?.author?.username || context.payload.pusher?.name;
+          const branch = context.ref.replace('refs/heads/', '');
+          const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+
+          await github.rest.issues.create({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            title: `Possible secret pushed directly to ${branch} by @${author}`,
+            body: [
+              `TruffleHog flagged a possible secret in ${context.sha}, pushed directly to \`${branch}\` (no PR).`,
+              '',
+              author ? `**@${author}** — please:` : 'Please:',
+              '1. Rotate/revoke the credential immediately — it is already in git history even if a later commit removes it.',
+              `2. Check the [workflow run](${runUrl}) for the exact match and file.`,
+              '3. Once rotated, this issue can be closed.',
+            ].join('\n'),
+            labels: ['secret-leak', 'security'],
+            assignees: author ? [author] : [],
+          });


### PR DESCRIPTION
## Summary

Adds automated secret scanning so committed credentials get caught on PRs and on direct pushes to `main`.

## Motivation

Native GitHub secret scanning/push protection are repo-level metadata settings — they don't travel when this repo is forked/copied for integrator engagements, and don't apply to private copies without an org-wide GHAS security configuration. A workflow file lives in repo content instead, so it copies automatically with the repo regardless of where it ends up.

## Changes

- New `.github/workflows/secret-scanning.yml` running [TruffleHog OSS](https://github.com/trufflesecurity/trufflehog) (pinned by commit SHA to `v3.96.0`, not `@main`) on `pull_request` and on `push` to `main`.
- Uses `--results=verified,unknown` — flags confirmed-live secrets plus unverifiable-but-suspicious matches, filtering out ones TruffleHog can positively confirm are already dead.
- Since a lot of contributors push directly to `main` without going through a PR, a failed scan on a `push` event also opens a GitHub issue, assigns the pusher, and labels it `secret-leak`/`security`, with instructions to rotate the credential immediately (it's already in git history even once removed from `HEAD`).

Out of scope: this detects post-push, it doesn't block the push itself — true prevention needs native GitHub push protection or a required-status-check + branch protection setup, which needs repo admin access to configure separately.

## Test strategy

- [ ] N/A (docs, config, or trivial change)

Workflow syntax has not been exercised against a live PR in this repo yet — first run against this PR itself will be the validation.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] `ruff check .` and `ruff format --check .` pass (no Python changed)
- [ ] `pytest` passes (no Python changed)
- [ ] No breaking changes to the `poly` CLI interface (or migration path documented) — N/A