### PR TITLE
feat: supervise multi-leg chat transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,12 @@ poly chat
 poly chat --environment live
 poly chat --channel webchat
 poly chat --metadata   # show functions, flows, and state each turn
+poly chat --multi-leg  # supervise agentic-dial and warm-transfer legs
 ```
+
+Multi-leg mode starts child agent conversations, routes dial status and agent messages
+between them, and keeps a bridge open until `/hangup`. Use `/legs`, `/parent`, and
+`/leg <dial-or-destination>` to inspect or select a leg.
 
 ### `poly docs`
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -444,6 +444,37 @@ poly chat --push -m 'Hello'
 
 If the push fails, the command exits without starting the chat session.
 
+#### Agentic dial and warm transfers
+
+Use `--multi-leg` (or `--multileg`) to supervise the whole call graph instead of ending
+the command when one conversation leg ends:
+
+~~~bash
+poly chat --multi-leg
+poly chat --multi-leg --environment sandbox
+~~~
+
+When the parent agent dials another agent, ADK starts a child chat with the resolved
+project, integration attributes, and agentic-dial headers. A parent branch prefers a
+matching sibling child project and that child's own current branch; deployed parents use
+the child environment resolved by the platform.
+
+Input targets the active leg. These commands control the simulation:
+
+| Command | Description |
+|---|---|
+| `/legs` | List parent and child legs with their current status. |
+| `/parent` | Target subsequent input at the parent agent. |
+| `/leg <dial-or-destination>` | Target a child by dial ID, prefix, or destination. |
+| `/fail [reason]` | Simulate a terminal child status such as `busy` or `no-answer`. |
+| `/hangup`, `/bridge-end` | End the simulated call and trigger any bridge-ended callback. |
+| `/restart` | End all legs and begin a new supervised call. |
+| `/exit` | End all legs and exit. |
+
+Once the platform returns a bridge instruction, agent turns pause while the supervisor
+keeps the bridged call open. Use `/hangup` to finish it; ending the child conversation by
+itself does not drop the parent or terminate another live leg.
+
 #### Language flags
 
 Use language flags to specify the expected input and output language when chatting against multilingual agents. If not specified, the project default is used.
@@ -464,6 +495,7 @@ Use language flags to specify the expected input and output language when chatti
 | `-m`, `--message MSG` | Send a message non-interactively (repeatable). |
 | `--input-file FILE` | Read messages line-by-line from a file (`-` for stdin). |
 | `--conversation-id`, `--conv-id` | Resume an existing conversation by ID. |
+| `--multi-leg`, `--multileg` | Supervise agentic-dial child legs, messages, failures, and bridges. |
 | `--json` | Emit a single JSON object when the session ends (see below). |
 | `--environment` | Target environment. Choices: `branch`, `sandbox`, `pre-release`, `live`. Defaults to `branch`. `branch` chats against the last **pushed** state of your current branch (not local uncommitted changes); on main it falls back to `sandbox`. Use `--push` to push local changes before chatting. |
 | `--channel` | Channel to use (e.g. `webchat`, `voice`). |
@@ -743,6 +775,7 @@ The exact fields vary by command. Common fields include:
 | `poly init --json` | `success`, `root_path` |
 | `poly project create --json` | `success`, `root_path` (via init); on error: `success`, `error` |
 | `poly chat --json` | `conversations` (array); optional `push` (when `--push` is used) |
+| `poly chat --multi-leg --json` | `multi_leg_sessions` (array); optional `push` (when `--push` is used) |
 | `poly deployments show --json` | `success`, `deployment`, `active_deployment_hashes`, `included_deployments`, `is_rollback` |
 | `poly deployments promote --json` | `success`, `from_hash`, `to_env`, `message`, `included_deployments`; `dry_run` when `--dry-run` is used |
 | `poly deployments rollback --json` | `success`, `target_hash`, `message`, `reverted_deployments`; `dry_run` when `--dry-run` is used |

--- a/src/poly/cli_commands/chat.py
+++ b/src/poly/cli_commands/chat.py
@@ -44,6 +44,9 @@ class ChatCommand(BaseCommand):
                 "  poly chat --conv-id <conversation_id>\n"
                 "  poly chat --conv-id <conversation_id> -m 'Follow-up message'\n"
                 "\n"
+                "Agentic dial and warm transfer supervision:\n"
+                "  poly chat --multi-leg\n"
+                "\n"
                 "Machine-readable output (emits a single JSON object when done):\n"
                 "  poly chat --json -m 'Hello'\n"
                 "  poly chat --json --input-file ./script.txt\n"
@@ -144,6 +147,16 @@ class ChatCommand(BaseCommand):
             default=None,
             help="Reuse an existing conversation ID instead of starting a new conversation.",
         )
+        chat_parser.add_argument(
+            "--multi-leg",
+            "--multileg",
+            action="store_true",
+            dest="multi_leg",
+            help=(
+                "Supervise agentic-dial child conversations and bridges instead of "
+                "ending when one leg ends."
+            ),
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
@@ -191,6 +204,7 @@ class ChatCommand(BaseCommand):
             input_messages=input_messages,
             conversation_id=args.conversation_id,
             output_json=args.json,
+            multi_leg=args.multi_leg,
         )
 
     @classmethod
@@ -209,6 +223,7 @@ class ChatCommand(BaseCommand):
         output_json: bool = False,
         input_messages: Optional[list[str]] = None,
         conversation_id: Optional[str] = None,
+        multi_leg: bool = False,
     ) -> None:
         """Start an interactive chat session with the agent."""
         import requests
@@ -276,6 +291,41 @@ class ChatCommand(BaseCommand):
             label += f" variant=[bold]{variant}[/bold]"
         if not output_json:
             info(f"Starting chat for {label}...")
+
+        if multi_leg:
+            from poly.cli_commands.multi_leg_chat import MultiLegChatSupervisor
+
+            sessions = []
+            while True:
+                supervisor = MultiLegChatSupervisor(
+                    project=project,
+                    environment=environment,
+                    channel=channel,
+                    variant=variant,
+                    input_lang=input_lang,
+                    output_lang=output_lang,
+                    show_functions=show_functions,
+                    show_flow=show_flow,
+                    show_state=show_state,
+                    output_json=output_json,
+                    conversation_id=conversation_id,
+                    reply_processor=lambda reply: cls._process_json_multi_leg_reply(
+                        reply,
+                        show_functions,
+                        show_flow,
+                        show_state,
+                    ),
+                )
+                restart, session = supervisor.run(input_messages=input_messages)
+                sessions.append(session)
+                if not restart:
+                    if output_json:
+                        json_output["multi_leg_sessions"] = sessions
+                        json_print(json_output)
+                    return
+                conversation_id = None
+                if not output_json:
+                    info("Restarting multi-leg chat session...")
 
         conversations: list[dict] = []
         while True:
@@ -540,3 +590,28 @@ class ChatCommand(BaseCommand):
                 processed_json["state_changes"] = state_reply
 
         return processed_json
+
+    @classmethod
+    def _process_json_multi_leg_reply(
+        cls,
+        reply: dict,
+        show_functions: bool,
+        show_flow: bool,
+        show_state: bool,
+    ) -> dict:
+        """Filter a reply while always retaining multi-leg control instructions."""
+        processed = cls._process_json_chat_reply(
+            reply,
+            show_functions,
+            show_flow,
+            show_state,
+        )
+        metadata = reply.get("metadata") or {}
+        control = {
+            key: metadata[key]
+            for key in ("agentic_dials", "bridge")
+            if metadata.get(key) is not None
+        }
+        if control:
+            processed["control"] = control
+        return processed

--- a/src/poly/cli_commands/multi_leg_chat.py
+++ b/src/poly/cli_commands/multi_leg_chat.py
@@ -1,0 +1,810 @@
+"""Multi-leg chat supervision for agentic dial and warm transfer flows.
+
+Copyright PolyAI Limited
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Literal, Optional
+
+import requests
+
+from poly.project import PROJECT_CONFIG_FILE, AgentStudioProject
+
+PARENT_CONVERSATION_HEADER = "X-PolyAI-AgenticDial-Parent-Conversation-ID"
+DIAL_ID_HEADER = "X-PolyAI-AgenticDial-Dial-ID"
+
+LegStatus = Literal["active", "holding", "bridged", "ended", "failed"]
+ReplyProcessor = Callable[[dict], dict]
+
+
+@dataclass
+class ChatLeg:
+    """One independently addressable conversation in a multi-leg call."""
+
+    key: str
+    project: AgentStudioProject
+    conversation_id: str
+    environment: str
+    role: Literal["parent", "child"]
+    status: LegStatus = "active"
+    dial_id: Optional[str] = None
+    destination: Optional[str] = None
+    parent_key: Optional[str] = None
+    turns: list[dict] = field(default_factory=list)
+    terminal_status_reported: bool = False
+
+
+class MultiLegChatSupervisor:
+    """Keep agentic-dial chat legs alive and route their control events."""
+
+    def __init__(
+        self,
+        *,
+        project: AgentStudioProject,
+        environment: str,
+        channel: str,
+        variant: Optional[str] = None,
+        input_lang: Optional[str] = None,
+        output_lang: Optional[str] = None,
+        show_functions: bool = False,
+        show_flow: bool = False,
+        show_state: bool = False,
+        output_json: bool = False,
+        conversation_id: Optional[str] = None,
+        reply_processor: Optional[ReplyProcessor] = None,
+    ) -> None:
+        """Initialize a supervisor around a parent Agent Studio project."""
+        self.parent_project = project
+        self.environment = environment
+        self.channel = channel
+        self.variant = variant
+        self.input_lang = input_lang
+        self.output_lang = output_lang
+        self.show_functions = show_functions
+        self.show_flow = show_flow
+        self.show_state = show_state
+        self.output_json = output_json
+        self.parent_conversation_id = conversation_id
+        self.reply_processor = reply_processor or self._default_reply_processor
+
+        self.legs: dict[str, ChatLeg] = {}
+        self.active_key = "parent"
+        self.events: list[dict] = []
+        self.bridged_dial_id: Optional[str] = None
+        self.bridged_parent_key: Optional[str] = None
+        self.bridge_started_at: Optional[float] = None
+        self.started_at = time.monotonic()
+        self.finished = False
+        self._cleanup_requested = False
+
+    def run(self, input_messages: Optional[list[str]] = None) -> tuple[bool, dict]:
+        """Start the parent leg and run the interactive or scripted control loop."""
+        from poly.output.console import error, info, plain
+
+        restart = False
+        try:
+            self._start_parent()
+        except (requests.HTTPError, ValueError) as exc:
+            if not self.output_json:
+                error(f"Failed to create multi-leg chat session: {exc}")
+            return False, {"success": False, "error": str(exc)}
+
+        if not self.output_json:
+            plain(
+                "[muted]Multi-leg mode: input follows the active leg. "
+                "Use /legs, /parent, /leg <dial-or-destination>, /fail, /hangup, "
+                "/restart, or /exit.[/muted]"
+            )
+
+        scripted = input_messages
+        try:
+            while not self.finished:
+                if scripted is not None:
+                    if not scripted:
+                        break
+                    user_input = scripted.pop(0).strip()
+                    if not self.output_json:
+                        plain(f"\n[muted]You:[/muted] {user_input}")
+                else:
+                    try:
+                        user_input = input(self._prompt()).strip()
+                    except (KeyboardInterrupt, EOFError):
+                        if not self.output_json:
+                            plain("")
+                        self._cleanup_requested = True
+                        break
+
+                if not user_input:
+                    continue
+                if user_input.startswith("/"):
+                    restart = self._handle_command(user_input)
+                    if restart or self._cleanup_requested:
+                        break
+                    continue
+
+                if self.bridged_dial_id:
+                    if not self.output_json:
+                        plain(
+                            "[muted]The call is bridged; agent chat turns are paused. "
+                            "Use /hangup when the simulated bridged call ends.[/muted]"
+                        )
+                    continue
+
+                leg = self.legs.get(self.active_key)
+                if leg is None or leg.status in {"ended", "failed"}:
+                    if not self.output_json:
+                        plain(
+                            "[muted]That leg is no longer active. Use /legs to select one.[/muted]"
+                        )
+                    continue
+                self._send_turn(leg, user_input)
+        finally:
+            if self._cleanup_requested:
+                self._close_all_legs()
+                if not self.output_json:
+                    info("Multi-leg chat session ended.")
+
+        return restart, self.to_dict()
+
+    def to_dict(self) -> dict:
+        """Return a machine-readable snapshot of the supervised call."""
+        return {
+            "success": True,
+            "bridged_dial_id": self.bridged_dial_id,
+            "bridged_parent_leg": self.bridged_parent_key,
+            "active_leg": self.active_key,
+            "events": self.events,
+            "legs": [
+                {
+                    "key": leg.key,
+                    "role": leg.role,
+                    "dial_id": leg.dial_id,
+                    "destination": leg.destination,
+                    "conversation_id": leg.conversation_id,
+                    "account_id": leg.project.account_id,
+                    "project_id": leg.project.project_id,
+                    "environment": leg.environment,
+                    "status": leg.status,
+                    "url": leg.project.get_conversation_url(leg.conversation_id),
+                    "turns": leg.turns,
+                }
+                for leg in self.legs.values()
+            ],
+        }
+
+    def _start_parent(self) -> None:
+        """Create or resume the root conversation."""
+        from poly.output.console import info, plain, success
+
+        response = None
+        if self.parent_conversation_id:
+            conversation_id = self.parent_conversation_id
+            if not self.output_json:
+                info(f"Resuming parent chat session (conversation: {conversation_id})...")
+        else:
+            if self.environment == "draft" and not self.output_json:
+                info("Preparing parent branch deployment...")
+            response = self.parent_project.create_chat_session(
+                self.environment,
+                self.channel,
+                self.variant,
+                self.input_lang,
+                self.output_lang,
+            )
+            conversation_id = response.get("conversation_id")
+            if not conversation_id:
+                raise ValueError(f"No conversation_id in response: {response}")
+
+        self.parent_conversation_id = conversation_id
+        parent = ChatLeg(
+            key="parent",
+            project=self.parent_project,
+            conversation_id=conversation_id,
+            environment=self.environment,
+            role="parent",
+        )
+        self.legs[parent.key] = parent
+        self.events.append(
+            {
+                "type": "leg_started",
+                "leg": parent.key,
+                "conversation_id": conversation_id,
+            }
+        )
+        if not self.output_json:
+            url = parent.project.get_conversation_url(conversation_id)
+            success(f"Parent leg started (conversation: [link={url}]{conversation_id}[/link])")
+        if response is not None:
+            self._process_reply(parent, response, user_input=None)
+            if not self.output_json and not response.get("response"):
+                plain("[muted]Parent agent started without a greeting.[/muted]")
+
+    def _send_turn(
+        self,
+        leg: ChatLeg,
+        text: str,
+        *,
+        external_events: Optional[list[dict]] = None,
+    ) -> Optional[dict]:
+        """Send one user or control turn to a leg and process its reply."""
+        from poly.output.console import error
+
+        try:
+            reply = leg.project.send_message(
+                leg.conversation_id,
+                text,
+                leg.environment,
+                self.input_lang,
+                self.output_lang,
+                external_events=external_events,
+            )
+        except requests.HTTPError as exc:
+            self.events.append({"type": "turn_failed", "leg": leg.key, "error": str(exc)})
+            if not self.output_json:
+                error(f"Failed to send a turn to {self._leg_label(leg)}: {exc}")
+            return None
+
+        self._process_reply(leg, reply, user_input=text if external_events is None else None)
+        return reply
+
+    def _process_reply(
+        self,
+        leg: ChatLeg,
+        reply: dict,
+        *,
+        user_input: Optional[str],
+    ) -> None:
+        """Record a reply, apply dial instructions, and route function messages."""
+        processed = self.reply_processor(reply)
+        leg.turns.append({"input": user_input, **processed})
+        self._render_reply(leg, reply)
+
+        metadata = reply.get("metadata") or {}
+        for dial in metadata.get("agentic_dials") or []:
+            self._start_child_leg(leg, dial)
+
+        self._route_function_messages(leg, metadata.get("function_events") or [])
+
+        if bridge := metadata.get("bridge"):
+            self._activate_bridge(leg, bridge.get("dial_id"))
+
+        if reply.get("conversation_ended"):
+            self._handle_leg_ended(leg)
+
+    def _start_child_leg(self, parent: ChatLeg, dial: dict) -> None:
+        """Start a child conversation for one sanitized agentic-dial instruction."""
+        from poly.output.console import error, info, success
+
+        dial_id = dial.get("dial_id")
+        destination = dial.get("destination") or dial_id or "unknown"
+        if not dial_id or dial_id in self.legs:
+            return
+
+        target = dial.get("target")
+        if not target:
+            reason = dial.get("resolution_error") or "dial target could not be resolved"
+            self.events.append(
+                {
+                    "type": "dial_failed",
+                    "parent_leg": parent.key,
+                    "dial_id": dial_id,
+                    "destination": destination,
+                    "reason": reason,
+                }
+            )
+            if not self.output_json:
+                error(f"Could not start child leg {destination}: {reason}")
+            self._send_dial_status(parent, dial_id, "failed", reason=reason)
+            return
+
+        child_project, local_project = self._resolve_project(parent.project, target)
+        child_environment = self._child_environment(
+            parent.environment,
+            child_project,
+            target.get("client_env"),
+            local_project=local_project,
+        )
+        headers = dict(dial.get("custom_sip_headers") or {})
+        headers[PARENT_CONVERSATION_HEADER] = parent.conversation_id
+        headers[DIAL_ID_HEADER] = dial_id
+
+        if not self.output_json:
+            location = "local branch" if child_environment == "draft" else child_environment
+            info(f"Starting child leg {destination} on {child_project.project_id} ({location})...")
+        try:
+            response = child_project.create_chat_session(
+                child_environment,
+                self.channel,
+                target.get("variant_id"),
+                self.input_lang,
+                self.output_lang,
+                integration_attributes=dial.get("integration_attributes") or {},
+                custom_sip_headers=headers,
+            )
+        except (requests.HTTPError, ValueError) as exc:
+            self.events.append(
+                {
+                    "type": "dial_failed",
+                    "parent_leg": parent.key,
+                    "dial_id": dial_id,
+                    "destination": destination,
+                    "reason": str(exc),
+                }
+            )
+            if not self.output_json:
+                error(f"Failed to start child leg {destination}: {exc}")
+            self._send_dial_status(parent, dial_id, "failed", reason=str(exc))
+            return
+
+        conversation_id = response.get("conversation_id")
+        if not conversation_id:
+            reason = f"No conversation_id in child response: {response}"
+            if not self.output_json:
+                error(reason)
+            self._send_dial_status(parent, dial_id, "failed", reason=reason)
+            return
+
+        parent.status = "holding"
+        child = ChatLeg(
+            key=dial_id,
+            project=child_project,
+            conversation_id=conversation_id,
+            environment=child_environment,
+            role="child",
+            dial_id=dial_id,
+            destination=destination,
+            parent_key=parent.key,
+        )
+        self.legs[child.key] = child
+        self.active_key = child.key
+        self.events.append(
+            {
+                "type": "leg_started",
+                "leg": child.key,
+                "parent_leg": parent.key,
+                "dial_id": dial_id,
+                "destination": destination,
+                "conversation_id": conversation_id,
+                "project_id": child.project.project_id,
+                "environment": child.environment,
+            }
+        )
+        if not self.output_json:
+            url = child.project.get_conversation_url(conversation_id)
+            success(
+                f"Child leg {destination} answered "
+                f"(conversation: [link={url}]{conversation_id}[/link])"
+            )
+
+        self._send_dial_status(parent, dial_id, "answered")
+        self._process_reply(child, response, user_input=None)
+
+    def _route_function_messages(self, leg: ChatLeg, function_events: list[dict]) -> None:
+        """Route child-to-parent and parent-to-child agentic-dial messages."""
+        for function_event in function_events:
+            control = function_event.get("agentic_dial") or {}
+            for message in control.get("messages_to_parent") or []:
+                if leg.parent_key and leg.dial_id:
+                    parent = self.legs.get(leg.parent_key)
+                    if parent:
+                        self._send_external_message(
+                            parent,
+                            leg.dial_id,
+                            message.get("content", ""),
+                            source_leg=leg,
+                        )
+
+            for message in control.get("messages_to_children") or []:
+                destination = message.get("destination")
+                child = self._find_child(leg.key, destination)
+                if child and child.dial_id:
+                    self._send_external_message(
+                        child,
+                        f"{child.dial_id}:child-inbox",
+                        message.get("content", ""),
+                        source_leg=leg,
+                    )
+
+            for destination in control.get("unsubscribed_destinations") or []:
+                child = self._find_child(leg.key, destination)
+                if child and child.status not in {"bridged", "ended", "failed"}:
+                    child.status = "ended"
+                    self.events.append(
+                        {
+                            "type": "dial_unsubscribed",
+                            "leg": child.key,
+                            "destination": destination,
+                        }
+                    )
+
+    def _send_external_message(
+        self,
+        target: ChatLeg,
+        event_id: str,
+        content: str,
+        *,
+        source_leg: ChatLeg,
+    ) -> None:
+        """Deliver an agentic-dial message as a structured external event."""
+        self.events.append(
+            {
+                "type": "message_routed",
+                "from_leg": source_leg.key,
+                "to_leg": target.key,
+                "event_id": event_id,
+                "content": content,
+            }
+        )
+        self._send_turn(
+            target,
+            "",
+            external_events=[self._external_event(event_id, "message", content=content)],
+        )
+
+    def _send_dial_status(
+        self,
+        parent: ChatLeg,
+        dial_id: str,
+        status: str,
+        *,
+        reason: Optional[str] = None,
+    ) -> None:
+        """Deliver one child dial status to its parent conversation."""
+        payload = {"event_type": "dial_status", "status": status}
+        if reason:
+            payload["reason"] = reason
+        self.events.append(
+            {
+                "type": "dial_status",
+                "leg": parent.key,
+                "dial_id": dial_id,
+                "status": status,
+                "reason": reason,
+            }
+        )
+        self._send_turn(
+            parent,
+            "",
+            external_events=[
+                {
+                    "ext_event_id": dial_id,
+                    "data": json.dumps(payload, separators=(",", ":")),
+                    "content_type": "application/json",
+                }
+            ],
+        )
+
+    def _activate_bridge(self, source: ChatLeg, dial_id: Optional[str]) -> None:
+        """Mark a parent and child as physically bridged without ending the session."""
+        from poly.output.console import success, warning
+
+        if not dial_id:
+            if not self.output_json:
+                warning("Agent returned a bridge instruction without a dial ID.")
+            return
+        child = self.legs.get(dial_id)
+        parent = self.legs.get(child.parent_key) if child and child.parent_key else source
+        if child is None:
+            if not self.output_json:
+                warning(f"Agent returned a bridge for unknown dial {dial_id}.")
+            return
+
+        self.bridged_dial_id = dial_id
+        self.bridged_parent_key = parent.key
+        self.bridge_started_at = time.monotonic()
+        child.status = "bridged"
+        parent.status = "bridged"
+        self.active_key = child.key
+        self.events.append(
+            {
+                "type": "bridge_started",
+                "parent_leg": parent.key,
+                "child_leg": child.key,
+                "dial_id": dial_id,
+            }
+        )
+        if not self.output_json:
+            success(
+                f"Bridge active: {self._leg_label(parent)} ↔ {self._leg_label(child)}. "
+                "The supervisor will keep the call open until /hangup."
+            )
+
+    def _handle_leg_ended(self, leg: ChatLeg) -> None:
+        """End only the affected leg, preserving every other live leg."""
+        from poly.output.console import plain
+
+        if leg.status == "bridged":
+            return
+        leg.status = "ended"
+        self.events.append({"type": "leg_ended", "leg": leg.key})
+        if not self.output_json:
+            plain(f"[muted]{self._leg_label(leg)} ended; other legs remain supervised.[/muted]")
+
+        if leg.role == "child" and leg.parent_key and leg.dial_id:
+            parent = self.legs.get(leg.parent_key)
+            if parent and not leg.terminal_status_reported:
+                leg.terminal_status_reported = True
+                self.active_key = parent.key
+                self._refresh_parent_status(parent)
+                self._send_dial_status(parent, leg.dial_id, "hangup")
+
+        live_legs = [
+            other for other in self.legs.values() if other.status not in {"ended", "failed"}
+        ]
+        if not live_legs and not self.bridged_dial_id:
+            self.finished = True
+
+    def _handle_command(self, command_line: str) -> bool:
+        """Apply a multi-leg slash command and return whether restart was requested."""
+        from poly.output.console import plain, warning
+
+        command, _, argument = command_line.partition(" ")
+        command = command.lower()
+        argument = argument.strip()
+        if command == "/legs":
+            self._show_legs()
+        elif command == "/parent":
+            self.active_key = "parent"
+            if not self.output_json:
+                plain("[muted]Input now targets the parent leg.[/muted]")
+        elif command == "/leg":
+            leg = self._select_leg(argument)
+            if leg:
+                self.active_key = leg.key
+                if not self.output_json:
+                    plain(f"[muted]Input now targets {self._leg_label(leg)}.[/muted]")
+            elif not self.output_json:
+                warning(f"No leg matches '{argument}'. Use /legs to list them.")
+        elif command == "/fail":
+            self._fail_active_child(argument or "failed")
+        elif command in {"/hangup", "/bridge-end"}:
+            self._cleanup_requested = True
+        elif command == "/exit":
+            self._cleanup_requested = True
+        elif command == "/restart":
+            self._cleanup_requested = True
+            return True
+        elif not self.output_json:
+            warning(f"Unknown command: {command}")
+        return False
+
+    def _fail_active_child(self, reason: str) -> None:
+        """Simulate a terminal status on the currently selected child leg."""
+        from poly.output.console import warning
+
+        child = self.legs.get(self.active_key)
+        if child is None or child.role != "child" or not child.parent_key or not child.dial_id:
+            if not self.output_json:
+                warning("Select a child leg before using /fail.")
+            return
+        if child.status in {"ended", "failed", "bridged"}:
+            if not self.output_json:
+                warning(f"{self._leg_label(child)} is already {child.status}.")
+            return
+
+        try:
+            child.project.end_chat(child.conversation_id, child.environment)
+        except requests.HTTPError:
+            pass
+        child.status = "failed"
+        child.terminal_status_reported = True
+        parent = self.legs[child.parent_key]
+        self.active_key = parent.key
+        self._refresh_parent_status(parent)
+        status = reason.lower() if reason.lower() in {"busy", "noanswer", "no-answer"} else "failed"
+        status_reason = None if status != "failed" else reason
+        self._send_dial_status(parent, child.dial_id, status, reason=status_reason)
+
+    def _close_all_legs(self) -> None:
+        """End the simulated call and every server-side conversation context."""
+        if self.bridged_dial_id:
+            parent = self.legs.get(self.bridged_parent_key or "parent")
+            if parent:
+                bridge_duration = int(
+                    time.monotonic() - (self.bridge_started_at or time.monotonic())
+                )
+                call_duration = int(time.monotonic() - self.started_at)
+                try:
+                    parent.project.bridge_ended(
+                        parent.conversation_id,
+                        bridge_duration_seconds=bridge_duration,
+                        call_duration_seconds=call_duration,
+                    )
+                    self.events.append(
+                        {
+                            "type": "bridge_ended",
+                            "dial_id": self.bridged_dial_id,
+                            "bridge_duration_seconds": bridge_duration,
+                            "call_duration_seconds": call_duration,
+                        }
+                    )
+                except requests.HTTPError as exc:
+                    self.events.append({"type": "bridge_end_failed", "error": str(exc)})
+
+        for leg in reversed(list(self.legs.values())):
+            if leg.status in {"ended", "failed"}:
+                continue
+            try:
+                leg.project.end_chat(leg.conversation_id, leg.environment)
+            except requests.HTTPError as exc:
+                self.events.append({"type": "leg_end_failed", "leg": leg.key, "error": str(exc)})
+            leg.status = "ended"
+        self.finished = True
+
+    def _refresh_parent_status(self, parent: ChatLeg) -> None:
+        """Reflect whether a parent still has another live child on hold."""
+        if parent.status in {"bridged", "ended", "failed"}:
+            return
+        has_live_child = any(
+            leg.role == "child"
+            and leg.parent_key == parent.key
+            and leg.status not in {"ended", "failed"}
+            for leg in self.legs.values()
+        )
+        parent.status = "holding" if has_live_child else "active"
+
+    def _resolve_project(
+        self,
+        source_project: AgentStudioProject,
+        target: dict,
+    ) -> tuple[AgentStudioProject, bool]:
+        """Use a matching sibling checkout when present, otherwise build a remote proxy."""
+        target_account = target.get("account_id") or source_project.account_id
+        target_project = target["project_id"]
+        if (
+            source_project.account_id == target_account
+            and source_project.project_id == target_project
+        ):
+            return source_project, True
+
+        source_root = Path(source_project.root_path)
+        candidate_roots = [source_root.parent / target_project]
+        try:
+            candidate_roots.extend(
+                child
+                for child in source_root.parent.iterdir()
+                if child.is_dir() and child != source_root and child not in candidate_roots
+            )
+        except OSError:
+            pass
+
+        for candidate in candidate_roots:
+            if not (candidate / PROJECT_CONFIG_FILE).is_file():
+                continue
+            try:
+                project = AgentStudioProject.from_file_path(str(candidate))
+            except (FileNotFoundError, ValueError, OSError):
+                continue
+            if project.account_id == target_account and project.project_id == target_project:
+                return project, True
+
+        return (
+            AgentStudioProject(
+                region=source_project.region,
+                account_id=target_account,
+                project_id=target_project,
+                root_path=str(source_root.parent / target_project),
+                resources={},
+                last_updated=datetime.now(),
+                branch_id="main",
+            ),
+            False,
+        )
+
+    @staticmethod
+    def _child_environment(
+        parent_environment: str,
+        project: AgentStudioProject,
+        target_environment: Optional[str],
+        *,
+        local_project: bool,
+    ) -> str:
+        """Prefer the child's own branch when a parent branch is being tested."""
+        if (
+            parent_environment == "draft"
+            and local_project
+            and project.branch_id
+            and project.branch_id != "main"
+        ):
+            return "draft"
+        aliases = {"prod": "live", "prelive": "pre-release", "pre_live": "pre-release"}
+        environment = aliases.get(target_environment or "", target_environment)
+        return environment or "sandbox"
+
+    def _find_child(self, parent_key: str, destination: Optional[str]) -> Optional[ChatLeg]:
+        """Find the newest live child for a destination under one parent."""
+        for leg in reversed(list(self.legs.values())):
+            if (
+                leg.role == "child"
+                and leg.parent_key == parent_key
+                and (leg.destination == destination or leg.dial_id == destination)
+                and leg.status not in {"ended", "failed"}
+            ):
+                return leg
+        return None
+
+    def _select_leg(self, selector: str) -> Optional[ChatLeg]:
+        """Select a leg by key, dial ID, destination, or unambiguous prefix."""
+        if not selector:
+            return None
+        if selector in self.legs:
+            return self.legs[selector]
+        matches = [
+            leg
+            for leg in self.legs.values()
+            if leg.destination == selector
+            or (leg.dial_id or "").startswith(selector)
+            or leg.key.startswith(selector)
+        ]
+        return matches[0] if len(matches) == 1 else None
+
+    def _show_legs(self) -> None:
+        """Render a compact list of all supervised legs."""
+        if self.output_json:
+            return
+        from poly.output.console import plain
+
+        for leg in self.legs.values():
+            marker = "*" if leg.key == self.active_key else " "
+            plain(
+                f"{marker} [bold]{self._leg_label(leg)}[/bold] "
+                f"status={leg.status} conversation={leg.conversation_id}"
+            )
+
+    def _render_reply(self, leg: ChatLeg, reply: dict) -> None:
+        """Render one reply with an explicit leg label."""
+        if self.output_json:
+            return
+        from poly.output.console import plain, print_turn_metadata
+
+        print_turn_metadata(reply, self.show_functions, self.show_flow, self.show_state)
+        if agent_text := reply.get("response"):
+            plain(f"\n[bold]{self._leg_label(leg)}:[/bold] {agent_text}")
+
+    def _prompt(self) -> str:
+        """Return an input prompt naming the currently selected leg."""
+        leg = self.legs.get(self.active_key)
+        return f"\nYou → {self._leg_label(leg) if leg else self.active_key}: "
+
+    @staticmethod
+    def _leg_label(leg: ChatLeg) -> str:
+        """Return a stable human-readable leg label."""
+        if leg.role == "parent":
+            return "Parent agent"
+        return f"Child agent ({leg.destination or leg.dial_id})"
+
+    @staticmethod
+    def _external_event(event_id: str, event_type: str, **payload: str) -> dict:
+        """Build an external event accepted by the debug-chat API."""
+        return {
+            "ext_event_id": event_id,
+            "data": json.dumps(
+                {"event_type": event_type, **payload},
+                separators=(",", ":"),
+            ),
+            "content_type": "application/json",
+        }
+
+    @staticmethod
+    def _default_reply_processor(reply: dict) -> dict:
+        """Keep JSON output useful without copying the full conversation state."""
+        metadata = reply.get("metadata") or {}
+        processed = {
+            "response": reply.get("response"),
+            "conversation_ended": reply.get("conversation_ended", False),
+        }
+        control = {
+            key: metadata[key]
+            for key in ("agentic_dials", "bridge")
+            if metadata.get(key) is not None
+        }
+        if control:
+            processed["control"] = control
+        return processed

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -606,6 +606,8 @@ class AgentStudioInterface:
         channel: str = "chat.polyai",
         input_lang: Optional[str] = None,
         output_lang: Optional[str] = None,
+        integration_attributes: Optional[dict] = None,
+        custom_sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -629,6 +631,8 @@ class AgentStudioInterface:
             channel,
             input_lang=input_lang,
             output_lang=output_lang,
+            integration_attributes=integration_attributes,
+            custom_sip_headers=custom_sip_headers,
         )
 
     @staticmethod
@@ -641,6 +645,7 @@ class AgentStudioInterface:
         environment: str = "sandbox",
         input_lang: str = None,
         output_lang: str = None,
+        external_events: Optional[list[dict]] = None,
     ) -> dict:
         """Send a message to an existing chat conversation.
 
@@ -664,6 +669,7 @@ class AgentStudioInterface:
             environment,
             input_lang=input_lang,
             output_lang=output_lang,
+            external_events=external_events,
         )
 
     def get_branch_chat_info(self, branch_id: str) -> dict:
@@ -695,6 +701,8 @@ class AgentStudioInterface:
         variant_id: Optional[str] = None,
         input_lang: str = None,
         output_lang: str = None,
+        integration_attributes: Optional[dict] = None,
+        custom_sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -720,6 +728,8 @@ class AgentStudioInterface:
             variant_id,
             input_lang=input_lang,
             output_lang=output_lang,
+            integration_attributes=integration_attributes,
+            custom_sip_headers=custom_sip_headers,
         )
 
     @staticmethod
@@ -731,6 +741,7 @@ class AgentStudioInterface:
         text: str,
         input_lang: str = None,
         output_lang: str = None,
+        external_events: Optional[list[dict]] = None,
     ) -> dict:
         """Send a message to an existing draft chat conversation.
 
@@ -752,6 +763,7 @@ class AgentStudioInterface:
             text,
             input_lang=input_lang,
             output_lang=output_lang,
+            external_events=external_events,
         )
 
     @staticmethod
@@ -776,6 +788,25 @@ class AgentStudioInterface:
         """
         return PlatformAPIHandler.end_chat(
             region, account_id, project_id, conversation_id, environment
+        )
+
+    @staticmethod
+    def bridge_ended(
+        region: str,
+        account_id: str,
+        project_id: str,
+        conversation_id: str,
+        bridge_duration_seconds: int = 0,
+        call_duration_seconds: int = 0,
+    ) -> dict:
+        """Trigger the callback registered for the end of a bridged debug call."""
+        return PlatformAPIHandler.bridge_ended(
+            region=region,
+            account_id=account_id,
+            project_id=project_id,
+            conversation_id=conversation_id,
+            bridge_duration_seconds=bridge_duration_seconds,
+            call_duration_seconds=call_duration_seconds,
         )
 
     @staticmethod

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -26,6 +26,9 @@ DRAFT_CHAT_CONVERSATION_URL = (
     "/adk/v1/accounts/{account_id}/projects/{project_id}/draft/chat/{conversation_id}"
 )
 CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/end"
+CHAT_BRIDGE_ENDED_URL = (
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conversation_id}/bridge-ended"
+)
 AB_TESTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests"
 AB_TEST_ACTIVE_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/active"
 AB_TEST_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/{ab_test_id}"
@@ -426,6 +429,8 @@ class PlatformAPIHandler:
         channel: str = "chat.polyai",
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
+        integration_attributes: ty.Optional[dict] = None,
+        custom_sip_headers: ty.Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -438,6 +443,8 @@ class PlatformAPIHandler:
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response,
+            integration_attributes: Optional attributes exposed to project functions
+            custom_sip_headers: Optional SIP headers exposed to the child conversation
 
         Returns:
             dict: The API response containing the conversation ID
@@ -453,6 +460,10 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if integration_attributes is not None:
+            data["integration_attributes"] = integration_attributes
+        if custom_sip_headers is not None:
+            data["custom_sip_headers"] = custom_sip_headers
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -465,6 +476,7 @@ class PlatformAPIHandler:
         environment: str = "sandbox",
         input_lang: str = None,
         output_lang: str = None,
+        external_events: ty.Optional[list[dict]] = None,
     ) -> dict:
         """Send a message to an existing chat conversation.
 
@@ -477,6 +489,7 @@ class PlatformAPIHandler:
             environment: The environment (sandbox, pre-release, live)
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response, e.g. "en-
+            external_events: Optional structured events to deliver with this turn
 
         Returns:
             dict: The API response containing the assistant's reply
@@ -491,6 +504,8 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if external_events is not None:
+            data["external_events"] = external_events
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -526,6 +541,31 @@ class PlatformAPIHandler:
         )
 
     @staticmethod
+    def bridge_ended(
+        region: str,
+        account_id: str,
+        project_id: str,
+        conversation_id: str,
+        bridge_duration_seconds: int = 0,
+        call_duration_seconds: int = 0,
+    ) -> dict:
+        """Trigger the callback registered for the end of a bridged debug call."""
+        endpoint = CHAT_BRIDGE_ENDED_URL.format(
+            account_id=account_id,
+            project_id=project_id,
+            conversation_id=conversation_id,
+        )
+        return PlatformAPIHandler.make_request(
+            region,
+            endpoint,
+            "POST",
+            data={
+                "bridge_duration_seconds": bridge_duration_seconds,
+                "call_duration_seconds": call_duration_seconds,
+            },
+        )
+
+    @staticmethod
     def create_draft_chat(
         region: str,
         account_id: str,
@@ -536,6 +576,8 @@ class PlatformAPIHandler:
         variant_id: ty.Optional[str] = None,
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
+        integration_attributes: ty.Optional[dict] = None,
+        custom_sip_headers: ty.Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -565,6 +607,10 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if integration_attributes is not None:
+            data["integration_attributes"] = integration_attributes
+        if custom_sip_headers is not None:
+            data["custom_sip_headers"] = custom_sip_headers
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -576,6 +622,7 @@ class PlatformAPIHandler:
         text: str,
         input_lang: str = None,
         output_lang: str = None,
+        external_events: ty.Optional[list[dict]] = None,
     ) -> dict:
         """Send a message to an existing draft chat conversation.
 
@@ -601,6 +648,8 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if external_events is not None:
+            data["external_events"] = external_events
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2336,6 +2336,8 @@ class AgentStudioProject:
         variant: Optional[str],
         input_lang: Optional[str] = None,
         output_lang: Optional[str] = None,
+        integration_attributes: Optional[dict] = None,
+        custom_sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a chat session (standard or draft).
 
@@ -2348,6 +2350,8 @@ class AgentStudioProject:
             variant (ty.Optional[str]): The variant ID to create the chat session in.
             input_lang (str): Optional. The language code for the input messages, e.g. "en-GB" or "fr-FR".
             output_lang (str): Optional. The language code for the agent's responses, e.g. "en-GB" or "fr-FR".
+            integration_attributes (dict): Optional attributes exposed to project functions.
+            custom_sip_headers (dict): Optional SIP headers exposed to the conversation.
 
         Returns:
             dict: API response with conversation_id and initial greeting.
@@ -2374,6 +2378,8 @@ class AgentStudioProject:
                 variant_id=variant,
                 input_lang=input_lang,
                 output_lang=output_lang,
+                integration_attributes=integration_attributes,
+                custom_sip_headers=custom_sip_headers,
             )
 
         return AgentStudioInterface.create_chat(
@@ -2385,6 +2391,8 @@ class AgentStudioProject:
             channel=channel,
             input_lang=input_lang,
             output_lang=output_lang,
+            integration_attributes=integration_attributes,
+            custom_sip_headers=custom_sip_headers,
         )
 
     def send_message(
@@ -2394,6 +2402,7 @@ class AgentStudioProject:
         environment: str,
         input_lang: str = None,
         output_lang: str = None,
+        external_events: Optional[list[dict]] = None,
     ) -> dict:
         """Send a message to an active chat conversation.
 
@@ -2403,6 +2412,7 @@ class AgentStudioProject:
             environment (str): The environment of the conversation: draft, sandbox, pre-release or live.
             input_lang (str): Optional. The language code of the input message, e.g. "en-GB" or "fr-FR".
             output_lang (str): Optional. The language code for the agent's response, e.g. "en-GB" or "fr-FR".
+            external_events (list[dict]): Optional structured events received this turn.
 
         Returns:
             dict: API response with the agent's reply.
@@ -2419,6 +2429,7 @@ class AgentStudioProject:
                 text=text,
                 input_lang=input_lang,
                 output_lang=output_lang,
+                external_events=external_events,
             )
         return AgentStudioInterface.send_chat_message(
             region=self.region,
@@ -2429,6 +2440,7 @@ class AgentStudioProject:
             environment=environment,
             input_lang=input_lang,
             output_lang=output_lang,
+            external_events=external_events,
         )
 
     def end_chat(
@@ -2454,6 +2466,22 @@ class AgentStudioProject:
             project_id=self.project_id,
             conversation_id=conversation_id,
             environment=environment,
+        )
+
+    def bridge_ended(
+        self,
+        conversation_id: str,
+        bridge_duration_seconds: int = 0,
+        call_duration_seconds: int = 0,
+    ) -> dict:
+        """Trigger the callback registered for the end of a bridged debug call."""
+        return AgentStudioInterface.bridge_ended(
+            region=self.region,
+            account_id=self.account_id,
+            project_id=self.project_id,
+            conversation_id=conversation_id,
+            bridge_duration_seconds=bridge_duration_seconds,
+            call_duration_seconds=call_duration_seconds,
         )
 
     @property

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -197,6 +197,80 @@ class GetProjects(unittest.TestCase):
         self.assertEqual(projects, {"p1": "Project One", "p2": "Project Two"})
 
 
+class MultiLegChatRequests(unittest.TestCase):
+    """Tests for multi-leg fields sent through the low-level chat API."""
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_create_chat_sends_child_context(self, mock_make_request):
+        PlatformAPIHandler.create_chat(
+            "us-1",
+            "account-1",
+            "project-1",
+            integration_attributes={"patient": "Ada"},
+            custom_sip_headers={"X-Dial-ID": "dial-1"},
+        )
+
+        mock_make_request.assert_called_once_with(
+            "us-1",
+            "/adk/v1/accounts/account-1/projects/project-1/chat",
+            "POST",
+            data={
+                "client_env": "sandbox",
+                "channel": "chat.polyai",
+                "integration_attributes": {"patient": "Ada"},
+                "custom_sip_headers": {"X-Dial-ID": "dial-1"},
+            },
+        )
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_send_message_sends_structured_external_events(self, mock_make_request):
+        external_events = [
+            {
+                "ext_event_id": "dial-1",
+                "data": '{"event_type":"dial_status","status":"answered"}',
+            }
+        ]
+
+        PlatformAPIHandler.send_chat_message(
+            "us-1",
+            "account-1",
+            "project-1",
+            "conversation-1",
+            "",
+            external_events=external_events,
+        )
+
+        mock_make_request.assert_called_once_with(
+            "us-1",
+            "/adk/v1/accounts/account-1/projects/project-1/chat/conversation-1",
+            "POST",
+            data={
+                "message": "",
+                "client_env": "sandbox",
+                "external_events": external_events,
+            },
+        )
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_bridge_ended_sends_call_durations(self, mock_make_request):
+        PlatformAPIHandler.bridge_ended(
+            "us-1",
+            "account-1",
+            "project-1",
+            "conversation-1",
+            bridge_duration_seconds=42,
+            call_duration_seconds=64,
+        )
+
+        mock_make_request.assert_called_once_with(
+            "us-1",
+            "/adk/v1/accounts/account-1/projects/project-1/chat/"
+            "conversation-1/bridge-ended",
+            "POST",
+            data={"bridge_duration_seconds": 42, "call_duration_seconds": 64},
+        )
+
+
 class GetConversationAudio(unittest.TestCase):
     """Tests for PlatformAPIHandler.get_conversation_audio."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1103,6 +1103,28 @@ class ChatCommandTest(unittest.TestCase):
 
         self.assertEqual(self.proj.send_message.call_count, 2)
 
+    @patch("poly.cli_commands.multi_leg_chat.MultiLegChatSupervisor")
+    def test_multi_leg_mode_delegates_to_supervisor(self, mock_supervisor):
+        """multi_leg=True runs the call-graph supervisor instead of the single chat loop."""
+        mock_supervisor.return_value.run.return_value = (
+            False,
+            {"success": True, "legs": []},
+        )
+        messages = ["Hello"]
+
+        ChatCommand.chat(
+            TEST_DIR,
+            environment="sandbox",
+            input_messages=messages,
+            multi_leg=True,
+        )
+
+        mock_supervisor.assert_called_once()
+        self.assertIs(mock_supervisor.call_args.kwargs["project"], self.proj)
+        self.assertEqual(mock_supervisor.call_args.kwargs["environment"], "sandbox")
+        mock_supervisor.return_value.run.assert_called_once_with(input_messages=messages)
+        self.proj.create_chat_session.assert_not_called()
+
     def test_push_before_chat_calls_push_project(self):
         """push_before_chat=True calls push_project before creating the chat session."""
         self.proj.push_project.return_value = (True, "Pushed successfully", None)

--- a/src/poly/tests/multi_leg_chat_test.py
+++ b/src/poly/tests/multi_leg_chat_test.py
@@ -1,0 +1,352 @@
+"""Tests for multi-leg chat supervision.
+
+Copyright PolyAI Limited
+"""
+
+import base64
+import json
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from poly.cli_commands.multi_leg_chat import (
+    DIAL_ID_HEADER,
+    PARENT_CONVERSATION_HEADER,
+    MultiLegChatSupervisor,
+)
+from poly.project import AgentStudioProject
+
+
+def _reply(
+    text: str = "",
+    *,
+    dials: list[dict] = None,
+    bridge: dict = None,
+    function_events: list[dict] = None,
+    ended: bool = False,
+) -> dict:
+    """Build a compact chat API reply for supervisor tests."""
+    return {
+        "response": text,
+        "conversation_ended": ended,
+        "metadata": {
+            "agentic_dials": dials,
+            "bridge": bridge,
+            "function_events": function_events or [],
+        },
+    }
+
+
+def _dial(dial_id: str = "dial-1", destination: str = "billing") -> dict:
+    """Build a sanitized agentic-dial control instruction."""
+    return {
+        "dial_id": dial_id,
+        "outbound_agent": "brightree-usp-outbound-sandbox",
+        "destination": destination,
+        "target": {
+            "account_id": "brightree-us",
+            "project_id": "brightree-usp-outbound",
+            "client_env": "sandbox",
+            "variant_id": "English",
+        },
+        "integration_attributes": {"patient_first_name": "Ada"},
+        "custom_sip_headers": {"X-Trace": "trace-123"},
+    }
+
+
+class MultiLegChatSupervisorTest(unittest.TestCase):
+    """Exercise parent/child lifecycle and bridge routing."""
+
+    def setUp(self) -> None:
+        self.parent = MagicMock(spec=AgentStudioProject)
+        self.parent.account_id = "brightree-us"
+        self.parent.project_id = "brightree-usp"
+        self.parent.region = "us-1"
+        self.parent.root_path = "/workspace/brightree-usp"
+        self.parent.branch_id = "parent-branch"
+        self.parent.get_conversation_url.side_effect = (
+            lambda conversation_id: f"https://example.com/{conversation_id}"
+        )
+
+        self.child = MagicMock(spec=AgentStudioProject)
+        self.child.account_id = "brightree-us"
+        self.child.project_id = "brightree-usp-outbound"
+        self.child.region = "us-1"
+        self.child.root_path = "/workspace/brightree-usp-outbound"
+        self.child.branch_id = "child-branch"
+        self.child.get_conversation_url.side_effect = (
+            lambda conversation_id: f"https://example.com/{conversation_id}"
+        )
+
+        self.supervisor = MultiLegChatSupervisor(
+            project=self.parent,
+            environment="draft",
+            channel="chat.polyai",
+            output_json=True,
+        )
+        self.project_patcher = patch.object(
+            self.supervisor,
+            "_resolve_project",
+            return_value=(self.child, True),
+        )
+        self.project_patcher.start()
+
+    def tearDown(self) -> None:
+        self.project_patcher.stop()
+
+    def test_dial_starts_local_child_branch_and_answers_parent(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply("Please hold", dials=[_dial()]),
+        }
+        self.parent.send_message.return_value = _reply("The other line answered")
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply("Hello, this is Ada"),
+        }
+
+        _, result = self.supervisor.run(input_messages=[])
+
+        self.assertEqual(result["active_leg"], "dial-1")
+        self.assertEqual(self.supervisor.legs["parent"].status, "holding")
+        self.assertEqual(self.supervisor.legs["dial-1"].status, "active")
+        self.child.create_chat_session.assert_called_once_with(
+            "draft",
+            "chat.polyai",
+            "English",
+            None,
+            None,
+            integration_attributes={"patient_first_name": "Ada"},
+            custom_sip_headers={
+                "X-Trace": "trace-123",
+                PARENT_CONVERSATION_HEADER: "parent-conv",
+                DIAL_ID_HEADER: "dial-1",
+            },
+        )
+        answered_event = self.parent.send_message.call_args.kwargs["external_events"][0]
+        self.assertEqual(answered_event["ext_event_id"], "dial-1")
+        self.assertEqual(json.loads(answered_event["data"])["status"], "answered")
+
+    def test_child_ready_bridges_without_dropping_when_child_response_ends(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply("Please hold", dials=[_dial()]),
+        }
+        self.parent.send_message.side_effect = [
+            _reply("The other line answered"),
+            _reply(bridge={"dial_id": "dial-1"}, ended=True),
+        ]
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply(
+                function_events=[
+                    {
+                        "agentic_dial": {
+                            "messages_to_parent": [{"content": "READY"}],
+                        }
+                    }
+                ],
+                ended=True,
+            ),
+        }
+
+        _, result = self.supervisor.run(input_messages=[])
+
+        self.assertEqual(result["bridged_dial_id"], "dial-1")
+        self.assertEqual(self.supervisor.legs["parent"].status, "bridged")
+        self.assertEqual(self.supervisor.legs["dial-1"].status, "bridged")
+        self.assertFalse(self.supervisor.finished)
+        ready_event = self.parent.send_message.call_args_list[1].kwargs["external_events"][0]
+        self.assertEqual(json.loads(ready_event["data"]), {"event_type": "message", "content": "READY"})
+
+    def test_child_end_reports_only_that_leg_and_returns_to_parent(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply("Please hold", dials=[_dial()]),
+        }
+        self.parent.send_message.side_effect = [
+            _reply("The other line answered"),
+            _reply("I could not reach them"),
+        ]
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply(ended=True),
+        }
+
+        _, result = self.supervisor.run(input_messages=[])
+
+        self.assertEqual(result["active_leg"], "parent")
+        self.assertEqual(self.supervisor.legs["parent"].status, "active")
+        self.assertEqual(self.supervisor.legs["dial-1"].status, "ended")
+        self.assertFalse(self.supervisor.finished)
+        hangup_event = self.parent.send_message.call_args_list[1].kwargs["external_events"][0]
+        self.assertEqual(json.loads(hangup_event["data"])["status"], "hangup")
+
+    def test_fail_busy_closes_child_and_keeps_parent_available(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply(dials=[_dial()]),
+        }
+        self.parent.send_message.side_effect = [
+            _reply(),
+            _reply("That line is busy"),
+        ]
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply(),
+        }
+
+        self.supervisor.run(input_messages=["/fail busy"])
+
+        self.child.end_chat.assert_called_once_with("child-conv", "draft")
+        self.assertEqual(self.supervisor.legs["dial-1"].status, "failed")
+        self.assertEqual(self.supervisor.legs["parent"].status, "active")
+        busy_event = self.parent.send_message.call_args_list[1].kwargs["external_events"][0]
+        self.assertEqual(json.loads(busy_event["data"])["status"], "busy")
+
+    def test_hangup_after_bridge_triggers_callback_and_closes_both_legs(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply(dials=[_dial()]),
+        }
+        self.parent.send_message.side_effect = [
+            _reply(),
+            _reply(bridge={"dial_id": "dial-1"}),
+        ]
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply(
+                function_events=[
+                    {
+                        "agentic_dial": {
+                            "messages_to_parent": [{"content": "READY"}],
+                        }
+                    }
+                ]
+            ),
+        }
+
+        self.supervisor.run(input_messages=["/hangup"])
+
+        self.parent.bridge_ended.assert_called_once()
+        self.child.end_chat.assert_called_once_with("child-conv", "draft")
+        self.parent.end_chat.assert_called_once_with("parent-conv", "draft")
+        self.assertTrue(self.supervisor.finished)
+
+    def test_parent_to_child_message_uses_child_inbox(self):
+        self.parent.create_chat_session.return_value = {
+            "conversation_id": "parent-conv",
+            **_reply(dials=[_dial()]),
+        }
+        self.parent.send_message.return_value = _reply(
+            function_events=[
+                {
+                    "agentic_dial": {
+                        "messages_to_children": [
+                            {"destination": "billing", "content": "CALLER_HUNG_UP"}
+                        ]
+                    }
+                }
+            ]
+        )
+        self.child.create_chat_session.return_value = {
+            "conversation_id": "child-conv",
+            **_reply(),
+        }
+        self.child.send_message.return_value = _reply()
+
+        self.supervisor.run(input_messages=[])
+
+        child_event = self.child.send_message.call_args.kwargs["external_events"][0]
+        self.assertEqual(child_event["ext_event_id"], "dial-1:child-inbox")
+        self.assertEqual(json.loads(child_event["data"])["content"], "CALLER_HUNG_UP")
+
+
+class ChildEnvironmentTest(unittest.TestCase):
+    """Tests for selecting branch or deployed child environments."""
+
+    def test_parent_draft_prefers_matching_local_child_branch(self):
+        project = MagicMock(branch_id="child-branch")
+
+        environment = MultiLegChatSupervisor._child_environment(
+            "draft",
+            project,
+            "sandbox",
+            local_project=True,
+        )
+
+        self.assertEqual(environment, "draft")
+
+    def test_deployed_parent_uses_connector_environment(self):
+        project = MagicMock(branch_id="child-branch")
+
+        environment = MultiLegChatSupervisor._child_environment(
+            "live",
+            project,
+            "prelive",
+            local_project=True,
+        )
+
+        self.assertEqual(environment, "pre-release")
+
+
+class LocalProjectDiscoveryTest(unittest.TestCase):
+    """Tests for locating a checked-out outbound project beside its parent."""
+
+    def test_resolves_sibling_project_with_its_own_branch(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            account_root = Path(temp_dir)
+            parent_root = account_root / "brightree-usp"
+            child_root = account_root / "brightree-usp-outbound"
+            parent_root.mkdir()
+            (child_root / "_gen").mkdir(parents=True)
+            (child_root / "project.yaml").write_text(
+                "project_id: brightree-usp-outbound\n"
+                "account_id: brightree-us\n"
+                "region: us-1\n",
+                encoding="utf-8",
+            )
+            status = base64.b64encode(
+                json.dumps(
+                    {
+                        "branch_id": "outbound-feature-branch",
+                        "resources": {},
+                        "migration_flags": [],
+                    }
+                ).encode()
+            )
+            (child_root / "_gen" / ".agent_studio_config").write_bytes(status)
+            parent = AgentStudioProject(
+                region="us-1",
+                account_id="brightree-us",
+                project_id="brightree-usp",
+                root_path=str(parent_root),
+                resources={},
+                last_updated=datetime.now(),
+                branch_id="parent-feature-branch",
+            )
+            supervisor = MultiLegChatSupervisor(
+                project=parent,
+                environment="draft",
+                channel="chat.polyai",
+                output_json=True,
+            )
+
+            project, local = supervisor._resolve_project(
+                parent,
+                {
+                    "account_id": "brightree-us",
+                    "project_id": "brightree-usp-outbound",
+                    "client_env": "sandbox",
+                },
+            )
+
+            self.assertTrue(local)
+            self.assertEqual(project.root_path, str(child_root))
+            self.assertEqual(project.branch_id, "outbound-feature-branch")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add an opt-in `poly chat --multi-leg` mode that supervises the full parent/child/bridge call graph instead of treating warm transfer as one disposable chat session.

## Motivation

The existing debug chat ends when a single leg ends. Real warm transfer can create nested, sequential, and concurrent child legs, so developers could not reproduce or inspect the complete lifecycle locally without calls dropping prematurely.

Platform dependency: https://github.com/PolyAI-LDN/poly_core/pull/44534

## Changes

- Add a reusable `MultiLegChatSupervisor` with independent leg lifecycle tracking
- Route dial status, parent/child messages, bridge state, failures, and hangups to the affected leg
- Prefer matching sibling child projects and feature branches for draft projects
- Add interactive leg inspection/control commands and JSON session output
- Document `--multi-leg` and its command set
- Preserve the existing single-leg chat path by making the feature opt-in

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly chat --help`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

Validation:
- Full suite: 960 passed, 21 warnings, 30 subtests
- Focused integration suite: 192 passed
- Ruff check and format check passed
- `git diff --check` passed

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (feature is opt-in)
- [x] Commit messages follow conventional commits

## Screenshots / Logs

N/A — CLI/API behavior is covered by automated tests.