### PR TITLE
feat: deployment mode detection and PostHog feature flags

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -31,6 +31,11 @@
   },
   {
     "License": "MIT License",
+    "Name": "backoff",
+    "URL": "https://github.com/litl/backoff"
+  },
+  {
+    "License": "MIT License",
     "Name": "cattrs",
     "URL": "https://catt.rs"
   },
@@ -58,6 +63,11 @@
     "License": "Python Software Foundation License",
     "Name": "distlib",
     "URL": "https://github.com/pypa/distlib"
+  },
+  {
+    "License": "Apache Software License",
+    "Name": "distro",
+    "URL": "https://github.com/python-distro/distro"
   },
   {
     "License": "MIT License",
@@ -138,6 +148,11 @@
     "License": "MIT License",
     "Name": "pluggy",
     "URL": "UNKNOWN"
+  },
+  {
+    "License": "MIT",
+    "Name": "posthog",
+    "URL": "https://github.com/posthog/posthog-python"
   },
   {
     "License": "MIT",
@@ -238,6 +253,11 @@
     "License": "MIT License",
     "Name": "ty",
     "URL": "https://github.com/astral-sh/ty/"
+  },
+  {
+    "License": "PSF-2.0",
+    "Name": "typing_extensions",
+    "URL": "https://github.com/python/typing_extensions"
   },
   {
     "License": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,8 @@ ignore_packages = [
     "rpds-py",
     "urllib3",
     "wcwidth",
+    "posthog",
+    "typing_extensions"
 ]
 
 [tool.semantic_release]
@@ -175,7 +177,8 @@ dependencies = [
     "ruff>=0.14.0",
     "ty",
     "argcomplete>=3.0.0",
-    "langcodes==3.5.1"
+    "langcodes==3.5.1",
+    "posthog==7.35.4"
 ]
 
 [project.license]

--- a/src/poly/cli_commands/shared.py
+++ b/src/poly/cli_commands/shared.py
@@ -243,3 +243,27 @@ def print_project_file_changes(
 
     if not modified_files and not new_files and not deleted_files and not files_with_conflicts:
         plain("\n[muted]No changes detected.[/muted]")
+
+
+def require_deployment_simplification(
+    project: AgentStudioProject, output_json: bool = False
+) -> None:
+    """Check if the project is using deployment simplification and exit if not.
+
+    Args:
+        project: The loaded project.
+        output_json: If True, output JSON and exit on failure.
+    """
+    from poly.output.console import error
+
+    if not project.using_simplified_deployments:
+        if output_json:
+            json_print(
+                {
+                    "success": False,
+                    "error": "Command is only available for projects using simplified deployments.",
+                }
+            )
+        else:
+            error("Command is only available for projects using simplified deployments.")
+        sys.exit(1)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -10,6 +10,7 @@ import requests
 from google.protobuf.message import Message
 
 from poly.handlers.platform_api import PlatformAPIHandler
+from poly.handlers.posthog import PosthogHandler
 from poly.handlers.protobuf.commands_pb2 import Command
 from poly.handlers.protobuf.handoff_pb2 import Handoff_SetDefault
 from poly.handlers.sdk import SourcererAPIError
@@ -135,6 +136,20 @@ class AgentStudioInterface:
             dict[str, str]: A dictionary mapping account ids to account names
         """
         return PlatformAPIHandler.get_accounts(region)
+
+    @staticmethod
+    def get_project(region: str, account_id: str, project_id: str) -> dict[str, Any]:
+        """Get the details of a specific project.
+
+        Args:
+            region (str): The region name
+            account_id (str): The account ID
+            project_id (str): The project ID
+
+        Returns:
+            dict[str, Any]: A dictionary containing the project's details
+        """
+        return PlatformAPIHandler.get_project(region, account_id, project_id)
 
     @staticmethod
     def get_projects(region: str, account_id: str) -> dict[str, str]:
@@ -1190,3 +1205,30 @@ class AgentStudioInterface:
             dict: The updated RTC config.
         """
         return PlatformAPIHandler.patch_rtc_variables(region, project_id, client_env, variables)
+
+    def feature_flag_enabled(
+        self,
+        key: str,
+        identity: Optional[str] = None,
+        region: Optional[str] = None,
+        project_id: Optional[str] = None,
+        default: bool = False,
+    ) -> bool:
+        """Check if a feature flag is enabled for a given identity.
+
+        Args:
+            key (str): The feature flag key to check.
+            identity (Optional[str]): The unique identifier for the user or entity.
+            region (Optional[str]): The region name for grouping.
+            project_id (Optional[str]): The project ID for grouping.
+            default (bool): The default value to return if the flag cannot be evaluated.
+
+        Returns:
+            bool: True if the feature flag is enabled, False otherwise.
+        """
+        return PosthogHandler.is_feature_enabled(
+            region=region,
+            key=key,
+            default=default,
+            project_id=project_id,
+        )

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -17,6 +17,7 @@ from poly.utils import any_credentials_exist, retrieve_api_key
 logger = logging.getLogger(__name__)
 ACCOUNTS_URL = "/adk/v1/accounts"
 PROJECTS_URL = "/adk/v1/accounts/{account_id}/projects"
+PROJECT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}"
 DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments"
 ACTIVE_DEPLOYMENTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/deployments/active"
 CHAT_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat"
@@ -218,6 +219,21 @@ class PlatformAPIHandler:
                 accounts[account.get("id")] = account.get("name")
 
         return accounts
+
+    @staticmethod
+    def get_project(region: str, account_id: str, project_id: str) -> dict:
+        """Get a specific project for a given account.
+
+        Args:
+            region (str): The region name
+            account_id (str): The account ID
+            project_id (str): The project ID
+
+        Returns:
+            dict: The project details
+        """
+        endpoint = PROJECT_URL.format(account_id=account_id, project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET")
 
     @staticmethod
     def get_projects(region: str, account_id: str) -> dict[str, str]:

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -1,0 +1,103 @@
+"""Client for the PolyAI Posthog tenant, used for feature flags in the PolyAI ADK CLI.
+
+Copyright PolyAI Limited
+"""
+
+import logging
+from typing import TYPE_CHECKING
+
+POSTHOG_HOST = "https://eu.i.posthog.com"
+POSTHOG_KEY = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
+FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
+logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from posthog import Posthog
+
+_client: Posthog | None = None
+
+region_to_posthog_cluster = {
+    "dev": "apollo",
+}
+
+
+def get_posthog_client() -> Posthog:
+    """Get a Posthog client instance.
+
+    Returns:
+        A Posthog client instance.
+    """
+    from posthog import Posthog
+
+    global _client
+
+    if _client is not None:
+        return _client
+    _client = Posthog(
+        project_api_key=POSTHOG_KEY,
+        host=POSTHOG_HOST,
+        feature_flags_request_timeout_seconds=FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS,
+    )
+    return _client
+
+
+def get_user_identity() -> str:
+    """Get the user identity for Posthog feature flag evaluation.
+
+    Returns:
+        The user identity (distinct_id) for Posthog.
+    """
+    import getpass
+
+    return getpass.getuser()
+
+
+class PosthogHandler:
+    """Handler for feature flags with the PolyAI Posthog tenant."""
+
+    @staticmethod
+    def is_feature_enabled(
+        region: str,
+        key: str,
+        *,
+        default: bool,
+        project_id: str | None = None,
+    ) -> bool:
+        """Evaluate a boolean feature flag against PostHog.
+
+        Args:
+            key: The PostHog feature flag key.
+            default: Returned whenever the flag cannot be evaluated. Pick the
+                safe state for the gated code path.
+            email: The requesting user's email, used as the PostHog
+                distinct_id. Required — without it, percentage rollouts
+                would bucket all reads together, so reads with no email
+                return `default` without evaluating.
+            project_id: The project ID (`project` group key). Workspace
+                targeting goes through the `project` group — the workspace id
+                lives on it as a group property in PostHog.
+
+        Returns:
+            The flag value, or `default` if it cannot be evaluated.
+        """
+        client = get_posthog_client()
+        if not client:
+            return default
+
+        groups = {"cluster": region_to_posthog_cluster.get(region, region)}
+        if project_id:
+            groups["project"] = project_id
+
+        try:
+            result = client.feature_enabled(
+                key,
+                distinct_id=get_user_identity(),
+                groups=groups,
+                send_feature_flag_events=False,
+            )
+        except Exception as exc:
+            logger.warning(f"PostHog flag evaluation failed key={key}", exc_info=exc)
+            return default
+
+        return default if result is None else result

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -12,6 +12,8 @@ import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, fields
 from datetime import datetime
+from enum import Enum
+from functools import cached_property
 from typing import Any, Optional, TypeAlias
 
 from google.protobuf.message import Message
@@ -86,6 +88,14 @@ class PushPhaseChangeSet:
     post: ResourceChangeSet
 
 
+class DeploymentMode(Enum):
+    """Deployment mode for the project"""
+
+    SIMPLE = "simple"
+    RELEASES = "releases"
+    RELEASES_BRANCHES = "releases_branches"
+
+
 @dataclass
 class AgentStudioProject:
     """Dataclass representing an Agent Studio Project"""
@@ -103,6 +113,7 @@ class AgentStudioProject:
     file_structure_info: dict[str, dict[str, str]] = None
     _migration_flags: set[MigrationFlag] = None
     rtc_metadata: Optional[dict[str, dict]] = None
+    __deployment_mode: Optional[DeploymentMode] = None
 
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
@@ -3061,7 +3072,6 @@ class AgentStudioProject:
         )
 
     # ── RTC (Real-Time Configuration) ──
-
     RTC_ENV_TO_DIR = {
         "sandbox": "draft_and_sandbox",
         "pre-release": "pre_release",
@@ -3437,3 +3447,27 @@ class AgentStudioProject:
             ]
         except (jsonschema.SchemaError, jsonschema.exceptions.UnknownType) as e:
             return [f"Invalid schema: {e}"]
+
+    def get_project_info(self) -> dict[str, Any]:
+        """Get basic information about the project from the API.
+
+        Returns:
+            dict[str, Any]: A dictionary containing project information.
+        """
+        return self.api_handler.get_project(self.region, self.account_id, self.project_id)
+
+    @property
+    def deployment_mode(self) -> DeploymentMode:
+        if self.__deployment_mode is None:
+            cfg = self.get_project_info().get("config") or {}
+            self.__deployment_mode = DeploymentMode(cfg.get("deployment_mode", "releases"))
+        return self.__deployment_mode
+
+    @cached_property
+    def using_simplified_deployments(self) -> bool:
+        return self.api_handler.feature_flag_enabled(
+            key="deployment-simplification",
+            region=self.region,
+            project_id=self.project_id,
+            default=False,
+        )

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -1,0 +1,159 @@
+"""Tests for the PostHog feature-flag handler.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from poly.handlers import posthog as posthog_module
+from poly.handlers.posthog import PosthogHandler, get_posthog_client, get_user_identity
+
+
+class IsFeatureEnabledTest(unittest.TestCase):
+    """Tests for PosthogHandler.is_feature_enabled."""
+
+    def setUp(self):
+        self.client = MagicMock()
+        self.client_patcher = patch(
+            "poly.handlers.posthog.get_posthog_client", return_value=self.client
+        )
+        self.client_patcher.start()
+        self.identity_patcher = patch(
+            "poly.handlers.posthog.get_user_identity", return_value="test-user"
+        )
+        self.identity_patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def test_returns_flag_value_when_evaluated(self):
+        """A resolved flag is returned as-is, for both True and False."""
+        for value in (True, False):
+            with self.subTest(value=value):
+                self.client.feature_enabled.return_value = value
+
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=not value
+                )
+
+                self.assertEqual(result, value)
+
+    def test_returns_default_when_flag_is_unresolved(self):
+        """A None result means PostHog could not evaluate the flag, so default wins."""
+        self.client.feature_enabled.return_value = None
+
+        for default in (True, False):
+            with self.subTest(default=default):
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=default
+                )
+
+                self.assertEqual(result, default)
+
+    def test_returns_default_when_evaluation_raises(self):
+        """Any exception from the client is swallowed and the default returned.
+
+        The 1s request timeout means a slow or unreachable PostHog must never
+        take down a gated CLI command.
+        """
+        self.client.feature_enabled.side_effect = RuntimeError("connection reset")
+
+        for default in (True, False):
+            with self.subTest(default=default):
+                result = PosthogHandler.is_feature_enabled(
+                    region="studio", key="some-flag", default=default
+                )
+
+                self.assertEqual(result, default)
+
+    def test_returns_default_when_client_is_unavailable(self):
+        """A falsy client short-circuits to the default without evaluating."""
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=None):
+            result = PosthogHandler.is_feature_enabled(
+                region="studio", key="some-flag", default=True
+            )
+
+        self.assertTrue(result)
+
+    def test_passes_key_identity_and_project_group(self):
+        """The flag key, distinct_id and project group are forwarded to PostHog."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(
+            region="studio",
+            key="deployment-simplification",
+            default=False,
+            project_id="proj-1",
+        )
+
+        self.client.feature_enabled.assert_called_once_with(
+            "deployment-simplification",
+            distinct_id="test-user",
+            groups={"cluster": "studio", "project": "proj-1"},
+            send_feature_flag_events=False,
+        )
+
+    def test_omits_project_group_when_no_project_id(self):
+        """Without a project id only the cluster group is sent."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(region="studio", key="some-flag", default=False)
+
+        self.assertEqual(
+            self.client.feature_enabled.call_args.kwargs["groups"], {"cluster": "studio"}
+        )
+
+    def test_region_is_mapped_to_posthog_cluster(self):
+        """Regions with a cluster alias are translated; others pass through unchanged."""
+        self.client.feature_enabled.return_value = True
+
+        for region, expected_cluster in (("dev", "apollo"), ("studio", "studio")):
+            with self.subTest(region=region):
+                PosthogHandler.is_feature_enabled(region=region, key="some-flag", default=False)
+
+                self.assertEqual(
+                    self.client.feature_enabled.call_args.kwargs["groups"]["cluster"],
+                    expected_cluster,
+                )
+
+
+class GetPosthogClientTest(unittest.TestCase):
+    """Tests for the module-level PostHog client singleton."""
+
+    def setUp(self):
+        self.original_client = posthog_module._client
+        posthog_module._client = None
+
+    def tearDown(self):
+        posthog_module._client = self.original_client
+
+    def test_client_is_constructed_once_and_reused(self):
+        """The client is built on first use and cached for subsequent calls."""
+        with patch("posthog.Posthog") as mock_posthog_cls:
+            first = get_posthog_client()
+            second = get_posthog_client()
+
+        self.assertIs(first, second)
+        mock_posthog_cls.assert_called_once()
+
+    def test_client_is_configured_with_a_request_timeout(self):
+        """A feature-flag read is bounded so the CLI cannot hang on PostHog."""
+        with patch("posthog.Posthog") as mock_posthog_cls:
+            get_posthog_client()
+
+        timeout = mock_posthog_cls.call_args.kwargs["feature_flags_request_timeout_seconds"]
+        self.assertEqual(timeout, posthog_module.FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS)
+
+
+class GetUserIdentityTest(unittest.TestCase):
+    """Tests for get_user_identity, the PostHog distinct_id source."""
+
+    def test_identity_is_the_local_username(self):
+        """The distinct_id is the OS username, so rollouts bucket per developer."""
+        with patch("getpass.getuser", return_value="ada"):
+            self.assertEqual(get_user_identity(), "ada")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from unittest.mock import MagicMock, patch
 
 import poly.resources.resource_utils as resource_utils
-from poly.project import AgentStudioProject
+from poly.project import AgentStudioProject, DeploymentMode
 from poly.resources import (
     AsrSettings,
     ChatGreeting,
@@ -3986,6 +3986,118 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
 
         self.assertIsNone(current_name)
         self.assertEqual(len(branches), 1)
+
+
+class UsingSimplifiedDeploymentsTest(unittest.TestCase):
+    """Tests for the AgentStudioProject.using_simplified_deployments property."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.branch_id = "main"
+        self.mock_api.feature_flag_enabled.return_value = True
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _build_project(self, flag_value: bool) -> AgentStudioProject:
+        """Build a fresh project whose flag resolves to the given value.
+
+        A fresh instance is required per value because the property is cached.
+        """
+        project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        api = MagicMock()
+        api.branch_id = "main"
+        api.feature_flag_enabled.return_value = flag_value
+        project._api_handler = api
+        return project
+
+    def test_reads_the_deployment_simplification_flag_for_this_project(self):
+        """The flag is looked up by key and scoped to the project's region and id."""
+        self.assertTrue(self.project.using_simplified_deployments)
+
+        self.mock_api.feature_flag_enabled.assert_called_once_with(
+            key="deployment-simplification",
+            region=self.project.region,
+            project_id=self.project.project_id,
+            default=False,
+        )
+
+    def test_defaults_to_disabled_when_the_flag_cannot_be_read(self):
+        """`default=False` is passed so an unreachable PostHog gates the new commands off."""
+        self.project.using_simplified_deployments
+
+        self.assertFalse(self.mock_api.feature_flag_enabled.call_args.kwargs["default"])
+
+    def test_returns_the_flag_value(self):
+        """Whatever the flag resolves to is what the property reports."""
+        for value in (True, False):
+            with self.subTest(value=value):
+                project = self._build_project(value)
+
+                self.assertEqual(project.using_simplified_deployments, value)
+
+    def test_flag_is_evaluated_once_and_cached(self):
+        """Repeated reads reuse the cached value instead of re-evaluating the flag."""
+        first = self.project.using_simplified_deployments
+        second = self.project.using_simplified_deployments
+
+        self.assertEqual(first, second)
+        self.mock_api.feature_flag_enabled.assert_called_once()
+
+
+class DeploymentModePropertyTest(unittest.TestCase):
+    """Tests for the AgentStudioProject.deployment_mode property."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.branch_id = "main"
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def test_reads_mode_from_remote_project_config(self):
+        """Each recognised config value maps to the matching enum member."""
+        for value, expected in (
+            ("simple", DeploymentMode.SIMPLE),
+            ("releases", DeploymentMode.RELEASES),
+            ("releases_branches", DeploymentMode.RELEASES_BRANCHES),
+        ):
+            with self.subTest(value=value):
+                self.project._AgentStudioProject__deployment_mode = None
+                self.mock_api.get_project.return_value = {"config": {"deployment_mode": value}}
+
+                self.assertEqual(self.project.deployment_mode, expected)
+
+    def test_defaults_to_releases_when_config_missing(self):
+        """A missing 'config', missing 'deployment_mode', or null config all default to releases."""
+        for payload in (
+            {"projectId": "test_project"},
+            {"config": {"other_setting": True}},
+            {"config": None},
+        ):
+            with self.subTest(payload=payload):
+                self.project._AgentStudioProject__deployment_mode = None
+                self.mock_api.get_project.return_value = payload
+
+                self.assertEqual(self.project.deployment_mode, DeploymentMode.RELEASES)
+
+    def test_mode_is_fetched_once_and_cached(self):
+        """Repeated reads reuse the cached mode instead of re-querying the API."""
+        self.mock_api.get_project.return_value = {"config": {"deployment_mode": "simple"}}
+
+        first = self.project.deployment_mode
+        second = self.project.deployment_mode
+
+        self.assertEqual(first, second)
+        self.mock_api.get_project.assert_called_once()
 
 
 class RtcPullEnvTest(unittest.TestCase):

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
 name = "cattrs"
 version = "24.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -139,6 +148,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/8e/709914eb2b5749865801041647dc7f4e6d00b549cfe88b65ca192995f07c/distlib-0.4.0.tar.gz", hash = "sha256:feec40075be03a04501a973d81f633735b4b69f98b05450592310c0f401a4e0d", size = 614605, upload-time = "2025-07-17T16:52:00.465Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/6b/e0547afaf41bf2c42e52430072fa5658766e3d65bd4b03a563d1b6336f57/distlib-0.4.0-py2.py3-none-any.whl", hash = "sha256:9659f7d87e46584a30b5780e43ac7a2143098441670ff0a49d5f9034c54a6c16", size = 469047, upload-time = "2025-07-17T16:51:58.613Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -341,12 +359,13 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.34.5"
+version = "0.36.3"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
     { name = "jsonschema" },
     { name = "langcodes" },
+    { name = "posthog" },
     { name = "protobuf" },
     { name = "python-dateutil" },
     { name = "questionary" },
@@ -376,6 +395,7 @@ requires-dist = [
     { name = "langcodes", specifier = "==3.5.1" },
     { name = "licensecheck", marker = "extra == 'dev'", specifier = ">=2024.3" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.1" },
+    { name = "posthog", specifier = "==7.35.4" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=4.21.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -390,6 +410,21 @@ requires-dist = [
     { name = "ty" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "posthog"
+version = "7.35.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backoff" },
+    { name = "distro" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/b9/9471861b836eed9be1da207792d8ad69b385e99a174029f13d52467493fa/posthog-7.35.4.tar.gz", hash = "sha256:b0342314599c25bd9d32877a9525f9632ed49037d3b25a920b01be641dd1b368", size = 395178, upload-time = "2026-07-31T11:15:39.463Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/94/4e63655fa86054459be1bb50497198efd27bb76db50da977643739fa1c25/posthog-7.35.4-py3-none-any.whl", hash = "sha256:79e3979e7a68b98d2ff2064916eed60b2ee3b2c687e73c41b77e4de00514ec74", size = 468387, upload-time = "2026-07-31T11:15:37.556Z" },
+]
 
 [[package]]
 name = "pre-commit"
@@ -744,6 +779,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/48/88/36c652c658fe96658043e4abc8ea97801de6fb6e63ab50aaa82807bff1d8/ty-0.0.20-py3-none-win32.whl", hash = "sha256:c7d32bfe93f8fcaa52b6eef3f1b930fd7da410c2c94e96f7412c30cfbabf1d17", size = 9744206, upload-time = "2026-03-02T15:51:54.183Z" },
     { url = "https://files.pythonhosted.org/packages/ff/a7/a4a13bed1d7fd9d97aaa3c5bb5e6d3e9a689e6984806cbca2ab4c9233cac/ty-0.0.20-py3-none-win_amd64.whl", hash = "sha256:a5e10f40fc4a0a1cbcb740a4aad5c7ce35d79f030836ea3183b7a28f43170248", size = 10711999, upload-time = "2026-03-02T15:51:29.212Z" },
     { url = "https://files.pythonhosted.org/packages/8d/7e/6bfd748a9f4ff9267ed3329b86a0f02cdf6ab49f87bc36c8a164852f99fc/ty-0.0.20-py3-none-win_arm64.whl", hash = "sha256:53f7a5c12c960e71f160b734f328eff9a35d578af4b67a36b0bb5990ac5cdc27", size = 10150143, upload-time = "2026-03-02T15:51:31.283Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds deployment-mode detection and a PostHog-backed feature-flag gate. This is pure plumbing — no user-facing command behavior changes yet — consumed by the two PRs stacked on top of this one.

## Motivation

The platform is rolling out a simplified deployment model (branch lineage, staging tags, soft-delete/restore) behind a feature flag, and ADK needs to know which deployment mode a project is in and whether that flag is enabled before it can build support for any of it.

## Changes

- `DeploymentMode` enum and `AgentStudioProject.deployment_mode`, read from the project's `config.deployment_mode` and defaulting to `releases`.
- `PosthogHandler` and `AgentStudioInterface.feature_flag_enabled`, backing `AgentStudioProject.using_simplified_deployments`.
- `require_deployment_simplification` helper for gating commands the platform only exposes under simplified deployments. Not called from any command yet — wired up by #253.
- `PlatformAPIHandler.get_project` / `AgentStudioInterface.get_project` to fetch the project config the deployment mode is read from.
- Adds the `posthog==7.35.4` dependency.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change) — no CLI-visible behavior in this PR

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
