### PR TITLE
feat: branch-from-branch creation and deployment-mode-aware merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,13 @@ poly revert file1.yaml file2.yaml  # revert specific files
 Manage branches (default branch is `main`):
 
 ```bash
-poly branch list
+poly branch list                       # active branches
 poly branch current
 poly branch create my-feature
 poly branch switch my-feature
 poly branch switch my-feature --force  # discard uncommitted changes
+poly branch merge 'Merge my-feature'   # merge into the parent branch
+poly branch delete
 ```
 
 ### `poly format`

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -15,6 +15,7 @@ from typing import Any, Optional
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project, parse_from_projection_json, read_project_config
 from poly.output.json_output import json_print
+from poly.project import DeploymentMode
 from poly.resources.resource_utils import contains_merge_conflict
 from poly.utils import merge_strings
 
@@ -105,7 +106,7 @@ class BranchCommand(BaseCommand):
                 "  poly branch list\n"
                 "  poly branch create new-branch\n"
                 "  poly branch switch existing-branch\n"
-                "  poly branch merge 'Merge branch'"
+                "  poly branch merge 'Merge branch'\n"
                 "  poly branch current\n"
                 "  poly branch delete\n"
             ),
@@ -113,6 +114,7 @@ class BranchCommand(BaseCommand):
         )
         branch_subparsers = branches_parser.add_subparsers(dest="branch_subcommand", required=True)
 
+        # -- list --
         branch_list_parser = branch_subparsers.add_parser(
             "list",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -120,6 +122,7 @@ class BranchCommand(BaseCommand):
         )
         branch_list_parser.set_defaults(branch_subcommand="list")
 
+        # -- create --
         branch_create_parser = branch_subparsers.add_parser(
             "create",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -145,6 +148,7 @@ class BranchCommand(BaseCommand):
         )
         branch_create_parser.set_defaults(branch_subcommand="create")
 
+        # -- switch --
         branch_switch_parser = branch_subparsers.add_parser(
             "switch",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -179,6 +183,7 @@ class BranchCommand(BaseCommand):
         )
         branch_switch_parser.set_defaults(branch_subcommand="switch")
 
+        # -- current --
         branch_current_parser = branch_subparsers.add_parser(
             "current",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -186,6 +191,7 @@ class BranchCommand(BaseCommand):
         )
         branch_current_parser.set_defaults(branch_subcommand="current")
 
+        # -- delete --
         branch_delete_parser = branch_subparsers.add_parser(
             "delete",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -199,10 +205,11 @@ class BranchCommand(BaseCommand):
         ).completer = cls._branch_name_completer
         branch_delete_parser.set_defaults(branch_subcommand="delete")
 
+        # -- merge --
         branch_merge_parser = branch_subparsers.add_parser(
             "merge",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
-            help="Merge branch into main",
+            help="Merge branch into its parent branch",
         )
         branch_merge_parser.add_argument(
             "message",
@@ -228,9 +235,15 @@ class BranchCommand(BaseCommand):
                 '- value: Optional custom value (use "theirs" strategy)'
             ),
         )
+        branch_merge_parser.add_argument(
+            "--force",
+            "-f",
+            action="store_true",
+            help="Skip the confirmation prompt when merging into main deploys to a live environment.",
+        )
         branch_merge_parser.set_defaults(branch_subcommand="merge")
 
-        # ── diff ──
+        # -- diff --
         branch_diff_parser = branch_subparsers.add_parser(
             "diff",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -249,7 +262,7 @@ class BranchCommand(BaseCommand):
         )
         branch_diff_parser.set_defaults(branch_subcommand="diff")
 
-        # ── review ──
+        # -- review --
         branch_review_parser = branch_subparsers.add_parser(
             "review",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -268,7 +281,7 @@ class BranchCommand(BaseCommand):
         )
         branch_review_parser.set_defaults(branch_subcommand="review")
 
-        # ── status ──
+        # -- status --
         branch_status_parser = branch_subparsers.add_parser(
             "status",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
@@ -315,7 +328,9 @@ class BranchCommand(BaseCommand):
             cls.branch_delete(args.path, args.branch_name, args.json)
 
         elif args.branch_subcommand == "merge":
-            cls.branch_merge(args.path, args.message, args.json, args.interactive, args.resolutions)
+            cls.branch_merge(
+                args.path, args.message, args.json, args.interactive, args.resolutions, args.force
+            )
 
         elif args.branch_subcommand == "diff":
             cls.branch_diff(args.path, args.branch_name, getattr(args, "files", None), args.json)
@@ -329,7 +344,12 @@ class BranchCommand(BaseCommand):
     @classmethod
     def branch_list(cls, base_path: str, output_json: bool = False) -> None:
         """List branches in the Agent Studio project."""
-        from poly.output.console import plain, print_branches, warning
+        from poly.output.console import (
+            plain,
+            print_branches,
+            print_releases_branches,
+            warning,
+        )
 
         project = load_project(base_path, output_json=output_json)
 
@@ -347,7 +367,10 @@ class BranchCommand(BaseCommand):
             plain("[muted]No branches found.[/muted]")
             return
 
-        print_branches(branches, current_branch)
+        if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            print_releases_branches(branches, current_branch)
+        else:
+            print_branches(branches, current_branch)
 
         if current_branch is None:
             warning(
@@ -368,21 +391,6 @@ class BranchCommand(BaseCommand):
         from poly.output.console import error, success, warning
 
         project = load_project(base_path, output_json=output_json)
-
-        if project.branch_id != "main":
-            if output_json:
-                json_print(
-                    {
-                        "success": False,
-                        "error": "Branches can only be created from the main branch (sandbox).",
-                    }
-                )
-            else:
-                error(
-                    "Branches can only be created from the [bold]main[/bold] branch (sandbox). "
-                    "Please switch and try again."
-                )
-            sys.exit(1)
 
         if env in ["pre-release", "live"]:
             # Checks for any local changes on main before creating env branch.
@@ -408,11 +416,22 @@ class BranchCommand(BaseCommand):
                 warning("No branch name provided. Exiting.")
                 return
 
-        new_branch_id = project.create_branch(branch_name)
+        base_branch_id = project.branch_id
+        base_branch_name = project.get_current_branch()
+        try:
+            new_branch_id = project.create_branch(branch_name)
+        except ValueError as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            sys.exit(1)
         if output_json:
             json_print(
                 {
                     "success": bool(new_branch_id),
+                    "base_branch_id": base_branch_id,
+                    "base_branch_name": base_branch_name,
                     "new_branch_id": new_branch_id,
                     "branch_name": branch_name,
                 }
@@ -422,7 +441,9 @@ class BranchCommand(BaseCommand):
             return
 
         if new_branch_id:
-            success(f"Branch '{branch_name}' created (ID: {new_branch_id})")
+            success(
+                f"Created new branch '{branch_name}' (ID: {new_branch_id}) from '{base_branch_name}'"
+            )
         else:
             error("Failed to create the branch.")
             sys.exit(1)
@@ -450,7 +471,7 @@ class BranchCommand(BaseCommand):
         """Switch to a different branch in the Agent Studio project."""
         import questionary
 
-        from poly.output.console import console, error, plain, success, warning
+        from poly.output.console import console, error, flatten_branch_tree, plain, success, warning
 
         project = load_project(base_path, output_json=output_json)
 
@@ -469,24 +490,27 @@ class BranchCommand(BaseCommand):
                 plain("[muted]No branches found.[/muted]")
                 return
 
-            # Create menu options from branch names
-            menu_options = []
-            for name in branches.keys():
-                if name == current_branch:
-                    menu_options.append(f"{name} (current)")
-                else:
-                    menu_options.append(name)
+            if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+                # Show branch-from-branch lineage via indentation/connectors.
+                choices = [
+                    questionary.Choice(title=title, value=value)
+                    for title, value in flatten_branch_tree(branches, current_branch)
+                ]
+            else:
+                choices = [
+                    questionary.Choice(
+                        title=f"{name} (current)" if name == current_branch else name,
+                        value=name,
+                    )
+                    for name in branches.keys()
+                ]
 
-            branch_menu = questionary.select(
-                "Select Branch", choices=menu_options, use_search_filter=True, use_jk_keys=False
+            branch_name = questionary.select(
+                "Select Branch", choices=choices, use_search_filter=True, use_jk_keys=False
             ).ask()
-            if not branch_menu:
+            if not branch_name:
                 warning("No branch selected. Exiting.")
                 return
-
-            # Get the selected branch name (remove "(current)" suffix if present)
-            selected_option = branch_menu
-            branch_name = selected_option.replace(" (current)", "")
 
         projection_json = parse_from_projection_json(
             from_projection,
@@ -532,26 +556,44 @@ class BranchCommand(BaseCommand):
 
     @classmethod
     def get_current_branch(cls, base_path: str, output_json: bool = False) -> None:
-        """Get the current branch of the Agent Studio project."""
+        """Get the current branch of the Agent Studio project, and its parent if it has one."""
         from poly.output.console import plain, warning
 
         project = load_project(base_path, output_json=output_json)
 
-        current_branch = project.get_current_branch()
-        if output_json:
-            json_output = {
-                "current_branch": current_branch,
-            }
-            json_print(json_output)
-            return
+        current_branch, branches = project.get_branches()
 
         if current_branch is None:
-            warning(
-                "Current local branch does not exist in Agent Studio. "
-                "It may have been deleted or merged."
-            )
+            if output_json:
+                json_print({"current_branch": None, "parent_branch": None})
+            else:
+                warning(
+                    "Current local branch does not exist in Agent Studio. "
+                    "It may have been deleted or merged."
+                )
             return
+
+        parent_branch_id = branches.get(current_branch, {}).get("parentBranchId")
+        parent_branch = (
+            next(
+                (
+                    name
+                    for name, meta in branches.items()
+                    if meta.get("branchId") == parent_branch_id
+                ),
+                parent_branch_id,
+            )
+            if parent_branch_id
+            else None
+        )
+
+        if output_json:
+            json_print({"current_branch": current_branch, "parent_branch": parent_branch})
+            return
+
         plain(f"Current branch: [bold]{current_branch}[/bold]")
+        if parent_branch and parent_branch != "main":
+            plain(f"Parent branch: [bold]{parent_branch}[/bold]")
 
     @classmethod
     def branch_delete(
@@ -566,7 +608,7 @@ class BranchCommand(BaseCommand):
         """
         import questionary
 
-        from poly.output.console import error, info, plain, success, warning
+        from poly.output.console import error, flatten_branch_tree, info, plain, success, warning
 
         project = load_project(base_path, output_json=output_json)
         current_branch, branches = project.get_branches()
@@ -615,17 +657,31 @@ class BranchCommand(BaseCommand):
             plain("[muted]No deletable branches found.[/muted]")
             return
 
-        choices = []
-        for name in deletable:
-            label = f"{name} (current)" if name == current_branch else name
-            choices.append(label)
+        if project.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            # Show 'main' as disabled tree context so lineage is visible, but not selectable.
+            choices = [
+                questionary.Choice(
+                    title=title,
+                    value=value,
+                    disabled="cannot delete main" if value == "main" else None,
+                )
+                for title, value in flatten_branch_tree(branches, current_branch)
+            ]
+        else:
+            choices = [
+                questionary.Choice(
+                    title=f"{name} (current)" if name == current_branch else name,
+                    value=name,
+                )
+                for name in deletable
+            ]
 
         selected = questionary.checkbox("Select branches to delete", choices=choices).ask()
         if not selected:
             warning("No branches selected. Exiting.")
             return
 
-        branch_names = [label.replace(" (current)", "") for label in selected]
+        branch_names = selected
         confirm_msg = f"Delete {len(branch_names)} branch(es): {', '.join(branch_names)}?"
         confirmed = questionary.confirm(confirm_msg, default=False).ask()
         if not confirmed:
@@ -634,8 +690,7 @@ class BranchCommand(BaseCommand):
 
         deleted_count = 0
         current_branch_deleted = False
-        for label in selected:
-            name = label.replace(" (current)", "")
+        for name in selected:
             try:
                 deleted = project.delete_branch(name)
                 if deleted:
@@ -822,8 +877,11 @@ class BranchCommand(BaseCommand):
         output_json: bool = False,
         interactive: bool = False,
         resolutions_file: str = None,
+        force: bool = False,
     ):
         """Merge the current branch into main, with optional conflict resolutions."""
+        import questionary
+
         from poly.output.console import (
             console,
             error,
@@ -871,8 +929,41 @@ class BranchCommand(BaseCommand):
 
         project = load_project(base_path, output_json=output_json)
 
-        branch_name = project.get_current_branch()
-        ctx = console.status("[info]Merging branch...[/info]") if not output_json else nullcontext()
+        current_branch_name, branches = project.get_branches()
+        current_branch_meta = branches.get(current_branch_name, {})
+        parent_branch_id = current_branch_meta.get("parentBranchId") or None
+        parent_branch_name = next(
+            (name for name, meta in branches.items() if meta.get("branchId") == parent_branch_id),
+            "main",
+        )
+
+        is_live_deploy = parent_branch_name == "main" and project.using_simplified_deployments
+
+        def _report_merge_success() -> None:
+            if is_live_deploy:
+                success(
+                    f"Branch '{current_branch_name}' merged into main — your changes are now live."
+                )
+            else:
+                success(f"Branch '{current_branch_name}' merged successfully.")
+            info(f"Switched to '{parent_branch_name}' branch after merge.")
+
+        if is_live_deploy:
+            if not output_json and not force:
+                warning("Merging into 'main' will deploy changes into live environment")
+                if not questionary.confirm(
+                    "Confirm Deployment?", default=False, auto_enter=False
+                ).ask():
+                    warning("Aborted.")
+                    sys.exit(0)
+
+        ctx = (
+            console.status(
+                f"[info]Merging branch '{current_branch_name}' into '{parent_branch_name}'...[/info]"
+            )
+            if not output_json
+            else nullcontext()
+        )
         with ctx:
             merge_success, conflicts, errors = project.merge_branch(
                 message=message, conflict_resolutions=file_resolutions
@@ -889,12 +980,11 @@ class BranchCommand(BaseCommand):
             return
 
         if merge_success:
-            success(f"Branch '{branch_name}' merged successfully.")
-            info('Switched to "main" branch after merge.')
+            _report_merge_success()
             return
 
         # Failed branch merge
-        error(f"Failed to merge branch '{branch_name}'.")
+        error(f"Failed to merge branch '{current_branch_name}'.")
         if errors:
             plain("\n[red]Errors:[/red]")
             for err in errors:
@@ -925,7 +1015,9 @@ class BranchCommand(BaseCommand):
             os.sep.join(r["path"]): r for r in (file_resolutions or []) if "path" in r
         }
         while True:
-            resolutions = cls._merge_interactively(enriched, existing_resolutions, branch_name)
+            resolutions = cls._merge_interactively(
+                enriched, existing_resolutions, current_branch_name
+            )
             if not resolutions:
                 warning("No resolutions provided. Exiting.")
                 sys.exit(1)
@@ -939,18 +1031,17 @@ class BranchCommand(BaseCommand):
                     message=message, conflict_resolutions=resolutions
                 )
             if merge_success:
-                success(f"Branch '{branch_name}' merged successfully.")
-                info('Switched to "main" branch after merge.')
+                _report_merge_success()
                 break
             if errors:
-                error(f"Failed to merge branch '{branch_name}' after conflict resolution.")
+                error(f"Failed to merge branch '{current_branch_name}' after conflict resolution.")
                 plain("\n[red]Errors:[/red]")
                 for err in errors:
                     error(f"- {err['path']}: {err['message']}")
                 sys.exit(1)
             if not conflicts:
                 error(
-                    f"Failed to merge branch '{branch_name}' after conflict resolution "
+                    f"Failed to merge branch '{current_branch_name}' after conflict resolution "
                     "(no conflicts or errors returned)."
                 )
                 sys.exit(1)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -527,17 +527,20 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
-    def create_branch(self, branch_name: Optional[str] = None) -> str:
+    def create_branch(
+        self, branch_name: Optional[str] = None, source_branch_id: Optional[str] = None
+    ) -> str:
         """Create a new branch in the project.
 
         Args:
             branch_name (str): The name of the new branch
+            source_branch_id (str): The ID of the source branch to create the new branch from. Defaults to 'main' if not provided.
 
         Returns:
             str: The ID of the newly created branch
         """
         try:
-            return self.sync_client.create_branch(branch_name)
+            return self.sync_client.create_branch(branch_name, source_branch_id=source_branch_id)
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -199,12 +199,14 @@ class SourcererSDK:
         self,
         expected_main_last_known_sequence: int = 0,
         branch_name: Optional[str] = None,
+        source_branch_id: Optional[str] = None,
     ) -> str:
         """Create a new branch for the project
 
         Args:
             expected_main_last_known_sequence: The expected sequence number from main branch
             branch_name: Optional name for the branch. If not provided, will generate a default name
+            source_branch_id: Optional source branch ID to create the new branch from. Defaults to main if not provided.
 
         Returns:
             The ID of the created branch
@@ -221,6 +223,10 @@ class SourcererSDK:
                 "expectedMainLastKnownSequence": expected_main_last_known_sequence,
                 "branchName": branch_name or f"sdk-branch-{os.urandom(4).hex()}",
             }
+
+            if source_branch_id is not None and source_branch_id != "main":
+                payload["sourceBranchId"] = source_branch_id
+
             response = self.session.post(self._get_branches_url(), json=payload)
             response.raise_for_status()
             branch_data = response.json()
@@ -241,9 +247,9 @@ class SourcererSDK:
         deployment_message: str = "",
         conflict_resolutions: Optional[list[dict[str, Any]]] = None,
     ) -> dict[str, Any]:
-        """Merge the current branch into the main branch
+        """Merge the current branch into the parent branch
 
-        This method merges changes from the current branch into the main branch.
+        This method merges changes from the current branch into it's parent branch.
         If conflicts are detected, they will be returned in the response for manual resolution.
         Once conflicts are resolved, call this method again with the conflict_resolutions parameter.
 

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -209,7 +209,9 @@ class SyncClientHandler:
                 return False
         return False
 
-    def create_branch(self, branch_name: Optional[str] = None) -> str:
+    def create_branch(
+        self, branch_name: Optional[str] = None, source_branch_id: Optional[str] = None
+    ) -> str:
         """Create a new branch for the project
 
         Args:
@@ -218,8 +220,9 @@ class SyncClientHandler:
         Returns:
             The ID of the created branch
         """
-        self.sdk.branch_id = "main"
-        self.sdk.get_project_data()
+        sequence_number = self.sdk.fetch_last_known_sequence_number(
+            branch_id=source_branch_id or "main"
+        )
 
         if branch_name is None:
             metadata = self.sdk.create_metadata()
@@ -228,11 +231,14 @@ class SyncClientHandler:
             suffix = f"{time_suffix}-{random_suffix}"  # to avoid duplicate names
             branch_name = f"ADK-{suffix}"
 
-        logger.info(f"Creating new branch '{branch_name}' from 'main' branch")
+        logger.info(
+            f"Creating new branch '{branch_name}' from branch '{source_branch_id or 'main'}'"
+        )
 
         self.sdk.branch_id = self.sdk.create_branch(
-            expected_main_last_known_sequence=self.sdk._last_known_sequence,
+            expected_main_last_known_sequence=sequence_number,
             branch_name=branch_name,
+            source_branch_id=source_branch_id,
         )
         logger.info(
             f"Created and switched to new branch. Name:'{branch_name}' ID:'{self.sdk.branch_id}'"
@@ -287,7 +293,7 @@ class SyncClientHandler:
     def merge_branch(
         self, message: str, conflict_resolutions: Optional[list[dict[str, Any]]] = None
     ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
-        """Merge the current branch into main.
+        """Merge the current branch into its parent branch.
 
         Args:
             message (str): The merge commit message
@@ -307,7 +313,7 @@ class SyncClientHandler:
             logger.error("Cannot merge 'main' branch into itself.")
             return False, [], []
 
-        logger.info(f"Merging branch '{self.sdk.branch_id}' into 'main'")
+        logger.info(f"Merging branch '{self.sdk.branch_id}' into its parent branch")
 
         try:
             result = self.sdk.merge_branch(
@@ -315,18 +321,20 @@ class SyncClientHandler:
                 conflict_resolutions=conflict_resolutions,
             )
         except SourcererAPIError as e:
-            logger.error(f"Failed to merge branch '{self.sdk.branch_id}' into 'main': {e}")
+            logger.error(
+                f"Failed to merge branch '{self.sdk.branch_id}' into its parent branch: {e}"
+            )
             return False, [], []
 
         if result.get("hasConflicts", False) or result.get("errors", []):
             logger.info(
-                f"Failed to merge branch '{self.sdk.branch_id}' into 'main' due to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
+                f"Failed to merge branch '{self.sdk.branch_id}' into its parent branch due to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
             )
             conflicts = result.get("conflicts", [])
             errors = result.get("errors", [])
             return False, conflicts, errors
 
-        logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into 'main'")
+        logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into its parent branch")
         return True, [], []
 
     def get_branch_chat_info(self, branch_id: str) -> dict[str, Any]:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -23,6 +23,7 @@ from rich.syntax import Syntax
 from rich.table import Table
 from rich.text import Text
 from rich.theme import Theme
+from rich.tree import Tree
 
 # Global verbose flag — set by CLI before commands run
 _verbose = False
@@ -148,6 +149,80 @@ def print_agents(agents: list[dict[str, Any]]) -> None:
             branches,
         )
     console.print(table)
+
+
+def _convert_flat_branches_to_tree(branches: dict[str, Any]) -> list[dict[str, Any]]:
+    """Group a flat branches dict into a forest of nodes linked by parentBranchId.
+
+    Two passes are required: branches can be listed in any order — including a
+    child appearing before its own parent — so every node must exist before any
+    parent lookup runs.
+    """
+    nodes = {
+        meta.get("branchId"): {"name": name, "meta": meta, "children": []}
+        for name, meta in branches.items()
+    }
+
+    roots = []
+    for node in nodes.values():
+        parent = nodes.get(node["meta"].get("parentBranchId"))
+        (parent["children"] if parent is not None else roots).append(node)
+    return roots
+
+
+def print_releases_branches(branches: dict[str, Any], current_branch: str | None) -> None:
+    """Print branches as a tree reflecting parent/child (branch-from-branch) relationships."""
+
+    def label(node: dict[str, Any]) -> str:
+        name = node["name"]
+        text = f"[success]{name}[/success]" if name == current_branch else name
+        if tag := node["meta"].get("tag"):
+            text += f" [info]({tag})[/info]"
+        if name == current_branch:
+            text += " [muted](current)[/muted]"
+        return text
+
+    def add(parent_tree: Tree, node: dict[str, Any]) -> None:
+        branch_tree = parent_tree.add(label(node))
+        for child in sorted(node["children"], key=lambda n: n["name"]):
+            add(branch_tree, child)
+
+    console.print("[label]Branches:[/label]")
+    tree = Tree("", hide_root=True, guide_style="dim")
+    for root in sorted(_convert_flat_branches_to_tree(branches), key=lambda n: n["name"]):
+        add(tree, root)
+    console.print(tree)
+
+
+def flatten_branch_tree(
+    branches: dict[str, Any], current_branch: str | None
+) -> list[tuple[str, str]]:
+    """Flatten the parent/child branch tree into (display_title, branch_name) pairs.
+
+    For use in flat pickers (e.g. questionary) that have no native tree rendering —
+    hierarchy is conveyed via indentation and connector characters in the title,
+    while the value stays the plain branch name.
+    """
+
+    def label(name: str) -> str:
+        return f"{name} (current)" if name == current_branch else name
+
+    def walk(nodes: list[dict[str, Any]], indent: str) -> list[tuple[str, str]]:
+        lines = []
+        nodes = sorted(nodes, key=lambda n: n["name"])
+        for i, node in enumerate(nodes):
+            is_last = i == len(nodes) - 1
+            connector = "└─ " if is_last else "├─ "
+            lines.append((indent + connector + label(node["name"]), node["name"]))
+            extension = "   " if is_last else "│  "
+            lines.extend(walk(node["children"], indent + extension))
+        return lines
+
+    lines = []
+    for root in sorted(_convert_flat_branches_to_tree(branches), key=lambda n: n["name"]):
+        lines.append((label(root["name"]), root["name"]))
+        lines.extend(walk(root["children"], ""))
+    return lines
 
 
 def print_branches(branches: dict[str, Any] | list[str], current_branch: str | None) -> None:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2257,7 +2257,32 @@ class AgentStudioProject:
         Returns:
             str: The ID of the newly created branch
         """
-        branch_id = self.api_handler.create_branch(branch_name)
+        if self.deployment_mode == DeploymentMode.SIMPLE:
+            branches = self.api_handler.get_branches()
+            if len(branches) >= 2:
+                raise ValueError(
+                    "Cannot create branch. Only one branch is allowed in simple deployment mode. Please delete/merge existing branches before creating a new one."
+                )
+        if self.deployment_mode == DeploymentMode.RELEASES:
+            if self.branch_id != "main":
+                raise ValueError(
+                    "Cannot create branch. Branches can only be created from the main branch in releases deployment mode."
+                )
+        if self.deployment_mode == DeploymentMode.RELEASES_BRANCHES:
+            branches = self.api_handler.get_branches()
+            current_branch_meta = next(
+                (meta for meta in branches.values() if meta["branchId"] == self.branch_id),
+                None,
+            )
+            if current_branch_meta is None or (
+                not current_branch_meta.get("branchId") == "main"
+                and current_branch_meta.get("parentBranchId") != "main"
+            ):
+                raise ValueError(
+                    "Cannot create branch. Branches with depth above 2 are not allowed in releases-branches deployment mode."
+                )
+
+        branch_id = self.api_handler.create_branch(branch_name, self.branch_id)
         self.branch_id = branch_id
         self.save_config()
         return branch_id
@@ -2695,8 +2720,10 @@ class AgentStudioProject:
             list[dict[str, str]]: A list of errors
         """
         branches = self.api_handler.get_branches()
-        branch_ids = {meta["branchId"] for meta in branches.values()}
-        if self.branch_id not in branch_ids:
+        branch_meta = {meta["branchId"]: meta for meta in branches.values()}
+        current_branch_meta = branch_meta.get(self.branch_id)
+
+        if not current_branch_meta:
             raise ValueError(f"Branch {self.branch_id} does not exist.")
 
         if self.branch_id == "main":
@@ -2720,7 +2747,10 @@ class AgentStudioProject:
             message=message, conflict_resolutions=conflict_resolutions
         )
         if success:
-            self.switch_branch("main", force=True)
+            parent_branch_id = current_branch_meta.get("parentBranchId") or "main"
+            parent_branch_meta = branch_meta.get(parent_branch_id) or {}
+            parent_branch_name = parent_branch_meta.get("name") or "main"
+            self.switch_branch(parent_branch_name, force=True)
             return True, [], []
 
         return False, conflicts, errors

--- a/src/poly/tests/api/sdk_test.py
+++ b/src/poly/tests/api/sdk_test.py
@@ -104,6 +104,61 @@ class FetchProjection(unittest.TestCase):
             sdk.fetch_projection()
 
 
+class CreateBranch(unittest.TestCase):
+    """Tests for the payload SourcererSDK.create_branch posts."""
+
+    def setUp(self):
+        self.sdk = build_sdk()
+        self.session = MagicMock()
+        self.session.post.return_value = make_mock_response(
+            200, json_body={"branchId": "new-branch-id"}
+        )
+        self.sdk._session = self.session
+
+    def _posted_payload(self):
+        """The JSON body sent to the branches endpoint."""
+        return self.session.post.call_args.kwargs["json"]
+
+    def test_returns_new_branch_id_from_response(self):
+        """The branchId from the API response is returned."""
+        branch_id = self.sdk.create_branch(branch_name="my-feature")
+
+        self.assertEqual(branch_id, "new-branch-id")
+
+    def test_payload_carries_branch_name_and_expected_sequence(self):
+        """The branch name and expected sequence number are always sent."""
+        self.sdk.create_branch(expected_main_last_known_sequence=12, branch_name="my-feature")
+
+        payload = self._posted_payload()
+        self.assertEqual(payload["branchName"], "my-feature")
+        self.assertEqual(payload["expectedMainLastKnownSequence"], 12)
+
+    def test_non_main_source_branch_is_sent(self):
+        """A source branch other than main is sent as sourceBranchId."""
+        self.sdk.create_branch(branch_name="my-feature", source_branch_id="branch-parent")
+
+        self.assertEqual(self._posted_payload()["sourceBranchId"], "branch-parent")
+
+    def test_source_branch_omitted_when_not_specified(self):
+        """With no source branch the payload has no sourceBranchId key at all."""
+        self.sdk.create_branch(branch_name="my-feature")
+
+        self.assertNotIn("sourceBranchId", self._posted_payload())
+
+    def test_source_branch_omitted_when_source_is_main(self):
+        """Main is the server-side default, so it is not sent explicitly."""
+        self.sdk.create_branch(branch_name="my-feature", source_branch_id="main")
+
+        self.assertNotIn("sourceBranchId", self._posted_payload())
+
+    def test_request_failure_raises_sourcerer_error(self):
+        """A failing create request raises SourcererAPIError."""
+        self.session.post.return_value = make_mock_response(409, json_body={"error": "conflict"})
+
+        with self.assertRaises(SourcererAPIError):
+            self.sdk.create_branch(branch_name="my-feature")
+
+
 class SendCommandBatch(unittest.TestCase):
     """Tests for SourcererSDK.send_command_batch serialization and lifecycle."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -17,6 +17,7 @@ from poly.cli_commands.project import InitCommand, ProjectCommand
 from poly.cli_commands.shared import compute_diff
 from poly.cli_commands.sync import FormatCommand, RevertCommand
 from poly.cli_commands.utils import CompletionCommand
+from poly.project import DeploymentMode
 from poly.tests.project_test import TEST_DIR
 
 
@@ -270,17 +271,83 @@ class BranchCreateFromEnvTest(unittest.TestCase):
         self.proj.create_branch.assert_called_once_with("my-branch")
         self.proj.push_project.assert_not_called()
 
-    def test_branch_create_blocked_when_not_on_main(self):
-        """branch create from non-main branch exits with an error."""
+    @patch("poly.output.console.error")
+    def test_branch_create_surfaces_deployment_mode_rejection(self, mock_error):
+        """A deployment-mode guard failure raised by the project is shown cleanly, not crashed.
+
+        The "which branches may be created from where" rules live in
+        AgentStudioProject.create_branch (they depend on the project's deployment
+        mode); the CLI catches that ValueError and reports it via error()/exit(1)
+        instead of letting it propagate as an unhandled exception.
+        """
         self.proj.branch_id = "example-feature-branch"
+        self.proj.create_branch.side_effect = ValueError(
+            "Cannot create a new branch from a non-main branch in releases deployment mode."
+        )
 
         with self.assertRaises(SystemExit) as ctx:
-            BranchCommand.branch_create(TEST_DIR, "my-branch", env="live", force=False)
+            BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
 
         self.assertEqual(ctx.exception.code, 1)
-        self.proj.pull_project_from_env.assert_not_called()
-        self.proj.create_branch.assert_not_called()
+        self.assertIn("non-main branch", mock_error.call_args[0][0])
         self.proj.push_project.assert_not_called()
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_branch_create_json_mode_surfaces_deployment_mode_rejection(self, mock_json):
+        """In --json mode, a deployment-mode guard failure is reported as JSON, not a crash."""
+        self.proj.branch_id = "example-feature-branch"
+        self.proj.create_branch.side_effect = ValueError(
+            "Cannot create a new branch from a non-main branch in releases deployment mode."
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_create(
+                TEST_DIR, "my-branch", output_json=True, env=None, force=False
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("non-main branch", payload["error"])
+
+    @patch("poly.output.console.success")
+    def test_branch_create_reports_branch_it_was_created_from(self, mock_success):
+        """The success message names the branch that was current before creation."""
+        self.proj.branch_id = "branch-a-id"
+        self.proj.get_current_branch.return_value = "feature-a"
+
+        BranchCommand.branch_create(TEST_DIR, "my-branch", env=None, force=False)
+
+        # No source branch is passed: the CLI relies on the project's own branch state.
+        self.proj.create_branch.assert_called_once_with("my-branch")
+        message = mock_success.call_args[0][0]
+        self.assertIn("my-branch", message)
+        self.assertIn("feature-a", message)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_branch_create_json_reports_base_branch_from_before_the_switch(self, mock_json):
+        """JSON output describes the base branch as it was before create_branch switched."""
+        self.proj.branch_id = "branch-a-id"
+        self.proj.get_current_branch.return_value = "feature-a"
+
+        def create_and_switch(_branch_name):
+            self.proj.branch_id = "new-branch-id"
+            return "new-branch-id"
+
+        self.proj.create_branch.side_effect = create_and_switch
+
+        BranchCommand.branch_create(TEST_DIR, "my-branch", output_json=True)
+
+        self.assertEqual(
+            mock_json.call_args[0][0],
+            {
+                "success": True,
+                "base_branch_id": "branch-a-id",
+                "base_branch_name": "feature-a",
+                "new_branch_id": "new-branch-id",
+                "branch_name": "my-branch",
+            },
+        )
 
     def test_branch_create_env_none_behaves_like_normal(self):
         """branch create with env=None skips env pull (default behavior)."""
@@ -475,12 +542,13 @@ class BranchDeleteTest(unittest.TestCase):
     @patch("questionary.confirm")
     @patch("questionary.checkbox")
     @patch("poly.output.console.success")
-    def test_interactive_current_branch_label_stripped(
+    def test_interactive_current_branch_uses_choice_value(
         self, mock_success, mock_checkbox, mock_confirm
     ):
-        """The ' (current)' suffix is stripped from labels before calling delete_branch."""
+        """Selecting the current branch calls delete_branch with the plain Choice value."""
         self.proj.get_branches.return_value = ("feature-a", dict(self.SAMPLE_BRANCHES))
-        mock_checkbox.return_value.ask.return_value = ["feature-a (current)"]
+        # questionary.checkbox resolves selected Choices to their .value — mocked directly here.
+        mock_checkbox.return_value.ask.return_value = ["feature-a"]
         mock_confirm.return_value.ask.return_value = True
 
         BranchCommand.branch_delete(TEST_DIR)
@@ -522,6 +590,280 @@ class BranchDeleteTest(unittest.TestCase):
         mock_error.assert_called_once()
         mock_success.assert_called_once()
         self.assertIn("1 branch(es)", mock_success.call_args[0][0])
+
+
+class BranchCurrentTest(unittest.TestCase):
+    """Tests for BranchCommand.get_current_branch."""
+
+    BRANCH_TREE = {
+        "main": {"branchId": "main"},
+        "feature-a": {"branchId": "id-a", "parentBranchId": "main"},
+        "feature-b": {"branchId": "id-b", "parentBranchId": "feature-a"},
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_name: str | None) -> None:
+        self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
+
+    @patch("poly.output.console.plain")
+    def test_does_not_show_parent_branch_when_parent_is_main(self, mock_plain):
+        """A branch with a parent shows both the current and parent branch."""
+        self._set_current_branch("feature-a")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        lines = [call.args[0] for call in mock_plain.call_args_list]
+        self.assertTrue(any("feature-a" in line for line in lines))
+        self.assertFalse(any("main" in line for line in lines))
+
+    @patch("poly.output.console.plain")
+    def test_shows_parent_branch_when_present_and_not_main(self, mock_plain):
+        """A branch with a parent shows both the current and parent branch."""
+        self._set_current_branch("feature-b")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        lines = [call.args[0] for call in mock_plain.call_args_list]
+        self.assertTrue(any("feature-b" in line for line in lines))
+        self.assertTrue(any("feature-a" in line for line in lines))
+
+    @patch("poly.output.console.plain")
+    def test_main_has_no_parent_branch_line(self, mock_plain):
+        """main has no parent, so only the current branch is shown."""
+        self._set_current_branch("main")
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        mock_plain.assert_called_once()
+        self.assertIn("main", mock_plain.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_no_current_branch_shows_warning(self, mock_warning):
+        """When the local branch no longer exists remotely, a warning is shown."""
+        self._set_current_branch(None)
+
+        BranchCommand.get_current_branch(TEST_DIR)
+
+        mock_warning.assert_called_once()
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_includes_parent_branch(self, mock_json_print):
+        """JSON mode includes both current_branch and parent_branch."""
+        self._set_current_branch("feature-a")
+
+        BranchCommand.get_current_branch(TEST_DIR, output_json=True)
+
+        mock_json_print.assert_called_once_with(
+            {"current_branch": "feature-a", "parent_branch": "main"}
+        )
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_main_has_null_parent(self, mock_json_print):
+        """JSON mode for main reports a null parent_branch."""
+        self._set_current_branch("main")
+
+        BranchCommand.get_current_branch(TEST_DIR, output_json=True)
+
+        mock_json_print.assert_called_once_with({"current_branch": "main", "parent_branch": None})
+
+
+class BranchSwitchInteractiveTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_switch's interactive picker (no branch_name given)."""
+
+    # Branch metadata as returned by the platform: 'feature-a' was branched off 'main'.
+    BRANCH_TREE = {
+        "main": {"branchId": "id-main", "parentBranchId": None},
+        "feature-a": {"branchId": "id-a", "parentBranchId": "id-main"},
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_branches.return_value = ("main", dict(self.BRANCH_TREE))
+        self.proj.switch_branch.return_value = (True, None)
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _choices(self, mock_select) -> list[tuple[str, str]]:
+        """Return the (title, value) pairs of the choices passed to questionary.select."""
+        choices = mock_select.call_args.kwargs["choices"]
+        return [(choice.title, choice.value) for choice in choices]
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_releases_branches_mode_offers_tree_indented_choices(self, mock_success, mock_select):
+        """In releases_branches mode, choices show branch lineage but keep plain name values."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        mock_select.return_value.ask.return_value = "feature-a"
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.assertEqual(
+            self._choices(mock_select),
+            [("main (current)", "main"), ("└─ feature-a", "feature-a")],
+        )
+        self.proj.switch_branch.assert_called_once()
+        self.assertEqual(self.proj.switch_branch.call_args[0][0], "feature-a")
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_simple_mode_offers_flat_choices(self, mock_success, mock_select):
+        """Outside releases_branches mode, choices are a flat list with no tree connectors."""
+        self.proj.deployment_mode = DeploymentMode.SIMPLE
+        self.proj.get_branches.return_value = (
+            "main",
+            {"main": "id-main", "feature-a": "id-a"},
+        )
+        mock_select.return_value.ask.return_value = "feature-a"
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.assertEqual(
+            self._choices(mock_select),
+            [("main (current)", "main"), ("feature-a", "feature-a")],
+        )
+        self.proj.switch_branch.assert_called_once()
+        self.assertEqual(self.proj.switch_branch.call_args[0][0], "feature-a")
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.warning")
+    def test_nothing_selected_shows_warning_and_does_not_switch(self, mock_warning, mock_select):
+        """Cancelling the picker warns the user and leaves the current branch alone."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        mock_select.return_value.ask.return_value = None
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.proj.switch_branch.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("No branch selected", mock_warning.call_args[0][0])
+
+    @patch("poly.output.console.plain")
+    def test_no_branches_shows_message_and_does_not_switch(self, mock_plain):
+        """When the project has no branches, a message is shown instead of a picker."""
+        self.proj.deployment_mode = DeploymentMode.RELEASES_BRANCHES
+        self.proj.get_branches.return_value = (None, {})
+
+        BranchCommand.branch_switch(TEST_DIR)
+
+        self.proj.switch_branch.assert_not_called()
+        self.assertIn("No branches found", mock_plain.call_args[0][0])
+
+
+class BranchMergeTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_merge's deploy confirmation and success messaging."""
+
+    # 'feature-a' sits directly under main; 'feature-a-child' sits under the 'Release 1' branch.
+    BRANCH_TREE = {
+        "main": {"branchId": "main", "name": "main"},
+        "Release 1": {"branchId": "id-release-1", "name": "Release 1", "parentBranchId": "main"},
+        "feature-a": {"branchId": "id-a", "name": "feature-a", "parentBranchId": "main"},
+        "feature-a-child": {
+            "branchId": "id-a-child",
+            "name": "feature-a-child",
+            "parentBranchId": "id-release-1",
+        },
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
+        self.proj.merge_branch.return_value = (True, [], [])
+        self._set_current_branch("feature-a")
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_name: str) -> None:
+        """Make the project report the given branch as checked out."""
+        self.proj.get_branches.return_value = (branch_name, dict(self.BRANCH_TREE))
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.success")
+    def test_merging_into_main_merges_after_deploy_confirmation(self, mock_success, mock_confirm):
+        """Merging into main warns about live deployment and proceeds once confirmed."""
+        mock_confirm.return_value.ask.return_value = True
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_called_once()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("now live", mock_success.call_args[0][0])
+
+    @patch("questionary.confirm")
+    def test_declining_deploy_confirmation_aborts_without_merging(self, mock_confirm):
+        """Answering no to the deployment prompt exits cleanly and leaves the branch unmerged."""
+        mock_confirm.return_value.ask.return_value = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        self.assertEqual(ctx.exception.code, 0)
+        self.proj.merge_branch.assert_not_called()
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.success")
+    def test_force_skips_deploy_confirmation(self, mock_success, mock_confirm):
+        """--force merges into main without asking for deployment confirmation."""
+        BranchCommand.branch_merge(TEST_DIR, message="ship it", force=True)
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("now live", mock_success.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_simplified_deployments_off_skips_confirmation_for_main(self, mock_info, mock_confirm):
+        """With simplified deployments off, merging into main skips the deploy prompt too."""
+        self.proj.using_simplified_deployments = False
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("main", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.output.console.info")
+    def test_merging_into_non_main_parent_skips_confirmation_and_names_parent(
+        self, mock_info, mock_confirm
+    ):
+        """Merging into a release branch deploys nothing live, so no prompt is shown."""
+        self._set_current_branch("feature-a-child")
+
+        BranchCommand.branch_merge(TEST_DIR, message="ship it")
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertIn("Release 1", mock_info.call_args[0][0])
+
+    @patch("questionary.confirm")
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_merges_without_confirmation(self, mock_json_print, mock_confirm):
+        """JSON mode is non-interactive, so it merges without prompting and reports success."""
+        BranchCommand.branch_merge(TEST_DIR, message="ship it", output_json=True)
+
+        mock_confirm.assert_not_called()
+        self.proj.merge_branch.assert_called_once_with(message="ship it", conflict_resolutions=None)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+
 
 
 class BranchMergeConflictHelpersTest(unittest.TestCase):
@@ -2886,3 +3228,15 @@ class ConversationsCommandTest(unittest.TestCase):
         )
         mock_success.assert_called_once()
         self.assertIn("2.0 MB", mock_success.call_args[0][0])
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -1,0 +1,182 @@
+"""Tests for poly/output/console.py display helpers.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+
+from poly.output.console import (
+    console,
+    flatten_branch_tree,
+    print_releases_branches,
+)
+
+
+def _branch(
+    branch_id: str, parent_branch_id: str | None = None, tag: str | None = None
+) -> dict[str, str | None]:
+    """Build the branch metadata shape returned by the platform for one branch."""
+    return {"branchId": branch_id, "parentBranchId": parent_branch_id, "tag": tag}
+
+
+class FlattenBranchTreeTest(unittest.TestCase):
+    """Tests for flatten_branch_tree, which renders a branch forest for flat pickers."""
+
+    def test_single_root_branch_has_no_prefix(self):
+        """A lone root branch is rendered as its plain name with no connector."""
+        branches = {"main": _branch("id-main")}
+
+        self.assertEqual(flatten_branch_tree(branches, current_branch=None), [("main", "main")])
+
+    def test_multi_level_tree_uses_connectors_and_indentation(self):
+        """Children are prefixed with connectors and indented once per level of depth."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "feature-b": _branch("id-b", "id-main"),
+            "sub-a": _branch("id-sub-a", "id-a"),
+            "sub-b": _branch("id-sub-b", "id-a"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [
+                ("main", "main"),
+                ("├─ feature-a", "feature-a"),
+                ("│  ├─ sub-a", "sub-a"),
+                ("│  └─ sub-b", "sub-b"),
+                ("└─ feature-b", "feature-b"),
+            ],
+        )
+
+    def test_last_sibling_subtree_indents_with_blank_continuation(self):
+        """Descendants of a last sibling indent with spaces, not a vertical guide."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "feature-b": _branch("id-b", "id-main"),
+            "grandchild": _branch("id-grandchild", "id-b"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [
+                ("main", "main"),
+                ("├─ feature-a", "feature-a"),
+                ("└─ feature-b", "feature-b"),
+                ("   └─ grandchild", "grandchild"),
+            ],
+        )
+
+    def test_siblings_are_sorted_alphabetically_at_every_level(self):
+        """Roots and children are both emitted in alphabetical order, not insertion order."""
+        branches = {
+            "zebra": _branch("id-zebra"),
+            "apple": _branch("id-apple"),
+            "z-child": _branch("id-z-child", "id-apple"),
+            "a-child": _branch("id-a-child", "id-apple"),
+        }
+
+        titles = [title for title, _ in flatten_branch_tree(branches, current_branch=None)]
+
+        self.assertEqual(titles, ["apple", "├─ a-child", "└─ z-child", "zebra"])
+
+    def test_current_branch_title_is_suffixed_but_value_is_not(self):
+        """The current branch shows '(current)' in its title while its value stays plain."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+        }
+
+        result = flatten_branch_tree(branches, current_branch="feature-a")
+
+        self.assertEqual(result, [("main", "main"), ("└─ feature-a (current)", "feature-a")])
+
+    def test_current_root_branch_title_is_suffixed(self):
+        """A root branch that is current is also suffixed, with no connector added."""
+        branches = {"main": _branch("id-main")}
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch="main"), [("main (current)", "main")]
+        )
+
+    def test_branch_with_unknown_parent_is_treated_as_root(self):
+        """A branch whose parent is missing from the dict is rendered as a root branch."""
+        branches = {
+            "main": _branch("id-main"),
+            "orphan": _branch("id-orphan", "id-deleted-parent"),
+        }
+
+        self.assertEqual(
+            flatten_branch_tree(branches, current_branch=None),
+            [("main", "main"), ("orphan", "orphan")],
+        )
+
+    def test_no_branches_returns_empty_list(self):
+        """An empty branches dict produces no rows."""
+        self.assertEqual(flatten_branch_tree({}, current_branch=None), [])
+
+    def test_values_are_always_raw_branch_names(self):
+        """Every value is the raw branch name, so callers can use it without stripping."""
+        branches = {
+            "main": _branch("id-main"),
+            "feature-a": _branch("id-a", "id-main"),
+            "sub-a": _branch("id-sub-a", "id-a"),
+        }
+
+        values = [value for _, value in flatten_branch_tree(branches, current_branch="sub-a")]
+
+        self.assertEqual(sorted(values), ["feature-a", "main", "sub-a"])
+
+
+class PrintReleasesBranchesTest(unittest.TestCase):
+    """Tests for print_releases_branches, the tree renderer used by `branch list`."""
+
+    def _render(self, branches: dict, current_branch: str | None = None) -> str:
+        with console.capture() as capture:
+            print_releases_branches(branches, current_branch)
+        return capture.get()
+
+    def test_tagged_branch_shows_tag_alongside_name(self):
+        """A branch with a tag renders '(tag)' after its name."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main", tag="staging"),
+        }
+
+        output = self._render(branches)
+
+        self.assertIn("Release 1 (staging)", output)
+
+    def test_untagged_branch_shows_no_tag_suffix(self):
+        """A branch with no tag renders its name with no trailing parenthetical."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main"),
+        }
+
+        output = self._render(branches)
+
+        self.assertIn("Release 1\n", output)
+        self.assertNotIn("(", output)
+
+    def test_current_and_tagged_branch_shows_both_markers(self):
+        """A branch that is both current and tagged shows the tag and '(current)'."""
+        branches = {
+            "main": _branch("id-main"),
+            "Release 1": _branch("id-release-1", "id-main", tag="staging"),
+        }
+
+        output = self._render(branches, current_branch="Release 1")
+
+        self.assertIn("Release 1 (staging) (current)", output)
+
+
+
+
+
+
+
+
+
+

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3712,6 +3712,16 @@ class MigrateFlowStepResourceIdsTest(unittest.TestCase):
         self.assertEqual(flow_steps["FLOW-abc_step-1"]["resource_id"], "FLOW-abc_step-1")
 
 
+
+
+
+
+
+
+
+
+
+
 class DiffBranchTest(unittest.TestCase):
     """Tests for the diff_branch method."""
 
@@ -3988,6 +3998,8 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
         self.assertEqual(len(branches), 1)
 
 
+
+
 class UsingSimplifiedDeploymentsTest(unittest.TestCase):
     """Tests for the AgentStudioProject.using_simplified_deployments property."""
 
@@ -4098,6 +4110,320 @@ class DeploymentModePropertyTest(unittest.TestCase):
 
         self.assertEqual(first, second)
         self.mock_api.get_project.assert_called_once()
+
+
+class CreateBranchDeploymentModeTest(unittest.TestCase):
+    """Tests for the deployment-mode guards in AgentStudioProject.create_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.create_branch.return_value = "new-branch-id"
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.mock_save_config = self.save_config_patcher.start()
+        self._set_current_branch("main")
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _set_deployment_mode(self, mode: str) -> None:
+        """Make the remote project report the given deployment mode."""
+        self.mock_api.get_project.return_value = {"config": {"deployment_mode": mode}}
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch."""
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    # -- simple mode: at most one branch may exist at a time --
+
+    def test_simple_mode_creates_branch_when_only_main_exists(self):
+        """In simple mode a branch can be created while main is the only branch."""
+        self._set_deployment_mode("simple")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main"}}
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+    def test_simple_mode_rejects_second_branch(self):
+        """In simple mode a second branch is refused while another branch exists."""
+        self._set_deployment_mode("simple")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "existing": {"branchId": "branch-existing", "parentBranchId": "main"},
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("simple deployment mode", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(self.project.branch_id, "main")
+
+    # -- releases mode: branches may only be created from main --
+
+    def test_releases_mode_creates_branch_from_main(self):
+        """In releases mode main is a valid source branch."""
+        self._set_deployment_mode("releases")
+        self._set_current_branch("main")
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+
+    def test_releases_mode_rejects_non_main_source_branch(self):
+        """In releases mode creating a branch from another branch is refused."""
+        self._set_deployment_mode("releases")
+        self._set_current_branch("branch-feature-a")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("releases deployment mode", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+        self.assertEqual(self.project.branch_id, "branch-feature-a")
+
+    # -- releases_branches mode: source branch must be a direct child of main --
+
+    def test_releases_branches_mode_creates_branch_from_direct_child_of_main(self):
+        """A branch whose parent is main may be used as the source branch."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+        }
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "branch-feature-a")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+    def test_releases_branches_mode_rejects_grandchild_of_main(self):
+        """A branch whose parent is not main is too deep to branch from again."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-feature-a-child")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main"},
+            "feature-a": {"branchId": "branch-feature-a", "parentBranchId": "main"},
+            "feature-a-child": {
+                "branchId": "branch-feature-a-child",
+                "parentBranchId": "branch-feature-a",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.create_branch("my-feature")
+
+        self.assertIn("depth", str(ctx.exception))
+        self.mock_api.create_branch.assert_not_called()
+
+    def test_releases_branches_mode_rejects_branch_missing_from_remote(self):
+        """A local branch that no longer exists remotely cannot be branched from."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("branch-deleted")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main"}}
+
+        with self.assertRaises(ValueError):
+            self.project.create_branch("my-feature")
+
+        self.mock_api.create_branch.assert_not_called()
+
+    def test_releases_branches_mode_creates_branch_from_main(self):
+        """Main itself may be used as the source branch, even though it has no parent."""
+        self._set_deployment_mode("releases_branches")
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        new_branch_id = self.project.create_branch("my-feature")
+
+        self.assertEqual(new_branch_id, "new-branch-id")
+        self.mock_api.create_branch.assert_called_once_with("my-feature", "main")
+        self.assertEqual(self.project.branch_id, "new-branch-id")
+        self.mock_save_config.assert_called()
+
+
+class MergeBranchTest(unittest.TestCase):
+    """Tests for AgentStudioProject.merge_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.merge_branch.return_value = (True, [], [])
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.mock_save_config = self.save_config_patcher.start()
+        # merge_branch refuses to run with uncommitted changes; default to a clean tree.
+        self.get_diffs_patcher = patch.object(AgentStudioProject, "get_diffs", return_value={})
+        self.mock_get_diffs = self.get_diffs_patcher.start()
+        # A successful merge switches to the parent branch; assert on the call, don't sync.
+        self.switch_branch_patcher = patch.object(
+            AgentStudioProject, "switch_branch", return_value=(True, {})
+        )
+        self.mock_switch_branch = self.switch_branch_patcher.start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch."""
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    def test_merging_direct_child_of_main_switches_to_main(self):
+        """A branch whose parent is main lands the user back on main after merging."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        result = self.project.merge_branch("ship it")
+
+        self.assertEqual(result, (True, [], []))
+        self.mock_api.merge_branch.assert_called_once_with(
+            message="ship it", conflict_resolutions=None
+        )
+        self.mock_switch_branch.assert_called_once_with("main", force=True)
+
+    def test_merging_grandchild_switches_to_its_parent_branch(self):
+        """A branch nested under a release branch lands on that release branch, not main."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "Release 1": {
+                "branchId": "branch-release-1",
+                "name": "Release 1",
+                "parentBranchId": "main",
+            },
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "branch-release-1",
+            },
+        }
+
+        result = self.project.merge_branch("ship it")
+
+        self.assertEqual(result, (True, [], []))
+        self.mock_switch_branch.assert_called_once_with("Release 1", force=True)
+
+    def test_failed_merge_returns_conflicts_and_stays_on_branch(self):
+        """When the platform reports a failure, conflicts pass through and no switch happens."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+        conflicts = [{"path": ["flows", "f1", "name"], "oursValue": "a", "theirsValue": "b"}]
+        errors = [{"path": ["flows", "f1"], "message": "boom"}]
+        self.mock_api.merge_branch.return_value = (False, conflicts, errors)
+
+        success, returned_conflicts, returned_errors = self.project.merge_branch("ship it")
+
+        self.assertFalse(success)
+        self.assertEqual(returned_conflicts, conflicts)
+        self.assertEqual(returned_errors, errors)
+        self.mock_switch_branch.assert_not_called()
+
+    def test_merging_from_main_is_rejected(self):
+        """Main has nothing to merge into, so merging from it is refused."""
+        self._set_current_branch("main")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("main", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_merging_branch_missing_from_remote_is_rejected(self):
+        """A local branch that no longer exists remotely cannot be merged."""
+        self._set_current_branch("branch-deleted")
+        self.mock_api.get_branches.return_value = {"main": {"branchId": "main", "name": "main"}}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("branch-deleted", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_merging_with_uncommitted_changes_is_rejected(self):
+        """Local edits must be pushed before merging."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+        self.mock_get_diffs.return_value = {"flows/my_flow.yaml": "some diff"}
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it")
+
+        self.assertIn("uncommitted", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_conflict_resolution_without_strategy_is_rejected(self):
+        """Every conflict resolution must say how the conflict should be resolved."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch("ship it", conflict_resolutions=[{"path": ["flows", "f1"]}])
+
+        self.assertIn("strategy", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
+
+    def test_conflict_resolution_with_unknown_strategy_is_rejected(self):
+        """Only 'ours', 'theirs', and 'base' are valid resolution strategies."""
+        self._set_current_branch("branch-feature-a")
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": "main", "name": "main"},
+            "feature-a": {
+                "branchId": "branch-feature-a",
+                "name": "feature-a",
+                "parentBranchId": "main",
+            },
+        }
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.merge_branch(
+                "ship it",
+                conflict_resolutions=[{"path": ["flows", "f1"], "strategy": "mine"}],
+            )
+
+        self.assertIn("mine", str(ctx.exception))
+        self.mock_api.merge_branch.assert_not_called()
 
 
 class RtcPullEnvTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Teaches `branch create`, `merge`, `current`, and `list` about branch lineage (branches created from other branches) and the project's deployment mode.

## Motivation

`poly branch merge` assumed every branch's parent was `main`, and `create` only allowed branching from `main`. Neither holds under the platform's simplified deployment model, where branches can be created from other branches and have a real parent/child lineage.

## Changes

- `branch create` now respects the project's deployment mode: one active branch in `simple`, main-only in `releases`, and branching off a direct child of main (max depth 2) in `releases_branches`. Replaces the previous unconditional "branches can only be created from main" guard.
- `branch merge` merges into the branch's actual parent instead of always `main`, switches to that parent afterwards, and shows a confirmation plus "now live" messaging when merging into main under simplified deployments.
- `branch current` also prints the parent branch, suppressed when the parent is `main` to avoid noise in the common case. `--json` always includes `parent_branch`.
- `branch list` and the `switch`/`delete` interactive pickers render lineage as an indented tree in `releases_branches` mode.
- `create_branch(..., source_branch_id)` added across the SDK, sync client, and interface.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
