### PR TITLE
feat: branch history, rename, archive/restore, sync, and tag/untag

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,28 @@ Manage branches (default branch is `main`):
 
 ```bash
 poly branch list                       # active branches
+poly branch list --archived            # soft-deleted branches
 poly branch current
 poly branch create my-feature
 poly branch switch my-feature
 poly branch switch my-feature --force  # discard uncommitted changes
+poly branch rename my-feature-v2       # rename the current branch
 poly branch merge 'Merge my-feature'   # merge into the parent branch
-poly branch delete
+poly branch sync                       # pull the parent branch's changes in
+poly branch history                    # merge history for the current branch
+poly branch delete                     # soft-delete, restorable for 30 days
+poly branch restore my-feature         # restore a soft-deleted branch
 ```
+
+Projects using simplified deployments can also stage a branch:
+
+```bash
+poly branch tag                        # tag the current branch, deploying it to staging
+poly branch untag                      # remove the tag
+```
+
+`poly branch sync`, `tag`, and `untag` are only available on projects with simplified deployments
+enabled; they exit with an error otherwise.
 
 ### `poly format`
 

--- a/src/poly/cli_commands/branch.py
+++ b/src/poly/cli_commands/branch.py
@@ -68,6 +68,42 @@ def _auto_merge_resolution(path: list[str], merged_value: str) -> dict[str, Any]
     return {"path": path, "value": merged_value, "strategy": "theirs"}
 
 
+def _build_branch_name_lookup(project: Any, archived: list[dict[str, Any]]) -> dict[str, str]:
+    """Map branch ids to branch names, for displaying archived branches' parents.
+
+    Archived entries reference their parent by id only, which means nothing to a
+    user. A parent is normally archived alongside its children, so the archive
+    resolves most ids on its own; the active branches are fetched only when an id
+    is still unresolved (a child archived while its parent stayed live).
+    """
+    names = {
+        branch["branchId"]: branch.get("name") or branch["branchId"]
+        for branch in archived
+        if branch.get("branchId")
+    }
+
+    unresolved = {
+        branch.get("parentBranchId")
+        for branch in archived
+        if branch.get("parentBranchId") and branch.get("parentBranchId") != "main"
+    } - names.keys()
+    if not unresolved:
+        return names
+
+    try:
+        _, active = project.get_branches()
+    except ValueError:
+        # The parent column is cosmetic — degrade to showing raw ids rather than
+        # failing the whole listing.
+        return names
+
+    for name, meta in active.items():
+        branch_id = meta.get("branchId")
+        if branch_id and branch_id not in names:
+            names[branch_id] = name
+    return names
+
+
 class BranchCommand(BaseCommand):
     """Manage branches in the Agent Studio project."""
 
@@ -104,11 +140,18 @@ class BranchCommand(BaseCommand):
                 "Manage branches in the Agent Studio project.\n\n"
                 "Examples:\n"
                 "  poly branch list\n"
+                "  poly branch list --archived\n"
                 "  poly branch create new-branch\n"
                 "  poly branch switch existing-branch\n"
+                "  poly branch rename new-name\n"
                 "  poly branch merge 'Merge branch'\n"
+                "  poly branch sync\n"
+                "  poly branch history\n"
                 "  poly branch current\n"
                 "  poly branch delete\n"
+                "  poly branch restore archived-branch\n"
+                "  poly branch tag\n"
+                "  poly branch untag\n"
             ),
             formatter_class=RawTextHelpFormatter,
         )
@@ -119,6 +162,11 @@ class BranchCommand(BaseCommand):
             "list",
             parents=[parents.path, parents.verbose, parents.json, parents.debug],
             help="List all branches in the project.",
+        )
+        branch_list_parser.add_argument(
+            "--archived",
+            action="store_true",
+            help="Show soft-deleted (archived) branches instead of active ones.",
         )
         branch_list_parser.set_defaults(branch_subcommand="list")
 
@@ -191,6 +239,21 @@ class BranchCommand(BaseCommand):
         )
         branch_current_parser.set_defaults(branch_subcommand="current")
 
+        # -- rename --
+        branch_rename_parser = branch_subparsers.add_parser(
+            "rename",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Rename the current branch.",
+        )
+        branch_rename_parser.add_argument(
+            "new_branch_name",
+            type=str,
+            nargs="?",
+            default=None,
+            help="New name for the current branch.",
+        )
+        branch_rename_parser.set_defaults(branch_subcommand="rename")
+
         # -- delete --
         branch_delete_parser = branch_subparsers.add_parser(
             "delete",
@@ -204,6 +267,25 @@ class BranchCommand(BaseCommand):
             help="Name of the branch to delete directly, skipping the interactive prompt.",
         ).completer = cls._branch_name_completer
         branch_delete_parser.set_defaults(branch_subcommand="delete")
+
+        # -- restore --
+        branch_restore_parser = branch_subparsers.add_parser(
+            "restore",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Restore a soft-deleted branch from the archive.",
+        )
+        branch_restore_parser.add_argument(
+            "branch_id",
+            type=str,
+            metavar="BRANCH",
+            nargs="?",
+            default=None,
+            help=(
+                "Branch id of the archived branch to restore. Archived names are not "
+                "unique, so ids are required — find them with 'poly branch list --archived'."
+            ),
+        )
+        branch_restore_parser.set_defaults(branch_subcommand="restore")
 
         # -- merge --
         branch_merge_parser = branch_subparsers.add_parser(
@@ -242,6 +324,48 @@ class BranchCommand(BaseCommand):
             help="Skip the confirmation prompt when merging into main deploys to a live environment.",
         )
         branch_merge_parser.set_defaults(branch_subcommand="merge")
+
+        # -- sync --
+        branch_sync_parser = branch_subparsers.add_parser(
+            "sync",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Sync branch with parent",
+        )
+        branch_sync_parser.add_argument(
+            "--interactive",
+            "-i",
+            action="store_true",
+            help="Enable interactive mode for resolving any merge conflicts. Set $EDITOR or $VISUAL to your preferred editor for editing merge conflict values if needed.",
+        )
+        branch_sync_parser.add_argument(
+            "--resolutions",
+            type=str,
+            default=None,
+            help=(
+                "Conflict resolutions as a JSON file path, inline JSON string, or '-' for stdin. "
+                "JSON should be an array of objects, each representing a conflict resolution:\n"
+                '- path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])\n'
+                '- strategy: Resolution strategy - "ours", "theirs", or "base"\n'
+                '- value: Optional custom value (use "theirs" strategy)'
+            ),
+        )
+        branch_sync_parser.set_defaults(branch_subcommand="sync")
+
+        # -- tag --
+        branch_tag_parser = branch_subparsers.add_parser(
+            "tag",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Tag the current branch and deploy to staging environment. Tagging 'main' branch is not supported.",
+        )
+        branch_tag_parser.set_defaults(branch_subcommand="tag")
+
+        # -- untag --
+        branch_untag_parser = branch_subparsers.add_parser(
+            "untag",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Remove a tag from the current branch. Untagging 'main' branch is not supported.",
+        )
+        branch_untag_parser.set_defaults(branch_subcommand="untag")
 
         # -- diff --
         branch_diff_parser = branch_subparsers.add_parser(
@@ -295,11 +419,32 @@ class BranchCommand(BaseCommand):
         ).completer = cls._branch_name_completer
         branch_status_parser.set_defaults(branch_subcommand="status")
 
+        # -- history --
+        branch_history_parser = branch_subparsers.add_parser(
+            "history",
+            parents=[parents.path, parents.verbose, parents.json, parents.debug],
+            help="Show the history of a branch.",
+        )
+        branch_history_parser.add_argument(
+            "--branch-name",
+            "-b",
+            type=str,
+            default=None,
+            help="Name of the branch to show history for. Defaults to the current branch.",
+        )
+        branch_history_parser.add_argument(
+            "--limit",
+            type=int,
+            default=10,
+            help="Number of history entries to show. Defaults to 10.",
+        )
+        branch_history_parser.set_defaults(branch_subcommand="history")
+
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the matching branch sub-handler."""
         if args.branch_subcommand == "list":
-            cls.branch_list(args.path, args.json)
+            cls.branch_list(args.path, args.json, getattr(args, "archived", False))
 
         elif args.branch_subcommand == "create":
             cls.branch_create(
@@ -332,6 +477,24 @@ class BranchCommand(BaseCommand):
                 args.path, args.message, args.json, args.interactive, args.resolutions, args.force
             )
 
+        elif args.branch_subcommand == "sync":
+            cls.branch_sync(args.path, args.json, args.interactive, args.resolutions)
+
+        elif args.branch_subcommand == "history":
+            cls.branch_history(args.path, args.branch_name, args.json, args.limit)
+
+        elif args.branch_subcommand == "rename":
+            cls.branch_rename(args.path, args.new_branch_name, args.json)
+
+        elif args.branch_subcommand == "restore":
+            cls.branch_restore(args.path, args.branch_id, args.json)
+
+        elif args.branch_subcommand == "tag":
+            cls.branch_tag(args.path, args.json)
+
+        elif args.branch_subcommand == "untag":
+            cls.branch_untag(args.path, args.json)
+
         elif args.branch_subcommand == "diff":
             cls.branch_diff(args.path, args.branch_name, getattr(args, "files", None), args.json)
 
@@ -342,16 +505,28 @@ class BranchCommand(BaseCommand):
             cls.branch_status(args.path, args.branch_name, args.json)
 
     @classmethod
-    def branch_list(cls, base_path: str, output_json: bool = False) -> None:
+    def branch_list(cls, base_path: str, output_json: bool = False, archived: bool = False) -> None:
         """List branches in the Agent Studio project."""
         from poly.output.console import (
             plain,
+            print_archived_branches,
             print_branches,
             print_releases_branches,
             warning,
         )
 
         project = load_project(base_path, output_json=output_json)
+
+        if archived:
+            branches = project.list_archived_branches()
+            if output_json:
+                json_print({"archived_branches": branches})
+                return
+            if not branches:
+                plain("[muted]No archived branches found.[/muted]")
+                return
+            print_archived_branches(branches, _build_branch_name_lookup(project, branches))
+            return
 
         current_branch, branches = project.get_branches()
 
@@ -1231,3 +1406,397 @@ class BranchCommand(BaseCommand):
 
         if not new_files and not modified_files and not deleted_files:
             plain("\n[muted]No changes on this branch.[/muted]")
+
+    @classmethod
+    def branch_sync(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+        interactive: bool = False,
+        resolutions_file: str = None,
+    ):
+        """Synch the current branch with it's parent, with optional conflict resolutions."""
+        from poly.cli_commands.shared import require_deployment_simplification
+        from poly.output.console import (
+            console,
+            error,
+            output_merge_conflict_table,
+            plain,
+            success,
+            warning,
+        )
+
+        if interactive and output_json:
+            json_print(
+                {
+                    "success": False,
+                    "error": "--interactive and --json cannot be used together.",
+                }
+            )
+            sys.exit(1)
+
+        file_resolutions: list[dict[str, Any]] | None = None
+        if resolutions_file:
+            try:
+                if resolutions_file == "-":
+                    file_resolutions = json.load(sys.stdin)
+                elif resolutions_file.lstrip().startswith("["):
+                    file_resolutions = json.loads(resolutions_file)
+                else:
+                    with open(resolutions_file, encoding="utf-8") as f:
+                        file_resolutions = json.load(f)
+                if not isinstance(file_resolutions, list):
+                    raise ValueError("Resolutions must be a JSON array.")
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                if output_json:
+                    json_print({"success": False, "error": f"Failed to parse resolutions: {exc}"})
+                else:
+                    error(f"Failed to parse resolutions: {exc}")
+                sys.exit(1)
+
+        project = load_project(base_path, output_json=output_json)
+
+        require_deployment_simplification(project, output_json=output_json)
+
+        branch_name = project.get_current_branch()
+        ctx = console.status("[info]Syncing branch...[/info]") if not output_json else nullcontext()
+        with ctx:
+            merge_success, conflicts, errors = project.sync_branch(
+                conflict_resolutions=file_resolutions
+            )
+
+        if output_json:
+            output = {"success": merge_success}
+            if conflicts or errors:
+                output["conflicts"] = conflicts
+                output["errors"] = errors
+            json_print(output)
+            if not merge_success:
+                sys.exit(1)
+            return
+
+        if merge_success:
+            success(f"Branch '{branch_name}' synced successfully.")
+            return
+
+        # Failed branch sync
+        error(f"Failed to sync branch '{branch_name}'.")
+        if errors:
+            plain("\n[red]Errors:[/red]")
+            for err in errors:
+                error(f"- {err['path']}: {err['message']}")
+
+        enriched = enrich_branch_merge_conflicts(conflicts) if conflicts else []
+        display_conflict = [
+            c for c in enriched if c.get("path") and c["path"][-1] not in {"updatedAt", "createdAt"}
+        ]
+        if display_conflict:
+            output_merge_conflict_table(
+                display_conflict, show_type=True, resolutions=file_resolutions
+            )
+
+        if errors:
+            sys.exit(1)
+
+        if not interactive:
+            plain(
+                "Merge conflicts detected. To resolve:\n"
+                "- Use 'poly branch sync -i' to resolve conflicts interactively\n"
+                "- Use 'poly branch sync --resolutions <file.json>' to provide pre-defined resolutions\n"
+                "- Merge manually on Agent Studio"
+            )
+            sys.exit(1)
+
+        existing_resolutions = {
+            os.sep.join(r["path"]): r for r in (file_resolutions or []) if "path" in r
+        }
+        while True:
+            resolutions = cls._merge_interactively(enriched, existing_resolutions, branch_name)
+            if not resolutions:
+                warning("No resolutions provided. Exiting.")
+                sys.exit(1)
+            ctx2 = (
+                console.status("[info]Sync branch...[/info]") if not output_json else nullcontext()
+            )
+            with ctx2:
+                merge_success, conflicts, errors = project.sync_branch(
+                    conflict_resolutions=resolutions
+                )
+            if merge_success:
+                success(f"Branch '{branch_name}' synced successfully.")
+                break
+            if errors:
+                error(f"Failed to sync branch '{branch_name}' after conflict resolution.")
+                plain("\n[red]Errors:[/red]")
+                for err in errors:
+                    error(f"- {err['path']}: {err['message']}")
+                sys.exit(1)
+            if not conflicts:
+                error(
+                    f"Failed to sync branch '{branch_name}' after conflict resolution "
+                    "(no conflicts or errors returned)."
+                )
+                sys.exit(1)
+            warning("Sync still blocked; resolve the remaining conflicts below.")
+            enriched = enrich_branch_merge_conflicts(conflicts)
+            display_conflict = [
+                c
+                for c in enriched
+                if c.get("path") and c["path"][-1] not in {"updatedAt", "createdAt"}
+            ]
+            if display_conflict:
+                output_merge_conflict_table(
+                    display_conflict,
+                    show_type=True,
+                    panel_title="Remaining merge conflicts",
+                )
+
+    @classmethod
+    def branch_history(
+        cls,
+        base_path: str,
+        branch_name: Optional[str] = None,
+        output_json: bool = False,
+        limit: int = 10,
+    ) -> None:
+        """Show the history of a branch in the Agent Studio project."""
+        from poly.output.console import plain, print_branch_history, warning
+
+        project = load_project(base_path, output_json=output_json)
+
+        current_branch, branches = project.get_branches()
+        if not branch_name:
+            branch_name = current_branch
+
+        if not branch_name:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "No current branch found. Please specify a branch name.",
+                    }
+                )
+            else:
+                warning("No current branch found. Please specify a branch name.")
+            return
+
+        branch_id = branches.get(branch_name, {}).get("branchId")
+        if not branch_id:
+            if output_json:
+                json_print({"success": False, "error": f"Branch '{branch_name}' does not exist."})
+            else:
+                warning(f"Branch '{branch_name}' does not exist.")
+            return
+
+        history = project.get_branch_history(branch_id)
+        history = history[:limit]
+
+        if output_json:
+            json_print({"branch_name": branch_name, "branch_id": branch_id, "history": history})
+            return
+
+        if not history:
+            plain(f"[muted]No history found for branch '{branch_name}'.[/muted]")
+            return
+
+        plain(f"History for branch '{branch_name}':")
+        print_branch_history(history)
+
+    @classmethod
+    def branch_rename(
+        cls, base_path: str, new_branch_name: Optional[str] = None, output_json: bool = False
+    ) -> None:
+        """Rename the current branch in the Agent Studio project."""
+        from poly.output.console import error, success, warning
+
+        project = load_project(base_path, output_json=output_json)
+
+        current_branch = project.get_current_branch()
+        if not current_branch:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "Current branch doesn't exist. Create a new branch before renaming.",
+                    }
+                )
+            else:
+                warning("Current branch doesn't exist. Create a new branch before renaming.")
+            return
+
+        if current_branch == "main":
+            if output_json:
+                json_print({"success": False, "error": "Cannot rename the main branch."})
+            else:
+                error("Cannot rename the main branch.")
+            return
+
+        if not new_branch_name:
+            if output_json:
+                json_print({"success": False, "error": "No new branch name provided."})
+            else:
+                new_branch_name = input("Enter the new name for the current branch: ").strip()
+                if not new_branch_name:
+                    warning("No new branch name provided. Exiting.")
+                    return
+
+        try:
+            renamed = project.rename_branch(new_branch_name)
+        except (ValueError, Exception) as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            return
+
+        if output_json:
+            json_print(
+                {
+                    "success": renamed,
+                    "old_branch_name": current_branch,
+                    "new_branch_name": new_branch_name,
+                }
+            )
+        else:
+            if renamed:
+                success(f"Renamed branch '{current_branch}' to '{new_branch_name}'.")
+            else:
+                error(f"Failed to rename branch '{current_branch}' to '{new_branch_name}'.")
+
+    @classmethod
+    def branch_restore(
+        cls,
+        base_path: str,
+        branch_id: Optional[str] = None,
+        output_json: bool = False,
+    ) -> None:
+        """Restore a soft-deleted branch from the archive, by branch id or name."""
+        import questionary
+
+        from poly.output.console import (
+            error,
+            plain,
+            resolve_parent_branch_label,
+            success,
+            warning,
+        )
+
+        project = load_project(base_path, output_json=output_json)
+
+        if not branch_id:
+            if output_json:
+                json_print(
+                    {
+                        "success": False,
+                        "error": "branch restore with --json requires a branch id argument.",
+                    }
+                )
+                sys.exit(1)
+
+            archived = project.list_archived_branches()
+            if not archived:
+                plain("[muted]No archived branches to restore.[/muted]")
+                return
+
+            name_by_branch_id = _build_branch_name_lookup(project, archived)
+            archived_branch_ids = {b["branchId"] for b in archived if b.get("branchId")}
+            choices = []
+            branch_by_label: dict[str, dict[str, Any]] = {}
+            for b in archived:
+                name = b.get("name", "—")
+                archived_branch_id = b.get("branchId", "")
+                parent = resolve_parent_branch_label(b, name_by_branch_id, archived_branch_ids)
+                # Names repeat across the archive, so the id and parent are what
+                # actually let the user tell two same-named entries apart.
+                label = f"{name} ({archived_branch_id}) — parent: {parent}"
+                choices.append(label)
+                branch_by_label[label] = b
+
+            selected = questionary.select(
+                "Select branch to restore",
+                choices=choices,
+                use_search_filter=True,
+                use_jk_keys=False,
+            ).ask()
+            if not selected:
+                warning("No branch selected. Exiting.")
+                return
+
+            selected_branch = branch_by_label[selected]
+            try:
+                restored = project.restore_branch(selected_branch["branchId"])
+            except (ValueError, Exception) as e:
+                error(str(e))
+                return
+            if restored:
+                success(f"Branch '{selected_branch.get('name', '—')}' restored.")
+            else:
+                error("Failed to restore selected branch.")
+            return
+
+        try:
+            restored = project.restore_branch(branch_id)
+        except (ValueError, Exception) as e:
+            if output_json:
+                json_print({"success": False, "error": str(e)})
+            else:
+                error(str(e))
+            return
+
+        if output_json:
+            json_print({"success": restored, "branch_id": branch_id})
+        else:
+            if restored:
+                success(f"Branch '{branch_id}' restored.")
+            else:
+                error(f"Failed to restore branch '{branch_id}'.")
+
+    @classmethod
+    def branch_tag(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+    ) -> None:
+        """Tag the current branch with a new tag."""
+        from poly.cli_commands.shared import require_deployment_simplification
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+        require_deployment_simplification(project, output_json=output_json)
+
+        tagged = project.tag_branch()
+
+        if output_json:
+            json_print({"success": tagged})
+        else:
+            if tagged:
+                success(
+                    f"Current branch '{project.get_current_branch()}' tagged and deployed to staging."
+                )
+            else:
+                error("Failed to tag the current branch.")
+
+    @classmethod
+    def branch_untag(
+        cls,
+        base_path: str,
+        output_json: bool = False,
+    ) -> None:
+        """Remove a tag from the current branch."""
+        from poly.cli_commands.shared import require_deployment_simplification
+        from poly.output.console import error, success
+
+        project = load_project(base_path, output_json=output_json)
+        require_deployment_simplification(project, output_json=output_json)
+
+        untagged = project.untag_branch()
+
+        if output_json:
+            json_print({"success": untagged})
+        else:
+            if untagged:
+                success(
+                    f"Staging tag removed from current branch '{project.get_current_branch()}'."
+                )
+            else:
+                error("Failed to remove tag from the current branch.")

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -580,6 +580,27 @@ class AgentStudioInterface:
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
+    def sync_branch(
+        self, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Sync the current branch with it's parent.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            success (bool): True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflict information if the merge failed, empty list if successful
+            list[dict[str, str]]: A list of error information if the merge failed, empty list if successful
+        """
+        try:
+            return self.sync_client.sync_branch(conflict_resolutions)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
     def delete_branch(self, branch_id: str) -> bool:
         """Delete a branch in the project.
 
@@ -1208,6 +1229,87 @@ class AgentStudioInterface:
             dict: The updated RTC config.
         """
         return PlatformAPIHandler.patch_rtc_variables(region, project_id, client_env, variables)
+
+    def get_branch_history(self, branch_name: str) -> list[dict[str, Any]]:
+        """Get the history of a specific branch.
+
+        Args:
+            branch_name (str): The name of the branch
+
+        Returns:
+            list[dict[str, Any]]: A list of commit history entries for the branch
+        """
+        try:
+            return self.sync_client.get_branch_history(branch_name)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch to a new name.
+
+        Args:
+            new_branch_name (str): The new name for the current branch
+
+        Returns:
+            bool: True if the branch was renamed successfully, False otherwise
+        """
+        try:
+            return self.sync_client.rename_branch(new_branch_name)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of archived branch entries.
+        """
+        try:
+            return self.sync_client.list_archived_branches()
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def restore_branch(self, branch_id: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id (str): The ID of the branch to restore.
+
+        Returns:
+            bool: True if the branch was restored successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.restore_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def tag_branch(self, branch_id: str) -> bool:
+        """Tag the current branch with a specific tag name.
+
+        Args:
+            branch_id (str): The ID of the branch to tag.
+
+        Returns:
+            bool: True if the branch was tagged successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.tag_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
+
+    def untag_branch(self, branch_id: str) -> bool:
+        """Remove a specific tag from the current branch.
+
+        Args:
+            branch_id (str): The ID of the branch to untag.
+
+        Returns:
+            bool: True if the branch was untagged successfully, False otherwise.
+        """
+        try:
+            return self.sync_client.untag_branch(branch_id)
+        except (requests.HTTPError, SourcererAPIError) as e:
+            self._handle_api_error(e)
 
     def feature_flag_enabled(
         self,

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -151,6 +151,10 @@ class SourcererSDK:
         """Get the branch merge endpoint URL"""
         return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/merge"
 
+    def _get_branch_sync_url(self) -> str:
+        """Get the branch sync endpoint URL"""
+        return f"{self.base_url}/accounts/{self.account_id}/projects/{self.project_id}/branches/{self.branch_id}/sync"
+
     def _initialize_branch(self) -> str:
         """Initialize branch_id by fetching existing branches or creating a new one"""
         try:
@@ -315,6 +319,108 @@ class SourcererSDK:
             logger.debug(f"Merge payload: {payload}")
 
             response = self.session.post(self._get_branch_merge_url(), json=payload)
+
+            # Handle conflict response (400 status with conflicts data)
+            if response.status_code == 400:
+                try:
+                    response_data = response.json()
+                    # Check if this is a conflict response
+                    if "conflicts" in response_data or "hasConflicts" in response_data:
+                        return response_data
+                    # Otherwise, it's a different error
+                    error_msg = f"API Error 400: {response_data}"
+                    raise SourcererAPIError(error_msg)
+                except (ValueError, KeyError):
+                    error_msg = f"API Error 400: {response.text}"
+                    raise SourcererAPIError(error_msg)
+
+            response.raise_for_status()
+
+            response_data = response.json()
+            logger.info(f"Branch merged successfully, sequence: {response_data.get('sequence')}")
+
+            return response_data
+
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def sync_branch(
+        self,
+        conflict_resolutions: Optional[list[dict[str, Any]]] = None,
+    ) -> dict[str, Any]:
+        """Sync the current branch with its parent
+
+        This method merges changes from the current branch's parent into the current branch.
+        If conflicts are detected, they will be returned in the response for manual resolution.
+        Once conflicts are resolved, call this method again with the conflict_resolutions parameter.
+
+        Args:
+            conflict_resolutions: Optional list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            Dictionary containing:
+            - If successful:
+                - sequence: The new sequence number after merge (as string)
+                - message: Success message
+                - testRunIds: List of test run IDs that were triggered
+            - If conflicts detected:
+                - hasConflicts: True
+                - conflicts: List of conflict objects, each containing:
+                    - path: Path to the conflicted field
+                    - baseValue: Original value from base
+                    - oursValue: Value from main branch
+                    - theirsValue: Value from the branch being merged
+                    - type: Type of conflict ("add", "modify", or "delete")
+
+        Raises:
+            SourcererAPIError: If the API request fails or sequence mismatch occurs
+
+        Example:
+            # Simple sync without conflicts
+            result = sdk.sync_branch()
+            if "hasConflicts" in result and result["hasConflicts"]:
+                print("Conflicts detected:", result["conflicts"])
+            else:
+                print("Sync successful, sequence:", result["sequence"])
+
+            # Sync with conflict resolution
+            resolutions = [
+                {
+                    "path": ["users", "1", "name"],
+                    "strategy": "ours",
+                },
+                {
+                    "path": ["settings", "theme"],
+                    "strategy": "theirs",
+                }
+            ]
+            result = sdk.sync_branch(
+                conflict_resolutions=resolutions
+            )
+        """
+        try:
+            payload = {
+                "expectedBranchSequence": self.get_last_known_sequence() or 0,
+            }
+
+            if conflict_resolutions is not None:
+                payload["conflictResolutions"] = conflict_resolutions
+
+            logger.info(f"Sync branch {self.branch_id} with parent")
+            logger.debug(f"Sync payload: {payload}")
+
+            response = self.session.post(self._get_branch_sync_url(), json=payload)
 
             # Handle conflict response (400 status with conflicts data)
             if response.status_code == 400:
@@ -707,3 +813,173 @@ class SourcererSDK:
             "projection": self._projection_cache,
             "last_known_sequence": self._last_known_sequence,
         }
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of commands for a specific branch.
+
+        Args:
+            branch_id: The branch ID to fetch history for.
+
+        Returns:
+            A list of dictionaries containing commit information for the branch.
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/merge-history"
+            response = self.session.get(url)
+            response.raise_for_status()
+            return response.json().get("merges", [])
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            A list of dictionaries containing archived branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/archive"
+            response = self.session.get(url)
+            response.raise_for_status()
+            return response.json().get("branches", [])
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def restore_branch(self, branch_id: str) -> dict[str, Any]:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id: The ID of the branch to restore.
+
+        Returns:
+            A dictionary containing the restored branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/restore"
+            response = self.session.post(url)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def rename_branch(self, new_branch_name: str) -> dict[str, Any]:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name: The new name for the current branch.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+        if not self.branch_id:
+            raise SourcererAPIError("No current branch found. Cannot rename.")
+
+        try:
+            url = f"{self._get_branches_url()}/{self.branch_id}"
+            payload = {"name": new_branch_name}
+            response = self.session.patch(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def tag_branch(self, branch_id: str) -> dict[str, Any]:
+        """Tag a branch for staging
+
+        Args:
+            branch_id: The ID of the branch to tag.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/tag"
+            payload = {"tag": "staging"}
+            response = self.session.put(url, json=payload)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e
+
+    def untag_branch(self, branch_id: str) -> dict[str, Any]:
+        """Untag a branch for staging
+
+        Args:
+            branch_id: The ID of the branch to untag.
+
+        Returns:
+            A dictionary containing the updated branch information.
+
+        Raises:
+            SourcererAPIError: If the API request fails or if there is no current branch.
+        """
+
+        try:
+            url = f"{self._get_branches_url()}/{branch_id}/tag"
+            response = self.session.delete(url)
+            response.raise_for_status()
+            return response.json()
+        except requests.exceptions.RequestException as e:
+            if hasattr(e, "response") and e.response is not None:
+                try:
+                    error_detail = e.response.json()
+                    error_msg = f"API Error {e.response.status_code}: {error_detail}"
+                except (ValueError, KeyError):
+                    error_msg = f"API request failed: {e}"
+            else:
+                error_msg = f"Request failed: {e}"
+            raise SourcererAPIError(error_msg) from e

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -337,7 +337,159 @@ class SyncClientHandler:
         logger.info(f"Successfully merged branch '{self.sdk.branch_id}' into its parent branch")
         return True, [], []
 
+    def sync_branch(
+        self, conflict_resolutions: Optional[list[dict[str, Any]]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Merge the parent branch into the current branch.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value (only used with custom strategy)
+
+        Returns:
+            success (bool): True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflict information if the merge failed, empty list if successful
+            list[dict[str, str]]: A list of error information if the merge failed, empty list if successful
+        """
+        self.assert_branch_exists()
+
+        if self.sdk.branch_id == "main":
+            logger.error("Cannot sync 'main' branch — it has no parent to sync from.")
+            return False, [], []
+
+        logger.info(f"Merging parent into '{self.sdk.branch_id}'")
+
+        try:
+            result = self.sdk.sync_branch(
+                conflict_resolutions=conflict_resolutions,
+            )
+        except SourcererAPIError as e:
+            logger.error(f"Failed to sync branch '{self.sdk.branch_id}': {e}")
+            return False, [], []
+
+        if result.get("hasConflicts", False) or result.get("errors", []):
+            logger.info(
+                f"Failed to sync branch '{self.sdk.branch_id}' to {len(result.get('conflicts', []))} conflicts and {len(result.get('errors', []))} errors"
+            )
+            conflicts = result.get("conflicts", [])
+            errors = result.get("errors", [])
+            return False, conflicts, errors
+
+        logger.info(f"Successfully synced branch '{self.sdk.branch_id}'")
+        return True, [], []
+
     def get_branch_chat_info(self, branch_id: str) -> dict[str, Any]:
         """Get deployment info needed to start a draft chat on a branch."""
         self.assert_branch_exists()
         return self.sdk.get_branch_chat_info(branch_id)
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of a specific branch.
+
+        Args:
+            branch_id (str): The ID of the branch to retrieve history for.
+
+        Returns:
+            list[dict[str, Any]]: A list of dictionaries containing commit information for the branch.
+        """
+        logger.info(f"Fetching history for branch ID:'{branch_id}'")
+        history = self.sdk.get_branch_history(branch_id)
+        logger.info(f"Fetched {len(history)} commits for branch ID:'{branch_id}'")
+        return history
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name (str): The new name for the current branch.
+
+        Returns:
+            bool: True if the rename was successful, False otherwise.
+        """
+        self.assert_branch_exists()
+
+        if self.sdk.branch_id == "main":
+            logger.error("Cannot rename 'main' branch.")
+            return False
+
+        logger.info(f"Renaming branch ID:'{self.sdk.branch_id}' to '{new_branch_name}'")
+
+        try:
+            self.sdk.rename_branch(new_branch_name=new_branch_name)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to rename branch ID:'{self.sdk.branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully renamed branch ID:'{self.sdk.branch_id}' to '{new_branch_name}'")
+        return True
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of dictionaries containing archived branch information.
+        """
+        logger.info("Fetching archived branches")
+        branches = self.sdk.list_archived_branches()
+        logger.info(f"Fetched {len(branches)} archived branches")
+        return branches
+
+    def restore_branch(self, branch_id: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Args:
+            branch_id (str): The ID of the branch to restore.
+
+        Returns:
+            bool: True if the restore was successful, False otherwise.
+        """
+        logger.info(f"Restoring branch ID:'{branch_id}'")
+
+        try:
+            self.sdk.restore_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to restore branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully restored branch ID:'{branch_id}'")
+        return True
+
+    def tag_branch(self, branch_id: str) -> bool:
+        """Tag a branch with staging tag
+
+        Args:
+            branch_id (str): The ID of the branch to tag.
+        Returns:
+            bool: True if the tagging was successful, False otherwise.
+        """
+        logger.info(f"Tagging branch ID:'{branch_id}' with staging tag")
+
+        try:
+            self.sdk.tag_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to tag branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully tagged branch ID:'{branch_id}' with staging tag")
+        return True
+
+    def untag_branch(self, branch_id: str) -> bool:
+        """Remove staging tag from a branch
+
+        Args:
+            branch_id (str): The ID of the branch to untag.
+        Returns:
+            bool: True if the untagging was successful, False otherwise.
+        """
+        logger.info(f"Removing staging tag from branch ID:'{branch_id}'")
+
+        try:
+            self.sdk.untag_branch(branch_id)
+        except SourcererAPIError as e:
+            logger.error(f"Failed to remove staging tag from branch ID:'{branch_id}': {e}")
+            return False
+
+        logger.info(f"Successfully removed staging tag from branch ID:'{branch_id}'")
+        return True

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -236,6 +236,93 @@ def print_branches(branches: dict[str, Any] | list[str], current_branch: str | N
             console.print(f"    {name}")
 
 
+def resolve_parent_branch_label(
+    branch: dict[str, Any],
+    name_by_branch_id: dict[str, str] | None = None,
+    archived_branch_ids: set[str] | None = None,
+) -> str:
+    """Describe an archived branch's parent for display.
+
+    Archived branches carry only a ``parentBranchId``, which is meaningless to a
+    user. Resolve it to a name where possible: ``main`` stands for itself, other
+    ids are looked up in ``name_by_branch_id`` (built from the archive itself and,
+    where needed, the active branches). An id with no known name falls back to the
+    id so the row is never silently blank.
+
+    A parent that is itself archived is marked ``(archived)`` — restoring a child
+    does not bring its parent back, so that distinction is load-bearing.
+
+    Returns plain text, not markup: this also labels the interactive restore
+    picker, which renders literally.
+    """
+    parent_branch_id = branch.get("parentBranchId")
+    if not parent_branch_id:
+        return "—"
+    if parent_branch_id == "main":
+        return "main"
+
+    label = (name_by_branch_id or {}).get(parent_branch_id, parent_branch_id)
+    if parent_branch_id in (archived_branch_ids or set()):
+        return f"{label} (archived)"
+    return label
+
+
+def print_archived_branches(
+    branches: list[dict[str, Any]], name_by_branch_id: dict[str, str] | None = None
+) -> None:
+    """Print a table of archived (soft-deleted) branches.
+
+    Args:
+        branches: Archived branch entries as returned by the platform.
+        name_by_branch_id: Branch id to name, used to render each row's parent.
+    """
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("Branch", no_wrap=True)
+    table.add_column("ID", style="muted", no_wrap=True)
+    table.add_column("Parent", no_wrap=True)
+    table.add_column("Archived", no_wrap=True)
+    table.add_column("Expires", no_wrap=True)
+
+    # Derived here rather than passed in so it cannot drift from the rows shown.
+    archived_branch_ids = {b["branchId"] for b in branches if b.get("branchId")}
+
+    for branch in branches:
+        archived_at = _format_iso_timestamp(branch.get("archivedAt", ""))
+        days_left = branch.get("daysLeft")
+        expires = f"{days_left} days left" if days_left is not None else "—"
+        table.add_row(
+            branch.get("name", "—"),
+            branch.get("branchId", "—"),
+            resolve_parent_branch_label(branch, name_by_branch_id, archived_branch_ids),
+            archived_at,
+            expires,
+        )
+
+    console.print(table)
+
+
+def print_branch_history(commits: list[dict[str, Any]]) -> None:
+    """Print a table of branch history commits."""
+    if not commits:
+        console.print("[muted]No commits found for this branch.[/muted]")
+        return
+
+    table = Table(box=None, show_header=False, header_style="bold", padding=(0, 1))
+    table.add_column("Merged At", no_wrap=True)
+    table.add_column("Branch", no_wrap=True)
+    table.add_column("Merged By", no_wrap=True)
+
+    for commit in commits:
+        merged_at = _format_iso_timestamp(commit.get("mergedAt", ""))
+        table.add_row(
+            merged_at,
+            commit.get("branchName", "—"),
+            commit.get("mergedBy", "—"),
+        )
+
+    console.print(table)
+
+
 def print_validation_errors(errors: list[str]) -> None:
     """Print validation errors in a styled list."""
     console.print("[error]Project configuration is invalid.[/error]")

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2755,6 +2755,54 @@ class AgentStudioProject:
 
         return False, conflicts, errors
 
+    def sync_branch(
+        self, conflict_resolutions: list[dict[str, Any]] = None
+    ) -> tuple[bool, list[dict[str, str]], list[dict[str, str]]]:
+        """Sync the current branch with its parent in the project.
+
+        Args:
+            conflict_resolutions (list[dict[str, Any]]): A list of conflict
+                resolutions. Each resolution should have:
+                - path: List of strings representing the path to the conflicted field (e.g., ["users", "1", "name"])
+                - strategy: Resolution strategy - "ours", "theirs", or "base"
+                - value: Optional custom value
+
+        Returns:
+            bool: True if the sync was successful, False otherwise
+            list[dict[str, str]]: A list of conflicts
+            list[dict[str, str]]: A list of errors
+        """
+        branches = self.api_handler.get_branches()
+        branch_ids = {meta["branchId"] for meta in branches.values()}
+        if self.branch_id not in branch_ids:
+            raise ValueError(f"Branch {self.branch_id} does not exist.")
+
+        if self.branch_id == "main":
+            raise ValueError("Syncing 'main' branch is not supported.")
+
+        if diffs := self.get_diffs():
+            raise ValueError(
+                f"Cannot sync branch with uncommitted changes, diffs: {list(diffs.keys())}"
+            )
+
+        for resolution in conflict_resolutions or []:
+            if "path" not in resolution or "strategy" not in resolution:
+                raise ValueError(f"Resolution must include 'path' and 'strategy': {resolution}")
+            if resolution["strategy"] not in {"ours", "theirs", "base"}:
+                raise ValueError(
+                    f"Invalid conflict resolution strategy: {resolution['strategy']} for path {resolution['path']}. "
+                    f"Must be one of 'ours', 'theirs', or 'base'."
+                )
+
+        success, conflicts, errors = self.api_handler.sync_branch(
+            conflict_resolutions=conflict_resolutions
+        )
+        if success:
+            self.pull_project(force=True)
+            return True, [], []
+
+        return False, conflicts, errors
+
     def delete_branch(self, branch_name: str) -> bool:
         """Delete a branch in the project.
 
@@ -3477,6 +3525,127 @@ class AgentStudioProject:
             ]
         except (jsonschema.SchemaError, jsonschema.exceptions.UnknownType) as e:
             return [f"Invalid schema: {e}"]
+
+    def get_branch_history(self, branch_id: str) -> list[dict[str, Any]]:
+        """Get the history of a branch.
+
+        Args:
+            branch_id (str): The ID of the branch to get history for.
+
+        Returns:
+            list[dict[str, Any]]: A list of commit history entries for the branch.
+        """
+        return self.api_handler.get_branch_history(branch_id)
+
+    def rename_branch(self, new_branch_name: str) -> bool:
+        """Rename the current branch.
+
+        Args:
+            new_branch_name (str): The new name for the current branch.
+
+        Returns:
+            bool: True if the rename was successful, False otherwise.
+        """
+        if not new_branch_name:
+            raise ValueError("New branch name must be provided.")
+
+        if self.branch_id == "main":
+            raise ValueError("Renaming 'main' branch is not supported.")
+
+        branches = self.api_handler.get_branches()
+
+        if new_branch_name in branches:
+            raise ValueError(f"Branch {new_branch_name} already exists.")
+
+        success = self.api_handler.rename_branch(new_branch_name=new_branch_name)
+        return success
+
+    def list_archived_branches(self) -> list[dict[str, Any]]:
+        """List soft-deleted (archived) branches for the project.
+
+        Returns:
+            list[dict[str, Any]]: A list of archived branch entries.
+        """
+        return self.api_handler.list_archived_branches()
+
+    def restore_branch(self, branch_id: str) -> bool:
+        """Restore a soft-deleted branch from the archive.
+
+        Identified by id rather than name because archived names are not unique —
+        the same branch name can be archived repeatedly. Use
+        ``list_archived_branches`` to find the id.
+
+        Args:
+            branch_id (str): The branch id of the archived branch to restore.
+
+        Returns:
+            bool: True if the branch was restored successfully, False otherwise.
+        """
+        if not branch_id:
+            raise ValueError("Branch id must be provided.")
+
+        archived = self.api_handler.list_archived_branches()
+        if not any(branch.get("branchId") == branch_id for branch in archived):
+            raise ValueError(
+                f"Branch '{branch_id}' not found in archive. "
+                "Use 'poly branch list --archived' to see available branches."
+            )
+
+        return self.api_handler.restore_branch(branch_id)
+
+    def tag_branch(self, branch_name: str = None) -> bool:
+        """Tag the current branch with a new tag.
+
+        Args:
+            branch_name (str): The name of the branch to tag. If None, tags the current branch.
+        Returns:
+            bool: True if the tagging was successful, False otherwise.
+        """
+        branches = self.api_handler.get_branches()
+        if branch_name is None:
+            branch_id = self.branch_id
+            branch_name = next(
+                (name for name, meta in branches.items() if meta["branchId"] == branch_id), None
+            )
+            if branch_name is None:
+                raise ValueError(f"Current branch ID {branch_id} does not exist.")
+        else:
+            if branch_name not in branches:
+                raise ValueError(f"Branch {branch_name} does not exist.")
+            branch_id = branches[branch_name]["branchId"]
+
+        if branch_id == "main":
+            raise ValueError("Tagging 'main' branch is not supported.")
+
+        success = self.api_handler.tag_branch(branch_id)
+        return success
+
+    def untag_branch(self, branch_name: str = None) -> bool:
+        """Remove a tag from a branch.
+
+        Args:
+            branch_name (str): The name of the branch to untag. If None, untags the current branch.
+        Returns:
+            bool: True if the untagging was successful, False otherwise.
+        """
+        branches = self.api_handler.get_branches()
+        if branch_name is None:
+            branch_id = self.branch_id
+            branch_name = next(
+                (name for name, meta in branches.items() if meta["branchId"] == branch_id), None
+            )
+            if branch_name is None:
+                raise ValueError(f"Current branch ID {branch_id} does not exist.")
+        else:
+            if branch_name not in branches:
+                raise ValueError(f"Branch {branch_name} does not exist.")
+            branch_id = branches[branch_name]["branchId"]
+
+        if branch_id == "main":
+            raise ValueError("Untagging 'main' branch is not supported.")
+
+        success = self.api_handler.untag_branch(branch_id)
+        return success
 
     def get_project_info(self) -> dict[str, Any]:
         """Get basic information about the project from the API.

--- a/src/poly/tests/api/interface_test.py
+++ b/src/poly/tests/api/interface_test.py
@@ -201,5 +201,139 @@ class QueueResources(unittest.TestCase):
         self.assertLess(types.index("variable_delete"), types.index("delete_topic"))
 
 
+class GetBranchHistoryInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.get_branch_history."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_history_from_sync_client(self):
+        """The interface delegates to sync_client and returns the result."""
+        expected = [{"commit_id": "c1", "message": "first commit"}]
+        self.interface.sync_client.get_branch_history.return_value = expected
+
+        result = self.interface.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        self.interface.sync_client.get_branch_history.assert_called_once_with("branch-1")
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.get_branch_history.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.get_branch_history("branch-1")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.get_branch_history.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.get_branch_history("branch-1")
+
+
+class RenameBranchInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.rename_branch."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns True on success."""
+        self.interface.sync_client.rename_branch.return_value = True
+
+        result = self.interface.rename_branch("new-name")
+
+        self.assertTrue(result)
+        self.interface.sync_client.rename_branch.assert_called_once_with("new-name")
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.rename_branch.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.rename_branch("new-name")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.rename_branch.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.rename_branch("new-name")
+
+
+class ListArchivedBranchesInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.list_archived_branches."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns the result."""
+        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
+        self.interface.sync_client.list_archived_branches.return_value = expected
+
+        result = self.interface.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        self.interface.sync_client.list_archived_branches.assert_called_once()
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.list_archived_branches.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.list_archived_branches()
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError is translated into a ValueError."""
+        self.interface.sync_client.list_archived_branches.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.list_archived_branches()
+
+
+class RestoreBranchInterface(unittest.TestCase):
+    """Tests for AgentStudioInterface.restore_branch."""
+
+    def setUp(self):
+        self.interface = AgentStudioInterface()
+        self.interface.sync_client = MagicMock()
+
+    def test_returns_result_from_sync_client(self):
+        """The interface delegates to sync_client and returns True on success."""
+        self.interface.sync_client.restore_branch.return_value = True
+
+        result = self.interface.restore_branch("branch-1")
+
+        self.assertTrue(result)
+        self.interface.sync_client.restore_branch.assert_called_once_with("branch-1")
+
+    def test_returns_false_from_sync_client(self):
+        """The interface returns False when sync_client returns False."""
+        self.interface.sync_client.restore_branch.return_value = False
+
+        result = self.interface.restore_branch("branch-1")
+
+        self.assertFalse(result)
+
+    def test_translates_http_error(self):
+        """An HTTPError from the sync client is translated into a ValueError."""
+        self.interface.sync_client.restore_branch.side_effect = requests.HTTPError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.restore_branch("branch-1")
+
+    def test_translates_sourcerer_api_error(self):
+        """A SourcererAPIError is translated into a ValueError."""
+        self.interface.sync_client.restore_branch.side_effect = SourcererAPIError("boom")
+
+        with self.assertRaises(ValueError):
+            self.interface.restore_branch("branch-1")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/api/sync_client_test.py
+++ b/src/poly/tests/api/sync_client_test.py
@@ -7,7 +7,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from poly.handlers.protobuf.commands_pb2 import Command
-from poly.handlers.sdk import SourcererSDK
+from poly.handlers.sdk import SourcererAPIError, SourcererSDK
 from poly.handlers.sync_client import SyncClientHandler
 
 
@@ -62,6 +62,157 @@ class SendQueuedCommands(unittest.TestCase):
 
         self.assertTrue(handler.send_queued_commands())
         handler._sdk.send_command_batch.assert_called_once()
+
+
+class GetBranchHistory(unittest.TestCase):
+    """Tests for SyncClientHandler.get_branch_history."""
+
+    def test_returns_history_from_sdk(self):
+        """The handler delegates to sdk.get_branch_history and returns its result."""
+        handler = build_handler()
+        expected = [{"commit_id": "c1", "message": "initial"}]
+        handler._sdk.get_branch_history.return_value = expected
+
+        result = handler.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        handler._sdk.get_branch_history.assert_called_once_with("branch-1")
+
+    def test_returns_empty_list_when_no_history(self):
+        """An empty history list is returned as-is."""
+        handler = build_handler()
+        handler._sdk.get_branch_history.return_value = []
+
+        result = handler.get_branch_history("branch-1")
+
+        self.assertEqual(result, [])
+
+
+class RenameBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.rename_branch."""
+
+    def test_successful_rename_returns_true(self):
+        """A successful SDK rename call returns True."""
+        handler = build_handler()
+        handler._sdk.branch_id = "branch-1"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "branch-1"}]}
+
+        result = handler.rename_branch("new-name")
+
+        self.assertTrue(result)
+        handler._sdk.rename_branch.assert_called_once_with(new_branch_name="new-name")
+
+    def test_main_branch_returns_false(self):
+        """Renaming the main branch returns False without calling the SDK."""
+        handler = build_handler()
+        handler._sdk.branch_id = "main"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "main"}]}
+
+        result = handler.rename_branch("new-name")
+
+        self.assertFalse(result)
+        handler._sdk.rename_branch.assert_not_called()
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during rename returns False."""
+        handler = build_handler()
+        handler._sdk.branch_id = "branch-1"
+        handler._sdk.fetch_branches.return_value = {"branches": [{"branchId": "branch-1"}]}
+        handler._sdk.rename_branch.side_effect = SourcererAPIError("rename failed")
+
+        result = handler.rename_branch("new-name")
+
+        self.assertFalse(result)
+
+
+class ListArchivedBranches(unittest.TestCase):
+    """Tests for SyncClientHandler.list_archived_branches."""
+
+    def test_returns_archived_branches_from_sdk(self):
+        """The handler delegates to sdk.list_archived_branches and returns its result."""
+        handler = build_handler()
+        expected = [{"branchId": "b-1", "name": "old-branch", "archivedAt": "2026-07-01"}]
+        handler._sdk.list_archived_branches.return_value = expected
+
+        result = handler.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        handler._sdk.list_archived_branches.assert_called_once()
+
+    def test_returns_empty_list_when_no_archived_branches(self):
+        """An empty list is returned as-is."""
+        handler = build_handler()
+        handler._sdk.list_archived_branches.return_value = []
+
+        result = handler.list_archived_branches()
+
+        self.assertEqual(result, [])
+
+
+class RestoreBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.restore_branch."""
+
+    def test_successful_restore_returns_true(self):
+        """A successful SDK restore call returns True."""
+        handler = build_handler()
+
+        result = handler.restore_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.restore_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during restore returns False."""
+        handler = build_handler()
+        handler._sdk.restore_branch.side_effect = SourcererAPIError("restore failed")
+
+        result = handler.restore_branch("branch-1")
+
+        self.assertFalse(result)
+
+
+class TagBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.tag_branch."""
+
+    def test_successful_tag_returns_true(self):
+        """A successful SDK tag call returns True."""
+        handler = build_handler()
+
+        result = handler.tag_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.tag_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during tagging returns False rather than propagating."""
+        handler = build_handler()
+        handler._sdk.tag_branch.side_effect = SourcererAPIError("tag failed")
+
+        result = handler.tag_branch("branch-1")
+
+        self.assertFalse(result)
+
+
+class UntagBranch(unittest.TestCase):
+    """Tests for SyncClientHandler.untag_branch."""
+
+    def test_successful_untag_returns_true(self):
+        """A successful SDK untag call returns True."""
+        handler = build_handler()
+
+        result = handler.untag_branch("branch-1")
+
+        self.assertTrue(result)
+        handler._sdk.untag_branch.assert_called_once_with("branch-1")
+
+    def test_api_error_returns_false(self):
+        """A SourcererAPIError during untagging returns False rather than propagating."""
+        handler = build_handler()
+        handler._sdk.untag_branch.side_effect = SourcererAPIError("untag failed")
+
+        result = handler.untag_branch("branch-1")
+
+        self.assertFalse(result)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -14,7 +14,7 @@ from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand
-from poly.cli_commands.shared import compute_diff
+from poly.cli_commands.shared import compute_diff, require_deployment_simplification
 from poly.cli_commands.sync import FormatCommand, RevertCommand
 from poly.cli_commands.utils import CompletionCommand
 from poly.project import DeploymentMode
@@ -864,6 +864,131 @@ class BranchMergeTest(unittest.TestCase):
         self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
 
 
+class BranchSyncTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_sync."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.sync_branch.return_value = (True, [], [])
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.error")
+    def test_sync_blocked_without_simplified_deployments(self, mock_error):
+        """Sync is refused locally rather than surfacing the platform's 404."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.sync_branch.assert_not_called()
+        self.proj.get_current_branch.assert_not_called()
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_sync_blocked_without_simplified_deployments_json(self, mock_json_print):
+        """The refusal is reported as JSON when --json is set."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(mock_json_print.call_args[0][0]["success"])
+        self.proj.sync_branch.assert_not_called()
+
+    @patch("poly.output.console.success")
+    def test_sync_success_reports_branch_name(self, mock_success):
+        """A successful sync reports the current branch name."""
+        BranchCommand.branch_sync(TEST_DIR)
+
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=None)
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+        self.assertIn("synced successfully", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_success(self, mock_json_print):
+        """JSON mode reports success without conflicts/errors keys."""
+        BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_failure_and_exits(self, mock_json_print):
+        """JSON mode reports conflicts/errors and exits non-zero on failure."""
+        conflicts = [{"path": ["a"], "type": "modify"}]
+        self.proj.sync_branch.return_value = (False, conflicts, [])
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        output = mock_json_print.call_args[0][0]
+        self.assertEqual(output["success"], False)
+        self.assertEqual(output["conflicts"], conflicts)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_interactive_and_json_together_is_rejected(self, mock_json_print):
+        """--interactive and --json cannot be combined."""
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, output_json=True, interactive=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_not_called()
+        self.assertFalse(mock_json_print.call_args[0][0]["success"])
+
+    @patch("poly.output.console.error")
+    def test_non_interactive_conflicts_exit_with_guidance(self, mock_error):
+        """Non-interactive conflicts print guidance and exit non-zero, without merging further."""
+        conflicts = [{"path": ["a"], "type": "modify"}]
+        self.proj.sync_branch.return_value = (False, conflicts, [])
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=None)
+        mock_error.assert_any_call("Failed to sync branch 'feature-a'.")
+
+    @patch("poly.output.console.error")
+    def test_errors_exit_before_conflict_prompt(self, mock_error):
+        """A hard error (not just conflicts) exits immediately, even without --interactive."""
+        self.proj.sync_branch.return_value = (
+            False,
+            [],
+            [{"path": "x", "message": "boom"}],
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_any_call("- x: boom")
+
+    def test_invalid_resolutions_json_exits(self):
+        """An unparseable --resolutions value exits with an error before syncing."""
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_sync(TEST_DIR, resolutions_file="not-json")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.proj.sync_branch.assert_not_called()
+
+    @patch("poly.output.console.success")
+    def test_inline_resolutions_json_is_parsed_and_forwarded(self, mock_success):
+        """An inline JSON array passed via --resolutions is forwarded to project.sync_branch."""
+        resolutions = [{"path": ["a"], "strategy": "ours"}]
+
+        BranchCommand.branch_sync(TEST_DIR, resolutions_file=str(resolutions).replace("'", '"'))
+
+        self.proj.sync_branch.assert_called_once_with(conflict_resolutions=resolutions)
+        mock_success.assert_called_once()
 
 
 class BranchMergeConflictHelpersTest(unittest.TestCase):
@@ -3230,13 +3355,576 @@ class ConversationsCommandTest(unittest.TestCase):
         self.assertIn("2.0 MB", mock_success.call_args[0][0])
 
 
+class BranchHistoryTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_history CLI handler."""
+
+    SAMPLE_BRANCHES = {
+        "main": {"branchId": "main-id"},
+        "feature-a": {"branchId": "branch-a-id"},
+    }
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_branches.return_value = ("feature-a", dict(self.SAMPLE_BRANCHES))
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_defaults_to_current_branch(self, mock_plain, mock_print_history):
+        """When no branch_name is given, history uses the current branch."""
+        self.proj.get_branch_history.return_value = [{"mergedAt": "2026-07-01", "branchName": "x"}]
+
+        BranchCommand.branch_history(TEST_DIR)
+
+        self.proj.get_branch_history.assert_called_once_with("branch-a-id")
+        mock_print_history.assert_called_once()
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_explicit_branch_name(self, mock_plain, mock_print_history):
+        """An explicit branch_name looks up its ID and fetches history."""
+        self.proj.get_branch_history.return_value = [{"mergedAt": "2026-07-01"}]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="main")
+
+        self.proj.get_branch_history.assert_called_once_with("main-id")
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_output(self, mock_json):
+        """JSON mode outputs branch_name, branch_id, and history."""
+        history = [{"mergedAt": "2026-07-01", "branchName": "feat"}]
+        self.proj.get_branch_history.return_value = history
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["branch_name"], "feature-a")
+        self.assertEqual(payload["branch_id"], "branch-a-id")
+        self.assertEqual(payload["history"], history)
+
+    @patch("poly.output.console.plain")
+    def test_empty_history_shows_message(self, mock_plain):
+        """When history is empty, a 'no history found' message is shown."""
+        self.proj.get_branch_history.return_value = []
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a")
+
+        mock_plain.assert_called_once()
+        self.assertIn("No history found", mock_plain.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_nonexistent_branch_shows_warning(self, mock_warning):
+        """A branch name not in the branches dict shows a warning."""
+        BranchCommand.branch_history(TEST_DIR, branch_name="no-such-branch")
+
+        self.proj.get_branch_history.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("does not exist", mock_warning.call_args[0][0])
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_limit_truncates_history(self, mock_plain, mock_print_history):
+        """--limit truncates history to the given number of entries."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", limit=5)
+
+        mock_print_history.assert_called_once()
+        printed = mock_print_history.call_args[0][0]
+        self.assertEqual(len(printed), 5)
+
+    @patch("poly.output.console.print_branch_history")
+    @patch("poly.output.console.plain")
+    def test_default_limit_is_10(self, mock_plain, mock_print_history):
+        """Without --limit, history is capped at 10 entries."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a")
+
+        mock_print_history.assert_called_once()
+        printed = mock_print_history.call_args[0][0]
+        self.assertEqual(len(printed), 10)
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_limit_applies_to_json_output(self, mock_json):
+        """--limit also truncates history in JSON mode."""
+        self.proj.get_branch_history.return_value = [
+            {"mergedAt": f"2026-07-{i:02d}"} for i in range(1, 21)
+        ]
+
+        BranchCommand.branch_history(TEST_DIR, branch_name="feature-a", output_json=True, limit=3)
+
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(len(payload["history"]), 3)
 
 
+class BranchRenameTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_rename CLI handler."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.rename_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_successful_rename(self, mock_success):
+        """A successful rename prints a success message."""
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_called_once_with("new-name")
+        mock_success.assert_called_once()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+        self.assertIn("new-name", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_successful_rename_json(self, mock_json):
+        """JSON mode outputs old_branch_name, new_branch_name, and success."""
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["old_branch_name"], "feature-a")
+        self.assertEqual(payload["new_branch_name"], "new-name")
+
+    @patch("poly.output.console.error")
+    def test_rename_failure_shows_error(self, mock_error):
+        """When rename_branch returns False, a failure message is shown."""
+        self.proj.rename_branch.return_value = False
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to rename", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.warning")
+    def test_no_current_branch_shows_warning(self, mock_warning):
+        """When current branch is None, a warning is shown."""
+        self.proj.get_current_branch.return_value = None
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_not_called()
+        mock_warning.assert_called_once()
+        self.assertIn("doesn't exist", mock_warning.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_current_branch_json(self, mock_json):
+        """JSON mode outputs error when no current branch exists."""
+        self.proj.get_current_branch.return_value = None
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("doesn't exist", payload["error"])
+
+    @patch("poly.output.console.error")
+    def test_main_branch_shows_error(self, mock_error):
+        """Renaming main branch shows an error."""
+        self.proj.get_current_branch.return_value = "main"
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name")
+
+        self.proj.rename_branch.assert_not_called()
+        mock_error.assert_called_once()
+        self.assertIn("Cannot rename the main branch", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_main_branch_json(self, mock_json):
+        """JSON mode outputs error when trying to rename main."""
+        self.proj.get_current_branch.return_value = "main"
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="new-name", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("Cannot rename the main branch", payload["error"])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_name_json_mode(self, mock_json):
+        """JSON mode outputs error when no name is provided."""
+        self.proj.rename_branch.side_effect = ValueError("New branch name must be provided.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name=None, output_json=True)
+
+        calls = mock_json.call_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertFalse(calls[0][0][0]["success"])
+        self.assertIn("No new branch name provided", calls[0][0][0]["error"])
+        self.assertFalse(calls[1][0][0]["success"])
+
+    @patch("poly.output.console.error")
+    def test_rename_exception_shows_error(self, mock_error):
+        """When rename_branch raises, the error message is shown."""
+        self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing")
+
+        mock_error.assert_called_once()
+        self.assertIn("Branch already exists", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_rename_exception_json(self, mock_json):
+        """JSON mode outputs the error when rename_branch raises."""
+        self.proj.rename_branch.side_effect = ValueError("Branch already exists.")
+
+        BranchCommand.branch_rename(TEST_DIR, new_branch_name="existing", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("Branch already exists", payload["error"])
 
 
+class BranchListArchivedTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_list with --archived flag."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.print_archived_branches")
+    def test_archived_flag_calls_list_archived(self, mock_print):
+        """--archived delegates to list_archived_branches and prints the table."""
+        archived = [
+            {
+                "branchId": "BRANCH-1",
+                "name": "old-prompts",
+                "parentBranchId": "main",
+                "archivedAt": "2026-07-05",
+                "daysLeft": 15,
+            },
+        ]
+        self.proj.list_archived_branches.return_value = archived
+
+        BranchCommand.branch_list(TEST_DIR, archived=True)
+
+        self.proj.list_archived_branches.assert_called_once()
+        mock_print.assert_called_once_with(archived, {"BRANCH-1": "old-prompts"})
+
+    @patch("poly.output.console.plain")
+    def test_archived_empty_shows_message(self, mock_plain):
+        """When no archived branches exist, a 'no archived' message is shown."""
+        self.proj.list_archived_branches.return_value = []
+
+        BranchCommand.branch_list(TEST_DIR, archived=True)
+
+        mock_plain.assert_called_once()
+        self.assertIn("No archived branches", mock_plain.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_archived_json_output(self, mock_json):
+        """JSON mode with --archived outputs archived_branches."""
+        archived = [{"branchId": "BRANCH-1", "name": "old", "daysLeft": 30}]
+        self.proj.list_archived_branches.return_value = archived
+
+        BranchCommand.branch_list(TEST_DIR, output_json=True, archived=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertEqual(payload["archived_branches"], archived)
+
+    @patch("poly.output.console.print_branches")
+    def test_no_archived_flag_uses_normal_list(self, mock_print):
+        """Without --archived, branch_list uses the normal get_branches flow."""
+        self.proj.get_branches.return_value = ("main", {"main": "main-id"})
+
+        BranchCommand.branch_list(TEST_DIR, archived=False)
+
+        self.proj.list_archived_branches.assert_not_called()
+        self.proj.get_branches.assert_called_once()
 
 
+class BranchRestoreTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_restore CLI handler."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.restore_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_successful_restore(self, mock_success):
+        """A successful restore prints a success message."""
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch")
+
+        self.proj.restore_branch.assert_called_once_with("old-branch")
+        mock_success.assert_called_once()
+        self.assertIn("old-branch", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_successful_restore_json(self, mock_json):
+        """JSON mode outputs success and the branch name."""
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertTrue(payload["success"])
+        self.assertEqual(payload["branch_id"], "old-branch")
+
+    @patch("poly.output.console.error")
+    def test_restore_failure(self, mock_error):
+        """When restore_branch returns False, a failure message is shown."""
+        self.proj.restore_branch.return_value = False
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id="old-branch")
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to restore", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_restore_not_found_shows_error(self, mock_error):
+        """When the branch isn't in the archive, the ValueError is shown."""
+        self.proj.restore_branch.side_effect = ValueError("not found in archive")
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch")
+
+        mock_error.assert_called_once()
+        self.assertIn("not found in archive", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_restore_not_found_json(self, mock_json):
+        """JSON mode outputs the error when restore_branch raises."""
+        self.proj.restore_branch.side_effect = ValueError("not found in archive")
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id="no-such-branch", output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("not found in archive", payload["error"])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_no_name_json_mode_exits(self, mock_json):
+        """JSON mode without a branch name prints error and exits."""
+        with self.assertRaises(SystemExit):
+            BranchCommand.branch_restore(TEST_DIR, branch_id=None, output_json=True)
+
+        mock_json.assert_called_once()
+        payload = mock_json.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("requires a branch id", payload["error"])
+
+    @patch("poly.output.console.plain")
+    def test_no_name_empty_archive_shows_message(self, mock_plain):
+        """Interactive mode with no archived branches shows a message."""
+        self.proj.list_archived_branches.return_value = []
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
+
+        mock_plain.assert_called_once()
+        self.assertIn("No archived branches", mock_plain.call_args[0][0])
+        self.proj.restore_branch.assert_not_called()
+
+    @patch("questionary.select")
+    @patch("poly.output.console.warning")
+    def test_no_name_user_cancels_shows_warning(self, mock_warning, mock_select):
+        """Interactive mode where user cancels shows a warning."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch"}
+        ]
+        mock_select.return_value.ask.return_value = None
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
+
+        mock_warning.assert_called_once()
+        self.assertIn("No branch selected", mock_warning.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.success")
+    def test_no_name_interactive_success(self, mock_success, mock_select):
+        """Interactive mode selects a branch and restores it."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch", "parentBranchId": "main"},
+            {"branchId": "BRANCH-2", "name": "old-branch", "parentBranchId": "BRANCH-1"},
+        ]
+        # BRANCH-1 is the parent and is itself archived, so the label marks it.
+        mock_select.return_value.ask.return_value = (
+            "old-branch (BRANCH-2) — parent: old-branch (archived)"
+        )
+        self.proj.restore_branch.return_value = True
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
+
+        self.proj.restore_branch.assert_called_once_with("BRANCH-2")
+        mock_success.assert_called_once()
+        self.assertIn("old-branch", mock_success.call_args[0][0])
+
+    @patch("questionary.select")
+    @patch("poly.output.console.error")
+    def test_no_name_interactive_restore_fails(self, mock_error, mock_select):
+        """Interactive mode shows error when restore returns False."""
+        self.proj.list_archived_branches.return_value = [
+            {"branchId": "BRANCH-1", "name": "old-branch", "parentBranchId": "main"},
+        ]
+        mock_select.return_value.ask.return_value = "old-branch (BRANCH-1) — parent: main"
+        self.proj.restore_branch.return_value = False
+
+        BranchCommand.branch_restore(TEST_DIR, branch_id=None)
+
+        mock_error.assert_called_once()
+        self.assertIn("Failed to restore", mock_error.call_args[0][0])
 
 
+class RequireDeploymentSimplificationTest(unittest.TestCase):
+    """Tests for the require_deployment_simplification CLI gate."""
+
+    def setUp(self):
+        self.proj = MagicMock()
+
+    @patch("poly.output.console.error")
+    def test_returns_silently_when_enabled(self, mock_error):
+        """An enabled project passes through without output or exit."""
+        self.proj.using_simplified_deployments = True
+
+        require_deployment_simplification(self.proj)
+
+        mock_error.assert_not_called()
+
+    @patch("poly.output.console.error")
+    def test_exits_with_error_when_disabled(self, mock_error):
+        """A disabled project is refused on stderr with exit code 1."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            require_deployment_simplification(self.proj)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_reports_failure_as_json(self, mock_json_print):
+        """In JSON mode the refusal is a machine-readable payload, not stderr text."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            require_deployment_simplification(self.proj, output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = mock_json_print.call_args[0][0]
+        self.assertFalse(payload["success"])
+        self.assertIn("simplified deployments", payload["error"])
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_json_payload_carries_no_rich_markup(self, mock_json_print):
+        """The JSON error stays markup-free so consumers get plain text."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit):
+            require_deployment_simplification(self.proj, output_json=True)
+
+        self.assertNotIn("[bold]", mock_json_print.call_args[0][0]["error"])
 
 
+class BranchTagTest(unittest.TestCase):
+    """Tests for BranchCommand.branch_tag and branch_untag."""
+
+    def setUp(self):
+        self.mock_load_patcher = patch("poly.cli_commands.branch.load_project")
+        self.mock_load = self.mock_load_patcher.start()
+        self.proj = MagicMock()
+        self.proj.using_simplified_deployments = True
+        self.proj.get_current_branch.return_value = "feature-a"
+        self.proj.tag_branch.return_value = True
+        self.proj.untag_branch.return_value = True
+        self.mock_load.return_value = self.proj
+
+    def tearDown(self):
+        patch.stopall()
+
+    @patch("poly.output.console.success")
+    def test_tag_success_reports_branch_name(self, mock_success):
+        """A successful tag names the branch that was staged."""
+        BranchCommand.branch_tag(TEST_DIR)
+
+        self.proj.tag_branch.assert_called_once_with()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("poly.output.console.success")
+    def test_untag_success_reports_branch_name(self, mock_success):
+        """A successful untag names the branch whose tag was removed."""
+        BranchCommand.branch_untag(TEST_DIR)
+
+        self.proj.untag_branch.assert_called_once_with()
+        self.assertIn("feature-a", mock_success.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_tag_failure_is_reported(self, mock_error):
+        """A False from the project layer surfaces as an error."""
+        self.proj.tag_branch.return_value = False
+
+        BranchCommand.branch_tag(TEST_DIR)
+
+        self.assertIn("Failed to tag", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_untag_failure_is_reported(self, mock_error):
+        """A False from the project layer surfaces as an error."""
+        self.proj.untag_branch.return_value = False
+
+        BranchCommand.branch_untag(TEST_DIR)
+
+        self.assertIn("Failed to remove tag", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.branch.json_print")
+    def test_json_mode_reports_outcome(self, mock_json_print):
+        """JSON mode reports the boolean outcome for both commands."""
+        BranchCommand.branch_tag(TEST_DIR, output_json=True)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": True})
+
+        self.proj.untag_branch.return_value = False
+        BranchCommand.branch_untag(TEST_DIR, output_json=True)
+        self.assertEqual(mock_json_print.call_args[0][0], {"success": False})
+
+    @patch("poly.output.console.error")
+    def test_tag_blocked_without_simplified_deployments(self, mock_error):
+        """Staging tags only exist under simplified deployments, so tag is gated."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_tag(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.tag_branch.assert_not_called()
+
+    @patch("poly.output.console.error")
+    def test_untag_blocked_without_simplified_deployments(self, mock_error):
+        """Untag is gated on the same flag as tag."""
+        self.proj.using_simplified_deployments = False
+
+        with self.assertRaises(SystemExit) as ctx:
+            BranchCommand.branch_untag(TEST_DIR)
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("simplified deployments", mock_error.call_args[0][0])
+        self.proj.untag_branch.assert_not_called()

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -8,7 +8,10 @@ import unittest
 from poly.output.console import (
     console,
     flatten_branch_tree,
+    print_archived_branches,
+    print_branch_history,
     print_releases_branches,
+    resolve_parent_branch_label,
 )
 
 
@@ -172,11 +175,208 @@ class PrintReleasesBranchesTest(unittest.TestCase):
         self.assertIn("Release 1 (staging) (current)", output)
 
 
+class PrintArchivedBranchesTest(unittest.TestCase):
+    """Tests for print_archived_branches, the table used by `branch list --archived`."""
+
+    def _render(self, branches: list[dict]) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches)
+        return capture.get()
+
+    def test_renders_a_row_per_archived_branch(self):
+        """Each archived branch contributes its name and id to the table."""
+        output = self._render(
+            [
+                {"name": "old-a", "branchId": "b-a", "archivedAt": "", "daysLeft": 30},
+                {"name": "old-b", "branchId": "b-b", "archivedAt": "", "daysLeft": 2},
+            ]
+        )
+
+        for expected in ("old-a", "b-a", "old-b", "b-b"):
+            self.assertIn(expected, output)
+
+    def test_shows_remaining_days_before_permanent_deletion(self):
+        """daysLeft is rendered so users know how long they have to restore."""
+        output = self._render([{"name": "old", "branchId": "b-1", "daysLeft": 7}])
+
+        self.assertIn("7 days left", output)
+
+    def test_missing_expiry_renders_a_placeholder(self):
+        """A branch with no daysLeft shows a dash rather than 'None'."""
+        output = self._render([{"name": "old", "branchId": "b-1"}])
+
+        self.assertNotIn("None", output)
+        self.assertIn("—", output)
+
+    def test_zero_days_left_is_rendered_not_treated_as_missing(self):
+        """daysLeft of 0 is a real value — the last day — and must still show."""
+        output = self._render([{"name": "old", "branchId": "b-1", "daysLeft": 0}])
+
+        self.assertIn("0 days left", output)
+
+    def test_missing_fields_render_placeholders(self):
+        """A row missing name and id degrades to dashes instead of raising."""
+        output = self._render([{}])
+
+        self.assertIn("—", output)
+
+    def test_empty_list_renders_headers_only(self):
+        """With nothing archived the table still renders its headers."""
+        output = self._render([])
+
+        self.assertIn("Branch", output)
+        self.assertIn("Expires", output)
 
 
+class PrintBranchHistoryTest(unittest.TestCase):
+    """Tests for print_branch_history, the table used by `branch history`."""
+
+    def _render(self, commits: list[dict]) -> str:
+        with console.capture() as capture:
+            print_branch_history(commits)
+        return capture.get()
+
+    def test_renders_a_row_per_merge(self):
+        """Each merge contributes its source branch and author to the table."""
+        output = self._render(
+            [
+                {"mergedAt": "", "branchName": "feature-a", "mergedBy": "ada@example.com"},
+                {"mergedAt": "", "branchName": "feature-b", "mergedBy": "grace@example.com"},
+            ]
+        )
+
+        for expected in ("feature-a", "ada@example.com", "feature-b", "grace@example.com"):
+            self.assertIn(expected, output)
+
+    def test_empty_history_reports_no_commits(self):
+        """An empty history is explained rather than rendered as a blank table."""
+        output = self._render([])
+
+        self.assertIn("No commits found for this branch.", output)
+
+    def test_missing_fields_render_placeholders(self):
+        """A merge record missing its branch or author degrades to dashes."""
+        output = self._render([{"mergedAt": ""}])
+
+        self.assertIn("—", output)
+        self.assertNotIn("None", output)
 
 
+class ResolveParentBranchLabelTest(unittest.TestCase):
+    """Tests for resolve_parent_branch_label, which names an archived branch's parent."""
+
+    def test_main_parent_is_named_directly(self):
+        """A top-level branch reports main without needing a lookup."""
+        label = resolve_parent_branch_label({"parentBranchId": "main"})
+
+        self.assertEqual(label, "main")
+
+    def test_parent_id_is_resolved_to_a_name(self):
+        """A sub-branch's parent id is resolved through the lookup."""
+        label = resolve_parent_branch_label(
+            {"parentBranchId": "BRANCH-P"}, {"BRANCH-P": "Release 1"}
+        )
+
+        self.assertEqual(label, "Release 1")
+
+    def test_unknown_parent_id_falls_back_to_the_id(self):
+        """An unresolvable parent shows its id rather than going blank."""
+        label = resolve_parent_branch_label({"parentBranchId": "BRANCH-GONE"}, {})
+
+        self.assertEqual(label, "BRANCH-GONE")
+
+    def test_missing_parent_renders_a_placeholder(self):
+        """An entry with no parent at all renders a dash."""
+        for branch in ({}, {"parentBranchId": None}, {"parentBranchId": ""}):
+            with self.subTest(branch=branch):
+                self.assertEqual(resolve_parent_branch_label(branch), "—")
 
 
+class PrintArchivedBranchesParentColumnTest(unittest.TestCase):
+    """Tests for the parent column in print_archived_branches."""
+
+    def _render(self, branches: list[dict], name_by_branch_id: dict | None = None) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches, name_by_branch_id)
+        return capture.get()
+
+    def test_parent_column_is_shown(self):
+        """The table gains a Parent header so lineage is visible."""
+        output = self._render([{"name": "old", "branchId": "b-1", "parentBranchId": "main"}])
+
+        self.assertIn("Parent", output)
+        self.assertIn("main", output)
+
+    def test_sub_branch_shows_its_parent_name(self):
+        """A branch archived under another branch names that parent, not its id."""
+        output = self._render(
+            [{"name": "child", "branchId": "b-2", "parentBranchId": "b-1"}],
+            {"b-1": "Release 1"},
+        )
+
+        self.assertIn("Release 1", output)
+
+    def test_renders_without_a_lookup(self):
+        """Omitting the lookup still renders, falling back to raw parent ids."""
+        output = self._render([{"name": "child", "branchId": "b-2", "parentBranchId": "b-1"}])
+
+        self.assertIn("b-1", output)
 
 
+class ArchivedParentMarkerTest(unittest.TestCase):
+    """Tests for marking a parent that is itself archived."""
+
+    def _render(self, branches: list[dict], name_by_branch_id: dict | None = None) -> str:
+        with console.capture() as capture:
+            print_archived_branches(branches, name_by_branch_id)
+        return capture.get()
+
+    def test_archived_parent_is_marked(self):
+        """A parent that is also in the archive is flagged, since restoring a child
+        does not bring the parent back."""
+        label = resolve_parent_branch_label(
+            {"parentBranchId": "b-1"}, {"b-1": "Release 1"}, {"b-1"}
+        )
+
+        self.assertEqual(label, "Release 1 (archived)")
+
+    def test_live_parent_is_not_marked(self):
+        """A parent that is still active is left unmarked."""
+        label = resolve_parent_branch_label({"parentBranchId": "b-1"}, {"b-1": "Release 1"}, set())
+
+        self.assertEqual(label, "Release 1")
+
+    def test_main_is_never_marked_archived(self):
+        """Main cannot be archived, so it is never flagged even if ids are passed."""
+        label = resolve_parent_branch_label({"parentBranchId": "main"}, {}, {"main"})
+
+        self.assertEqual(label, "main")
+
+    def test_unresolved_archived_parent_marks_the_raw_id(self):
+        """An archived parent with no known name still gets the marker."""
+        label = resolve_parent_branch_label({"parentBranchId": "b-9"}, {}, {"b-9"})
+
+        self.assertEqual(label, "b-9 (archived)")
+
+    def test_table_marks_parents_present_in_the_same_listing(self):
+        """The table derives the archived set from its own rows, so a parent listed
+        alongside its child is marked without the caller passing anything extra."""
+        output = self._render(
+            [
+                {"name": "Release 1", "branchId": "b-1", "parentBranchId": "main"},
+                {"name": "child", "branchId": "b-2", "parentBranchId": "b-1"},
+            ],
+            {"b-1": "Release 1", "b-2": "child"},
+        )
+
+        self.assertIn("(archived)", output)
+
+    def test_table_does_not_mark_a_live_parent(self):
+        """A parent absent from the listing is still live, so it is not marked."""
+        output = self._render(
+            [{"name": "child", "branchId": "b-2", "parentBranchId": "b-live"}],
+            {"b-live": "Active Release"},
+        )
+
+        self.assertIn("Active Release", output)
+        self.assertNotIn("(archived)", output)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -3712,14 +3712,284 @@ class MigrateFlowStepResourceIdsTest(unittest.TestCase):
         self.assertEqual(flow_steps["FLOW-abc_step-1"]["resource_id"], "FLOW-abc_step-1")
 
 
+class SyncBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.sync_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def _make_branches(self, *branch_ids):
+        """Build a branches dict with the given branch IDs."""
+        return {bid: {"branchId": bid, "name": f"name-{bid}"} for bid in branch_ids}
+
+    def test_branch_not_found_raises(self):
+        """A branch_id not present in any branch metadata raises ValueError."""
+        self.project.branch_id = "nonexistent-branch"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.sync_branch()
+
+        self.assertIn("nonexistent-branch", str(ctx.exception))
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_main_branch_raises(self):
+        """Syncing the main branch raises ValueError."""
+        self.project.branch_id = "main"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main")
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.sync_branch()
+
+        self.assertIn("main", str(ctx.exception))
+        self.assertIn("not supported", str(ctx.exception))
+
+    def test_uncommitted_changes_raises(self):
+        """Uncommitted changes (non-empty get_diffs) raises ValueError listing the diffs."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value={"topic/foo": "modified"}):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch()
+
+        self.assertIn("uncommitted changes", str(ctx.exception))
+        self.assertIn("topic/foo", str(ctx.exception))
+
+    def test_invalid_resolution_missing_path(self):
+        """A resolution dict missing 'path' raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(conflict_resolutions=[{"strategy": "ours"}])
+
+        self.assertIn("path", str(ctx.exception))
+        self.assertIn("strategy", str(ctx.exception))
+
+    def test_invalid_resolution_missing_strategy(self):
+        """A resolution dict missing 'strategy' raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(conflict_resolutions=[{"path": ["users", "name"]}])
+
+        self.assertIn("path", str(ctx.exception))
+        self.assertIn("strategy", str(ctx.exception))
+
+    def test_invalid_resolution_bad_strategy(self):
+        """A strategy not in {ours, theirs, base} raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with self.assertRaises(ValueError) as ctx:
+                    self.project.sync_branch(
+                        conflict_resolutions=[{"path": ["users", "name"], "strategy": "invalid"}]
+                    )
+
+        self.assertIn("Invalid conflict resolution strategy", str(ctx.exception))
+        self.assertIn("invalid", str(ctx.exception))
+
+    def test_successful_sync_pulls_and_returns_true(self):
+        """On success, pull_project(force=True) is called and (True, [], []) is returned."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (True, [], [])
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project") as mock_pull:
+                    result = self.project.sync_branch()
+
+        self.assertEqual(result, (True, [], []))
+        mock_pull.assert_called_once_with(force=True)
+        mock_api.sync_branch.assert_called_once_with(conflict_resolutions=None)
+
+    def test_sync_with_conflicts_returns_false(self):
+        """When the API reports conflicts, returns (False, conflicts, errors) without pulling."""
+        self.project.branch_id = "branch-1"
+        conflicts = [{"path": "topic/foo", "type": "content"}]
+        errors = [{"message": "merge error"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (False, conflicts, errors)
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project") as mock_pull:
+                    result = self.project.sync_branch()
+
+        self.assertEqual(result, (False, conflicts, errors))
+        mock_pull.assert_not_called()
+
+    def test_none_resolutions_accepted(self):
+        """Passing None for conflict_resolutions skips validation and works."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = self._make_branches("main", "branch-1")
+            mock_api.sync_branch.return_value = (True, [], [])
+            with patch.object(self.project, "get_diffs", return_value=None):
+                with patch.object(self.project, "pull_project"):
+                    result = self.project.sync_branch(conflict_resolutions=None)
+
+        self.assertEqual(result, (True, [], []))
+        mock_api.sync_branch.assert_called_once_with(conflict_resolutions=None)
 
 
+class GetBranchHistoryProject(unittest.TestCase):
+    """Tests for AgentStudioProject.get_branch_history."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """get_branch_history passes through to the api_handler and returns its result."""
+        expected = [{"commit_id": "c1"}, {"commit_id": "c2"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branch_history.return_value = expected
+
+            result = self.project.get_branch_history("branch-1")
+
+        self.assertEqual(result, expected)
+        mock_api.get_branch_history.assert_called_once_with("branch-1")
 
 
+class RenameBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.rename_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_name_raises_value_error(self):
+        """An empty branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("")
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_none_name_raises_value_error(self):
+        """A None branch name raises ValueError."""
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch(None)
+
+        self.assertIn("New branch name must be provided", str(ctx.exception))
+
+    def test_main_branch_raises_value_error(self):
+        """Renaming the main branch raises ValueError."""
+        self.project.branch_id = "main"
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.rename_branch("new-name")
+
+        self.assertIn("main", str(ctx.exception))
+
+    def test_duplicate_name_raises_value_error(self):
+        """A name that already exists raises ValueError."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"new-name": "branch-id-123"}
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.rename_branch("new-name")
+
+        self.assertIn("already exists", str(ctx.exception))
+
+    def test_successful_rename_returns_true(self):
+        """A valid rename delegates to api_handler and returns its result."""
+        self.project.branch_id = "branch-1"
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.get_branches.return_value = {"other-branch": "id-456"}
+            mock_api.rename_branch.return_value = True
+
+            result = self.project.rename_branch("new-name")
+
+        self.assertTrue(result)
+        mock_api.rename_branch.assert_called_once_with(new_branch_name="new-name")
 
 
+class ListArchivedBranchesProject(unittest.TestCase):
+    """Tests for AgentStudioProject.list_archived_branches."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_delegates_to_api_handler(self):
+        """list_archived_branches passes through to the api_handler."""
+        expected = [{"branchId": "b-1", "name": "old", "archivedAt": "2026-07-01"}]
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = expected
+
+            result = self.project.list_archived_branches()
+
+        self.assertEqual(result, expected)
+        mock_api.list_archived_branches.assert_called_once()
 
 
+class RestoreBranchProject(unittest.TestCase):
+    """Tests for AgentStudioProject.restore_branch."""
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+
+    def test_empty_branch_id_raises_value_error(self):
+        """An empty branch id raises ValueError before any API call."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("")
+
+        self.assertIn("Branch id must be provided", str(ctx.exception))
+        mock_api.restore_branch.assert_not_called()
+
+    def test_restore_delegates_the_branch_id_to_the_api(self):
+        """A branch id present in the archive is restored."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+            mock_api.restore_branch.return_value = True
+
+            result = self.project.restore_branch("BRANCH-1")
+
+        self.assertTrue(result)
+        mock_api.restore_branch.assert_called_once_with("BRANCH-1")
+
+    def test_branch_id_not_in_archive_raises_value_error(self):
+        """An id that is not archived is refused before any restore is attempted."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+
+            with self.assertRaises(ValueError) as ctx:
+                self.project.restore_branch("BRANCH-NOPE")
+
+        self.assertIn("not found in archive", str(ctx.exception))
+        mock_api.restore_branch.assert_not_called()
+
+    def test_matching_is_by_id_not_name(self):
+        """A branch name is not accepted, even when it is unique in the archive."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+
+            with self.assertRaises(ValueError):
+                self.project.restore_branch("old-branch")
+
+        mock_api.restore_branch.assert_not_called()
+
+    def test_api_failure_is_returned_to_the_caller(self):
+        """A False from the API layer is passed through rather than raised."""
+        with patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock) as mock_api:
+            mock_api.list_archived_branches.return_value = [
+                {"branchId": "BRANCH-1", "name": "old-branch"},
+            ]
+            mock_api.restore_branch.return_value = False
+
+            self.assertFalse(self.project.restore_branch("BRANCH-1"))
 
 
 class DiffBranchTest(unittest.TestCase):
@@ -3998,6 +4268,111 @@ class GetBranchesReturnTypeTest(unittest.TestCase):
         self.assertEqual(len(branches), 1)
 
 
+class BranchTaggingTest(unittest.TestCase):
+    """Tests for AgentStudioProject.tag_branch and untag_branch."""
+
+    BRANCHES = {
+        "main": {"branchId": "main"},
+        "feature-a": {"branchId": "branch-a", "parentBranchId": "main"},
+    }
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.get_branches.return_value = deepcopy(self.BRANCHES)
+        self.mock_api.tag_branch.return_value = True
+        self.mock_api.untag_branch.return_value = True
+        self.project._api_handler = self.mock_api
+        self.save_config_patcher = patch.object(AgentStudioProject, "save_config")
+        self.save_config_patcher.start()
+        self._set_current_branch("branch-a")
+
+    def tearDown(self):
+        self.save_config_patcher.stop()
+
+    def _set_current_branch(self, branch_id: str) -> None:
+        """Put the project and its API handler on the given branch.
+
+        The ``api_handler`` property re-reads ``branch_id`` from the handler on
+        every access, so both sides have to agree.
+        """
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    def test_tags_current_branch_by_default(self):
+        """With no branch name the current branch's id is tagged."""
+        self.assertTrue(self.project.tag_branch())
+
+        self.mock_api.tag_branch.assert_called_once_with("branch-a")
+
+    def test_untags_current_branch_by_default(self):
+        """With no branch name the current branch's id is untagged."""
+        self.assertTrue(self.project.untag_branch())
+
+        self.mock_api.untag_branch.assert_called_once_with("branch-a")
+
+    def test_named_branch_is_resolved_to_its_id(self):
+        """An explicit branch name is resolved to the branch id before the API call."""
+        self._set_current_branch("main")
+
+        self.project.tag_branch("feature-a")
+
+        self.mock_api.tag_branch.assert_called_once_with("branch-a")
+
+    def test_rejects_unknown_branch_name(self):
+        """A name that is not in the branch list is refused before any API call."""
+        for method in (self.project.tag_branch, self.project.untag_branch):
+            with self.subTest(method=method.__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    method("no-such-branch")
+
+                self.assertIn("no-such-branch", str(ctx.exception))
+
+        self.mock_api.tag_branch.assert_not_called()
+        self.mock_api.untag_branch.assert_not_called()
+
+    def test_rejects_current_branch_missing_from_branch_list(self):
+        """A local branch id with no remote counterpart is reported rather than tagged."""
+        self._set_current_branch("branch-gone")
+
+        for method in (self.project.tag_branch, self.project.untag_branch):
+            with self.subTest(method=method.__name__):
+                with self.assertRaises(ValueError) as ctx:
+                    method()
+
+                self.assertIn("branch-gone", str(ctx.exception))
+
+    def test_rejects_main_branch(self):
+        """Main carries the live deployment, so it can be neither tagged nor untagged."""
+        self._set_current_branch("main")
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.tag_branch()
+        self.assertIn("Tagging 'main' branch is not supported", str(ctx.exception))
+
+        with self.assertRaises(ValueError) as ctx:
+            self.project.untag_branch()
+        self.assertIn("Untagging 'main' branch is not supported", str(ctx.exception))
+
+        self.mock_api.tag_branch.assert_not_called()
+        self.mock_api.untag_branch.assert_not_called()
+
+    def test_rejects_main_when_named_explicitly(self):
+        """Naming main explicitly is refused the same way as being on it."""
+        self._set_current_branch("branch-a")
+
+        with self.assertRaises(ValueError):
+            self.project.tag_branch("main")
+
+        self.mock_api.tag_branch.assert_not_called()
+
+    def test_api_failure_is_returned_to_the_caller(self):
+        """A False from the API layer is passed through, not raised."""
+        self.mock_api.tag_branch.return_value = False
+        self.mock_api.untag_branch.return_value = False
+
+        self.assertFalse(self.project.tag_branch())
+        self.assertFalse(self.project.untag_branch())
 
 
 class UsingSimplifiedDeploymentsTest(unittest.TestCase):


### PR DESCRIPTION
Part of a 3-PR stack: #251 → #252 → this PR (top of stack). Builds on #252's lineage-aware create/merge.

## Summary

Adds the remaining branch-lifecycle commands: `sync`, `history`, `rename`, `restore`, `tag`/`untag`, and `list --archived`.

## Motivation

The simplified deployment model also introduces staging tags and soft-archive/restore with a 30-day window, and lets a branch pull its parent's changes without merging upward. ADK had no support for any of it.

## Changes

- `poly branch sync` — merge the parent branch's changes into the current branch, reusing the existing merge-conflict UX (`-i`/`--interactive`, `--resolutions`).
- `poly branch history [--branch-name] [--limit]` — merge history for a branch, 10 entries by default.
- `poly branch rename [new_name]` — rename the current branch.
- `poly branch restore [branch]` — restore a soft-deleted branch from the archive.
- `poly branch tag` / `poly branch untag` — tag the current branch to deploy it to staging, or remove the tag.
- `poly branch list --archived` — list soft-deleted branches instead of active ones.
- `sync`, `tag`, and `untag` are gated behind `require_deployment_simplification` — the three endpoints the platform 404s when the deployment-simplification flag is off. They now exit 1 with an explanatory message in both human and `--json` modes, instead of surfacing a bare `API error: 404 Client Error`.

## Follow-ups (tracked separately, not silently dropped)

- The `sandbox` environment does not exist under simplified deployments, but it's still the hardcoded default for `deployments list`/`show`, `diff`, `chat`, and the `rtc` commands, so those return empty results rather than an explanation. Fixing that also means introducing a shared environment constant — the three-environment literal is currently duplicated at 15+ sites — and renaming `sandbox`/`pre-release` to the branches/staging vocabulary the product now uses.
- `deployments list`/`promote`/`rollback` deployment-mode awareness.
- `poly branch create --from <branch>` to pick an explicit source branch, rather than always using the current one.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1149 passed, 53 subtests)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
