### PR TITLE
feat: add SIP header overrides to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,8 +201,13 @@ Start an interactive chat session with your agent:
 poly chat
 poly chat --environment live
 poly chat --channel webchat
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 poly chat --metadata   # show functions, flows, and state each turn
 ```
+
+`--sip-header NAME=VALUE` is repeatable and simulates headers exposed to project
+functions through `conv.sip_headers`. It does not create a SIP call or reproduce
+carrier-level SIP behaviour.
 
 ### `poly docs`
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,12 @@ Start an interactive chat session with your agent:
 poly chat
 poly chat --environment live
 poly chat --channel webchat
-poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 poly chat --metadata   # show functions, flows, and state each turn
+
+# Simulate one SIP header
+poly chat --sip-header X-Customer-ID=12345
+# Simulate multiple SIP headers
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 ```
 
 `--sip-header NAME=VALUE` is repeatable and simulates headers exposed to project

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -398,6 +398,7 @@ Examples:
 poly chat
 poly chat --environment live
 poly chat --channel webchat
+poly chat --sip-header X-Customer-ID=12345
 poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 poly chat --metadata
 poly chat --lang fr-FR
@@ -460,7 +461,14 @@ Use language flags to specify the expected input and output language when chatti
 #### Simulating SIP headers
 
 Use `--sip-header NAME=VALUE` to simulate a SIP header when starting a conversation.
-Repeat the flag to provide multiple headers:
+
+Single header:
+
+~~~bash
+poly chat --sip-header X-Customer-ID=12345
+~~~
+
+Multiple headers are supported by repeating the flag:
 
 ~~~bash
 poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -398,6 +398,7 @@ Examples:
 poly chat
 poly chat --environment live
 poly chat --channel webchat
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
 poly chat --metadata
 poly chat --lang fr-FR
 poly chat --input-lang en-US --output-lang fr-FR
@@ -456,6 +457,19 @@ Use language flags to specify the expected input and output language when chatti
 
 `--input-lang` and `--output-lang` take precedence over `--lang` when both are supplied.
 
+#### Simulating SIP headers
+
+Use `--sip-header NAME=VALUE` to simulate a SIP header when starting a conversation.
+Repeat the flag to provide multiple headers:
+
+~~~bash
+poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB
+~~~
+
+The values are exposed to project functions through `conv.sip_headers`. This is for
+testing agent behaviour only; it does not create a SIP call or reproduce carrier-level
+SIP behaviour. SIP headers cannot be changed when resuming an existing conversation.
+
 #### `poly chat` flags summary
 
 | Flag | Description |
@@ -467,6 +481,7 @@ Use language flags to specify the expected input and output language when chatti
 | `--json` | Emit a single JSON object when the session ends (see below). |
 | `--environment` | Target environment. Choices: `branch`, `sandbox`, `pre-release`, `live`. Defaults to `branch`. `branch` chats against the last **pushed** state of your current branch (not local uncommitted changes); on main it falls back to `sandbox`. Use `--push` to push local changes before chatting. |
 | `--channel` | Channel to use (e.g. `webchat`, `voice`). |
+| `--sip-header NAME=VALUE` | Simulate a SIP header at conversation start (repeatable). |
 | `--lang` | Set both input and output language. |
 | `--input-lang` | Set input language only. |
 | `--output-lang` | Set output language only. |

--- a/src/poly/cli_commands/chat.py
+++ b/src/poly/cli_commands/chat.py
@@ -6,7 +6,13 @@ Copyright PolyAI Limited
 import json
 import os
 import sys
-from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+from argparse import (
+    ArgumentParser,
+    ArgumentTypeError,
+    Namespace,
+    RawTextHelpFormatter,
+    _SubParsersAction,
+)
 from contextlib import nullcontext
 from typing import Optional
 
@@ -14,6 +20,17 @@ from poly.cli_commands.base import BaseCommand, Parents
 from poly.cli_commands.shared import load_project
 from poly.output.json_output import json_print
 from poly.project import AgentStudioProject
+
+
+def _parse_sip_header(value: str) -> tuple[str, str]:
+    """Parse a SIP header supplied as NAME=VALUE."""
+    name, separator, header_value = value.partition("=")
+    name = name.strip()
+    if not separator or not name:
+        raise ArgumentTypeError("SIP headers must use NAME=VALUE format")
+    if "\r" in value or "\n" in value:
+        raise ArgumentTypeError("SIP headers cannot contain newlines")
+    return name, header_value
 
 
 class ChatCommand(BaseCommand):
@@ -34,6 +51,7 @@ class ChatCommand(BaseCommand):
                 "  poly chat\n"
                 "  poly chat --environment live\n"
                 "  poly chat --path /path/to/project -e sandbox\n"
+                "  poly chat --sip-header X-Customer-ID=12345\n"
                 "\n"
                 "Non-interactive (scripted) mode:\n"
                 "  poly chat -m 'Hello' -m 'What can you help with?'\n"
@@ -91,6 +109,14 @@ class ChatCommand(BaseCommand):
             default="voice",
             choices=["voice", "webchat"],
             help="Channel to chat against. Defaults to voice.",
+        )
+        chat_parser.add_argument(
+            "--sip-header",
+            dest="sip_headers",
+            action="append",
+            type=_parse_sip_header,
+            metavar="NAME=VALUE",
+            help=("Simulate a SIP header at conversation start. Repeat for multiple headers."),
         )
         chat_parser.add_argument(
             "--functions",
@@ -184,6 +210,7 @@ class ChatCommand(BaseCommand):
             args.channel,
             input_lang=input_lang,
             output_lang=output_lang,
+            sip_headers=dict(args.sip_headers or []) or None,
             show_functions=show_all or args.functions,
             show_flow=show_all or args.flows,
             show_state=show_all or args.state,
@@ -203,6 +230,7 @@ class ChatCommand(BaseCommand):
         input_lang: str = None,
         push_before_chat: bool = False,
         output_lang: str = None,
+        sip_headers: Optional[dict[str, str]] = None,
         show_functions: bool = False,
         show_flow: bool = False,
         show_state: bool = False,
@@ -293,6 +321,7 @@ class ChatCommand(BaseCommand):
                         variant,
                         input_lang,
                         output_lang,
+                        sip_headers=sip_headers,
                     )
                 except (requests.HTTPError, ValueError) as e:
                     if output_json:

--- a/src/poly/cli_commands/chat.py
+++ b/src/poly/cli_commands/chat.py
@@ -52,6 +52,7 @@ class ChatCommand(BaseCommand):
                 "  poly chat --environment live\n"
                 "  poly chat --path /path/to/project -e sandbox\n"
                 "  poly chat --sip-header X-Customer-ID=12345\n"
+                "  poly chat --sip-header X-Customer-ID=12345 --sip-header X-Language=en-GB\n"
                 "\n"
                 "Non-interactive (scripted) mode:\n"
                 "  poly chat -m 'Hello' -m 'What can you help with?'\n"

--- a/src/poly/docs/docs.md
+++ b/src/poly/docs/docs.md
@@ -75,7 +75,7 @@ Each project defines an AI voice or webchat agent. Resources in the project (flo
 | `poly validate` | Validate project configuration locally |
 | `poly review` | Diff review page: `create` (local vs remote, version hash, or `--before`/`--after`), `list`, `delete` |
 | `poly deployments` | Manage deployments (`list`, with `--env`, `--limit`, `--offset`, `--hash`, `--details`) |
-| `poly chat` | Interactive chat session with the agent (`--environment`, `--channel`, `--functions`, `--flows`, `--state`) |
+| `poly chat` | Interactive chat session with the agent (`--environment`, `--channel`, `--sip-header`, `--functions`, `--flows`, `--state`) |
 | `poly docs` | Output resource documentation (`poly docs flows functions topics`, or `--all` for everything) |
 
 Use `poly -h` and `poly {command} -h` for more detailed information

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -606,6 +606,7 @@ class AgentStudioInterface:
         channel: str = "chat.polyai",
         input_lang: Optional[str] = None,
         output_lang: Optional[str] = None,
+        sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -616,6 +617,7 @@ class AgentStudioInterface:
             environment: The environment to chat against (sandbox, pre-release, live)
             variant_id: Optional variant ID (e.g. 'Voice')
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
+            sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
 
         Returns:
             dict: The API response containing the conversation ID and initial greeting
@@ -629,6 +631,7 @@ class AgentStudioInterface:
             channel,
             input_lang=input_lang,
             output_lang=output_lang,
+            sip_headers=sip_headers,
         )
 
     @staticmethod
@@ -695,6 +698,7 @@ class AgentStudioInterface:
         variant_id: Optional[str] = None,
         input_lang: str = None,
         output_lang: str = None,
+        sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -706,6 +710,7 @@ class AgentStudioInterface:
             lambda_deployment_version: Branch lambda version from sourcerer
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             variant_id: Optional variant ID (e.g. 'Voice')
+            sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
 
         Returns:
             dict: The API response containing the conversation ID and initial greeting
@@ -720,6 +725,7 @@ class AgentStudioInterface:
             variant_id,
             input_lang=input_lang,
             output_lang=output_lang,
+            sip_headers=sip_headers,
         )
 
     @staticmethod

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -432,6 +432,7 @@ class PlatformAPIHandler:
         channel: str = "chat.polyai",
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
+        sip_headers: ty.Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -444,6 +445,7 @@ class PlatformAPIHandler:
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response,
+            sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
 
         Returns:
             dict: The API response containing the conversation ID
@@ -459,6 +461,8 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if sip_headers:
+            data["sip_headers"] = sip_headers
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -542,6 +546,7 @@ class PlatformAPIHandler:
         variant_id: ty.Optional[str] = None,
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
+        sip_headers: ty.Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -555,6 +560,7 @@ class PlatformAPIHandler:
             variant_id: Optional variant ID (e.g. 'Voice')
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response, e.g. "en-
+            sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
 
         Returns:
             dict: The API response containing the conversation ID
@@ -571,6 +577,8 @@ class PlatformAPIHandler:
             data["asr_lang_code"] = input_lang
         if output_lang:
             data["tts_lang_code"] = output_lang
+        if sip_headers:
+            data["sip_headers"] = sip_headers
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -2362,6 +2362,7 @@ class AgentStudioProject:
         variant: Optional[str],
         input_lang: Optional[str] = None,
         output_lang: Optional[str] = None,
+        sip_headers: Optional[dict[str, str]] = None,
     ) -> dict:
         """Create a chat session (standard or draft).
 
@@ -2374,6 +2375,8 @@ class AgentStudioProject:
             variant (ty.Optional[str]): The variant ID to create the chat session in.
             input_lang (str): Optional. The language code for the input messages, e.g. "en-GB" or "fr-FR".
             output_lang (str): Optional. The language code for the agent's responses, e.g. "en-GB" or "fr-FR".
+            sip_headers (dict[str, str]): Optional. Simulated SIP headers exposed to
+                project functions through conv.sip_headers.
 
         Returns:
             dict: API response with conversation_id and initial greeting.
@@ -2400,6 +2403,7 @@ class AgentStudioProject:
                 variant_id=variant,
                 input_lang=input_lang,
                 output_lang=output_lang,
+                sip_headers=sip_headers,
             )
 
         return AgentStudioInterface.create_chat(
@@ -2411,6 +2415,7 @@ class AgentStudioProject:
             channel=channel,
             input_lang=input_lang,
             output_lang=output_lang,
+            sip_headers=sip_headers,
         )
 
     def send_message(

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -53,6 +53,42 @@ class GetBaseUrl(unittest.TestCase):
             PlatformAPIHandler.get_base_url("mars-1", use_jupiter_api=True)
 
 
+class CreateChat(unittest.TestCase):
+    """Tests for chat creation request payloads."""
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_standard_chat_includes_sip_headers(self, mock_make_request):
+        sip_headers = {"X-Customer-ID": "12345"}
+
+        PlatformAPIHandler.create_chat(
+            "uk-1",
+            "ACCOUNT-123",
+            "PROJECT-123",
+            sip_headers=sip_headers,
+        )
+
+        self.assertEqual(
+            mock_make_request.call_args.kwargs["data"]["sip_headers"], sip_headers
+        )
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_draft_chat_includes_sip_headers(self, mock_make_request):
+        sip_headers = {"X-Customer-ID": "12345"}
+
+        PlatformAPIHandler.create_draft_chat(
+            "uk-1",
+            "ACCOUNT-123",
+            "PROJECT-123",
+            "artifact-version",
+            "lambda-version",
+            sip_headers=sip_headers,
+        )
+
+        self.assertEqual(
+            mock_make_request.call_args.kwargs["data"]["sip_headers"], sip_headers
+        )
+
+
 class MakeRequest(unittest.TestCase):
     """Tests for PlatformAPIHandler.make_request HTTP behaviour."""
 

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -1013,6 +1013,31 @@ class ChatLoopTest(unittest.TestCase):
         self.assertIn("error", conversation["turns"][0])
 
 
+class ChatArgumentsTest(unittest.TestCase):
+    """Tests for chat-specific CLI argument parsing."""
+
+    @patch("poly.cli_commands.chat.ChatCommand.chat")
+    def test_sip_headers_are_parsed_and_forwarded(self, mock_chat):
+        AgentStudioCLI().main(
+            [
+                "chat",
+                "--sip-header",
+                "X-Customer-ID=12345",
+                "--sip-header",
+                "X-Token=part=two",
+            ]
+        )
+
+        self.assertEqual(
+            mock_chat.call_args.kwargs["sip_headers"],
+            {"X-Customer-ID": "12345", "X-Token": "part=two"},
+        )
+
+    def test_invalid_sip_header_is_rejected(self):
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI().main(["chat", "--sip-header", "X-Customer-ID"])
+
+
 class ChatCommandTest(unittest.TestCase):
     """Tests for ChatCommand.chat.
 
@@ -1059,6 +1084,25 @@ class ChatCommandTest(unittest.TestCase):
         )
 
         self.proj.create_chat_session.assert_called_once()
+
+    def test_sip_headers_are_forwarded_when_creating_session(self):
+        sip_headers = {"X-Customer-ID": "12345"}
+
+        ChatCommand.chat(
+            TEST_DIR,
+            environment="sandbox",
+            sip_headers=sip_headers,
+            input_messages=[],
+        )
+
+        self.proj.create_chat_session.assert_called_once_with(
+            "sandbox",
+            "chat.polyai",
+            None,
+            None,
+            None,
+            sip_headers=sip_headers,
+        )
 
     @patch("poly.cli_commands.chat.json_print")
     def test_json_conv_id_emits_conversations_list(self, mock_json):


### PR DESCRIPTION
## Summary

Adds a repeatable `poly chat --sip-header NAME=VALUE` option that simulates SIP headers on chat conversations, so agent behaviour that reads `conv.sip_headers` can be exercised without arranging a real SIP call.

## Motivation

Testing header-dependent agent logic today requires a real SIP call. This gives developers a quick local way to inject agent-visible header values from the chat CLI. Note the option is additive and simulates agent-visible values only; it does not reproduce SIP transport or carrier behaviour, and header injection depends on server-side chat API support rolling out separately.

## Changes

- Add a repeatable `--sip-header NAME=VALUE` option to the modular chat command
- Validate header syntax while preserving values that contain `=`
- Forward simulated headers through standard and draft conversation creation
- Document the option

## Test strategy

- [x] Added/updated unit tests (CLI parsing, session forwarding, API payloads)
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

`pytest -q` result: 994 passed, 30 subtests passed
