### PR TITLE
fix: handle null schema/variables in RTC merge and diff paths

### DIFF
--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -551,8 +551,8 @@ class RTCCommand(BaseCommand):
                 "or use --force to overwrite.",
             }
 
-        remote_schema = remote_config.get("schema", {})
-        remote_variables = remote_config.get("variables", {})
+        remote_schema = remote_config.get("schema") or {}
+        remote_variables = remote_config.get("variables") or {}
 
         if not output_json:
             info("Remote has changed since your last pull. Attempting merge...")

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3399,13 +3399,13 @@ class AgentStudioProject:
         if os.path.exists(schema_path):
             with open(schema_path, "r", encoding="utf-8") as f:
                 local_schema = json.load(f)
-            remote_schema = remote_config.get("schema", {})
+            remote_schema = remote_config.get("schema") or {}
             env_diff["schema"] = utils.diff_dicts(local_schema, remote_schema)
 
         if os.path.exists(data_path):
             with open(data_path, "r", encoding="utf-8") as f:
                 local_data = json.load(f)
-            remote_data = remote_config.get("variables", {})
+            remote_data = remote_config.get("variables") or {}
             env_diff["data"] = utils.diff_dicts(local_data, remote_data)
 
         return env_diff


### PR DESCRIPTION
## Summary

Fix crash when `poly rtc push` triggers a merge against a remote config with null schema or variables.

## Motivation

When a project has no RTC configured, the API returns `{"schema": null, "variables": null}`. The merge and diff code paths used `.get("schema", {})`, which returns `None` when the key exists with a null value (the default `{}` is only used when the key is absent). This caused `merge_rtc_dicts` to crash with `'NoneType' object is not iterable`.

## Changes

- Use `.get("schema") or {}` instead of `.get("schema", {})` in the RTC merge path (`rtc.py`)
- Apply the same fix in the RTC diff path (`project.py`)
- Matches the pattern already used in `rtc_pull_env` after the earlier null fix

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

<img width="462" height="68" alt="image" src="https://github.com/user-attachments/assets/f0d15c48-6018-416e-a9a9-5f093f182303" />

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)