### PR TITLE
feat: add poly metrics commands (list, export, add, edit, import)

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -18,6 +18,7 @@ from poly.cli_commands.branch import BranchCommand
 from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
+from poly.cli_commands.metrics import MetricsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand, StudioCommand
 from poly.cli_commands.review import ReviewCommand
 from poly.cli_commands.sync import (
@@ -51,6 +52,7 @@ COMMANDS = [
     ReviewCommand,
     BranchCommand,
     DeploymentsCommand,
+    MetricsCommand,
     ConversationsCommand,
     TestingCommand,
     ChatCommand,

--- a/src/poly/cli_commands/metrics.py
+++ b/src/poly/cli_commands/metrics.py
@@ -1,0 +1,486 @@
+"""Metrics command family: list, add, edit, and import custom metrics.
+
+Copyright PolyAI Limited
+"""
+
+import logging
+import os
+import sys
+from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
+
+from ruamel.yaml import YAML, YAMLError
+
+from poly.cli_commands.base import BaseCommand, Parents
+from poly.cli_commands.shared import load_project
+from poly.handlers.interface import AgentStudioInterface
+from poly.output.console import error, plain, print_metrics, success, warning
+from poly.output.json_output import json_print
+
+logger = logging.getLogger(__name__)
+
+VALID_METRIC_TYPES = ["string", "int", "bool", "float"]
+
+
+def _parse_bool_flag(value: str) -> bool:
+    """Convert a string flag value to a boolean."""
+    if value.lower() in ("true", "1", "yes"):
+        return True
+    if value.lower() in ("false", "0", "no"):
+        return False
+    raise ValueError(f"Invalid boolean value: {value!r}. Use true/false.")
+
+
+class MetricsCommand(BaseCommand):
+    """Manage custom metrics in the Agent Studio project."""
+
+    command = "metrics"
+
+    @classmethod
+    def add_arguments(cls, subparsers: _SubParsersAction[ArgumentParser], parents: Parents) -> None:
+        """Register the ``metrics`` subcommand tree."""
+        metrics_parser = subparsers.add_parser(
+            "metrics",
+            parents=[parents.verbose],
+            help="Manage custom metrics in the Agent Studio project.",
+            description=(
+                "Manage custom metrics in the Agent Studio project.\n\n"
+                "Examples:\n"
+                "  poly metrics list\n"
+                "  poly metrics add --name SCORE --type int --description 'CSAT Score'\n"
+                "  poly metrics edit CSAT_OFFERED --no-active\n"
+                "  poly metrics import metrics.yaml"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        metrics_subparsers = metrics_parser.add_subparsers(dest="metrics_subcommand", required=True)
+
+        metrics_subparsers.add_parser(
+            "list",
+            parents=[parents.path, parents.json],
+            help="List all custom metrics in the project.",
+            description="List all custom metrics for the current project.",
+            formatter_class=RawTextHelpFormatter,
+        )
+
+        export_parser = metrics_subparsers.add_parser(
+            "export",
+            parents=[parents.path, parents.json],
+            help="Export all custom metrics as YAML.",
+            description=(
+                "Export all custom metrics as YAML.\n\n"
+                "Examples:\n"
+                "  poly metrics export\n"
+                "  poly metrics export metrics.yaml\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        export_parser.add_argument(
+            "file",
+            nargs="?",
+            default=None,
+            type=str,
+            help="Output file path. Prints to stdout when omitted.",
+        )
+
+        add_parser = metrics_subparsers.add_parser(
+            "add",
+            parents=[parents.path, parents.json],
+            help="Create a new custom metric.",
+            description=(
+                "Create a new custom metric. Required fields prompt\n"
+                "interactively when omitted.\n\n"
+                "Examples:\n"
+                "  poly metrics add --name CALL_DURATION --type int"
+                " --description 'Duration in seconds'\n"
+                "  poly metrics add  # interactive mode\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        add_parser.add_argument(
+            "--name",
+            type=str,
+            help="Metric name.",
+        )
+        add_parser.add_argument(
+            "--type",
+            type=str,
+            dest="metric_type",
+            choices=VALID_METRIC_TYPES,
+            help="Metric value type: string, int, bool, or float.",
+        )
+        add_parser.add_argument(
+            "--description",
+            type=str,
+            default=None,
+            help="Optional description for the metric.",
+        )
+        add_parser.add_argument(
+            "--api",
+            action="store_true",
+            default=False,
+            help="Mark as an API metric.",
+        )
+        add_parser.add_argument(
+            "--expected-values",
+            type=str,
+            nargs="+",
+            default=None,
+            help="Expected values (only valid for string type).",
+        )
+
+        edit_parser = metrics_subparsers.add_parser(
+            "edit",
+            parents=[parents.path, parents.json],
+            help="Update an existing custom metric.",
+            description=(
+                "Update an existing custom metric. At least one flag required.\n\n"
+                "Examples:\n"
+                "  poly metrics edit CARRIER_ID --description 'Carrier handling the shipment'\n"
+                "  poly metrics edit CSAT_OFFERED --active false\n"
+                "  poly metrics edit SCORE --api\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        edit_parser.add_argument(
+            "name",
+            type=str,
+            help="Name of the metric to edit.",
+        )
+        edit_parser.add_argument(
+            "--description",
+            type=str,
+            default=None,
+            help="New description for the metric.",
+        )
+        edit_parser.add_argument(
+            "--api",
+            type=_parse_bool_flag,
+            nargs="?",
+            const=True,
+            default=None,
+            help="Set API flag (true/false). Omit value to set true.",
+        )
+        edit_parser.add_argument(
+            "--active",
+            type=_parse_bool_flag,
+            nargs="?",
+            const=True,
+            default=None,
+            help="Set active state (true/false). Omit value to set true.",
+        )
+        edit_parser.add_argument(
+            "--expected-values",
+            type=str,
+            nargs="+",
+            default=None,
+            help="Expected values (only valid for string type).",
+        )
+
+        import_parser = metrics_subparsers.add_parser(
+            "import",
+            parents=[parents.path, parents.json],
+            help="Bulk-import metrics from a YAML file.",
+            description=(
+                "Bulk-import metrics from a YAML file. Creates metrics that\n"
+                "don't already exist and skips those that do. Never deletes.\n\n"
+                "Examples:\n"
+                "  poly metrics import metrics.yaml\n"
+                "  poly metrics import metrics.yaml --dry-run\n"
+            ),
+            formatter_class=RawTextHelpFormatter,
+        )
+        import_parser.add_argument(
+            "file",
+            type=str,
+            help="Path to the YAML file to import.",
+        )
+        import_parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Preview what would be created/skipped without making changes.",
+        )
+
+    @classmethod
+    def run(cls, args: Namespace) -> None:
+        """Dispatch to the matching metrics sub-handler."""
+        if args.metrics_subcommand == "list":
+            cls.metrics_list(args.path, output_json=args.json)
+        elif args.metrics_subcommand == "export":
+            cls.metrics_export(args.path, file_path=args.file, output_json=args.json)
+        elif args.metrics_subcommand == "add":
+            cls.metrics_add(
+                args.path,
+                name=args.name,
+                metric_type=args.metric_type,
+                description=args.description,
+                api=args.api,
+                expected_values=args.expected_values,
+                output_json=args.json,
+            )
+        elif args.metrics_subcommand == "edit":
+            cls.metrics_edit(
+                args.path,
+                name=args.name,
+                description=args.description,
+                api=args.api,
+                active=args.active,
+                expected_values=args.expected_values,
+                output_json=args.json,
+            )
+        elif args.metrics_subcommand == "import":
+            cls.metrics_import(
+                args.path,
+                file_path=args.file,
+                dry_run=args.dry_run,
+                output_json=args.json,
+            )
+
+    @classmethod
+    def metrics_list(cls, base_path: str, output_json: bool = False) -> None:
+        """List all custom metrics for the project."""
+        project = load_project(base_path, output_json=output_json)
+        metrics = AgentStudioInterface.get_custom_metrics(
+            project.region, project.account_id, project.project_id
+        )
+
+        if output_json:
+            json_print(metrics)
+        else:
+            print_metrics(metrics)
+
+    @classmethod
+    def metrics_export(
+        cls,
+        base_path: str,
+        file_path: str | None = None,
+        output_json: bool = False,
+    ) -> None:
+        """Export all custom metrics as YAML."""
+        project = load_project(base_path, output_json=output_json)
+        metrics = AgentStudioInterface.export_custom_metrics(
+            project.region, project.account_id, project.project_id
+        )
+
+        if output_json:
+            json_print(metrics)
+            return
+
+        ry = YAML()
+        if file_path:
+            with open(file_path, "w") as f:
+                ry.dump(metrics, f)
+            success(f"Exported metrics to {file_path}")
+        else:
+            ry.dump(metrics, sys.stdout)
+
+    @classmethod
+    def metrics_add(
+        cls,
+        base_path: str,
+        name: str | None = None,
+        metric_type: str | None = None,
+        description: str | None = None,
+        api: bool = False,
+        expected_values: list[str] | None = None,
+        output_json: bool = False,
+    ) -> None:
+        """Create a new custom metric."""
+        project = load_project(base_path, output_json=output_json)
+
+        if name is None:
+            if output_json:
+                json_print({"success": False, "error": "--name is required when using --json."})
+                sys.exit(1)
+            import questionary
+
+            name = questionary.text("Metric name:").ask()
+            if name is None:
+                sys.exit(1)
+            name = name.strip()
+            if not name:
+                error("Metric name is required.")
+                sys.exit(1)
+
+        if metric_type is None:
+            if output_json:
+                json_print({"success": False, "error": "--type is required when using --json."})
+                sys.exit(1)
+            import questionary
+
+            metric_type = questionary.select("Metric type:", choices=VALID_METRIC_TYPES).ask()
+            if metric_type is None:
+                sys.exit(1)
+
+        if description is None and not output_json:
+            import questionary
+
+            desc = questionary.text("Description (optional):").ask()
+            if desc is None:
+                sys.exit(1)
+            description = desc.strip() or None
+
+        if api is False and not output_json:
+            import questionary
+
+            api_result = questionary.confirm("API metric?", default=False).ask()
+            if api_result is None:
+                sys.exit(1)
+            api = api_result
+
+        data: dict = {"name": name, "type": metric_type}
+        if description:
+            data["description"] = description
+        if api:
+            data["api"] = True
+        if expected_values:
+            data["expected_values"] = expected_values
+
+        result = AgentStudioInterface.create_custom_metric(
+            project.region, project.account_id, project.project_id, data
+        )
+
+        if output_json:
+            json_print({"success": True, "metric": result})
+        else:
+            success(f"Created metric {name} ({metric_type})")
+
+    @classmethod
+    def metrics_edit(
+        cls,
+        base_path: str,
+        name: str,
+        description: str | None = None,
+        api: bool | None = None,
+        active: bool | None = None,
+        expected_values: list[str] | None = None,
+        output_json: bool = False,
+    ) -> None:
+        """Update an existing custom metric."""
+        project = load_project(base_path, output_json=output_json)
+
+        data: dict = {}
+        if description is not None:
+            data["description"] = description
+        if api is not None:
+            data["api"] = api
+        if active is not None:
+            data["active"] = active
+        if expected_values is not None:
+            data["expected_values"] = expected_values
+
+        if not data:
+            msg = "At least one flag is required (--description, --api, --active, etc.)."
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        result = AgentStudioInterface.update_custom_metric(
+            project.region, project.account_id, project.project_id, name, data
+        )
+
+        if output_json:
+            json_print({"success": True, "metric": result})
+        else:
+            if data.get("active") is False:
+                success(f"Deactivated metric {name}")
+            else:
+                success(f"Updated metric {name}")
+
+    @classmethod
+    def metrics_import(
+        cls,
+        base_path: str,
+        file_path: str,
+        dry_run: bool = False,
+        output_json: bool = False,
+    ) -> None:
+        """Bulk-import metrics from a YAML file."""
+        project = load_project(base_path, output_json=output_json)
+
+        if not os.path.exists(file_path):
+            msg = f"File not found: {file_path}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        with open(file_path) as f:
+            yaml_content = f.read()
+
+        try:
+            ry = YAML()
+            local_metrics = ry.load(yaml_content) or {}
+        except YAMLError as e:
+            msg = f"Invalid YAML: {e}"
+            if output_json:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
+        local_names = set(local_metrics.keys())
+
+        preview = AgentStudioInterface.preview_metrics_import(
+            project.region, project.account_id, project.project_id, local_names
+        )
+
+        if dry_run:
+            cls._print_dry_run(preview, output_json)
+            return
+
+        # Warn about metrics not in the file
+        if preview["remote_only"] and not output_json:
+            warning(
+                f"Metrics on remote but not in file (not deleted):"
+                f" {', '.join(preview['remote_only'])}"
+            )
+
+        import_result = AgentStudioInterface.import_custom_metrics(
+            project.region,
+            project.account_id,
+            project.project_id,
+            yaml_content,
+            dry_run=False,
+        )
+
+        if output_json:
+            json_print({"success": True, **import_result})
+        else:
+            metadata = import_result.get("metadata", {})
+            created = metadata.get("created", [])
+            ignored = metadata.get("ignored", [])
+
+            if created:
+                plain(f"Created: {', '.join(created)}")
+            if ignored:
+                plain(f"Skipped (already exist): {', '.join(ignored)}")
+
+            created_count = len(created)
+            skipped_count = len(ignored)
+            success(f"Imported {created_count} metrics ({skipped_count} skipped)")
+
+    # Helper function
+
+    @staticmethod
+    def _print_dry_run(
+        preview: dict[str, list[str]],
+        output_json: bool,
+    ) -> None:
+        """Display the results of a dry-run import."""
+        if output_json:
+            json_print({"dry_run": True, **preview})
+        else:
+            plain("[dim]Dry run — no changes will be made.[/dim]")
+            if preview["would_create"]:
+                plain(f"Would create: {', '.join(preview['would_create'])}")
+            if preview["would_skip"]:
+                plain(f"Would skip (already exist): {', '.join(preview['would_skip'])}")
+            if preview["remote_only"]:
+                warning(
+                    f"Metrics on remote but not in file (will NOT be deleted):"
+                    f" {', '.join(preview['remote_only'])}"
+                )

--- a/src/poly/cli_commands/metrics.py
+++ b/src/poly/cli_commands/metrics.py
@@ -340,6 +340,12 @@ class MetricsCommand(BaseCommand):
             project.region, project.account_id, project.project_id, data
         )
 
+        # The server ignores the api flag on create, so follow up with an edit
+        if api:
+            result = AgentStudioInterface.update_custom_metric(
+                project.region, project.account_id, project.project_id, name, {"api": True}
+            )
+
         if output_json:
             json_print({"success": True, "metric": result})
         else:

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1097,3 +1097,142 @@ class AgentStudioInterface:
             dict: The created test run response.
         """
         return PlatformAPIHandler.trigger_test_run(region, project_id, test_case_ids, branch_id)
+
+    @staticmethod
+    def get_custom_metrics(
+        region: str,
+        account_id: str,
+        project_id: str,
+    ) -> list[dict]:
+        """List all custom metrics for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            list[dict]: List of custom metric records.
+        """
+        return PlatformAPIHandler.get_custom_metrics(region, account_id, project_id)
+
+    @staticmethod
+    def create_custom_metric(
+        region: str,
+        account_id: str,
+        project_id: str,
+        data: dict,
+    ) -> dict:
+        """Create a new custom metric.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            data: Metric payload — name, type, description, expected_values, api.
+
+        Returns:
+            dict: The created metric record.
+        """
+        return PlatformAPIHandler.create_custom_metric(region, account_id, project_id, data)
+
+    @staticmethod
+    def update_custom_metric(
+        region: str,
+        account_id: str,
+        project_id: str,
+        metric_name: str,
+        data: dict,
+    ) -> dict:
+        """Update an existing custom metric.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            metric_name: Name of the metric to update.
+            data: Fields to update — description, expected_values, active, api.
+
+        Returns:
+            dict: The updated metric record.
+        """
+        return PlatformAPIHandler.update_custom_metric(
+            region, account_id, project_id, metric_name, data
+        )
+
+    @staticmethod
+    def export_custom_metrics(
+        region: str,
+        account_id: str,
+        project_id: str,
+    ) -> dict:
+        """Export all custom metrics as a YAML-parsed dict.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            dict: Mapping of metric name to metric definition.
+        """
+        return PlatformAPIHandler.export_custom_metrics(region, account_id, project_id)
+
+    @staticmethod
+    def preview_metrics_import(
+        region: str,
+        account_id: str,
+        project_id: str,
+        local_metric_names: set[str],
+    ) -> dict[str, list[str]]:
+        """Fetch remote metrics and compute what an import would do.
+
+        Compares the local metric names against the remote set to determine
+        which metrics would be created, skipped, or exist only on the remote.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            local_metric_names: Set of metric names from the local YAML file.
+
+        Returns:
+            dict with keys ``would_create``, ``would_skip``, and ``remote_only``,
+            each a sorted list of metric names.
+        """
+        remote_metrics = PlatformAPIHandler.get_custom_metrics(region, account_id, project_id)
+        remote_names = {m["name"] for m in remote_metrics if "name" in m}
+
+        would_create = local_metric_names - remote_names
+        would_skip = local_metric_names & remote_names
+        remote_only = remote_names - local_metric_names
+
+        return {
+            "would_create": sorted(would_create),
+            "would_skip": sorted(would_skip),
+            "remote_only": sorted(remote_only),
+        }
+
+    @staticmethod
+    def import_custom_metrics(
+        region: str,
+        account_id: str,
+        project_id: str,
+        yaml_content: str,
+        dry_run: bool = False,
+    ) -> dict:
+        """Bulk-import custom metrics from YAML content.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            yaml_content: Raw YAML string with metric definitions.
+            dry_run: If True, preview changes without applying.
+
+        Returns:
+            dict: Import result with metadata.created and metadata.ignored.
+        """
+        return PlatformAPIHandler.import_custom_metrics(
+            region, account_id, project_id, yaml_content, dry_run
+        )

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -3,6 +3,7 @@
 Copyright PolyAI Limited
 """
 
+import io
 import json
 import logging
 import typing as ty
@@ -30,6 +31,16 @@ CHAT_END_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/chat/{conver
 AB_TESTS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests"
 AB_TEST_ACTIVE_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/active"
 AB_TEST_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/ab-tests/{ab_test_id}"
+CUSTOM_METRICS_URL = "/adk/v1/accounts/{account_id}/projects/{project_id}/custom-metrics"
+CUSTOM_METRIC_URL = (
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/custom-metrics/{metric_name}"
+)
+CUSTOM_METRICS_EXPORT_URL = (
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/custom-metrics/export"
+)
+CUSTOM_METRICS_IMPORT_URL = (
+    "/adk/v1/accounts/{account_id}/projects/{project_id}/custom-metrics/import"
+)
 # These use public APIs not /adk endpoints
 PROMOTE_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/promote"
 ROLLBACK_URL = "/v1/agents/{project_id}/deployments/{deployment_id}/rollback"
@@ -1065,3 +1076,108 @@ class PlatformAPIHandler:
             "branchId": branch_id,
         }
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def export_custom_metrics(region: str, account_id: str, project_id: str) -> dict:
+        """Export all custom metrics for a project as a YAML-parsed dict.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            dict: Mapping of metric name to metric definition.
+        """
+        endpoint = CUSTOM_METRICS_EXPORT_URL.format(account_id=account_id, project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "GET", response_format="yaml")
+
+    @staticmethod
+    def get_custom_metrics(region: str, account_id: str, project_id: str) -> list[dict]:
+        """List all custom metrics for a project.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+
+        Returns:
+            list[dict]: List of custom metric records.
+        """
+        endpoint = CUSTOM_METRICS_URL.format(account_id=account_id, project_id=project_id)
+        result = PlatformAPIHandler.make_request(region, endpoint, "GET")
+        if isinstance(result, list):
+            return result
+        return result.get("metrics", result.get("data", []))
+
+    @staticmethod
+    def create_custom_metric(region: str, account_id: str, project_id: str, data: dict) -> dict:
+        """Create a new custom metric.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            data: Metric payload — name, type, description, expected_values, api.
+
+        Returns:
+            dict: The created metric record.
+        """
+        endpoint = CUSTOM_METRICS_URL.format(account_id=account_id, project_id=project_id)
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
+
+    @staticmethod
+    def update_custom_metric(
+        region: str,
+        account_id: str,
+        project_id: str,
+        metric_name: str,
+        data: dict,
+    ) -> dict:
+        """Update an existing custom metric.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            metric_name: Name of the metric to update.
+            data: Fields to update — description, expected_values, active, api.
+
+        Returns:
+            dict: The updated metric record.
+        """
+        endpoint = CUSTOM_METRIC_URL.format(
+            account_id=account_id, project_id=project_id, metric_name=metric_name
+        )
+        return PlatformAPIHandler.make_request(region, endpoint, "PATCH", data=data)
+
+    @staticmethod
+    def import_custom_metrics(
+        region: str,
+        account_id: str,
+        project_id: str,
+        yaml_content: str,
+        dry_run: bool = False,
+    ) -> dict:
+        """Bulk-import custom metrics from YAML content.
+
+        Args:
+            region: The region name.
+            account_id: The account ID.
+            project_id: The project ID.
+            yaml_content: Raw YAML string with metric definitions.
+            dry_run: If True, preview changes without applying.
+
+        Returns:
+            dict: Import result with metadata.created and metadata.ignored.
+        """
+        endpoint = CUSTOM_METRICS_IMPORT_URL.format(account_id=account_id, project_id=project_id)
+        params = {"type": "yaml", "dry_run": str(dry_run).lower()}
+        files = {
+            "yaml": (
+                "metrics.yaml",
+                io.BytesIO(yaml_content.encode("utf-8")),
+                "application/x-yaml",
+            )
+        }
+        return PlatformAPIHandler.make_request(region, endpoint, "POST", params=params, files=files)

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -10,6 +10,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import requests
+from ruamel.yaml import YAML
 
 from poly.constants import DEFAULT_VOICE_ID_FALLBACK, DEFAULT_VOICE_IDS
 from poly.utils import any_credentials_exist, retrieve_api_key
@@ -91,19 +92,28 @@ class PlatformAPIHandler:
         data: ty.Optional[dict] = None,
         params: ty.Optional[dict] = None,
         headers: ty.Optional[dict] = None,
+        files: ty.Optional[dict] = None,
+        response_format: str = "json",
         use_jupiter_api: bool = False,
     ) -> dict:
         """Make a request to the Platform API.
 
         Args:
-            region (str): The region name
-            endpoint (str): The API endpoint
-            method (str): The HTTP method
-            data (dict | None): The request body for POST/PUT requests
-            params (dict | None): Query string parameters
+            region (str): The region name.
+            endpoint (str): The API endpoint.
+            method (str): The HTTP method.
+            data (dict | None): The request body for POST/PUT requests.
+            params (dict | None): Query string parameters.
+            headers (dict | None): Override headers. Built automatically when None.
+            files (dict | None): Multipart file upload fields. When set, ``data``
+                is ignored and ``Content-Type`` is omitted so ``requests`` can set
+                the multipart boundary automatically.
+            response_format (str): How to parse the response. "json" (default)
+                or "yaml".
+            use_jupiter_api (bool): Whether to use the Jupiter API.
 
         Returns:
-            dict: The response JSON
+            dict: The parsed response.
         """
         url = PlatformAPIHandler.get_base_url(region, use_jupiter_api) + endpoint
         correlation_id = f"adk-{uuid.uuid4()}"
@@ -112,9 +122,10 @@ class PlatformAPIHandler:
             headers = {
                 "X-API-KEY": retrieve_api_key(region),
                 "X-PolyAI-Correlation-Id": correlation_id,
-                "Content-Type": "application/json",
                 "X-Poly-Source": "adk",
             }
+            if not files:
+                headers["Content-Type"] = "application/json"
 
         logger.info(f"Making {method} request to {url}")
 
@@ -125,7 +136,8 @@ class PlatformAPIHandler:
             headers=headers,
             params=params,
             allow_redirects=False,
-            data=json.dumps(data) if data else None,
+            files=files,
+            data=json.dumps(data) if data and not files else None,
         )
 
         logger.debug(
@@ -137,7 +149,8 @@ class PlatformAPIHandler:
             api_response.raise_for_status()
         except requests.HTTPError:
             logger.debug(
-                f"Error in request status_code={api_response.status_code!r} response={api_response.text!r}"
+                f"Error in request status_code={api_response.status_code!r}"
+                f" response={api_response.text!r}"
             )
             raise
 
@@ -145,13 +158,21 @@ class PlatformAPIHandler:
             logger.info(f"Request to {url} successful (no content)")
             return {}
 
+        if response_format == "yaml":
+            content = api_response.text.strip()
+            if not content:
+                return {}
+            ry = YAML()
+            result = ry.load(content)
+            return dict(result) if result else {}
+
         try:
-            api_response = api_response.json()
+            parsed = api_response.json()
         except json.JSONDecodeError as e:
             raise ValueError(f"Failed to parse JSON response: {e}")
 
         logger.info(f"Request to {url} successful")
-        return api_response
+        return parsed
 
     @staticmethod
     def get_accessible_regions(regions: list[str]) -> list[str]:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -136,6 +136,46 @@ def print_agents(agents: list[dict[str, Any]]) -> None:
     console.print(table)
 
 
+def print_metrics(metrics: list[dict[str, Any]]) -> None:
+    """Print a table of custom metrics.
+
+    Args:
+        metrics: List of metric dicts from the API.
+    """
+    if not metrics:
+        plain("No metrics found.")
+        return
+
+    table = Table(box=None, show_header=True, header_style="bold", padding=(0, 1))
+    table.add_column("Name", style="bold yellow", no_wrap=True)
+    table.add_column("Type", no_wrap=True)
+    table.add_column("Active", no_wrap=True)
+    table.add_column("API", no_wrap=True)
+    table.add_column("Description", max_width=50)
+
+    active_count = 0
+    inactive_count = 0
+    for m in metrics:
+        is_active = m.get("active", True)
+        if is_active:
+            active_count += 1
+        else:
+            inactive_count += 1
+
+        desc = m.get("description", "") or ""
+
+        table.add_row(
+            m.get("name", "—"),
+            m.get("type", "—"),
+            "✓" if is_active else "✗",
+            "✓" if m.get("api", False) else "✗",
+            desc,
+        )
+
+    console.print(table)
+    console.print(f"\n{len(metrics)} metrics ({active_count} active, {inactive_count} inactive)")
+
+
 def print_branches(branches: dict[str, str] | list[str], current_branch: str | None) -> None:
     """Print branch list with current branch highlighted."""
     console.print("[label]Branches:[/label]")

--- a/src/poly/tests/metrics_test.py
+++ b/src/poly/tests/metrics_test.py
@@ -1,0 +1,503 @@
+"""Tests for the metrics CLI commands.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from poly.cli_commands.metrics import VALID_METRIC_TYPES, MetricsCommand, _parse_bool_flag
+
+
+class ParseBoolFlagTest(unittest.TestCase):
+    """Tests for _parse_bool_flag helper."""
+
+    def test_true_values(self):
+        """Accepts 'true', '1', 'yes' (case-insensitive) as True."""
+        for val in ("true", "True", "TRUE", "1", "yes", "Yes", "YES"):
+            self.assertTrue(_parse_bool_flag(val), f"Expected True for {val!r}")
+
+    def test_false_values(self):
+        """Accepts 'false', '0', 'no' (case-insensitive) as False."""
+        for val in ("false", "False", "FALSE", "0", "no", "No", "NO"):
+            self.assertFalse(_parse_bool_flag(val), f"Expected False for {val!r}")
+
+    def test_invalid_value_raises(self):
+        """Raises ValueError for unrecognized strings."""
+        with self.assertRaises(ValueError) as ctx:
+            _parse_bool_flag("maybe")
+        self.assertIn("maybe", str(ctx.exception))
+
+    def test_empty_string_raises(self):
+        """Raises ValueError for an empty string."""
+        with self.assertRaises(ValueError):
+            _parse_bool_flag("")
+
+
+class MetricsListTest(unittest.TestCase):
+    """Tests for MetricsCommand.metrics_list."""
+
+    @patch("poly.cli_commands.metrics.print_metrics")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.get_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_list_calls_print_metrics(self, mock_load, mock_get, mock_print):
+        """metrics_list fetches metrics and prints them in table mode."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_get.return_value = [{"name": "SCORE", "type": "int"}]
+
+        MetricsCommand.metrics_list("/fake/path", output_json=False)
+
+        mock_get.assert_called_once_with("us", "acc1", "proj1")
+        mock_print.assert_called_once_with([{"name": "SCORE", "type": "int"}])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.get_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_list_json_output(self, mock_load, mock_get, mock_json):
+        """metrics_list uses json_print when output_json=True."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        metrics = [{"name": "SCORE"}]
+        mock_get.return_value = metrics
+
+        MetricsCommand.metrics_list("/fake/path", output_json=True)
+
+        mock_json.assert_called_once_with(metrics)
+
+
+class MetricsExportTest(unittest.TestCase):
+    """Tests for MetricsCommand.metrics_export."""
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.export_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_export_json_output(self, mock_load, mock_export, mock_json):
+        """In JSON mode, export passes the dict straight to json_print."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        data = {"SCORE": {"type": "int"}, "STATUS": {"type": "string"}}
+        mock_export.return_value = data
+
+        MetricsCommand.metrics_export("/fake/path", output_json=True)
+
+        mock_json.assert_called_once_with(data)
+
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.export_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_export_to_stdout(self, mock_load, mock_export):
+        """Without a file path, YAML is dumped to stdout."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_export.return_value = {"SCORE": {"type": "int"}}
+
+        with patch("poly.cli_commands.metrics.YAML") as mock_yaml_cls:
+            mock_ry = MagicMock()
+            mock_yaml_cls.return_value = mock_ry
+            MetricsCommand.metrics_export("/fake/path", file_path=None, output_json=False)
+
+            import sys
+
+            mock_ry.dump.assert_called_once_with({"SCORE": {"type": "int"}}, sys.stdout)
+
+    @patch("poly.cli_commands.metrics.success")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.export_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_export_to_file(self, mock_load, mock_export, mock_success):
+        """With a file path, YAML is written to file and success message shown."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_export.return_value = {"SCORE": {"type": "int"}}
+
+        with (
+            patch("poly.cli_commands.metrics.YAML") as mock_yaml_cls,
+            patch("builtins.open", unittest.mock.mock_open()) as mock_file,
+        ):
+            mock_ry = MagicMock()
+            mock_yaml_cls.return_value = mock_ry
+            MetricsCommand.metrics_export("/fake/path", file_path="out.yaml", output_json=False)
+
+            mock_file.assert_called_once_with("out.yaml", "w")
+            mock_ry.dump.assert_called_once()
+            mock_success.assert_called_once()
+            self.assertIn("out.yaml", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.export_custom_metrics")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_export_empty_metrics(self, mock_load, mock_export):
+        """Export with empty dict still dumps without error."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_export.return_value = {}
+
+        with patch("poly.cli_commands.metrics.YAML") as mock_yaml_cls:
+            mock_ry = MagicMock()
+            mock_yaml_cls.return_value = mock_ry
+            MetricsCommand.metrics_export("/fake/path", output_json=False)
+
+            mock_ry.dump.assert_called_once_with({}, unittest.mock.ANY)
+
+
+class MetricsAddTest(unittest.TestCase):
+    """Tests for MetricsCommand.metrics_add."""
+
+    @patch("poly.cli_commands.metrics.success")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.create_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_with_all_args(self, mock_load, mock_create, mock_update, mock_success):
+        """Non-interactive add passes all fields to create_custom_metric."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_create.return_value = {"name": "SCORE", "type": "int"}
+        mock_update.return_value = {"name": "SCORE", "type": "int", "api": True}
+
+        MetricsCommand.metrics_add(
+            "/fake/path",
+            name="SCORE",
+            metric_type="int",
+            description="CSAT Score",
+            api=True,
+            expected_values=None,
+            output_json=False,
+        )
+
+        mock_create.assert_called_once_with(
+            "us",
+            "acc1",
+            "proj1",
+            {"name": "SCORE", "type": "int", "description": "CSAT Score", "api": True},
+        )
+        mock_update.assert_called_once_with("us", "acc1", "proj1", "SCORE", {"api": True})
+        mock_success.assert_called_once()
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.create_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_without_api_skips_update(self, mock_load, mock_create, mock_update, mock_json):
+        """When api=False, no follow-up update call is made."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_create.return_value = {"name": "SCORE", "type": "int"}
+
+        MetricsCommand.metrics_add(
+            "/fake/path",
+            name="SCORE",
+            metric_type="int",
+            api=False,
+            output_json=True,
+        )
+
+        mock_create.assert_called_once()
+        mock_update.assert_not_called()
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.create_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_passes_expected_values(self, mock_load, mock_create, mock_json):
+        """Expected values are included in the data dict when provided."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_create.return_value = {}
+
+        MetricsCommand.metrics_add(
+            "/fake/path",
+            name="STATUS",
+            metric_type="string",
+            description=None,
+            api=False,
+            expected_values=["open", "closed"],
+            output_json=True,
+        )
+
+        data = mock_create.call_args[0][3]
+        self.assertEqual(data["expected_values"], ["open", "closed"])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_json_error_when_name_missing(self, mock_load, mock_json):
+        """In JSON mode, missing --name prints an error and exits."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit) as ctx:
+            MetricsCommand.metrics_add(
+                "/fake/path",
+                name=None,
+                metric_type="int",
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_json.assert_called_once()
+        printed = mock_json.call_args[0][0]
+        self.assertFalse(printed["success"])
+        self.assertIn("--name", printed["error"])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_json_error_when_type_missing(self, mock_load, mock_json):
+        """In JSON mode, missing --type prints an error and exits."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit) as ctx:
+            MetricsCommand.metrics_add(
+                "/fake/path",
+                name="SCORE",
+                metric_type=None,
+                output_json=True,
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        printed = mock_json.call_args[0][0]
+        self.assertIn("--type", printed["error"])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.create_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_add_json_output_on_success(self, mock_load, mock_create, mock_json):
+        """In JSON mode, successful add prints success with the metric."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        result = {"name": "SCORE", "type": "int"}
+        mock_create.return_value = result
+
+        MetricsCommand.metrics_add(
+            "/fake/path",
+            name="SCORE",
+            metric_type="int",
+            output_json=True,
+        )
+
+        mock_json.assert_called_once_with({"success": True, "metric": result})
+
+
+class MetricsEditTest(unittest.TestCase):
+    """Tests for MetricsCommand.metrics_edit."""
+
+    @patch("poly.cli_commands.metrics.success")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_with_description(self, mock_load, mock_update, mock_success):
+        """Editing description passes it through to update_custom_metric."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_update.return_value = {}
+
+        MetricsCommand.metrics_edit(
+            "/fake/path", name="SCORE", description="New desc", output_json=False
+        )
+
+        mock_update.assert_called_once_with(
+            "us", "acc1", "proj1", "SCORE", {"description": "New desc"}
+        )
+
+    @patch("poly.cli_commands.metrics.success")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_deactivate_metric(self, mock_load, mock_update, mock_success):
+        """Setting active=False prints 'Deactivated' message."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_update.return_value = {}
+
+        MetricsCommand.metrics_edit("/fake/path", name="SCORE", active=False, output_json=False)
+
+        mock_update.assert_called_once_with("us", "acc1", "proj1", "SCORE", {"active": False})
+        mock_success.assert_called_once()
+        self.assertIn("Deactivated", mock_success.call_args[0][0])
+
+    @patch("poly.cli_commands.metrics.success")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_multiple_flags(self, mock_load, mock_update, mock_success):
+        """Multiple flags are combined into one update call."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_update.return_value = {}
+
+        MetricsCommand.metrics_edit(
+            "/fake/path",
+            name="SCORE",
+            description="Updated",
+            api=True,
+            active=True,
+            output_json=False,
+        )
+
+        data = mock_update.call_args[0][4]
+        self.assertEqual(data["description"], "Updated")
+        self.assertTrue(data["api"])
+        self.assertTrue(data["active"])
+
+    @patch("poly.cli_commands.metrics.error")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_no_flags_exits(self, mock_load, mock_error):
+        """Exits with error when no update flags are provided."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit) as ctx:
+            MetricsCommand.metrics_edit("/fake/path", name="SCORE", output_json=False)
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_no_flags_json_exits(self, mock_load, mock_json):
+        """In JSON mode, no flags prints error JSON and exits."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit):
+            MetricsCommand.metrics_edit("/fake/path", name="SCORE", output_json=True)
+
+        printed = mock_json.call_args[0][0]
+        self.assertFalse(printed["success"])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.update_custom_metric")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_edit_json_output(self, mock_load, mock_update, mock_json):
+        """In JSON mode, successful edit prints success with the metric."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        result = {"name": "SCORE", "active": True}
+        mock_update.return_value = result
+
+        MetricsCommand.metrics_edit("/fake/path", name="SCORE", active=True, output_json=True)
+
+        mock_json.assert_called_once_with({"success": True, "metric": result})
+
+
+class MetricsImportTest(unittest.TestCase):
+    """Tests for MetricsCommand.metrics_import."""
+
+    @patch("poly.cli_commands.metrics.error")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_import_file_not_found(self, mock_load, mock_error):
+        """Exits with error when the import file does not exist."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit) as ctx:
+            MetricsCommand.metrics_import(
+                "/fake/path", file_path="/nonexistent/metrics.yaml", output_json=False
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        mock_error.assert_called_once()
+        self.assertIn("File not found", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.metrics.json_print")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_import_file_not_found_json(self, mock_load, mock_json):
+        """In JSON mode, missing file prints error JSON and exits."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit):
+            MetricsCommand.metrics_import(
+                "/fake/path", file_path="/nonexistent/metrics.yaml", output_json=True
+            )
+
+        printed = mock_json.call_args[0][0]
+        self.assertFalse(printed["success"])
+
+    @patch("builtins.open", unittest.mock.mock_open(read_data="{{invalid"))
+    @patch("os.path.exists", return_value=True)
+    @patch("poly.cli_commands.metrics.error")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_import_invalid_yaml(self, mock_load, mock_error, mock_exists):
+        """Exits with error when YAML parsing fails."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+
+        with self.assertRaises(SystemExit) as ctx:
+            MetricsCommand.metrics_import("/fake/path", file_path="bad.yaml", output_json=False)
+
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch("builtins.open", unittest.mock.mock_open(read_data="SCORE:\n  type: int\n"))
+    @patch("os.path.exists", return_value=True)
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.import_custom_metrics")
+    @patch("poly.cli_commands.metrics.AgentStudioInterface.preview_metrics_import")
+    @patch("poly.cli_commands.metrics.load_project")
+    def test_import_success(self, mock_load, mock_preview, mock_import, mock_exists):
+        """Successful import calls import_custom_metrics and prints summary."""
+        project = MagicMock(region="us", account_id="acc1", project_id="proj1")
+        mock_load.return_value = project
+        mock_preview.return_value = {"remote_only": []}
+        mock_import.return_value = {
+            "metadata": {"created": ["SCORE"], "ignored": []},
+        }
+
+        with patch("poly.cli_commands.metrics.success"), patch("poly.cli_commands.metrics.plain"):
+            MetricsCommand.metrics_import("/fake/path", file_path="metrics.yaml", output_json=False)
+
+        mock_import.assert_called_once()
+        # Verify dry_run=False was passed
+        self.assertFalse(mock_import.call_args[1]["dry_run"])
+
+
+class PrintDryRunTest(unittest.TestCase):
+    """Tests for MetricsCommand._print_dry_run static method."""
+
+    @patch("poly.cli_commands.metrics.json_print")
+    def test_dry_run_json_output(self, mock_json):
+        """JSON dry-run output includes would_create, would_skip, remote_only."""
+        preview = {
+            "would_create": ["A", "C"],
+            "would_skip": ["B"],
+            "remote_only": ["D"],
+        }
+
+        MetricsCommand._print_dry_run(preview, output_json=True)
+
+        result = mock_json.call_args[0][0]
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["would_create"], ["A", "C"])
+        self.assertEqual(result["would_skip"], ["B"])
+        self.assertEqual(result["remote_only"], ["D"])
+
+    @patch("poly.cli_commands.metrics.warning")
+    @patch("poly.cli_commands.metrics.plain")
+    def test_dry_run_text_output(self, mock_plain, mock_warning):
+        """Text dry-run shows create, skip, and remote-only warnings."""
+        preview = {
+            "would_create": ["NEW_METRIC"],
+            "would_skip": ["EXISTING"],
+            "remote_only": ["REMOTE_ONLY"],
+        }
+
+        MetricsCommand._print_dry_run(preview, output_json=False)
+
+        calls = [c[0][0] for c in mock_plain.call_args_list]
+        self.assertTrue(any("Would create" in c for c in calls))
+        self.assertTrue(any("Would skip" in c for c in calls))
+        mock_warning.assert_called_once()
+
+    @patch("poly.cli_commands.metrics.plain")
+    def test_dry_run_empty_preview(self, mock_plain):
+        """With empty lists, only the dim header is printed."""
+        preview = {"would_create": [], "would_skip": [], "remote_only": []}
+
+        MetricsCommand._print_dry_run(preview, output_json=False)
+
+        # Only the dim header should be printed
+        self.assertEqual(mock_plain.call_count, 1)
+
+
+class ValidMetricTypesTest(unittest.TestCase):
+    """Tests for the VALID_METRIC_TYPES constant."""
+
+    def test_contains_expected_types(self):
+        """All expected metric types are present."""
+        self.assertEqual(VALID_METRIC_TYPES, ["string", "int", "bool", "float"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add `poly metrics` CLI commands for managing custom metrics in Agent Studio projects — list, export, add, edit, and bulk import from YAML.

## Motivation

Custom metrics are currently only manageable through the Agent Studio UI. This adds full CLI support so teams can script metric setup, export/import metric definitions across projects, and integrate metric management into CI pipelines.

Th

## Changes

### Commands

- **`poly metrics list`** — display all custom metrics in a Rich table (Name, Type, Active, API, Description) with active/inactive count summary; `--json` for machine-readable output
- **`poly metrics export [file]`** — export all metrics as YAML to stdout or a file; `--json` outputs JSON instead
- **`poly metrics add`** — create a new metric with `--name`, `--type`, `--description`, `--api`, `--expected-values`; omit required flags for interactive mode (name text input, type selector, description prompt, API confirm via `questionary`)
- **`poly metrics edit <name>`** — update an existing metric's `--description`, `--api` (bool), `--active` (bool), or `--expected-values`; `--api`/`--active` accept `true`/`false` or can be used bare to set `true`
- **`poly metrics import <file>`** — bulk-import metrics from a YAML file; creates new metrics and skips existing ones; `--dry-run` previews what would be created/skipped and warns about remote-only metrics that won't be deleted

### API flag workaround

The server's `create_custom_metric` route hardcodes `api=False`, ignoring the client-supplied value (the AS UI also doesn't set this on create). When `--api` is passed, under the hood the the CLI follows up with a PATCH to set `api=True`.

### Implementation notes

- Platform API: 5 new methods on `PlatformAPIHandler`; `make_request` extended with `files` (multipart upload) and `response_format` (YAML parsing) params . These were needed for import and export YAML as file handling only previously supported JSON.
- Interface: 6 static methods on `AgentStudioInterface` including `preview_metrics_import` which computes the set diff for dry-run
- Display: `print_metrics` in `console.py` renders the Rich table
- Tests: 30 unit tests across 8 test classes

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly metrics` for all subcommands)
- [x] Tested against a live Agent Studio project

**Manual test spreadsheet**: [Google Sheet](https://docs.google.com/spreadsheets/d/1ahhwLpTKTt_pApH7Z_oESQkX8ki-vj2GrHf2ABO75Zw/edit?gid=246662677#gid=246662677)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

### `poly metrics list`
<img width="565" height="296" alt="Screenshot 2026-07-31 at 15 06 03" src="https://github.com/user-attachments/assets/efc5dfb6-b3cb-4783-8bae-2d64c8173106" />

### `poly metrics add` (interactive)
<img width="294" height="87" alt="Screenshot 2026-08-04 at 16 53 09" src="https://github.com/user-attachments/assets/dc4d33ea-11c2-476b-8593-0bbd6f116857" />

### `poly metrics add` — API flag prompt
<img width="225" height="29" alt="Screenshot 2026-07-31 at 15 17 40" src="https://github.com/user-attachments/assets/d1ef1e1e-a0c0-453e-bc8e-069bd8f43c84" />

### `poly metrics add --expected-values` (JSON output)
<img width="358" height="230" alt="Screenshot 2026-07-31 at 15 21 57" src="https://github.com/user-attachments/assets/7d14753f-f65f-418c-ae30-92e5ab7e6582" />

### `poly metrics add --api` (JSON output)
<img width="358" height="178" alt="Screenshot 2026-07-31 at 15 30 58" src="https://github.com/user-attachments/assets/3f6e919f-db79-427d-98d6-1425238d4ce2" />
