### PR TITLE
fix: preserve non-ASCII characters when writing RTC JSON files

### DIFF
--- a/src/poly/cli_commands/rtc.py
+++ b/src/poly/cli_commands/rtc.py
@@ -19,7 +19,7 @@ from poly.utils import merge_rtc_dicts
 
 def _to_sorted_json(data: dict) -> str:
     """Serialize a dict to deterministically ordered JSON for merging."""
-    return json.dumps(data, indent=2, sort_keys=True) + "\n"
+    return json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
 
 def _merge_rtc_file(
@@ -624,7 +624,7 @@ class RTCCommand(BaseCommand):
             content = variables
             filename = "data.json"
 
-        content_str = json.dumps(content, indent=2, sort_keys=True) + "\n"
+        content_str = json.dumps(content, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
 
         try:
             edited_str = edit_in_editor(content_str, extension=".json", filename=filename)
@@ -796,8 +796,11 @@ def _print_change(change: dict) -> None:
     change_type = change["type"]
 
     if change_type == "added_locally":
-        info(f"    + {path}: {json.dumps(change['local'])}")
+        info(f"    + {path}: {json.dumps(change['local'], ensure_ascii=False)}")
     elif change_type == "only_remote":
-        info(f"    - {path}: {json.dumps(change['remote'])} (only on remote)")
+        info(f"    - {path}: {json.dumps(change['remote'], ensure_ascii=False)} (only on remote)")
     elif change_type == "changed":
-        info(f"    ~ {path}: {json.dumps(change['remote'])} → {json.dumps(change['local'])}")
+        info(
+            f"    ~ {path}: {json.dumps(change['remote'], ensure_ascii=False)} → "
+            f"{json.dumps(change['local'], ensure_ascii=False)}"
+        )

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -4,7 +4,9 @@ Copyright PolyAI Limited
 """
 
 import copy
+import tempfile
 import unittest
+from pathlib import Path
 
 import poly.resources.resource_utils as resource_utils
 from poly import utils
@@ -1082,6 +1084,23 @@ class FlowUtilsTests(unittest.TestCase):
         self.assertIsNone(flow_name_none)
 
     # TODO: Test assigning positions to flow steps
+
+
+class JsonIoTests(unittest.TestCase):
+    """Tests for JSON file read/write helpers."""
+
+    def test_write_json_file_preserves_unicode(self):
+        data = {"site_name": "Côte Barbican"}
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "data.json"
+            utils.write_json_file(str(path), data)
+
+            raw = path.read_text(encoding="utf-8")
+            self.assertIn("Côte Barbican", raw)
+            self.assertNotIn("\\u00f4", raw)
+
+            self.assertEqual(utils.read_json_file(str(path)), data)
 
 
 if __name__ == "__main__":

--- a/src/poly/utils/json_io.py
+++ b/src/poly/utils/json_io.py
@@ -11,7 +11,7 @@ from typing import Optional
 def write_json_file(path: str, data: object) -> None:
     """Write data as pretty-printed JSON with trailing newline."""
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2, sort_keys=True)
+        json.dump(data, f, indent=2, sort_keys=True, ensure_ascii=False)
         f.write("\n")
 
 


### PR DESCRIPTION
## Summary

`poly rtc pull` writes local `schema.json`/`data.json` files via `json.dump(..., indent=2, sort_keys=True)`, which defaults to `ensure_ascii=True`. Every non-ASCII character (e.g. `ô` in "Côte") gets escaped to `ô` even though the file is opened with `encoding="utf-8"`. The same issue affects `rtc edit`'s editor buffer and `rtc diff`'s console output.

Adds `ensure_ascii=False` to the JSON serialization calls in the RTC pull/edit/diff paths so files and terminal output contain the real UTF-8 characters.
<img width="531" height="338" alt="image" src="https://github.com/user-attachments/assets/cdaf8b42-5d8d-41e8-aa93-69cbbbd9d3e7" />

## Test Strategy

- [x] Unit test added: `JsonIoTests.test_write_json_file_preserves_unicode` in `src/poly/tests/utils_test.py`
- [x] Full test suite passes locally (`uv run pytest`, 995 passed)
- [x] `ruff check` / `ruff format --check` clean on changed files