### PR TITLE
fix: skip documents without readable contents

### DIFF
--- a/src/poly/resources/documents.py
+++ b/src/poly/resources/documents.py
@@ -129,12 +129,14 @@ class Document(Resource):
         for document_id, document_data in (
             projection.get("documents", {}).get("documents", {}).get("entities", {}).items()
         ):
+            if "contents" not in document_data:
+                continue
             path = document_data.get("path", "") or ""
             name = path.removesuffix(".md")
             documents[document_id] = Document(
                 resource_id=document_id,
                 name=name,
                 path=path,
-                contents=document_data.get("content", ""),
+                contents=document_data["contents"],
             )
         return documents

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -8330,6 +8330,50 @@ class DocumentTests(unittest.TestCase):
         self.assertEqual(doc_lower.file_path, doc_mixed.file_path)
 
 
+class DocumentFromProjection(unittest.TestCase):
+    """Tests for Document.from_projection."""
+
+    def test_parses_document_fields(self):
+        """Verify document name, path, and contents are parsed correctly."""
+        projection = {
+            "documents": {
+                "documents": {
+                    "entities": {
+                        "DOC-1": {
+                            "path": "faq.md",
+                            "contents": "Frequently asked questions",
+                        }
+                    }
+                }
+            }
+        }
+        documents = Document.from_projection(projection)
+        self.assertEqual(list(documents), ["DOC-1"])
+        document = documents["DOC-1"]
+        self.assertIsInstance(document, Document)
+        self.assertEqual(document.name, "faq")
+        self.assertEqual(document.contents, "Frequently asked questions")
+
+    def test_skips_document_without_contents(self):
+        """A document missing 'contents' means the user lacks read permission, so it's skipped."""
+        projection = {
+            "documents": {
+                "documents": {
+                    "entities": {
+                        "DOC-1": {"path": "unreadable.md"},
+                        "DOC-2": {"path": "readable.md", "contents": "visible"},
+                    }
+                }
+            }
+        }
+        documents = Document.from_projection(projection)
+        self.assertEqual(list(documents), ["DOC-2"])
+
+    def test_empty_projection_yields_no_documents(self):
+        """An empty projection should return an empty dict."""
+        self.assertEqual(Document.from_projection({}), {})
+
+
 class TopicFromProjection(unittest.TestCase):
     """Tests for Topic.from_projection."""
 


### PR DESCRIPTION
## Summary

Documents the current user lacks read permission for come back from the platform without a `contents` field. `Document.from_projection` now skips those entries instead of creating a `Document` with empty content.

## Motivation

Previously, a document missing `contents` in the projection was still materialized locally with an empty string, silently masking the fact that the user couldn't actually read it.

## Changes

- `Document.from_projection` skips entities that don't have a `contents` key
- Reads the field via `document_data["contents"]` directly (only reached once presence is confirmed)

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow conventional commits

## Screenshots / Logs

N/A