### PR TITLE
ci: make TruffleHog output actionable and drop the Lob false positive

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -20,9 +20,49 @@ jobs:
         fetch-depth: 0
 
     - name: Scan for secrets
+      id: scan
       uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
       with:
-        extra_args: --results=verified,unknown
+        # Tag as published on ghcr — no leading "v" (v3.96.0 is a 404 there,
+        # even though the action's own git tag does carry the v).
+        version: 3.96.0
+        # --exclude-detectors=lob: the Lob detector's pattern is
+        # `\b((live|test)_[a-zA-Z0-9_]{35})\b` with no keyword requirement, so it
+        # matches any 40-character `test_*` Python identifier. It also treats
+        # HTTP 403/422 from api.lob.com as "verified", so those match as verified
+        # secrets. ADK does not use Lob, so there is no coverage to lose.
+        extra_args: --results=verified,unknown --exclude-detectors=lob
+
+    # The action runs TruffleHog with --github-actions, whose printer emits only
+    # "Found verified <Detector> result" — the file and line go into annotation
+    # metadata that never renders in the log, and the match is never printed at
+    # all. That is not enough to tell a leak from a false positive. Re-run on
+    # failure with --json and report file, line, commit and a truncated match.
+    # Only a 12-char prefix is printed: enough to identify the string, not to
+    # use it. This step exits 0 — the gate above already failed the job.
+    - name: Report what was flagged
+      if: failure() && steps.scan.outcome == 'failure'
+      env:
+        BASE: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+        HEAD: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      run: |
+        docker run --rm -v .:/tmp -w /tmp \
+          ghcr.io/trufflesecurity/trufflehog:3.96.0 \
+          git file:///tmp/ \
+          --since-commit "$BASE" \
+          --branch "$HEAD" \
+          --no-update \
+          --json \
+          --results=verified,unknown \
+          --exclude-detectors=lob \
+        | jq -r 'select(.DetectorName) | [
+              "──────────────────────────────────────────",
+              "detector: \(.DetectorName) [\(if .Verified then "verified" else "unverified" end)]",
+              "file:     \(.SourceMetadata.Data.Git.file)",
+              "line:     \(.SourceMetadata.Data.Git.line)",
+              "commit:   \(.SourceMetadata.Data.Git.commit[0:12]) by \(.SourceMetadata.Data.Git.email)",
+              "match:    \(.Raw[0:12])… (\(.Raw | length) chars)"
+            ] | join("\n")'
 
     # Direct pushes to main skip PR review entirely, so the Actions tab may be
     # the only signal. Open an issue and assign the pusher so it can't be missed.


### PR DESCRIPTION
## What happened

The secret-scanning gate failed on #259 with exactly one line of output:

```
##[warning]Found verified Lob result 🐷🔑
```

No file, no line, no match. The actual trigger was a Python test function name — [`src/poly/tests/metrics_test.py:321`](https://github.com/polyai/adk/blob/main/src/poly/tests/metrics_test.py#L321):

```python
def test_add_duplicate_metric_friendly_error(self, mock_load, mock_create, mock_error):
```

That's two separate problems, and this PR fixes both.

## 1. The finding was noise

TruffleHog's Lob detector combines two individually-weak choices:

```go
keyPat = regexp.MustCompile(`\b((live|test)_[a-zA-Z0-9_]{35})\b`)   // no keyword-proximity gate
func (s Scanner) Keywords() []string { return []string{"live_", "test_"} }
```

The `Keywords()` prefilter is the pytest naming convention, so **every chunk in our test suite** reaches an ungated regex that matches any 40-character `test_*` identifier. It also treats HTTP **403 and 422** from `api.lob.com` as "verified" — only 401 counts as invalid — which is how a function name got reported as a *verified* secret.

Measured against this repo with TruffleHog 3.96.0 (`--no-verification`, all result types):

| Scope | Findings | After `--exclude-detectors=lob` |
|---|---|---|
| Working tree | 51 (all Lob) | 0 |
| Full `main` history | 85 (all Lob) | 0 |

Lob is **100% of the finding surface**. `main` already contains 36 more identifiers that match the pattern — they only stay quiet because scans are limited to each PR's commit range, so this would have recurred on any PR touching those lines. Roughly 4% of test names in the repo land on exactly 40 characters.

ADK does not use Lob (direct-mail API), so there is no coverage to lose.

### Other detectors were checked, not assumed

Of 870 detectors, 133 lack a keyword-proximity gate and 74 have a prefilter keyword present in this repo. Intersecting gives 19 others that are live *and* ungated. All were tested against the source tree — **zero matches and zero near-misses**:

```
uri (user:pass@host)  0    twilio AC<32hex>   0    stripe pi_..._secret_  0
redis:// creds        0    twilio SK<32>      0    zohocrm 1000.hex.hex   0
ftp:// creds          0    launchdarkly       0    sendgrid SG.           0
mongodb:// creds      0    salesforce         0    mailchimp <32hex>-usN  0
gemini master-/account- 0  closecrm api_<45>  0    lob (contrast)        43
```

Two worth noting: **Twilio** (`AC`+32hex) is the one to watch given our telephony code — clean today, but a realistic-shaped dummy SID in a fixture will fire it. **Auth0** looks alarming (`\b(ey[a-zA-Z0-9._-]+)\b` with prefilter keywords `token`/`domain`) but `FromData` requires a 2000–5000 char match paired with an `*.auth0.com` domain, so it's well gated.

## 2. The output was unactionable regardless

The action always passes `--github-actions`, and that printer emits only the detector name and verification status:

```go
fmt.Printf("::warning file=%s,line=%d,endLine=%d::%s", out.Filename, out.StartLine, out.StartLine, message)
// message = "Found verified Lob result 🐷🔑"
```

File and line go into annotation *metadata* that never renders in the log, and the match is never printed at all. `extra_args` can't remove `--github-actions`, but `--json` outranks it in TruffleHog's printer selection, so a diagnostic step re-runs the scan on failure:

```
──────────────────────────────────────────
detector: Lob [verified]
file:     src/poly/tests/metrics_test.py
line:     321
commit:   0b99540672d0 by Bill <bill@poly-ai.com>
match:    test_add_dup… (40 chars)
```

Only a 12-character prefix is printed — enough to triage, not enough to use. The step exits 0; the gate above has already failed the job.

## 3. Also: the scanner version was floating

The action was SHA-pinned, but its `version` input defaulted to `latest` — the failing run logs `VERSION: latest`. The pin covered the wrapper, not the binary doing the scanning. Now pinned to `v3.96.0`.

## Testing

- YAML validated.
- `jq` filter tested against a real TruffleHog JSON result record.
- Exclusion confirmed to take both the working tree and full `main` history to zero findings.
- Diagnostic step mirrors the gate's `--exclude-detectors` so the two can't disagree.

## Note for reviewers

This repo is public, and the description above documents which detector is disabled and that `--results=verified,unknown` filters out unverifiable detectors (`jwt`, `uri`, `sqlserver`). It's all derived from TruffleHog's public source. Happy to trim if anyone would rather that analysis live internally.