### PR TITLE
fix: read document projection field as content not contents

### DIFF
--- a/src/poly/resources/documents.py
+++ b/src/poly/resources/documents.py
@@ -129,7 +129,9 @@ class Document(Resource):
         for document_id, document_data in (
             projection.get("documents", {}).get("documents", {}).get("entities", {}).items()
         ):
-            if "contents" not in document_data:
+            # The projection carries the proto field name, "content". An entity without it is
+            # one the current user lacks read permission for, so skip it.
+            if "content" not in document_data:
                 continue
             path = document_data.get("path", "") or ""
             name = path.removesuffix(".md")
@@ -137,6 +139,6 @@ class Document(Resource):
                 resource_id=document_id,
                 name=name,
                 path=path,
-                contents=document_data["contents"],
+                contents=document_data["content"],
             )
         return documents

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -8341,7 +8341,7 @@ class DocumentFromProjection(unittest.TestCase):
                     "entities": {
                         "DOC-1": {
                             "path": "faq.md",
-                            "contents": "Frequently asked questions",
+                            "content": "Frequently asked questions",
                         }
                     }
                 }
@@ -8354,20 +8354,31 @@ class DocumentFromProjection(unittest.TestCase):
         self.assertEqual(document.name, "faq")
         self.assertEqual(document.contents, "Frequently asked questions")
 
-    def test_skips_document_without_contents(self):
-        """A document missing 'contents' means the user lacks read permission, so it's skipped."""
+    def test_skips_document_without_content(self):
+        """A document missing 'content' means the user lacks read permission, so it's skipped."""
         projection = {
             "documents": {
                 "documents": {
                     "entities": {
                         "DOC-1": {"path": "unreadable.md"},
-                        "DOC-2": {"path": "readable.md", "contents": "visible"},
+                        "DOC-2": {"path": "readable.md", "content": "visible"},
                     }
                 }
             }
         }
         documents = Document.from_projection(projection)
         self.assertEqual(list(documents), ["DOC-2"])
+
+    def test_keeps_document_with_empty_content(self):
+        """An empty 'content' is a readable but empty document, not a permission failure."""
+        projection = {
+            "documents": {
+                "documents": {"entities": {"DOC-1": {"path": "empty.md", "content": ""}}}
+            }
+        }
+        documents = Document.from_projection(projection)
+        self.assertEqual(list(documents), ["DOC-1"])
+        self.assertEqual(documents["DOC-1"].contents, "")
 
     def test_empty_projection_yields_no_documents(self):
         """An empty projection should return an empty dict."""


### PR DESCRIPTION
## Summary

Follow-up to #262. The permission check there gates on a `contents` key, but the document projection carries the proto field name `content` (see `Document` in `documents_pb2.pyi`). Every entity therefore fails the check and `Document.from_projection` returns an empty dict, so no documents are pulled at all.

## Changes

- `from_projection` checks for and reads `content` instead of `contents`
- Updated the projection fixtures in the tests, which had the same typo and so passed against the broken code
- Added a case covering an empty-but-present `content` (readable, empty document — kept, not skipped)

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)