### PR TITLE
chore(poc): add `poly docs --claude-code` to set up coding agent files

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,14 @@ poly docs {documentation (e.g topics)}
 poly docs --output doc_file.md
 ```
 
+Set up Claude Code for the project, installing the `poly-adk` skill into
+`.claude/skills/` and a `poly-adk` section into `CLAUDE.md`:
+```bash
+poly docs --claude-code
+poly docs --claude-code --force   # skip the confirmation prompt
+```
+Re-running only rewrites what changed, and your own `CLAUDE.md` content is kept.
+
 ## Bugs & Feature Requests
 
 Please report bugs or request features via the [GitHub Issues](https://github.com/PolyAI/adk/issues) page.

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -742,6 +742,39 @@ Available resource names include:
 | `voice_settings` | Voice greeting, disclaimer, style prompt |
 | `variables` | State variables referenced in code |
 
+#### `poly docs --claude-code`
+
+Set up Claude Code for the project instead of printing documentation. This installs the same reference material as files the agent picks up on its own, so you no longer need to generate `rules.md` and paste it into a prompt.
+
+Examples:
+
+~~~bash
+poly docs --claude-code
+poly docs --claude-code --force
+poly docs --claude-code --path ./account/project
+~~~
+
+It writes two things into the project:
+
+| Path | Purpose |
+|---|---|
+| `.claude/skills/poly-adk/` | The `poly-adk` skill: `SKILL.md` plus a `references/` file per resource type. Claude Code loads it on demand when you work on agent resources. |
+| `CLAUDE.md` | A `poly-adk` section covering the project layout, CLI workflow, and the rules that apply across every resource. Read on every session. |
+
+Behaviour on re-run:
+
+- Files that already match what the CLI ships are left alone, so re-running is a no-op.
+- An existing `CLAUDE.md` is never replaced. The `poly-adk` section is delimited by `<!-- BEGIN poly-adk -->` and `<!-- END poly-adk -->` markers, and only the text between those markers is rewritten. Anything you add around it survives.
+- Locally edited skill files, and skill files the CLI no longer ships, are listed and confirmed before being overwritten or deleted. Pass `--force` to skip the prompt, which is what you want in CI or a setup script.
+
+Re-run the command after upgrading the CLI to pick up documentation changes.
+
+| Option | Description |
+|---|---|
+| `--claude-code` | Install the skill and memory files rather than printing docs. |
+| `-f`, `--force` | Overwrite and remove existing files without confirmation. |
+| `--path` | Base path to the project. Defaults to the current working directory. |
+
 ### `poly deployments`
 
 Manage deployments for the project.

--- a/docs/docs/reference/tooling.md
+++ b/docs/docs/reference/tooling.md
@@ -51,7 +51,17 @@ Claude Code is particularly useful for:
 
 #### Loading ADK rules into Claude Code
 
-Before starting a session with Claude Code or another external coding tool, generate a documentation file and pass it as context:
+Run this once inside the project:
+
+~~~bash
+poly docs --claude-code
+~~~
+
+It installs the `poly-adk` skill into `.claude/skills/` and a `poly-adk` section into `CLAUDE.md`. Claude Code reads the memory section on every session and loads the skill when you work on agent resources, so you do not need to pass anything as context yourself.
+
+Both are safe to refresh: re-running only rewrites what changed, and it never replaces the parts of `CLAUDE.md` you wrote. Run it again after upgrading the CLI. See [`poly docs --claude-code`](./cli.md#poly-docs-claude-code) for the full behaviour.
+
+For other coding tools, generate a documentation file and pass it as context instead:
 
 ~~~bash
 poly docs --all --output rules.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,11 @@ exclude = [
 "poly.docs" = [
     "*.md",
 ]
+"poly.skills" = [
+    "*.md",
+    "poly-adk/*.md",
+    "poly-adk/references/*.md",
+]
 
 [tool.ruff]
 target-version = "py314"

--- a/src/poly/cli_commands/utils.py
+++ b/src/poly/cli_commands/utils.py
@@ -4,6 +4,7 @@ Copyright PolyAI Limited
 """
 
 import os
+import sys
 from argparse import ArgumentParser, Namespace, RawTextHelpFormatter, _SubParsersAction
 from typing import Optional
 
@@ -11,6 +12,13 @@ import argcomplete
 
 from poly.cli_commands.base import BaseCommand, Parents
 from poly.project import AgentStudioProject
+from poly.utils.agent_setup import (
+    MEMORY_FILE,
+    SKILL_NAME,
+    ClaudeCodePlan,
+    apply_claude_code_setup,
+    plan_claude_code_setup,
+)
 
 DOCUMENT_CHOICES = AgentStudioProject.discover_docs()
 
@@ -25,9 +33,14 @@ class DocsCommand(BaseCommand):
         """Register the ``docs`` subcommand."""
         docs_parser = subparsers.add_parser(
             "docs",
-            parents=[parents.verbose],
+            parents=[parents.verbose, parents.path],
             help="Outputs documentation for a given topic.",
-            description="Generate documentation",
+            description=(
+                "Generate documentation.\n\n"
+                "With no arguments, prints the top-level docs. Pass topic names or --all for\n"
+                "more. Pass --claude-code to install this documentation into the project as\n"
+                "Claude Code memory and skill files instead of printing it."
+            ),
             formatter_class=RawTextHelpFormatter,
         )
         docs_parser.add_argument(
@@ -50,15 +63,142 @@ class DocsCommand(BaseCommand):
             dest="output",
             help="Write output to FILE_PATH instead of stdout.",
         )
+        docs_parser.add_argument(
+            "--claude-code",
+            action="store_true",
+            dest="claude_code",
+            help=(
+                "Set up Claude Code for this project: install the poly-adk skill into\n"
+                ".claude/skills/ and a poly-adk section into CLAUDE.md."
+            ),
+        )
+        docs_parser.add_argument(
+            "--force",
+            "-f",
+            action="store_true",
+            help="Overwrite existing agent setup files without confirmation.",
+        )
 
     @classmethod
     def run(cls, args: Namespace) -> None:
         """Dispatch to the docs handler."""
+        if getattr(args, "claude_code", False):
+            cls._reject_claude_code_conflicts(args)
+            cls.setup_claude_code(
+                path=getattr(args, "path", os.getcwd()),
+                force=getattr(args, "force", False),
+            )
+            return
+
         cls.docs(
             documents=args.documents,
             all_documents=getattr(args, "all", False),
             output=getattr(args, "output", None),
         )
+
+    @classmethod
+    def _reject_claude_code_conflicts(cls, args: Namespace) -> None:
+        """Exit if --claude-code is combined with the printing arguments.
+
+        --claude-code installs files rather than printing, so topic names, --all
+        and --output have nothing to act on. Silently ignoring them would look
+        like the requested documentation had been written somewhere.
+
+        Args:
+            args: Parsed CLI arguments.
+        """
+        from poly.output.console import error
+
+        conflicting: list[str] = []
+        if args.documents:
+            conflicting.append(" ".join(args.documents))
+        if getattr(args, "all", False):
+            conflicting.append("--all")
+        if getattr(args, "output", None):
+            conflicting.append("--output")
+
+        if conflicting:
+            error(
+                f"--claude-code cannot be combined with {', '.join(conflicting)}. "
+                "It installs the skill and CLAUDE.md instead of printing documentation. "
+                "Run the two commands separately."
+            )
+            sys.exit(1)
+
+    @classmethod
+    def setup_claude_code(cls, path: str, force: bool = False) -> None:
+        """Install the poly-adk skill and CLAUDE.md memory into a project.
+
+        Args:
+            path: Project directory to install into.
+            force: Overwrite existing files without asking.
+        """
+        from poly.output.console import info, plain, success, warning
+
+        plan = plan_claude_code_setup(path)
+
+        if plan.is_noop:
+            success(f"Claude Code setup is already up to date in {plan.target_dir}")
+            return
+
+        cls._print_claude_code_plan(plan)
+
+        if plan.needs_confirmation and not force:
+            if not sys.stdin.isatty():
+                warning(
+                    "Existing files would be overwritten or removed. "
+                    "Re-run with --force to proceed."
+                )
+                sys.exit(1)
+
+            import questionary
+
+            confirmed = questionary.confirm(
+                "Apply these changes? The existing files listed above are overwritten or removed.",
+                default=False,
+            ).ask()
+            if not confirmed:
+                warning("Aborted. Nothing was written.")
+                return
+
+        applied, removed = apply_claude_code_setup(plan)
+
+        success(f"Claude Code setup written to {plan.target_dir}")
+        info(f"{len(applied)} file(s) written, {len(removed)} removed.")
+        plain(
+            f"\nStart Claude Code in this directory. It reads {MEMORY_FILE} on every session "
+            f"and loads the '{SKILL_NAME}' skill when you work on agent resources.\n"
+            "Re-run this command after upgrading the CLI to refresh both."
+        )
+
+    @classmethod
+    def _print_claude_code_plan(cls, plan: ClaudeCodePlan) -> None:
+        """Show the user which files a Claude Code setup plan touches."""
+        from poly.output.console import print_file_list
+
+        def relative(path: str) -> str:
+            return os.path.relpath(path, plan.target_dir)
+
+        by_action: dict[str, list[str]] = {}
+        for write in plan.pending:
+            by_action.setdefault(write.action, []).append(relative(write.path))
+
+        styles = {"create": "green", "append": "cyan", "overwrite": "yellow"}
+        titles = {
+            "create": "New files",
+            "append": f"Appending the poly-adk section to {MEMORY_FILE}",
+            "overwrite": "Existing files that will be overwritten",
+        }
+        for action, style in styles.items():
+            if by_action.get(action):
+                print_file_list(titles[action], sorted(by_action[action]), style)
+
+        if plan.removals:
+            print_file_list(
+                "Stale skill files that will be removed",
+                sorted(relative(path) for path in plan.removals),
+                "red",
+            )
 
     @classmethod
     def docs(

--- a/src/poly/docs/docs.md
+++ b/src/poly/docs/docs.md
@@ -76,7 +76,7 @@ Each project defines an AI voice or webchat agent. Resources in the project (flo
 | `poly review` | Diff review page: `create` (local vs remote, version hash, or `--before`/`--after`), `list`, `delete` |
 | `poly deployments` | Manage deployments (`list`, with `--env`, `--limit`, `--offset`, `--hash`, `--details`) |
 | `poly chat` | Interactive chat session with the agent (`--environment`, `--channel`, `--sip-header`, `--functions`, `--flows`, `--state`) |
-| `poly docs` | Output resource documentation (`poly docs flows functions topics`, or `--all` for everything) |
+| `poly docs` | Output resource documentation (`poly docs flows functions topics`, or `--all` for everything). `--claude-code` installs this documentation as Claude Code skill and CLAUDE.md memory files instead |
 
 Use `poly -h` and `poly {command} -h` for more detailed information
 
@@ -114,6 +114,8 @@ These placeholders can be used in prompts, rules, topics, and other text fields 
 ## Documentation
 
 Resource-specific documentation is available via `poly docs {resource} [resource ...]` or `poly docs --all`.
+
+To set up Claude Code for a project, run `poly docs --claude-code`. It installs the `poly-adk` skill into `.claude/skills/` and a `poly-adk` section into `CLAUDE.md`, so the agent picks up this documentation on its own. Re-running only rewrites what changed and keeps your own `CLAUDE.md` content; pass `--force` to skip the confirmation prompt.
 
 | Name | Description |
 |------|-------------|

--- a/src/poly/skills/__init__.py
+++ b/src/poly/skills/__init__.py
@@ -1,0 +1,8 @@
+"""Coding-agent asset templates shipped with the poly CLI.
+
+Holds the ``poly-adk`` Claude Code skill (``poly-adk/SKILL.md`` plus
+``poly-adk/references/*.md``) and the ``memory.md`` block installed into a
+project's ``CLAUDE.md``. Installed by ``poly docs --claude-code``.
+
+Copyright PolyAI Limited
+"""

--- a/src/poly/skills/memory.md
+++ b/src/poly/skills/memory.md
@@ -1,0 +1,56 @@
+<!-- BEGIN poly-adk -->
+## PolyAI Agent Studio project
+
+This directory is a PolyAI Agent Studio project managed by the `poly` CLI (poly-adk).
+The agent's behaviour lives in YAML and Python under `flows/`, `functions/`, `topics/`,
+`agent_settings/` and `config/`. Changes reach the agent by being pushed to the Agent
+Studio platform, not by deploying this directory.
+
+### Skill
+
+Per-resource reference material lives in the `poly-adk` skill at `.claude/skills/poly-adk/`.
+Read `SKILL.md`, then the matching `references/*.md` file, before making non-trivial edits
+to a resource type.
+
+### Workflow
+
+| Step | Command |
+|---|---|
+| Pull remote config into local | `poly pull` |
+| Work on a branch | `poly branch create <name>` |
+| See what changed | `poly status`, `poly diff` |
+| Check before pushing | `poly validate` |
+| Publish to the platform | `poly push` |
+| Test the agent | `poly chat` |
+
+Run commands from inside the project folder, or pass `--path`. Always run `poly validate`
+before `poly push`, and prefer `poly push --dry-run` when the change is large.
+
+### Rules
+
+- **Never edit `_gen/`.** It holds generated stubs and is overwritten on every pull.
+- **No deterministic logic in prompts.** Value checks and branching belong in Python
+  (function steps, transition functions), which then transition to the right step.
+- **State syntax depends on context.** In Python: `conv.state.x`. In prompts, topics and
+  SMS templates: `$x` or `{{vrbl:x}}`, never `conv.state.x`.
+- **Every function step must advance the conversation**, via `flow.goto_step(...)`,
+  `conv.exit_flow()`, or a returned transition.
+- **Filenames are derived, not chosen.** Topic and test filenames are the `name` field in
+  lowercase snake_case; a mismatch fails validation on pull and push.
+- **No hardcoded IDs.** Reference flows, steps, functions and handoffs by name.
+
+### Reference syntax
+
+Usable in prompts, rules, topic actions and other text fields, but never inside a topic's
+`content`:
+
+| Syntax | Resolves to |
+|---|---|
+| `{{fn:name}}` | Global function |
+| `{{ft:name}}` | Flow transition function (same flow only) |
+| `{{entity:name}}` | Collected entity value |
+| `{{attr:name}}` | Variant attribute |
+| `{{ho:name}}` | Handoff destination |
+| `{{twilio_sms:name}}` | SMS template |
+| `{{vrbl:name}}` | State variable |
+<!-- END poly-adk -->

--- a/src/poly/skills/poly-adk/SKILL.md
+++ b/src/poly/skills/poly-adk/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: poly-adk
+description: Use whenever working with a PolyAI Agent Studio project managed by the poly-adk CLI — creating, editing, reviewing, or debugging flows, topics, functions, entities, variants, tests, rules, handoffs, SMS templates, API integrations, safety filters, or any other resource under an account/project folder. Also use when running poly init/pull/push/status/diff/validate/branch/review/chat/deployments, or when resolving {{fn:}}/{{ft:}}/{{attr:}}/{{entity:}}/{{ho:}}/{{twilio_sms:}}/{{vrbl:}} reference syntax. Trigger this even if the user only pastes YAML/Python from flows/, topics/, functions/, or project.yaml, or mentions a project by account/project name, without saying "poly-adk" explicitly.
+---
+
+# Poly ADK
+
+Poly-ADK is a CLI and Python package for managing PolyAI Agent Studio projects locally — a Git-like workflow for
+syncing agent configuration (flows, topics, functions, entities, settings) between the local filesystem and the
+Agent Studio platform.
+
+## Project structure
+
+```
+<account>/<project>/
+├── _gen/                       # Generated stubs - never edit
+├── agent_settings/              # personality.yaml, role.yaml, rules.txt, safety_filters.yaml, experimental_config.json
+├── config/                      # api_integrations.yaml, entities.yaml, handoffs.yaml, sms_templates.yaml,
+│                                 # translations.yaml, variant_attributes.yaml
+├── voice/                       # configuration.yaml, safety_filters.yaml, speech_recognition/, response_control/
+├── chat/                        # configuration.yaml, safety_filters.yaml
+├── context/                     # {document_name}.md — background docs, not read at runtime
+├── flows/{flow_name}/           # flow_config.yaml, steps/, function_steps/, functions/
+├── functions/                   # global functions, start_function.py, end_function.py
+├── topics/{topic_name}.yaml     # RAG knowledge base
+├── test_suite/{test_name}.yaml  # simulated conversation tests
+└── project.yaml                 # region, account_id, project_id
+```
+
+## CLI commands
+
+| Command | Description |
+|---|---|
+| `poly init` | Initialize a project (interactive or `--region --account_id --project_id`); the agent must already exist on Agent Studio |
+| `poly pull` | Pull remote config into local (`-f` force overwrite) |
+| `poly push` | Push local changes (`-f` force, `--dry-run`, `--skip-validation`) |
+| `poly status` | List changed files |
+| `poly diff` | Show diffs (files, deployment hashes, or `--before`/`--after`) |
+| `poly revert` | Revert local changes (all, or specific files) |
+| `poly branch` | `list` / `create` / `switch` / `current` |
+| `poly format` | Format resource files (all or `--files`) |
+| `poly validate` | Validate project config locally |
+| `poly review` | Diff review page: `create` / `list` / `delete` — needs a GitHub token |
+| `poly deployments` | `list` (`--env --limit --offset --hash --details`) |
+| `poly chat` | Interactive chat with the agent (`--environment --channel --functions --flows --state`) |
+| `poly docs` | `poly docs {resource}` or `--all` — dumps resource docs identical to this skill's reference files. `--claude-code` reinstalls this skill and the project's CLAUDE.md section |
+
+Run `poly -h` / `poly {command} -h` for details. Commands must run from inside the project folder, or pass `--path`.
+
+## Standard workflow
+
+1. `poly init` (agent must already exist on Agent Studio) → creates `account_id/project_id`
+2. `poly pull` (`-f`/`--force` to override all local changes)
+3. `poly branch create {name}` from `main`. Navigate with `switch`, check with `current`/`list`
+4. Edit files locally; track with `poly status` / `poly diff`
+5. `poly validate`
+6. `poly push`
+7. `poly chat` to test
+8. (Optional) `poly review create` vs `main`/`sandbox` → shareable GitHub Gist for reviewers
+9. Merge the branch on the Agent Studio UI
+
+If Agent Studio UI changes are made on your branch, `poly pull` merges them in (shows merge markers on conflict).
+
+## Resource reference syntax
+
+Used inside prompts, rules, topics, greetings, and other text fields — **never** inside topic `content`.
+
+| Syntax | Resolves to | Usable in |
+|---|---|---|
+| `{{fn:function_name}}` | Global function | Rules, topics (actions), advanced step prompts |
+| `{{ft:function_name}}` | Flow transition function | Advanced step prompts, same flow only |
+| `{{entity:entity_name}}` | Collected entity value | Flow step prompts |
+| `{{attr:attribute_name}}` | Variant attribute | Rules, prompts, topics (actions), greeting, disclaimer, personality, role |
+| `{{twilio_sms:template_name}}` | SMS template | Rules, topics (actions) |
+| `{{ho:handoff_name}}` | Handoff destination | Rules |
+| `{{vrbl:variable_name}}` (preferred) / `$variable_name` | State variable | Prompts, topic actions, SMS templates |
+
+## Rules that apply across every resource
+
+- **No deterministic logic in prompts.** Never write "If $x == 0 do A else B" in a prompt. Do value checks and
+  branching in Python (function steps / transition functions), then transition to the right step.
+- **State syntax differs by context.** In Python: `conv.state.x = value` / `conv.state.x`. In prompts/topics/SMS:
+  `$x` or `{{vrbl:x}}` — never `conv.state.x`, and never `$x.attribute` (stringify complex objects in Python first).
+- **Flow control must always advance.** Every function step and flow function must end by calling
+  `flow.goto_step(...)` or `conv.exit_flow()`, or by returning a transition. Never leave the agent stuck with no
+  navigation.
+- **Don't mix exit and navigation.** Use either `conv.exit_flow()` + returned content, or a transition/`goto_flow`
+  — not both in the same return; a later `goto_flow` overrides an earlier `exit_flow`.
+- **No hardcoded IDs.** Reference flows/steps/functions/handoffs by their resource name, not internal IDs.
+- **Filenames are derived, not chosen.** Topic and test filenames are the `name` field cleaned to lowercase
+  snake_case; a mismatch fails validation on `pull`/`push`.
+- **No "Anything else?" step.** End a flow with `conv.exit_flow()` and return that prompt as context from the
+  function instead of adding a dedicated step for it.
+
+## Reference files
+
+Read the relevant file below before making non-trivial edits to that resource type — each has full field lists,
+validation rules, and examples.
+
+| Resource | File | Read this when... |
+|---|---|---|
+| Flows | `references/flows.md` | Writing/editing flow_config.yaml, steps, function_steps, or flow functions |
+| Functions | `references/functions.md` | Writing global/flow functions, start/end functions, decorators, state, metrics |
+| Topics | `references/topics.md` | Writing the RAG knowledge base |
+| Entities | `references/entities.md` | Defining structured data to collect (dates, enums, phone numbers, etc.) |
+| Variants | `references/variants.md` | Per-location/environment config via `{{attr:...}}` |
+| Tests | `references/tests.md` | Writing test_suite/*.yaml simulated conversations |
+| Agent Settings | `references/agent_settings.md` | personality.yaml, role.yaml, rules.txt |
+| Voice Settings | `references/voice_settings.md` | voice/configuration.yaml (greeting, style, disclaimer) |
+| Chat Settings | `references/chat_settings.md` | chat/configuration.yaml |
+| Speech Recognition | `references/speech_recognition.md` | asr_settings.yaml, keyphrase_boosting.yaml, transcript_corrections.yaml |
+| Response Control | `references/response_control.md` | pronunciations.yaml, phrase_filtering.yaml |
+| Safety Filters | `references/safety_filters.md` | Any of the three safety_filters.yaml files |
+| Handoffs | `references/handoffs.md` | SIP call transfer config |
+| API Integrations | `references/api_integrations.md` | Defining/calling external HTTP APIs via `conv.api.*` |
+| SMS Templates | `references/sms_templates.md` | Outbound text message templates |
+| Translations | `references/translations.md` | Localized text strings per language |
+| Languages | `references/languages.md` | Default/additional language config |
+| Variables | `references/variables.md` | How `conv.state` variables are discovered and referenced |
+| Experimental Config | `references/experimental_config.md` | agent_settings/experimental_config.json feature flags |
+| Context | `references/context.md` | context/*.md background docs (non-runtime) |

--- a/src/poly/skills/poly-adk/references/agent_settings.md
+++ b/src/poly/skills/poly-adk/references/agent_settings.md
@@ -1,0 +1,58 @@
+# Agent Settings
+
+## Overview
+Define the agent's identity and behavioral rules, in `agent_settings/`: personality, role, and rules.
+
+## File structure
+```
+agent_settings/
+├── personality.yaml
+├── role.yaml
+├── rules.txt
+└── experimental_config.json   # see references/experimental_config.md
+```
+
+## Personality (`personality.yaml`)
+Controls conversational tone.
+| Field | Notes |
+|---|---|
+| `adjectives` | Map of trait → boolean. Allowed: `Polite`, `Calm`, `Kind`, `Funny`, `Energetic`, `Thoughtful`, `Other`. If `Other: true`, no other adjective can be selected. |
+| `custom` | Free-text description; supports `{{attr:...}}` and `{{vrbl:...}}` |
+
+```yaml
+adjectives:
+  Polite: true
+  Calm: true
+  Kind: true
+custom: ""
+```
+
+## Role (`role.yaml`)
+Defines what the agent is (job title / purpose).
+| Field | Notes |
+|---|---|
+| `value` | Role name, e.g. `Customer Service Representative`. If `other`, `custom` is used. |
+| `additional_info` | Extra context about the role |
+| `custom` | Free-text role, only valid when `value: other`; supports `{{attr:...}}` and `{{vrbl:...}}` |
+
+```yaml
+value: Customer Service Representative
+additional_info: Handles customer inquiries and bookings
+custom: ""
+```
+
+## Rules (`rules.txt`)
+Plain-text behavioral instructions followed every turn — a key file for shaping behavior.
+
+**Supported references**: `{{fn:function_name}}`, `{{twilio_sms:template_name}}`, `{{ho:handoff_name}}`,
+`{{attr:attribute_name}}`, `{{vrbl:variable_name}}`.
+
+```text
+Be helpful and professional at all times.
+Use {{fn:validate_email}} when the user provides an email address.
+For complex issues, use {{ho:escalation_handoff}} to transfer to a specialist.
+Send confirmation via {{twilio_sms:confirmation_template}} after booking.
+```
+
+**Best practices**: keep rules concise/actionable; use references instead of hardcoded values; avoid encoding
+branching logic here — use flows/functions instead.

--- a/src/poly/skills/poly-adk/references/api_integrations.md
+++ b/src/poly/skills/poly-adk/references/api_integrations.md
@@ -1,0 +1,75 @@
+# API Integrations
+
+## Purpose
+Define external HTTP APIs and call them from functions/flows without writing custom request code — for fetching
+or sending data to a CRM, ticketing, booking, or payments system, or calling internal services.
+
+## Location
+`config/api_integrations.yaml`, listed under the `api_integrations` key.
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` | Identifier; becomes the runtime namespace `conv.api.<name>` |
+| `description` | Optional description |
+| `environments` | Per-environment config (see below) |
+| `operations` | List of HTTP operations |
+
+## Environments
+Separate config per: `sandbox` (draft), `pre_release`, `live`. Per environment:
+| Field | Notes |
+|---|---|
+| `base_url` | Base URL for that environment |
+| `auth_type` | `none`, `basic`, `apiKey`, `oauth2`, etc. |
+Lets you test against staging in sandbox and promote without code changes.
+
+## Operations
+| Field | Notes |
+|---|---|
+| `name` | Operation name; runtime call is `conv.api.<api_name>.<operation_name>(...)` |
+| `method` | `GET`, `POST`, `PUT`, `DELETE`, etc. |
+| `resource` | Path template, e.g. `/tickets/{id}`; path variables become call arguments |
+
+## Usage
+- Call an operation with `conv.api.<api_name>.<operation_name>(...)`; path variables can be positional or keyword.
+- Return value is a `requests.Response`-like object: `.status_code`, `.text`, `.json()`.
+- Operations accept keyword args for `params`, `json`, `headers`, like a standard HTTP client.
+- Auth is configured at the API level per environment; credentials are managed by Agent Studio, never stored in
+  YAML or embedded in flows/functions.
+
+## Example
+```yaml
+api_integrations:
+  - name: salesforce
+    description: CRM and contact lookup
+    environments:
+      sandbox:
+        base_url: https://sandbox-api.salesforce.com
+        auth_type: oauth2
+      pre-release:
+        base_url: https://staging-api.salesforce.com
+        auth_type: oauth2
+      live:
+        base_url: https://api.salesforce.com
+        auth_type: oauth2
+    operations:
+      - name: get_contact
+        method: GET
+        resource: /contacts/{contact_id}
+      - name: update_contact
+        method: PATCH
+        resource: /contacts/{contact_id}
+```
+
+In a function:
+```python
+response = conv.api.salesforce.get_contact("123")
+data = response.json()
+return {"content": f"Status: {data.get('status', 'unknown')}."}
+```
+```python
+response = conv.api.salesforce.update_contact(
+    params={"id": "123"},
+    json={"phone_number": "456"}
+)
+```

--- a/src/poly/skills/poly-adk/references/chat_settings.md
+++ b/src/poly/skills/poly-adk/references/chat_settings.md
@@ -1,0 +1,31 @@
+# Chat Settings
+
+## Overview
+Configures the agent's behavior on the web chat channel, in `chat/configuration.yaml`.
+
+## Greeting
+| Field | Notes |
+|---|---|
+| `welcome_message` (required) | Greeting text; supports `{{attr:...}}` and `{{vrbl:...}}` |
+| `language_code` (required) | BCP-47 code, e.g. `en-GB`, `en-US` |
+
+```yaml
+greeting:
+  welcome_message: Hi there! How can I help you today?
+  language_code: en-GB
+```
+
+## Style prompt
+Chat-specific guidance (e.g. "keep responses concise", "use bullet points for lists").
+| Field | Notes |
+|---|---|
+| `prompt` | Free-text style instructions; no resource references allowed |
+
+## Full example
+```yaml
+greeting:
+  welcome_message: Hi! How can I help you today?
+  language_code: en-GB
+style_prompt:
+  prompt: You are a helpful and professional web chat assistant. Keep responses concise.
+```

--- a/src/poly/skills/poly-adk/references/context.md
+++ b/src/poly/skills/poly-adk/references/context.md
@@ -1,0 +1,20 @@
+# Context
+
+## Overview
+Background/documentation markdown files under `context/`, providing project knowledge. These do **not** affect
+runtime behavior of the agent — they're documentation only, and are also surfaced to Poly's Studio Assistant as a
+place for ongoing project context.
+
+## File structure
+Only `*.md` files are discovered, read from the `context/` folder:
+```
+<account>/<project>/
+  context/
+    CONTEXT.md
+    FUNCTION_GUIDELINES.md
+    SUCCESS_CRITERIA.md
+```
+
+Use this for anything a human or the Studio Assistant needs to know about the project that shouldn't live inside
+a runtime resource (flows, topics, rules) — e.g. why a design decision was made, non-obvious constraints, or
+success criteria for the build.

--- a/src/poly/skills/poly-adk/references/entities.md
+++ b/src/poly/skills/poly-adk/references/entities.md
@@ -1,0 +1,64 @@
+# Entities
+
+## Purpose
+Entities define structured data the agent can collect (date of birth, phone number, choice from a list). Used in
+flow steps via `extracted_entities` (what to collect) and `required_entities` (what must be collected before a
+condition triggers). Can also be referenced in executed Python.
+
+## Location
+`config/entities.yaml`, listed under the `entities` key.
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` | Identifier (snake_case); used in prompts as `{{entity:entity_name}}` |
+| `description` | What the entity represents, shown to the LLM to guide extraction |
+| `entity_type` | One of the types below |
+| `config` | Type-specific settings |
+
+## Entity types and config
+| Type | Config fields | Description |
+|---|---|---|
+| `numeric` | `has_decimal`, `has_range`, `min`, `max` | Numbers (account number, quantity) |
+| `alphanumeric` | `enabled`, `validation_type`, `regular_expression` | Mixed text (booking reference) |
+| `enum` | `options` (list) | Fixed set of choices |
+| `date` | `relative_date` | Calendar dates |
+| `phone_number` | `enabled`, `country_codes` | Phone numbers with country validation |
+| `time` | `enabled`, `start_time`, `end_time` | Times or time ranges |
+| `address` | `{}` | Physical addresses |
+| `free_text` | `{}` | Unstructured text |
+| `name_config` | `{}` | Person names |
+
+## Usage
+- In flow prompts: `{{entity:entity_name}}` for the collected value.
+- In function steps: `conv.entities.entity_name.value` to read; `if conv.entities.entity_name:` to check.
+- In default step conditions: `required_entities` gates a condition — triggers only once all listed entities are
+  collected.
+- In default steps: `extracted_entities` tells the agent what to collect; ASR biasing auto-configures from entity
+  types.
+
+## Example
+```yaml
+entities:
+  - name: date_of_birth
+    description: The customer's date of birth
+    entity_type: date
+    config:
+      relative_date: false
+  - name: party_size
+    description: Number of guests for the reservation
+    entity_type: numeric
+    config:
+      has_decimal: false
+      min: 1
+      max: 20
+  - name: meal_preference
+    description: The customer's preferred meal type
+    entity_type: enum
+    config:
+      options:
+        - vegetarian
+        - vegan
+        - standard
+        - halal
+```

--- a/src/poly/skills/poly-adk/references/experimental_config.md
+++ b/src/poly/skills/poly-adk/references/experimental_config.md
@@ -1,0 +1,36 @@
+# Experimental Config
+
+## Purpose
+Optional JSON enabling experimental features (feature flags, ASR tuning, conversation control, debug options).
+
+## Location
+`agent_settings/experimental_config.json`
+
+## Structure
+Flat or nested JSON. Top-level keys are feature categories; values are feature-specific settings.
+
+```json
+{
+  "asr": {
+    "disable_itn": true,
+    "eager_final": true
+  },
+  "conversation_control": {
+    "enhanced_tts_preprocessing_enabled": false,
+    "max_silence_count": 1000,
+    "min_chunk_size": 1
+  }
+}
+```
+
+## Schema
+Available features/types are defined in `src/poly/resources/experimental_config_schema.yaml`. `poly validate`
+checks this file against that schema. Invalid config in a deployed agent is not read at runtime.
+
+## When to use
+Tuning ASR/TTS beyond standard settings; enabling experimental platform features early; adjusting conversation
+control (silence handling, chunk sizes).
+
+## Best practices
+Only set values you intend to override — omit defaults; validate locally with `poly validate` before pushing;
+remove flags no longer needed.

--- a/src/poly/skills/poly-adk/references/flows.md
+++ b/src/poly/skills/poly-adk/references/flows.md
@@ -1,0 +1,126 @@
+# Flows
+
+## Purpose
+Flows choreograph multi-step processes. The LLM only sees the current step's prompt and tools. Prefer one task per
+step; do branching and conditionals in Python via transitions, not in prompts.
+
+## Entering a flow
+- **From code**: `conv.goto_flow('Flow Name')` (enters at the configured Start Step).
+- **Via return**: `return {"transition": {"goto_flow": "Flow Name", "goto_step": "Step Name"}}`.
+- **Within a flow**: `flow.goto_step("Step Name")` — flow functions only.
+
+## File structure
+```
+flows/
+└── {flow_name}/                    # lowercase, snake_case
+    ├── flow_config.yaml
+    ├── steps/
+    │   └── {step_name}.yaml        # default or advanced steps
+    ├── function_steps/
+    │   └── {function_step}.py      # deterministic Python steps
+    └── functions/
+        └── {function_name}.py      # transition functions (called from advanced steps)
+```
+Directory and file names are cleaned to lowercase snake_case.
+
+## Flow config (`flow_config.yaml`)
+| Field | Notes |
+|---|---|
+| `name` | Human-readable flow name |
+| `description` (required) | What this flow does |
+| `start_step` (required) | Step to enter on trigger; must match a real step name |
+
+```yaml
+name: Example Flow
+description: Handles the booking process
+start_step: Collect Details
+```
+
+## Flow steps
+Three types: default steps (no code), advanced steps, and function steps.
+
+### Default steps (`steps/*.yaml`)
+LLM-only logic. Cannot reference transition functions. ASR biasing is auto-configured from requested entities.
+
+| Field | Notes |
+|---|---|
+| `step_type` | `default_step` |
+| `name` | Human-readable step name |
+| `conditions` | List of conditions to transition out (see below) |
+| `extracted_entities` | Entities to extract this step (from `config/entities.yaml`) |
+| `prompt` | Instructions for the LLM; use `{{entity:entity_name}}`; cannot call functions |
+
+**Conditions**
+| Field | Notes |
+|---|---|
+| `condition_type` | `step_condition` (go to another step) or `exit_flow_condition` (exit flow) |
+| `description` | When this condition applies |
+| `child_step` | Next step — only for `step_condition`; omit for `exit_flow_condition` |
+| `required_entities` | Entities that must be collected before this condition can trigger |
+
+`child_step` rules: for a default/advanced step use its `name:`; for a function step use the Python filename
+without `.py`, in snake_case.
+
+### Advanced steps (`steps/*.yaml`)
+Adds custom ASR/DTMF rules and the ability to call transition functions from the prompt.
+
+| Field | Notes |
+|---|---|
+| `step_type` | `advanced_step` |
+| `name` | Human-readable step name |
+| `asr_biasing.is_enabled` | Boolean |
+| `asr_biasing.{alphanumeric, name_spelling, numeric, party_size, precise_date, relative_date, single_number, time, yes_no, address}` | Booleans — tune ASR for that input type |
+| `asr_biasing.custom_keywords` | List of words to bias for |
+| `dtmf_config.is_enabled` | Boolean |
+| `dtmf_config.inter_digit_timeout` | Seconds between key presses |
+| `dtmf_config.max_digits` | Max digits to collect |
+| `dtmf_config.end_key` | Key that ends collection |
+| `dtmf_config.collect_while_agent_speaking` | Boolean |
+| `dtmf_config.is_pii` | Boolean — does input count as PII |
+| `prompt` | Instructions; can call functions via `{{ft:flow_function}}` |
+
+### Function steps (`function_steps/*.py`)
+Deterministic Python — no LLM. Best for API calls, validation, and routing. Cannot have extra parameters or a
+description (unlike transition functions).
+
+**Signature**: `def function_name(conv: Conversation, flow: Flow):`
+
+- Read entities: `conv.entities.entity_name.value`; check with `if conv.entities.entity_name:`
+- State: `conv.state.variable_name = value` (reference as `$variable_name` in prompts)
+- Must call `flow.goto_step('Step Name', 'Reason')` or `conv.exit_flow()`
+- Return: optional string used as LLM context (what happened, what to tell the user)
+- Errors: try/except; log; `flow.goto_step('error_step', 'Reason')`, return a context string
+- Logging/metrics: `conv.log.info/warning/error(...)`, `conv.write_metric("NAME", value)`
+
+## Transition functions (`functions/*.py`)
+Called from `advanced_step` prompts via `{{ft:flow_function}}`; same flow only. Unlike function steps, they can
+define custom parameters and a description that the LLM uses to decide when to call them. Put logic reused across
+functions into global functions and call via `conv.functions.my_global_function(...)`. Keep flow functions simple.
+
+## Best practices
+- No "Anything else?" step — `conv.exit_flow()` and return that prompt as context from the function instead.
+- Hard-coded utterances go in `utterances.py`, returned from the caller (e.g. `start_function`) — don't add a
+  flow function just to return one phrase.
+- Prompts: markdown headers, clear order of operations, validation/edge cases, voice-friendly phrasing ("read
+  digit by digit"), and explicit "Once X, then Y" transitions.
+- Concepts: linear (A→B→C), branching, loops (back to earlier steps), `exit_flow_condition` to leave the flow,
+  `required_entities`/`extracted_entities` for collection and gating.
+
+## Common mistakes
+- Flow functions must always advance — use `flow.goto_step(...)` or a transition; never leave the flow stuck.
+- No deterministic logic in prompts — do value checks/branching in Python, then transition.
+- No hardcoded IDs — use resource names.
+- Don't read entities in default-step code — entity values are only available in prompts via `{{entity:...}}`.
+- Function steps must control flow — every one must call `flow.goto_step(...)` or `conv.exit_flow()` and return
+  LLM context. Keep complex logic here, not in prompts.
+- `end_turn=False` only when the agent must immediately call a function after speaking with no user reply — don't
+  use it just to add a question after an utterance; put the question in the utterance.
+- Don't mix exit and navigation — `conv.exit_flow()` **or** a transition/`goto_flow`, not both; a later
+  `goto_flow` overrides an earlier `exit_flow`.
+
+## Design principles
+1. Start with a single path, then add branching.
+2. Add a confirmation step before function steps that change state.
+3. Add steps/conditions for errors and failures.
+4. One clear purpose per step; meaningful step names.
+5. Test the full path from start to exit.

--- a/src/poly/skills/poly-adk/references/functions.md
+++ b/src/poly/skills/poly-adk/references/functions.md
@@ -1,0 +1,131 @@
+# Functions
+
+## Overview
+Functions are Python files adding deterministic logic. They can be called by the LLM during conversation, used as
+flow steps, or run automatically at call start/end.
+
+## Location
+```
+functions/                          # Global functions
+├── start_function.py               # Optional - runs once at call start
+├── end_function.py                 # Optional - runs once at call end
+└── {function_name}.py              # Called by LLM via {{fn:function_name}}
+flows/{flow_name}/
+├── functions/
+│   └── {function_name}.py          # Flow transition functions, called via {{ft:function_name}}
+└── function_steps/
+    └── {function_step}.py          # Deterministic flow steps (no LLM)
+```
+
+## Function types
+| Type | Location | Signature | Referenced as |
+|---|---|---|---|
+| Global | `functions/` | `def name(conv: Conversation, ...)` | `{{fn:name}}` |
+| Transition | `flows/{flow}/functions/` | `def name(conv: Conversation, flow: Flow, ...)` | `{{ft:name}}` (same flow only) |
+| Function step | `flows/{flow}/function_steps/` | `def name(conv: Conversation, flow: Flow)` | Stepped into via conditions |
+| Start | `functions/start_function.py` | `def start_function(conv: Conversation)` | Runs automatically |
+| End | `functions/end_function.py` | `def end_function(conv: Conversation)` | Runs automatically |
+
+## File structure rules
+- Every `.py` file must define a function with the **same name as the file** — the entry point when called by the LLM.
+- Only the main function needs `@func_` decorators.
+- Include `from _gen import *  # <AUTO GENERATED>` to match the imports used at runtime. This line is not pushed
+  to Agent Studio and must match this exact pattern.
+
+## Decorators
+- `@func_description('...')` — required for global and transition functions; shown to the LLM to decide when to call.
+- `@func_parameter('param_name', '...')` — required per parameter (except `conv`/`flow`); parameter also needs a
+  typed annotation (e.g. `booking_ref: str`).
+- `@func_latency_control(...)` — optional; configures delay messages while the function runs.
+
+Function steps support neither `@func_parameter` nor `@func_description`.
+
+### Parameter types
+| Python type | Schema type |
+|---|---|
+| `str` | `string` |
+| `int` | `integer` |
+| `float` | `number` |
+| `bool` | `boolean` |
+
+### Example
+```python
+from _gen import *  # <AUTO GENERATED>
+
+
+@func_description("Look up a booking by reference number.")
+@func_parameter("booking_ref", "The booking reference provided by the customer")
+@func_parameter("include_history", "Whether to include booking history")
+def lookup_booking(conv: Conversation, booking_ref: str, include_history: bool):
+    result = external_api.get_booking(booking_ref, include_history)
+    if not result:
+        return "No booking found. Ask the customer to verify the reference number."
+    conv.state.booking = str(result)
+    return f"Booking found: {result['status']}. Confirm the details with the customer."
+```
+
+## Naming
+Name after the **event that should trigger the call** (e.g. `first_name_provided`, `booking_confirmed`), not the
+action (`store_first_name`, `send_confirmation`) — this helps the LLM know when to call it.
+
+## Returns and control flow
+| Return | Effect |
+|---|---|
+| `return "string"` | Injected as system context to the LLM |
+| `conv.say("exact phrase")` | Speak/send exact text (first sentence should be static, for cached audio) |
+| `conv.goto_flow("name")` | Navigate to a flow |
+| `flow.goto_step("Step Name", "reason")` | Navigate to a step — flow functions only |
+| `conv.exit_flow()` | Exit the current flow |
+| `conv.call_handoff(destination="...", reason="...")` | Transfer the call |
+| `return {"hangup": True}` | End the call |
+| `return {"transition": {"goto_flow": "...", "goto_step": "..."}}` | Navigate via dict |
+| `return {"utterance": "...", "end_turn": False}` | Speak and continue immediately, no user reply |
+
+**Calling other functions**: global via `conv.functions.my_global_function(...)`; flow via
+`flow.functions.my_flow_function(...)`.
+
+## Special functions
+### Start function (`start_function.py`)
+Runs once at call start, before the first user input. Signature: `def start_function(conv: Conversation):` — no
+`flow`, no `@func_parameter`. Typical use: initialize state, read SIP headers, set language, write initial
+metrics, then `conv.goto_flow("...")`.
+
+### End function (`end_function.py`)
+Runs once at call end. Signature: `def end_function(conv: Conversation):`. Typical use: aggregate
+`conv.metric_events`, write summary metrics (e.g. `CALL_OUTCOME`), optionally trigger post-call webhooks when
+`conv.env == "live"`.
+
+## Utility modules
+A function file not meant to be called by the LLM still needs a main function matching the filename. Decorate it
+and have it return a "utility module" message. Do not decorate helper functions.
+
+## State
+`conv.state` persists between turns.
+- Set: `conv.state.variable_name = value`
+- Read: `conv.state.variable_name` (returns `None` if unset)
+- In prompts: `$variable` or `{{vrbl:variable}}` — never `conv.state.variable`, never `$var.attribute`
+  (stringify complex objects in Python first).
+
+**Counters**: use `conv.state.counter` (init + increment) to avoid infinite retries; after a limit (e.g. 3), hand
+off or exit.
+
+## Metrics
+- Write: `conv.write_metric("EVENT_NAME")`, `conv.write_metric("NAME", value)`, `conv.write_metric("NAME", write_once=True)`
+- Naming: `SCREAMING_SNAKE_CASE`, grouped with prefixes (e.g. `SMS_OFFERED`, `SMS_ACCEPTED`, `SMS_SENT`)
+- Use for events you'll filter/analyze on: flow entry, decisions, key moments.
+- `write_once=True` for metrics that should record once (e.g. flow entered) — avoid repeat writes in a loop.
+- Log important outcomes (`conv.log.info` / `conv.log.error`) around external calls and failures.
+
+## Quick reference
+| Task | Code |
+|---|---|
+| State in prompt | `$variable` or `{{vrbl:variable}}` |
+| State in code | `conv.state.variable` |
+| Persist data | `conv.state.variable = value` |
+| Track event | `conv.write_metric("NAME", value)` |
+| Call global function | `conv.functions.my_function(...)` |
+| Call flow function | `flow.functions.my_function(...)` |
+| Navigate to flow | `conv.goto_flow("Flow Name")` |
+| Navigate to step | `flow.goto_step("Step Name", "reason")` |
+| Exit flow | `conv.exit_flow()` |
+| Transfer call | `conv.call_handoff(destination="...", reason="...")` |

--- a/src/poly/skills/poly-adk/references/handoffs.md
+++ b/src/poly/skills/poly-adk/references/handoffs.md
@@ -1,0 +1,51 @@
+# Handoffs
+
+## Overview
+Configure SIP call transfers for voice agents — how and where to transfer a call (invite, refer, or end).
+
+## Location
+`config/handoffs.yaml`, listed under the `handoffs` key.
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` (string) | Identifier; referenced in rules as `{{ho:handoff_name}}` |
+| `description` (string) | What this handoff does |
+| `is_default` (bool) | Whether this is the default handoff |
+| `sip_config` (object) | Transfer method config (see below) |
+| `sip_headers` (list, optional) | Custom SIP headers as `key`/`value` pairs |
+
+## SIP config types
+| Method | Use | Fields |
+|---|---|---|
+| `invite` | Outbound new call | `phone_number` (E.164), `outbound_endpoint`, `outbound_encryption` (`TLS/SRTP` or `UDP/RTP`) |
+| `refer` | Transfer existing call | `phone_number` (E.164) |
+| `bye` | End call | No extra fields |
+
+## Example
+```yaml
+handoffs:
+  - name: escalation_handoff
+    description: Transfer to a live agent for complex issues
+    is_default: false
+    sip_config:
+      method: refer
+      phone_number: "+15551234567"
+    sip_headers:
+      - key: X-Reason
+        value: escalation
+  - name: end_call
+    description: End the call gracefully
+    is_default: false
+    sip_config:
+      method: bye
+```
+
+## Usage
+- In code: `conv.call_handoff(destination="handoff_name", reason="transfer_reason")`
+- In rules: `{{ho:handoff_name}}` with instructions for when to use it.
+- In topics/flows: instruct the LLM to call a function that performs the handoff (e.g. `{{fn:transfer_call}}`).
+
+## Best practices
+Clear/descriptive names; E.164 phone numbers; one config per purpose (don't reuse a config for different
+destinations); keep `sip_headers` minimal.

--- a/src/poly/skills/poly-adk/references/languages.md
+++ b/src/poly/skills/poly-adk/references/languages.md
@@ -1,0 +1,31 @@
+# Languages
+
+## Purpose
+Configure which languages the agent supports. One default language, zero or more additional languages. Drives
+translation validation — every configured language must have entries in each translation key.
+
+## Location
+`agent_settings/languages.yaml`
+
+## Structure
+| Field | Notes |
+|---|---|
+| `default_language` | Primary language code (BCP 47, e.g. `en-GB`) |
+| `additional_languages` | List of additional language codes |
+
+```yaml
+default_language: en-GB
+additional_languages:
+  - fr-FR
+  - de-DE
+```
+
+## Validation
+- Default language required, must be valid BCP 47.
+- Additional codes must be valid BCP 47.
+- A code cannot appear as both default and additional.
+- No duplicate additional codes.
+
+## Best practices
+Set default to the primary user-base language; add additional languages only once translations are ready for all
+keys; use standard BCP 47 codes with region subtags.

--- a/src/poly/skills/poly-adk/references/response_control.md
+++ b/src/poly/skills/poly-adk/references/response_control.md
@@ -1,0 +1,59 @@
+# Response Control
+
+## Overview
+Manages what the agent says before it reaches the user — TTS pronunciation fixes and phrase filtering — under
+`voice/response_control/`:
+```
+voice/response_control/
+├── pronunciations.yaml             # Optional - TTS pronunciation rules
+└── phrase_filtering.yaml           # Optional - block/intercept phrases before TTS
+```
+
+## Pronunciations (`pronunciations.yaml`)
+Regex-based TTS rules applied before speech synthesis. Order matters.
+| Field | Notes |
+|---|---|
+| `regex` (required) | Pattern to match in the agent's output text |
+| `replacement` (required) | What to replace with for TTS (can be `""`) |
+| `case_sensitive` (bool) | Default `false` |
+| `language_code` (optional) | Restrict to one language |
+| `description` (optional) | What this rule does |
+
+```yaml
+pronunciations:
+  - regex: "\\bDr\\."
+    replacement: Doctor
+    case_sensitive: true
+  - regex: "\\bMr\\."
+    replacement: Mister
+    case_sensitive: true
+```
+
+## Phrase filters (`phrase_filtering.yaml`)
+Intercept/block phrases in the agent's output before they're spoken; can trigger a function on match.
+| Field | Notes |
+|---|---|
+| `name` (required) | Filter identifier |
+| `description` | What it does |
+| `regular_expressions` (required) | List of patterns |
+| `say_phrase` (bool) | `true` = still speak the match; `false` (default) = suppress |
+| `language_code` (optional) | Restrict to one language |
+| `function` (optional) | Global function to call on match — not a flow function |
+
+```yaml
+phrase_filtering:
+  - name: Block Profanity
+    description: Blocks profane words from being spoken
+    regular_expressions:
+      - "\\bbadword\\b"
+    say_phrase: false
+  - name: Competitor Mention Handler
+    description: Intercept competitor names and redirect
+    regular_expressions:
+      - "\\bcompetitor_name\\b"
+    say_phrase: true
+    function: handle_competitor_mention
+```
+
+**Best practices**: use for safety (profanity, PII leakage) and brand protection; keep regex specific to avoid
+false positives.

--- a/src/poly/skills/poly-adk/references/safety_filters.md
+++ b/src/poly/skills/poly-adk/references/safety_filters.md
@@ -1,0 +1,72 @@
+# Safety Filters
+
+## Overview
+Automatically blocks harmful content and unsafe responses in real time, on both user input and AI output, across
+four categories (violence, hate, sexual, self-harm) — settable at project level and per channel.
+
+## File structure
+```
+agent_settings/
+└── safety_filters.yaml       # Project-level (general) defaults
+voice/
+└── safety_filters.yaml       # Voice channel overrides
+chat/
+└── safety_filters.yaml       # Chat channel overrides
+```
+All three share the same schema; channel-level files override project-level defaults for that channel.
+
+## Fields
+| Field | Notes |
+|---|---|
+| `enabled` | `true`/`false` — whether filtering is active |
+| `categories` | Map of the four categories, each with `enabled` (bool) and `level` (`lenient`/`medium`/`strict`) |
+
+### Categories
+| Category | Description |
+|---|---|
+| `violence` | Violent or graphic content |
+| `hate` | Hateful or discriminatory content |
+| `sexual` | Sexually explicit content |
+| `self_harm` | Self-harm related content |
+
+## Example — project-level (general)
+```yaml
+categories:
+  violence:
+    enabled: true
+    level: medium
+  hate:
+    enabled: true
+    level: medium
+  sexual:
+    enabled: true
+    level: medium
+  self_harm:
+    enabled: true
+    level: medium
+```
+
+## Example — per-channel (includes global toggle)
+```yaml
+enabled: true
+categories:
+  violence:
+    enabled: true
+    level: medium
+  hate:
+    enabled: true
+    level: medium
+  sexual:
+    enabled: true
+    level: medium
+  self_harm:
+    enabled: true
+    level: medium
+```
+
+## Validation
+- All four categories must be present, each with both `enabled` and `level` set.
+- `level` must be `lenient`, `medium`, or `strict`.
+
+## Best practices
+Keep settings consistent across channels unless a channel's risk profile genuinely differs.

--- a/src/poly/skills/poly-adk/references/sms_templates.md
+++ b/src/poly/skills/poly-adk/references/sms_templates.md
@@ -1,0 +1,36 @@
+# SMS Templates
+
+## Purpose
+Text messages the agent can send during a conversation (confirmations, links, verification codes), with dynamic
+content via variables.
+
+## Location
+`config/sms_templates.yaml`, listed under the `sms_templates` key.
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` | Identifier; referenced as `{{twilio_sms:template_name}}` |
+| `text` | Message body; use `{{vrbl:variable_name}}` for dynamic values from `conv.state` |
+| `env_phone_numbers` (optional) | Per-environment sender numbers: `sandbox`, `pre_release`, `live` |
+
+```yaml
+sms_templates:
+  - name: booking_confirmation
+    text: "Hi {{vrbl:customer_name}}, your booking for {{vrbl:booking_date}} is confirmed. Reference: {{vrbl:booking_ref}}"
+    env_phone_numbers:
+      sandbox: "+15551234567"
+      live: "+15559876543"
+  - name: verification_code
+    text: "Your verification code is {{vrbl:verification_code}}. It expires in 10 minutes."
+```
+
+## Usage
+- In rules/topics/flows: `{{twilio_sms:template_name}}` instructs the LLM to send it at the right moment.
+- In code: call a function that triggers the SMS via `conv` or the platform API.
+- Variables: set the referenced state (e.g. `conv.state.customer_name`) before the SMS is triggered, so
+  `{{vrbl:...}}` resolves.
+
+## Best practices
+Set state variables before sending; use separate templates per purpose (confirmation, verification, follow-up);
+configure `env_phone_numbers` per environment.

--- a/src/poly/skills/poly-adk/references/speech_recognition.md
+++ b/src/poly/skills/poly-adk/references/speech_recognition.md
@@ -1,0 +1,72 @@
+# Speech Recognition
+
+## Overview
+Controls how the agent processes voice input, under `voice/speech_recognition/`:
+```
+voice/speech_recognition/
+├── asr_settings.yaml               # Barge-in, interaction style
+├── keyphrase_boosting.yaml         # Optional - bias ASR toward specific words
+└── transcript_corrections.yaml     # Optional - regex corrections on ASR output
+```
+
+## ASR settings (`asr_settings.yaml`)
+| Field | Notes |
+|---|---|
+| `barge_in` (bool) | Allow the user to interrupt the agent while speaking. Default `false`. |
+| `interaction_style` (string) | `balanced` (default), `precise`, `swift`, `sonic`, `turbo` |
+
+```yaml
+barge_in: false
+interaction_style: balanced
+```
+| Style | Behavior |
+|---|---|
+| `precise` | Higher accuracy, higher latency |
+| `balanced` | Default balance |
+| `swift` | Faster, slightly less accurate |
+| `sonic` / `turbo` | Lowest latency |
+
+## Keyphrase boosting (`keyphrase_boosting.yaml`)
+Biases the recognizer toward brand names, product names, jargon.
+| Field | Notes |
+|---|---|
+| `keyphrase` (required) | Word/phrase to boost |
+| `level` | `default` (default), `boosted`, `maximum` |
+
+```yaml
+keyphrases:
+  - keyphrase: PolyAI
+    level: maximum
+  - keyphrase: reservation
+    level: boosted
+  - keyphrase: check-in
+    level: default
+```
+
+## Transcript corrections (`transcript_corrections.yaml`)
+Post-process ASR output with regex to fix common misrecognitions (email domains, spelled-out values, jargon).
+| Field | Notes |
+|---|---|
+| `name` (required) | Correction group identifier |
+| `description` | What it fixes |
+| `regular_expressions` | List of `{regular_expression, replacement, replacement_type}` |
+| `replacement_type` | `full` (default, replaces entire match) or `partial`/`substring` |
+
+```yaml
+corrections:
+  - name: Email domain fix
+    description: Correct common email domain misrecognitions
+    regular_expressions:
+      - regular_expression: at gmail dot com
+        replacement: "@gmail.com"
+        replacement_type: full
+      - regular_expression: at hotmail dot com
+        replacement: "@hotmail.com"
+        replacement_type: full
+  - name: Number normalization
+    description: Normalize spoken numbers to digits
+    regular_expressions:
+      - regular_expression: \bdouble (\d)\b
+        replacement: \1\1
+        replacement_type: partial
+```

--- a/src/poly/skills/poly-adk/references/tests.md
+++ b/src/poly/skills/poly-adk/references/tests.md
@@ -1,0 +1,73 @@
+# Tests
+
+## Overview
+Tests are simulated conversations that validate agent behavior in Agent Studio. Each defines a user scenario, the
+channel, optional tags, and assertions on the agent's response and function calls.
+
+## Location
+`test_suite/`, one file per test: `test_suite/{test_name}.yaml`. Filenames are cleaned to lowercase snake_case
+(e.g. `"Greeting flow test"` → `test_suite/greeting_flow_test.yaml`).
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` (string) | Display name — filename is derived from this |
+| `scenario` (string) | Simulated user input that starts the conversation |
+| `channel` (string) | `voice` or `webchat` |
+| `tags` (list, optional) | Labels for grouping/filtering |
+| `variant` (string, optional) | Variant to run against |
+| `language` (string) | Language code, e.g. `en-GB` |
+| `prompt_assertions` (list, optional) | Expected agent behaviors |
+| `function_call_assertions` (list, optional) | Expected function calls + arguments |
+
+```yaml
+name: Greeting flow test
+scenario: Ask for help with booking.
+channel: voice
+language: en-GB
+tags:
+- booking
+- smoke
+prompt_assertions:
+- The agent offers to help with booking
+function_call_assertions:
+- name: test_function
+  arguments:
+  - parameter_name: param1
+    expected_value: hello
+    value_type: string
+```
+
+## Prompt assertions
+Natural-language descriptions of what the agent should do/say, evaluated against the simulated conversation. One
+assertion per expected behavior; check one thing per line.
+
+## Function call assertions
+| Field | Notes |
+|---|---|
+| `name` | Must be a valid global function in the project |
+| `arguments` | List of `{parameter_name, expected_value, value_type}` |
+| `value_type` | `string`, `integer`, `number`, or `boolean` |
+
+## Channels
+| YAML value | Description |
+|---|---|
+| `voice` | Voice channel |
+| `webchat` | Web chat channel |
+
+## Naming and filenames
+`name` can contain spaces/mixed case; filename must match its cleaned version or `pull`/`push` fails validation.
+
+## Validation (on push)
+- `channel` must be `voice` or `webchat`.
+- `scenario` required, non-empty.
+- `language` required and must match a configured project language (default or additional).
+- `variant`, if set, must match an existing project variant.
+- `function_call_assertions`: function name must match a global function; each `value_type` must be `string`,
+  `integer`, `number`, or `boolean`.
+
+## Best practices
+- Tag with `smoke` / `regression` to group related tests.
+- Write scenarios as realistic user utterances.
+- Combine prompt assertions (what's said) with function call assertions (what's done) for end-to-end coverage.
+- One test per behavior/flow path.

--- a/src/poly/skills/poly-adk/references/topics.md
+++ b/src/poly/skills/poly-adk/references/topics.md
@@ -1,0 +1,72 @@
+# Topics
+
+## Overview
+Topics are the agent's knowledge base, queried via RAG. When user input matches a topic, the agent retrieves its
+content and follows its actions.
+
+## Location
+`topics/`, one file per topic: `topics/{topic_name}.yaml`. Filenames are cleaned to lowercase snake_case (e.g.
+`"Opening Hours & Locations"` → `topics/opening_hours_locations.yaml`).
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` (string) | Canonical display name — filename is derived from this |
+| `enabled` (bool) | Default `true` |
+| `example_queries` | List of example user inputs that should trigger this topic |
+| `content` | Factual info retrieved via RAG — **no** function calls or variable references |
+| `actions` | Behavioral instructions when triggered — references allowed here |
+
+```yaml
+name: Opening Hours & Locations
+enabled: true
+example_queries:
+  - What are your opening hours?
+  - When are you open?
+  - Are you open on weekends?
+  - What time do you close?
+content: |-
+  The office is open Monday to Friday from 9am to 5pm.
+  Weekend hours are Saturday 10am to 2pm. Closed on Sundays.
+actions: |-
+  Tell the user the opening hours from the content above.
+
+  ## If the user asks about a specific location
+  Check the location using {{attr:office_location}} and provide the hours for that location.
+
+  ## If the user wants to speak to someone
+  Use {{fn:transfer_to_agent}} to connect them with a representative.
+```
+
+## Naming and filenames
+- `name` can contain spaces, punctuation, mixed case.
+- The filename must match the cleaned (lowercase snake_case) version of `name` — mismatch raises a validation
+  error on `pull`/`push`.
+
+## Example queries
+- Max **20**.
+- Cover different phrasings of the same underlying question.
+- Don't try to cover every minor variation — the model generalizes.
+
+## Content
+- Facts only — this is what's retrieved via RAG.
+- **No** `{{fn:...}}`, `{{ft:...}}`, `$variable`, or `{{attr:...}}` references.
+- Use `|-` for multi-line content.
+
+## Actions
+References allowed **only here**, not in `content` or `example_queries`:
+- `{{fn:function_name}}` / `{{fn:function_name}}('arg')` — call a global function, with/without an argument
+- `{{attr:attribute_name}}` — variant attribute
+- `{{twilio_sms:template_name}}` — SMS template
+- `{{ho:handoff_name}}` — handoff
+- `$variable` — state variable
+
+Use markdown headers (`##`, `###`) for conditional branches; keep actions scannable rather than one dense
+paragraph.
+
+## Best practices
+- Don't prompt `"Say: '...'"` — hurts multilingual support; use `"Tell the user that ..."` instead.
+- Prefer structured `## Conditional Branch` sections over one dense paragraph.
+- Keep content (facts) and actions (behavior) separate.
+- One topic per subject area — split when a topic gets too large.
+- Disable with `enabled: false` rather than deleting during development.

--- a/src/poly/skills/poly-adk/references/translations.md
+++ b/src/poly/skills/poly-adk/references/translations.md
@@ -1,0 +1,36 @@
+# Translations
+
+## Purpose
+Localized text strings across languages. Each has a key and language-specific values so the agent can respond in
+the user's configured language.
+
+## Location
+`config/translations.yaml`, listed under the `translations` key.
+
+## Structure
+| Field | Notes |
+|---|---|
+| `name` | Translation key identifier (e.g. `greeting`, `farewell`) |
+| `translations` | Map of language code → localized text |
+
+```yaml
+translations:
+  - name: greeting
+    translations:
+      en-GB: Hello, how can I help you?
+      fr-FR: Bonjour, comment puis-je vous aider?
+  - name: farewell
+    translations:
+      en-GB: Goodbye, have a nice day!
+      fr-FR: Au revoir, bonne journée!
+```
+
+## Validation
+- `name` cannot be empty.
+- Each translation needs at least one language entry.
+- If languages are configured (see `references/languages.md`), every configured language (default + additional)
+  must have an entry in each translation, or validation fails.
+
+## Best practices
+Descriptive keys (`greeting`, `error_not_found`); every configured language covered for every key; consistent
+tone/meaning across languages.

--- a/src/poly/skills/poly-adk/references/variables.md
+++ b/src/poly/skills/poly-adk/references/variables.md
@@ -1,0 +1,40 @@
+# Variables
+
+## Overview
+Virtual resources representing state values used in agent code. Unlike other resources, variables have no files
+on disk — they're discovered automatically by scanning function code for `conv.state.<name>` usage.
+
+## How they work
+Writing `conv.state.customer_name = "Alice"` in any function makes `customer_name` a tracked variable. The ADK
+scans all function files (global functions, flow functions, function steps) for state attribute access.
+
+Reference in prompts/templates as `$variable_name` or `{{vrbl:variable_name}}` — interchangeable; prefer
+`{{vrbl:...}}` since it's validated by the ADK.
+
+## Setting state in code
+```python
+conv.state.customer_name = "Alice"
+conv.state.account_balance = 150.00
+conv.state.is_verified = True
+```
+
+## Reading state in code
+```python
+name = conv.state.customer_name  # None if unset
+if conv.state.is_verified:
+    ...
+```
+
+## Using variables in prompts and templates
+```
+The customer's name is $customer_name and their balance is $account_balance.
+```
+```yaml
+text: "Hi {{vrbl:customer_name}}, your booking is confirmed for {{vrbl:booking_date}}."
+```
+Never use `conv.state.variable` syntax in prompts. Never use `$var.attribute` — stringify complex objects in
+Python first, then store the string in state.
+
+## Best practices
+Auto-discovered, no manual registration; descriptive snake_case names; initialize in `start_function` or early in
+the flow to avoid `None` values; keep names consistent across functions and prompts.

--- a/src/poly/skills/poly-adk/references/variants.md
+++ b/src/poly/skills/poly-adk/references/variants.md
@@ -1,0 +1,84 @@
+# Variants
+
+## Purpose
+Variant attributes provide per-variant configuration (location, environment, tenant). The platform picks a
+variant at runtime; the agent reads that variant's attributes so prompts/behavior vary without separate code or
+deployments.
+
+## Location
+`config/variant_attributes.yaml`
+
+## Structure
+Two top-level keys:
+
+**`variants`** — list of variants
+| Field | Notes |
+|---|---|
+| `name` (required) | Unique identifier (location/environment/tenant); used as the key in `values` |
+| `is_default` (optional) | Exactly one variant must have `is_default: true` — used when no variant resolves at runtime |
+
+**`attributes`** — list of attributes
+| Field | Notes |
+|---|---|
+| `name` | Attribute identifier (snake_case), e.g. `greeting_name`, `support_phone_number` |
+| `values` | Map from variant name → string value; one entry per variant; `""`, single-line, or multi-line (`\|-`) |
+
+## Example
+```yaml
+variants:
+  - name: new_york
+    is_default: true
+  - name: london
+  - name: tokyo
+
+attributes:
+  - name: office_phone
+    values:
+      new_york: "+12125551234"
+      london: "+442071234567"
+      tokyo: "+81312345678"
+  - name: office_hours
+    values:
+      new_york: "9am - 5pm EST"
+      london: "9am - 5pm GMT"
+      tokyo: "9am - 5pm JST"
+  - name: greeting_name
+    values:
+      new_york: "New York Office"
+      london: "London Office"
+      tokyo: "Tokyo Office"
+  - name: custom_disclaimer
+    values:
+      new_york: |-
+        This call is recorded for quality assurance.
+        You may request a copy of this recording.
+      london: |-
+        This call may be recorded in accordance with UK regulations.
+      tokyo: ""
+```
+Quote variant names with special characters (e.g. `&`, parentheses).
+
+## Usage
+**In prompts/resource files** — `{{attr:attribute_name}}` in: flow step prompts, topic actions (not content or
+example_queries), rules.txt, greeting (`welcome_message`), disclaimer, personality `custom`, role `custom`.
+
+**In Python**:
+```python
+phone = conv.variant.office_phone
+hours = conv.variant.office_hours
+```
+
+## Typical attribute types
+- Branding: greeting name, company name
+- Contact: phone numbers, addresses, office hours
+- IDs: location_id, region code
+- Feature flags: `"True"` / `"False"` strings, checked in Python
+- URLs: portal link, payment link
+- Environment: timezone, is_live
+
+## Best practices
+- Keep variant names stable; quote special characters.
+- Exactly one `is_default` variant.
+- Provide a value (or `""`) for every variant in every attribute's `values` map — missing one fails validation.
+- Prefer `{{attr:...}}` over hardcoded strings for anything location/environment-specific.
+- Use `|-` for multi-line values (disclaimers, hours, instructions).

--- a/src/poly/skills/poly-adk/references/voice_settings.md
+++ b/src/poly/skills/poly-adk/references/voice_settings.md
@@ -1,0 +1,50 @@
+# Voice Settings
+
+## Overview
+Configures the agent's behavior on the voice channel, in `voice/configuration.yaml`.
+
+## Greeting
+| Field | Notes |
+|---|---|
+| `welcome_message` (required) | Greeting text; supports `{{attr:...}}` and `{{vrbl:...}}` |
+| `language_code` (required) | BCP-47 code, e.g. `en-GB`, `en-US` |
+
+```yaml
+greeting:
+  welcome_message: Hello! Welcome to our service. How can I assist you today?
+  language_code: en-GB
+```
+
+## Style prompt
+Voice-specific phrasing/verbosity/tone guidance — separate from personality.
+| Field | Notes |
+|---|---|
+| `prompt` | Free-text style instructions; no resource references allowed |
+
+```yaml
+style_prompt:
+  prompt: You are a helpful and professional customer service assistant. Use natural, conversational phrasing.
+```
+
+## Disclaimer message
+Optional message played before the greeting (e.g. "This call may be recorded").
+| Field | Notes |
+|---|---|
+| `message` | Disclaimer text; supports `{{attr:...}}` and `{{vrbl:...}}` |
+| `enabled` | Boolean toggle |
+| `language_code` | BCP-47 code |
+
+## Full example
+```yaml
+greeting:
+  welcome_message: Hello! Welcome to our service. Your account shows {{attr:member_status}}. How can I assist you today?
+  language_code: en-GB
+style_prompt:
+  prompt: You are a helpful and professional customer service assistant.
+disclaimer_messages:
+  message: This conversation may be recorded for quality assurance.
+  enabled: true
+  language_code: en-GB
+```
+
+See also: `references/speech_recognition.md`, `references/response_control.md`.

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -4,6 +4,8 @@ Copyright PolyAI Limited
 """
 
 import os
+import re
+import tempfile
 import unittest
 from io import StringIO
 from unittest.mock import MagicMock, patch
@@ -17,8 +19,9 @@ from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand
 from poly.cli_commands.shared import compute_diff
 from poly.cli_commands.sync import FormatCommand, RevertCommand
-from poly.cli_commands.utils import CompletionCommand
+from poly.cli_commands.utils import CompletionCommand, DocsCommand
 from poly.tests.project_test import TEST_DIR
+from poly.utils import agent_setup
 
 
 def _run_result(returncode: int, stdout: str = "", stderr: str = ""):
@@ -3129,3 +3132,382 @@ class AudioCacheCommandTest(unittest.TestCase):
         )
         mock_success.assert_called_once()
         self.assertIn("entry-1-preview.wav", mock_success.call_args[0][0])
+
+
+class ClaudeCodeSetupTest(unittest.TestCase):
+    """Tests for `poly docs --claude-code` and the agent setup planner."""
+
+    CLI_COMMANDS = {
+        "test_fresh_install_writes_skill_and_memory": "poly docs --claude-code --path <project>",
+        "test_rerun_is_a_noop": "poly docs --claude-code --path <project>",
+        "test_existing_memory_is_appended_to": "poly docs --claude-code --path <project>",
+        "test_existing_block_is_replaced_in_place": "poly docs --claude-code --path <project> -f",
+        "test_edited_skill_file_needs_confirmation": "poly docs --claude-code --path <project>",
+        "test_stale_skill_files_are_removed": "poly docs --claude-code --path <project> -f",
+        "test_unterminated_block_raises": "poly docs --claude-code --path <project>",
+    }
+
+    def setUp(self):
+        cmd = self.CLI_COMMANDS.get(self._testMethodName, "")
+        print("\n" + "─" * 60 + f"\n  {self._testMethodName}\n  $ {cmd}\n" + "─" * 60)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.project_dir = self._tmp.name
+        self.skill_dir = os.path.join(self.project_dir, ".claude", "skills", "poly-adk")
+        self.memory_path = os.path.join(self.project_dir, "CLAUDE.md")
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        print("─" * 60 + "\n")
+
+    def _install(self, force: bool = True) -> None:
+        DocsCommand.setup_claude_code(self.project_dir, force=force)
+
+    def _read_memory(self) -> str:
+        with open(self.memory_path, encoding="utf-8") as f:
+            return f.read()
+
+    def test_fresh_install_writes_skill_and_memory(self):
+        """A fresh install writes SKILL.md, every reference file, and CLAUDE.md."""
+        self._install()
+
+        self.assertTrue(os.path.exists(os.path.join(self.skill_dir, "SKILL.md")))
+        references = os.listdir(os.path.join(self.skill_dir, "references"))
+        self.assertIn("flows.md", references)
+        self.assertGreater(len(references), 10)
+        self.assertIn(agent_setup.MEMORY_BEGIN, self._read_memory())
+
+    def test_rerun_is_a_noop(self):
+        """Re-running against an up-to-date project plans no changes."""
+        self._install()
+
+        plan = agent_setup.plan_claude_code_setup(self.project_dir)
+
+        self.assertTrue(plan.is_noop)
+        self.assertEqual([], plan.pending)
+        self.assertFalse(plan.needs_confirmation)
+
+    def test_existing_memory_is_appended_to(self):
+        """An existing CLAUDE.md keeps its content and gains the poly-adk block."""
+        with open(self.memory_path, "w", encoding="utf-8") as f:
+            f.write("# My project\n\nSome existing notes.\n")
+
+        plan = agent_setup.plan_claude_code_setup(self.project_dir)
+        memory_write = next(w for w in plan.writes if w.path == self.memory_path)
+        self.assertEqual(agent_setup.APPEND, memory_write.action)
+        # Appending is additive, so it must not trigger a confirmation prompt.
+        self.assertFalse(plan.needs_confirmation)
+
+        self._install()
+        memory = self._read_memory()
+        self.assertIn("Some existing notes.", memory)
+        self.assertIn(agent_setup.MEMORY_BEGIN, memory)
+
+    def test_existing_block_is_replaced_in_place(self):
+        """Refreshing rewrites the poly-adk block and leaves surrounding text alone."""
+        self._install()
+        with open(self.memory_path, encoding="utf-8") as f:
+            installed = f.read()
+        with open(self.memory_path, "w", encoding="utf-8") as f:
+            f.write("# Header\n\n" + installed.replace("poly pull", "STALE") + "\n## Footer\n")
+
+        self._install()
+
+        memory = self._read_memory()
+        self.assertIn("# Header", memory)
+        self.assertIn("## Footer", memory)
+        self.assertNotIn("STALE", memory)
+        self.assertIn("poly pull", memory)
+        self.assertEqual(1, memory.count(agent_setup.MEMORY_BEGIN))
+
+    def test_edited_skill_file_needs_confirmation(self):
+        """A locally edited skill file is planned as a destructive overwrite."""
+        self._install()
+        skill_path = os.path.join(self.skill_dir, "SKILL.md")
+        with open(skill_path, "a", encoding="utf-8") as f:
+            f.write("\nlocal edit\n")
+
+        plan = agent_setup.plan_claude_code_setup(self.project_dir)
+
+        self.assertTrue(plan.needs_confirmation)
+        self.assertEqual([skill_path], [w.path for w in plan.destructive])
+
+    def test_stale_skill_files_are_removed(self):
+        """Files in the skill directory that the CLI no longer ships are deleted."""
+        self._install()
+        stale = os.path.join(self.skill_dir, "references", "removed_resource.md")
+        with open(stale, "w", encoding="utf-8") as f:
+            f.write("dropped in a later release")
+
+        plan = agent_setup.plan_claude_code_setup(self.project_dir)
+        self.assertEqual([stale], plan.removals)
+
+        self._install()
+        self.assertFalse(os.path.exists(stale))
+
+    def test_unterminated_block_raises(self):
+        """A CLAUDE.md with an opening marker but no closing marker is rejected."""
+        with open(self.memory_path, "w", encoding="utf-8") as f:
+            f.write(f"{agent_setup.MEMORY_BEGIN}\nhalf a block\n")
+
+        with self.assertRaises(ValueError):
+            agent_setup.plan_claude_code_setup(self.project_dir)
+
+
+class DocsCommandDispatchTest(unittest.TestCase):
+    """Tests for `poly docs` argument handling and dispatch."""
+
+    CLI_COMMANDS = {
+        "test_claude_code_flag_dispatches_to_setup": "poly docs --claude-code",
+        "test_plain_docs_still_prints": "poly docs flows",
+        "test_path_and_force_are_forwarded": "poly docs --claude-code --path <dir> -f",
+        "test_claude_code_rejects_all": "poly docs --all --claude-code",
+        "test_claude_code_rejects_output": "poly docs --claude-code --output out.md",
+        "test_claude_code_rejects_topic_names": "poly docs flows --claude-code",
+    }
+
+    def setUp(self):
+        cmd = self.CLI_COMMANDS.get(self._testMethodName, "")
+        print("\n" + "─" * 60 + f"\n  {self._testMethodName}\n  $ {cmd}\n" + "─" * 60)
+
+    def tearDown(self):
+        print("─" * 60 + "\n")
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    def test_claude_code_flag_dispatches_to_setup(self, mock_setup):
+        """--claude-code routes to the setup handler, not the doc printer."""
+        AgentStudioCLI().main(["docs", "--claude-code"])
+
+        mock_setup.assert_called_once()
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    @patch("poly.cli_commands.utils.DocsCommand.docs")
+    def test_plain_docs_still_prints(self, mock_docs, mock_setup):
+        """Without --claude-code the command prints documentation as before."""
+        AgentStudioCLI().main(["docs", "flows"])
+
+        mock_setup.assert_not_called()
+        mock_docs.assert_called_once_with(
+            documents=["flows"], all_documents=False, output=None
+        )
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    def test_path_and_force_are_forwarded(self, mock_setup):
+        """--path and --force reach the setup handler."""
+        AgentStudioCLI().main(["docs", "--claude-code", "--path", "/tmp/x", "--force"])
+
+        mock_setup.assert_called_once_with(path="/tmp/x", force=True)
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    def test_claude_code_rejects_all(self, mock_setup):
+        """--claude-code with --all exits rather than silently ignoring --all."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI().main(["docs", "--all", "--claude-code"])
+
+        mock_setup.assert_not_called()
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    def test_claude_code_rejects_output(self, mock_setup):
+        """--claude-code with --output exits; nothing would have been written there."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI().main(["docs", "--claude-code", "--output", "out.md"])
+
+        mock_setup.assert_not_called()
+
+    @patch("poly.cli_commands.utils.DocsCommand.setup_claude_code")
+    def test_claude_code_rejects_topic_names(self, mock_setup):
+        """--claude-code with topic names exits."""
+        with self.assertRaises(SystemExit):
+            AgentStudioCLI().main(["docs", "flows", "--claude-code"])
+
+        mock_setup.assert_not_called()
+
+
+class ClaudeCodeSetupPromptTest(unittest.TestCase):
+    """Tests for the confirmation behaviour of `poly docs --claude-code`."""
+
+    CLI_COMMANDS = {
+        "test_noop_reports_up_to_date": "poly docs --claude-code",
+        "test_non_tty_overwrite_exits": "poly docs --claude-code",
+        "test_declining_the_prompt_writes_nothing": "poly docs --claude-code",
+        "test_accepting_the_prompt_writes": "poly docs --claude-code",
+        "test_force_skips_the_prompt": "poly docs --claude-code --force",
+    }
+
+    def setUp(self):
+        cmd = self.CLI_COMMANDS.get(self._testMethodName, "")
+        print("\n" + "─" * 60 + f"\n  {self._testMethodName}\n  $ {cmd}\n" + "─" * 60)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.project_dir = self._tmp.name
+        self.skill_path = os.path.join(
+            self.project_dir, ".claude", "skills", "poly-adk", "SKILL.md"
+        )
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        print("─" * 60 + "\n")
+
+    def _install_then_edit(self) -> str:
+        """Install the assets, then locally edit SKILL.md so a re-run must confirm."""
+        DocsCommand.setup_claude_code(self.project_dir, force=True)
+        with open(self.skill_path, "a", encoding="utf-8") as f:
+            f.write("\nlocal edit\n")
+        with open(self.skill_path, encoding="utf-8") as f:
+            return f.read()
+
+    def _read_skill(self) -> str:
+        with open(self.skill_path, encoding="utf-8") as f:
+            return f.read()
+
+    @patch("poly.output.console.success")
+    def test_noop_reports_up_to_date(self, mock_success):
+        """A second run against an unchanged project reports success and writes nothing."""
+        DocsCommand.setup_claude_code(self.project_dir, force=True)
+        before = self._read_skill()
+        mock_success.reset_mock()
+
+        DocsCommand.setup_claude_code(self.project_dir)
+
+        self.assertIn("already up to date", mock_success.call_args[0][0])
+        self.assertEqual(before, self._read_skill())
+
+    @patch("sys.stdin.isatty", return_value=False)
+    def test_non_tty_overwrite_exits(self, _mock_isatty):
+        """Without a terminal to prompt in, a destructive run exits instead of clobbering."""
+        edited = self._install_then_edit()
+
+        with self.assertRaises(SystemExit) as ctx:
+            DocsCommand.setup_claude_code(self.project_dir)
+
+        self.assertEqual(1, ctx.exception.code)
+        self.assertEqual(edited, self._read_skill())
+
+    @patch("questionary.confirm")
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_declining_the_prompt_writes_nothing(self, _mock_isatty, mock_confirm):
+        """Answering no to the prompt leaves every file untouched."""
+        edited = self._install_then_edit()
+        mock_confirm.return_value.ask.return_value = False
+
+        DocsCommand.setup_claude_code(self.project_dir)
+
+        mock_confirm.assert_called_once()
+        self.assertEqual(edited, self._read_skill())
+
+    @patch("questionary.confirm")
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_accepting_the_prompt_writes(self, _mock_isatty, mock_confirm):
+        """Answering yes restores the edited file to what the CLI ships."""
+        edited = self._install_then_edit()
+        mock_confirm.return_value.ask.return_value = True
+
+        DocsCommand.setup_claude_code(self.project_dir)
+
+        self.assertNotEqual(edited, self._read_skill())
+        self.assertNotIn("local edit", self._read_skill())
+
+    @patch("questionary.confirm")
+    @patch("sys.stdin.isatty", return_value=True)
+    def test_force_skips_the_prompt(self, _mock_isatty, mock_confirm):
+        """--force overwrites without asking, which is what CI and setup scripts need."""
+        self._install_then_edit()
+
+        DocsCommand.setup_claude_code(self.project_dir, force=True)
+
+        mock_confirm.assert_not_called()
+        self.assertNotIn("local edit", self._read_skill())
+
+
+class PackagedSkillTest(unittest.TestCase):
+    """Tests that the shipped poly-adk skill stays internally consistent."""
+
+    def setUp(self):
+        print("\n" + "─" * 60 + f"\n  {self._testMethodName}\n" + "─" * 60)
+
+    def tearDown(self):
+        print("─" * 60 + "\n")
+
+    @staticmethod
+    def _skill_markdown() -> str:
+        skill_path = os.path.join(agent_setup.SKILLS_PACKAGE_DIR, "poly-adk", "SKILL.md")
+        with open(skill_path, encoding="utf-8") as f:
+            return f.read()
+
+    def test_skill_has_frontmatter(self):
+        """SKILL.md needs name and description frontmatter for Claude Code to load it."""
+        content = self._skill_markdown()
+
+        self.assertTrue(content.startswith("---\n"))
+        frontmatter = content.split("---", 2)[1]
+        self.assertIn("name: poly-adk", frontmatter)
+        self.assertIn("description:", frontmatter)
+
+    def test_referenced_files_all_exist(self):
+        """Every references/*.md path named in SKILL.md is actually shipped."""
+        referenced = set(re.findall(r"references/([\w-]+\.md)", self._skill_markdown()))
+        shipped = {
+            os.path.basename(relative)
+            for _, relative in agent_setup.discover_skill_files()
+            if relative.startswith("references")
+        }
+
+        self.assertTrue(referenced, "SKILL.md should reference its reference files")
+        self.assertEqual(set(), referenced - shipped, "SKILL.md references missing files")
+        self.assertEqual(set(), shipped - referenced, "shipped files missing from SKILL.md")
+
+    def test_no_reference_files_are_empty(self):
+        """An empty reference file would silently give the agent nothing to read."""
+        for source, relative in agent_setup.discover_skill_files():
+            with self.subTest(relative):
+                with open(source, encoding="utf-8") as f:
+                    self.assertGreater(len(f.read().strip()), 100)
+
+    def test_skill_tree_stays_within_the_packaged_globs(self):
+        """No skill file may nest deeper than references/, or it won't be packaged.
+
+        pyproject.toml globs `poly-adk/*.md` and `poly-adk/references/*.md`, neither of
+        which recurses. A file added below those would be missing from the wheel.
+        """
+        for _, relative in agent_setup.discover_skill_files():
+            parts = relative.split(os.sep)
+            with self.subTest(relative):
+                self.assertLessEqual(len(parts), 2)
+                if len(parts) == 2:
+                    self.assertEqual("references", parts[0])
+
+
+class RenderMemoryTest(unittest.TestCase):
+    """Tests for merging the poly-adk block into an existing CLAUDE.md."""
+
+    BLOCK = f"{agent_setup.MEMORY_BEGIN}\nbody\n{agent_setup.MEMORY_END}\n"
+
+    def setUp(self):
+        print("\n" + "─" * 60 + f"\n  {self._testMethodName}\n" + "─" * 60)
+
+    def tearDown(self):
+        print("─" * 60 + "\n")
+
+    def test_missing_file_becomes_the_block(self):
+        """No CLAUDE.md yet means the file is just the block."""
+        self.assertEqual(self.BLOCK, agent_setup.render_memory(None, self.BLOCK))
+
+    def test_whitespace_only_file_is_replaced(self):
+        """A blank CLAUDE.md is treated as absent rather than appended to."""
+        self.assertEqual(self.BLOCK, agent_setup.render_memory("\n  \n", self.BLOCK))
+
+    def test_file_without_trailing_newline_is_separated(self):
+        """Appending inserts a blank line even when the existing file lacks a newline."""
+        result = agent_setup.render_memory("# Notes", self.BLOCK)
+
+        self.assertEqual(f"# Notes\n\n{self.BLOCK}", result)
+
+    def test_existing_block_is_replaced_not_duplicated(self):
+        """Re-rendering swaps the block body and leaves one copy of the markers."""
+        existing = f"# Top\n\n{agent_setup.MEMORY_BEGIN}\nold\n{agent_setup.MEMORY_END}\n\n# End\n"
+
+        result = agent_setup.render_memory(existing, self.BLOCK)
+
+        self.assertEqual(1, result.count(agent_setup.MEMORY_BEGIN))
+        self.assertIn("# Top", result)
+        self.assertIn("# End", result)
+        self.assertIn("body", result)
+        self.assertNotIn("old", result)

--- a/src/poly/utils/__init__.py
+++ b/src/poly/utils/__init__.py
@@ -8,6 +8,12 @@ public names re-exported here for convenience and backwards compatibility.
 Copyright PolyAI Limited
 """
 
+from poly.utils.agent_setup import (
+    ClaudeCodePlan,
+    apply_claude_code_setup,
+    plan_claude_code_setup,
+    render_memory,
+)
 from poly.utils.commands import create_command_webchat_channel_update_status
 from poly.utils.credentials import (
     CREDENTIALS_FILE_PATH,
@@ -32,7 +38,9 @@ from poly.utils.variable_references import (
 __all__ = [
     "CREDENTIALS_FILE_PATH",
     "FUNCTION_TYPE_TO_VAR_REF_FIELD",
+    "ClaudeCodePlan",
     "any_credentials_exist",
+    "apply_claude_code_setup",
     "compute_variable_references",
     "diff_dicts",
     "create_command_webchat_channel_update_status",
@@ -43,7 +51,9 @@ __all__ = [
     "func_parameter",
     "merge_rtc_dicts",
     "merge_strings",
+    "plan_claude_code_setup",
     "read_json_file",
+    "render_memory",
     "retrieve_api_key",
     "save_api_key_credential_file",
     "save_imports",

--- a/src/poly/utils/agent_setup.py
+++ b/src/poly/utils/agent_setup.py
@@ -1,0 +1,263 @@
+"""Install coding-agent memory and skill files into a project.
+
+Backs ``poly docs --claude-code``. The assets themselves are shipped as package
+data under ``poly/skills`` and copied verbatim into the target project, so
+upgrading the CLI and re-running the command refreshes them.
+
+The work is split into a plan and an apply step: ``plan_claude_code_setup``
+decides what each file needs (create, overwrite, append or nothing) without
+touching disk, and ``apply_claude_code_setup`` writes it. That lets the CLI show
+the user exactly what will change and ask before clobbering anything.
+
+Copyright PolyAI Limited
+"""
+
+import os
+from dataclasses import dataclass, field
+
+SKILL_NAME = "poly-adk"
+"""Directory name of the skill inside ``.claude/skills``."""
+
+MEMORY_FILE = "CLAUDE.md"
+"""Project memory file Claude Code loads on every session."""
+
+MEMORY_BEGIN = "<!-- BEGIN poly-adk -->"
+MEMORY_END = "<!-- END poly-adk -->"
+
+_POLY_PACKAGE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SKILLS_PACKAGE_DIR = os.path.join(_POLY_PACKAGE_DIR, "skills")
+"""Absolute path to the ``poly/skills`` package data directory."""
+
+# What a planned write does to the file at its path.
+CREATE = "create"
+OVERWRITE = "overwrite"
+APPEND = "append"
+UNCHANGED = "unchanged"
+
+
+@dataclass
+class PlannedWrite:
+    """A single file the setup wants to write."""
+
+    path: str
+    """Absolute path of the file to write."""
+
+    content: str
+    """Full content to write to ``path``."""
+
+    action: str
+    """One of ``create``, ``overwrite``, ``append`` or ``unchanged``."""
+
+    @property
+    def destructive(self) -> bool:
+        """Whether applying this write would discard existing content."""
+        return self.action == OVERWRITE
+
+
+@dataclass
+class ClaudeCodePlan:
+    """Everything ``poly docs --claude-code`` intends to change."""
+
+    target_dir: str
+    """Project directory the assets are installed into."""
+
+    writes: list[PlannedWrite] = field(default_factory=list)
+    """Planned writes, in the order they should be applied."""
+
+    removals: list[str] = field(default_factory=list)
+    """Installed skill files no longer shipped by this CLI version."""
+
+    @property
+    def pending(self) -> list[PlannedWrite]:
+        """Writes that would actually change something on disk."""
+        return [write for write in self.writes if write.action != UNCHANGED]
+
+    @property
+    def destructive(self) -> list[PlannedWrite]:
+        """Writes that would discard existing content, needing confirmation."""
+        return [write for write in self.writes if write.destructive]
+
+    @property
+    def needs_confirmation(self) -> bool:
+        """Whether applying this plan would destroy anything the user has."""
+        return bool(self.destructive or self.removals)
+
+    @property
+    def is_noop(self) -> bool:
+        """Whether everything is already up to date."""
+        return not self.pending and not self.removals
+
+
+def _read(path: str) -> str | None:
+    """Read a UTF-8 file, or return None if it doesn't exist."""
+    if not os.path.exists(path):
+        return None
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+def load_memory_block() -> str:
+    """Load the packaged memory block written into the project's CLAUDE.md.
+
+    Returns:
+        str: The memory block, delimited by the begin and end markers.
+
+    Raises:
+        ValueError: If the packaged memory file is missing.
+    """
+    memory_path = os.path.join(SKILLS_PACKAGE_DIR, "memory.md")
+    content = _read(memory_path)
+    if content is None:
+        raise ValueError(f"Packaged memory file not found: {memory_path}")
+    return content.strip() + "\n"
+
+
+def discover_skill_files() -> list[tuple[str, str]]:
+    """Find the packaged skill files to install.
+
+    Returns:
+        list[tuple[str, str]]: ``(absolute source path, path relative to the
+        skill directory)`` pairs, sorted for stable output.
+
+    Raises:
+        ValueError: If the packaged skill directory is missing.
+    """
+    skill_dir = os.path.join(SKILLS_PACKAGE_DIR, SKILL_NAME)
+    if not os.path.isdir(skill_dir):
+        raise ValueError(f"Packaged skill not found: {skill_dir}")
+
+    files: list[tuple[str, str]] = []
+    for root, _, file_names in os.walk(skill_dir):
+        for file_name in file_names:
+            if not file_name.endswith(".md"):
+                continue
+            source = os.path.join(root, file_name)
+            files.append((source, os.path.relpath(source, skill_dir)))
+    return sorted(files, key=lambda pair: pair[1])
+
+
+def render_memory(existing: str | None, block: str) -> str:
+    """Merge the poly-adk memory block into an existing CLAUDE.md.
+
+    A CLAUDE.md that already carries the block has it replaced in place, so
+    anything the user wrote around it survives. A CLAUDE.md without the block
+    gets it appended.
+
+    Args:
+        existing: Current CLAUDE.md content, or None if the file doesn't exist.
+        block: The memory block to install.
+
+    Returns:
+        str: The full content the CLAUDE.md should have.
+
+    Raises:
+        ValueError: If the existing file opens the block but never closes it.
+    """
+    if existing is None or not existing.strip():
+        return block
+
+    if MEMORY_BEGIN not in existing:
+        return existing.rstrip("\n") + "\n\n" + block
+
+    if MEMORY_END not in existing:
+        raise ValueError(
+            f"{MEMORY_FILE} contains '{MEMORY_BEGIN}' with no matching '{MEMORY_END}'. "
+            "Fix or remove the partial block and re-run."
+        )
+
+    before = existing.split(MEMORY_BEGIN, 1)[0]
+    after = existing.split(MEMORY_END, 1)[1]
+    return before + block.rstrip("\n") + after
+
+
+def _plan_write(path: str, content: str, append: bool = False) -> PlannedWrite:
+    """Classify a single write against what is already on disk."""
+    current = _read(path)
+    if current is None:
+        action = CREATE
+    elif current == content:
+        action = UNCHANGED
+    else:
+        action = APPEND if append else OVERWRITE
+    return PlannedWrite(path=path, content=content, action=action)
+
+
+def _find_stale_files(skill_dir: str, expected: set[str]) -> list[str]:
+    """List files under an installed skill directory that are no longer shipped."""
+    if not os.path.isdir(skill_dir):
+        return []
+    stale = [
+        os.path.join(root, file_name)
+        for root, _, file_names in os.walk(skill_dir)
+        for file_name in file_names
+        if os.path.join(root, file_name) not in expected
+    ]
+    return sorted(stale)
+
+
+def plan_claude_code_setup(target_dir: str) -> ClaudeCodePlan:
+    """Work out what installing the Claude Code assets would change.
+
+    Args:
+        target_dir: Project directory to install into.
+
+    Returns:
+        ClaudeCodePlan: The planned writes and removals, without touching disk.
+
+    Raises:
+        ValueError: If the packaged assets are missing, or an existing
+            CLAUDE.md has a malformed poly-adk block.
+    """
+    target_dir = os.path.abspath(target_dir)
+    plan = ClaudeCodePlan(target_dir=target_dir)
+
+    skill_dir = os.path.join(target_dir, ".claude", "skills", SKILL_NAME)
+    for source, relative in discover_skill_files():
+        content = _read(source) or ""
+        plan.writes.append(_plan_write(os.path.join(skill_dir, relative), content))
+
+    memory_path = os.path.join(target_dir, MEMORY_FILE)
+    existing_memory = _read(memory_path)
+    merged = render_memory(existing_memory, load_memory_block())
+    # Appending to a CLAUDE.md the user already had is additive, so it never
+    # needs a confirmation prompt; replacing an existing block does.
+    is_append = existing_memory is not None and MEMORY_BEGIN not in existing_memory
+    plan.writes.append(_plan_write(memory_path, merged, append=is_append))
+
+    # The installed skill mirrors the packaged one exactly, so a reference file
+    # dropped or renamed in a later release must not linger and mislead the agent.
+    plan.removals = _find_stale_files(skill_dir, {write.path for write in plan.writes})
+
+    return plan
+
+
+def apply_claude_code_setup(plan: ClaudeCodePlan) -> tuple[list[PlannedWrite], list[str]]:
+    """Write every pending file in a plan and delete its stale files.
+
+    Args:
+        plan: The plan produced by ``plan_claude_code_setup``.
+
+    Returns:
+        tuple[list[PlannedWrite], list[str]]: The writes applied and the paths removed.
+    """
+    applied = plan.pending
+    for write in applied:
+        parent = os.path.dirname(write.path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        with open(write.path, "w", encoding="utf-8") as f:
+            f.write(write.content)
+
+    for path in plan.removals:
+        os.remove(path)
+
+    # Drop any directories the removals emptied out.
+    skill_dir = os.path.join(plan.target_dir, ".claude", "skills", SKILL_NAME)
+    if plan.removals and os.path.isdir(skill_dir):
+        for root, dir_names, _ in os.walk(skill_dir, topdown=False):
+            for dir_name in dir_names:
+                path = os.path.join(root, dir_name)
+                if not os.listdir(path):
+                    os.rmdir(path)
+
+    return applied, plan.removals


### PR DESCRIPTION
> [!WARNING]
> **This is a proof of concept. Please do not merge.**
> It is opened to demonstrate the approach and gather feedback. The development team
> should review it and re-architect or rewrite any part of it as needed before any
> version of this ships.

## Summary

Adds `poly docs --claude-code`, which installs the ADK's resource documentation into a
project as Claude Code files: the `poly-adk` skill in `.claude/skills/`, and a delimited
`poly-adk` section in `CLAUDE.md`.

## Motivation

The documented path for coding agents today is `poly docs --all --output rules.md`, then
manually referencing that file in every session prompt. That is easy to forget, easy to
let go stale, and pushes ~64KB into context whether or not it is relevant.

A skill lets the agent load only the reference file for the resource it is touching,
while `CLAUDE.md` carries the small always-on set of rules. Both refresh with the CLI.

## Changes

- New `poly docs --claude-code [--path DIR] [--force]`.
- Ships the `poly-adk` skill as package data under `src/poly/skills/` (SKILL.md plus one
  reference file per resource type). Verified present in both the built wheel and sdist.
- New `src/poly/utils/agent_setup.py`, which plans the install (create / append /
  overwrite / unchanged / remove) before applying it, so the CLI can show and confirm.
- Idempotent: files already matching what the CLI ships are left alone, so re-running is
  a no-op.
- `CLAUDE.md` is never replaced. Only text between `<!-- BEGIN poly-adk -->` and
  `<!-- END poly-adk -->` is rewritten; content around it survives.
- Destructive changes are listed and confirmed. `--force` skips the prompt, and a
  non-interactive shell exits 1 rather than clobbering.
- `--claude-code` combined with topic names, `--all` or `--output` is rejected rather
  than silently ignored.
- Docs: `README.md`, `reference/cli.md`, `reference/tooling.md`, `src/poly/docs/docs.md`.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly docs --claude-code`)
- [x] Tested against a live Agent Studio project

26 new tests across four classes: dispatch and flag conflicts (driven through
`AgentStudioCLI().main()` so real argument parsing is exercised), the confirmation
paths (no-op, non-tty exit, decline, accept, `--force`), packaged-skill consistency,
and `render_memory` edge cases.

Coverage on the touched files: `agent_setup.py` 97%, `cli_commands/utils.py` 65% -> 82%.
The remaining gap in `utils.py` is the pre-existing untested `docs()` function.

Also verified by hand, since the automated tests cannot cover them:

- The interactive confirmation prompt in a real terminal. The unit tests mock the
  prompt library, which proves the branching but not the rendering.
- A run inside a live initialised Agent Studio project, followed by `poly status` and
  `poly validate`, confirming neither command sees `.claude/` or `CLAUDE.md`.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1034 passed)
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

Titled `chore(poc):` rather than `feat:` on purpose. `POC:` is not one of the types the
`pr-title` CI job accepts, and `chore` is non-releasing, so merging this by accident
cannot cut a release or publish to PyPI.

## Notes for reviewers

- `.claude/` and `CLAUDE.md` sit outside every path the project loader reads, so
  `pull` / `push` / `status` / `validate` ignore them. Resource discovery is
  whitelist-based, with no tree walk.
- The command deliberately does not require an initialised project, so it can be run
  before `poly init`.
- `--claude-code` is a flag per agent. The plan/apply core is agent-agnostic, so
  `--codex` / `--cursor` can be added without reworking it.
- One test guards a packaging trap: `pyproject.toml` globs `poly-adk/references/*.md`,
  which does not recurse, so a file nested deeper would silently not ship.
- Open question worth settling: should the installed `.claude/` and `CLAUDE.md` be
  committed to the agent project's repo? I would say yes, so a team shares one setup.
