### PR TITLE
fix: Fake diff on test_suite

### DIFF
--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -441,11 +441,13 @@ class TestCase(YamlResource):
         if isinstance(sip_headers, TestCaseSipHeaders):
             self.sip_headers = sip_headers
         else:
-            self.sip_headers = TestCaseSipHeaders(**sip_headers)
+            self.sip_headers = TestCaseSipHeaders(**(sip_headers or {}))
         if isinstance(integration_attributes, TestCaseIntegrationAttributes):
             self.integration_attributes = integration_attributes
         else:
-            self.integration_attributes = TestCaseIntegrationAttributes(**integration_attributes)
+            self.integration_attributes = TestCaseIntegrationAttributes(
+                **(integration_attributes or {})
+            )
 
     @property
     def file_path(self) -> str:

--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -441,17 +441,11 @@ class TestCase(YamlResource):
         if isinstance(sip_headers, TestCaseSipHeaders):
             self.sip_headers = sip_headers
         else:
-            self.sip_headers = TestCaseSipHeaders(
-                resource_id=resource_id, name="sip_headers", headers=sip_headers or {}
-            )
+            self.sip_headers = TestCaseSipHeaders(**sip_headers)
         if isinstance(integration_attributes, TestCaseIntegrationAttributes):
             self.integration_attributes = integration_attributes
         else:
-            self.integration_attributes = TestCaseIntegrationAttributes(
-                resource_id=resource_id,
-                name="integration_attributes",
-                attributes=integration_attributes or {},
-            )
+            self.integration_attributes = TestCaseIntegrationAttributes(**integration_attributes)
 
     @property
     def file_path(self) -> str:

--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -440,13 +440,17 @@ class TestCase(YamlResource):
         # comparing subresources — an absent one cannot differ from anything.
         if isinstance(sip_headers, TestCaseSipHeaders):
             self.sip_headers = sip_headers
+        elif sip_headers:
+            self.sip_headers = TestCaseSipHeaders(**sip_headers)
         else:
-            self.sip_headers = TestCaseSipHeaders(**(sip_headers or {}))
+            self.sip_headers = TestCaseSipHeaders(resource_id=resource_id, name="sip_headers")
         if isinstance(integration_attributes, TestCaseIntegrationAttributes):
             self.integration_attributes = integration_attributes
+        elif integration_attributes:
+            self.integration_attributes = TestCaseIntegrationAttributes(**integration_attributes)
         else:
             self.integration_attributes = TestCaseIntegrationAttributes(
-                **(integration_attributes or {})
+                resource_id=resource_id, name="integration_attributes"
             )
 
     @property


### PR DESCRIPTION
## Summary
Integration attributes and sip headers were giving a fake diff due to how the origin is being loaded back from disk

## Motivation
When loading a project, the previous known remote version was being loaded wrong, creating a spurious diff

## Changes
- Load the object directly, not putting into the attribute or sip_headers part

## Test strategy

<!-- How did you verify this works? Check all that apply. -->

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs
Before:
```
-sip_headers:
-  resource_id: TEST_CASES-974954e0
-  name: sip_headers
-  headers: {}
-integration_attributes:
-  resource_id: TEST_CASES-974954e0
-  name: integration_attributes
-  attributes: {}
```
After:
```
No changes detected.
```