### PR TITLE
fix: bump experimental config schema with AssemblyAI ASR

### DIFF
--- a/src/poly/resources/experimental_config_schema.yaml
+++ b/src/poly/resources/experimental_config_schema.yaml
@@ -31,6 +31,7 @@ components:
         - deepgram
         - raven
         - soniox
+        - assemblyai
 
     asr_common_config_properties:
       type: object
@@ -47,6 +48,7 @@ components:
             - deepgram: Deepgram cloud speech recognition
             - raven: PolyAI Raven Omni speech recognition
             - soniox: Soniox cloud speech recognition
+            - assemblyai: AssemblyAI v3 Streaming speech recognition
         model:
           type: string
           minLength: 1
@@ -61,6 +63,7 @@ components:
             - deepgram: "nova-3", "nova-2"
             - raven: "raven-omni"
             - soniox: "stt-rt-v5"
+            - assemblyai: "universal-3-5-pro", "u3-rt-pro-beta-1"
         language:
           type: string
           minLength: 2

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.36.3"
+version = "0.43.0"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

Adds `assemblyai` as a supported ASR provider in the experimental config schema.

## Motivation

AssemblyAI v3 Streaming is landing as a speech recognition provider on the platform side, and Agent
Studio already accepts the provider in published configs. Without this schema entry, a reverse-synced
`experimental_config.json` that selects `assemblyai` fails ADK validation in deployment CI until the
config is manually stripped, exactly as happened for Soniox.

## Changes

- Added `assemblyai` to the ASR provider enum list
- Added `assemblyai: AssemblyAI v3 Streaming speech recognition` to the provider description enum
- Added `assemblyai: "universal-3-5-pro", "u3-rt-pro-beta-1"` to the model documentation

## Test strategy

- [x] Validated `assemblyai` configs against the updated schema with
  `jsonschema.Draft202012Validator`: top-level provider, provider with `provider_config`, the
  private-beta model, and the per-language `language_overrides` shape all validate; `soniox` is
  unchanged; an unknown provider such as `assembly-ai` is still rejected at both the top level and
  inside `language_overrides`
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1294 passed, 83 subtests)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
