### PR TITLE
fix: align handoff/review behavior with refreshed docs

### DIFF
--- a/src/poly/cli_commands/review.py
+++ b/src/poly/cli_commands/review.py
@@ -297,6 +297,15 @@ class ReviewCommand(BaseCommand):
         choices = [format_gist_choice(g) for g in gists]
         description_to_id = {format_gist_choice(g): g["id"] for g in gists}
 
+        if output_json:
+            json_print(
+                {
+                    "success": False,
+                    "error": "Please provide a gist ID to delete when using JSON output.",
+                }
+            )
+            return
+
         selected = questionary.checkbox("Select gists to delete", choices=choices).ask()
         if not selected:
             warning("No gists selected. Exiting.")

--- a/src/poly/resources/handoff.py
+++ b/src/poly/resources/handoff.py
@@ -136,13 +136,15 @@ class Handoff(MultiResourceYamlResource):
         return handoffs
 
     def to_yaml_dict(self) -> dict:
-        return {
+        result = {
             "name": self.name,
             "description": self.description,
             "is_default": self.is_default,
             "sip_config": self.sip_config.to_yaml_dict(),
-            "sip_headers": self.sip_headers,
         }
+        if self.sip_headers:
+            result["sip_headers"] = self.sip_headers
+        return result
 
     @property
     def file_path(self) -> str:

--- a/src/poly/tests/github_api_test.py
+++ b/src/poly/tests/github_api_test.py
@@ -321,15 +321,23 @@ class DeleteGistsTest(unittest.TestCase):
     @patch("poly.cli_commands.review.GitHubAPIHandler.delete_gist")
     @patch("questionary.checkbox")
     @patch("poly.cli_commands.review.json_print")
-    def test_json_output_prints_success(self, mock_json_print, mock_checkbox, mock_delete, mock_list):
-        """With output_json=True, a success JSON object is printed after deletion."""
+    def test_json_output_without_gist_id_errors_without_prompting(
+        self, mock_json_print, mock_checkbox, mock_delete, mock_list
+    ):
+        """With output_json=True and no gist_id, a JSON error is printed and the
+        interactive checkbox prompt is never shown."""
         mock_list.return_value = self.SAMPLE_GISTS
-        first_choice = format_gist_choice(self.SAMPLE_GISTS[0])
-        mock_checkbox.return_value.ask.return_value = [first_choice]
 
         ReviewCommand.delete_gists(output_json=True)
 
-        mock_json_print.assert_called_once_with({"success": True})
+        mock_checkbox.assert_not_called()
+        mock_delete.assert_not_called()
+        mock_json_print.assert_called_once_with(
+            {
+                "success": False,
+                "error": "Please provide a gist ID to delete when using JSON output.",
+            }
+        )
 
 
 class ListGistsTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Two small code fixes discovered while writing the resource and CLI reference docs, so behavior matches what's now documented. Stacked on #278 — this PR's diff is just the files below once that one merges.

## Motivation

Auditing `handoffs.md` and `reference/cli/review.md` against source surfaced two spots where actual behavior didn't match what a reasonable reading of the docs (or the `--json` contract documented elsewhere in the CLI reference) would expect.

## Changes

- `src/poly/resources/handoff.py`: omit `sip_headers` from the serialized YAML when empty instead of always writing it out, matching its documented optional status
- `src/poly/cli_commands/review.py`: `poly review delete --json` now returns a JSON error instead of falling through to an interactive checkbox prompt when no gist ID is given, consistent with the "`--json` requires explicit flags" pattern documented for other commands
- `src/poly/tests/github_api_test.py`: updated the one test that encoded the old (interactive-fallback) behavior to assert the new error-and-return behavior instead; the existing "gist ID + `--json`" success-path test was unaffected

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

N/A