### PR TITLE
fix: create new variants with their local attribute values

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1517,7 +1517,10 @@ class AgentStudioProject:
             current_resources=self.resources,
         )
         prepush.default_new_variant_attributes(
-            new_resources, deleted_resources, current_resources=self.resources
+            new_resources,
+            deleted_resources,
+            current_resources=self.resources,
+            updated_resources=updated_resources,
         )
         prepush.filter_nondefault_variant_updates(updated_resources)
         prepush.fix_conditions_for_deleted_steps(

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -29,6 +29,10 @@ class Variant(MultiResourceYamlResource):
     is_default: bool = False
     top_level_name: ClassVar[str] = "variants"
     attribute_ids: list[str] = field(default_factory=list, repr=False, init=False)
+    # Attribute values to send when the variant is created, keyed by attribute id.
+    # Populated pre-push from the local variant_attributes.yaml so a newly created
+    # variant lands with its real values rather than blanks.
+    attribute_values: dict[str, str] = field(default_factory=dict, repr=False, init=False)
 
     def __init__(
         self,
@@ -41,6 +45,7 @@ class Variant(MultiResourceYamlResource):
         self.name = name
         self.is_default = is_default
         self.attribute_ids = []
+        self.attribute_values = {}
 
     def to_yaml_dict(self) -> dict:
         yaml_dict = {
@@ -110,7 +115,10 @@ class Variant(MultiResourceYamlResource):
             id=self.resource_id,
             name=self.name,
             attribute_values=AttributeValues(
-                values={attribute_id: "" for attribute_id in self.attribute_ids}
+                values={
+                    attribute_id: self.attribute_values.get(attribute_id, "")
+                    for attribute_id in self.attribute_ids
+                }
             ),
         )
 

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -18,6 +18,7 @@ from poly.resources import (
     ResourceMapping,
     SMSTemplate,
     Variable,
+    Variant,
     VariantAttribute,
 )
 from poly.resources.flows import (
@@ -1098,6 +1099,7 @@ class FlowUtilsTests(unittest.TestCase):
 
     # TODO: Test assigning positions to flow steps
 
+
 class ClearUnusedSettingsFromFlowStepTest(unittest.TestCase):
     """Tests for prepush.clear_unused_settings_from_flow_step.
 
@@ -1256,6 +1258,76 @@ class JsonIoTests(unittest.TestCase):
             self.assertNotIn("\\u00f4", raw)
 
             self.assertEqual(utils.read_json_file(str(path)), data)
+
+
+class DefaultNewVariantAttributesTest(unittest.TestCase):
+    """Tests for prepush.default_new_variant_attributes.
+
+    A variant created on a branch must carry the attribute values from the
+    local variant_attributes.yaml. Non-default variant updates are never
+    pushed, so if creation sends "" the variant stays blank on the branch,
+    and a later 3-way merge that prefers the branch wipes main's values.
+    """
+
+    def _attr(self, resource_id: str, mappings: dict[str, str]) -> VariantAttribute:
+        return VariantAttribute(resource_id=resource_id, name=resource_id, mappings=mappings)
+
+    def test_new_variant_gets_local_values_on_create(self):
+        new_variant = Variant(resource_id="VARIANTS-new", name="New Site")
+        current = {
+            VariantAttribute: {
+                "ATTR-a": self._attr("ATTR-a", {"VARIANTS-default": "a-default"}),
+                "ATTR-b": self._attr("ATTR-b", {"VARIANTS-default": "b-default"}),
+                "ATTR-gone": self._attr("ATTR-gone", {"VARIANTS-default": "x"}),
+            }
+        }
+        # The local attribute resources are the ones being pushed as updates and
+        # already hold the new variant's values.
+        updated = {
+            VariantAttribute: {
+                "ATTR-a": self._attr(
+                    "ATTR-a", {"VARIANTS-default": "a-default", "VARIANTS-new": "a-new"}
+                ),
+                "ATTR-b": self._attr("ATTR-b", {"VARIANTS-default": "b-default"}),
+            }
+        }
+        new = {Variant: {"VARIANTS-new": new_variant}}
+        deleted = {VariantAttribute: {"ATTR-gone": current[VariantAttribute]["ATTR-gone"]}}
+
+        prepush.default_new_variant_attributes(
+            new, deleted, current_resources=current, updated_resources=updated
+        )
+
+        self.assertEqual(sorted(new_variant.attribute_ids), ["ATTR-a", "ATTR-b"])
+        proto = new_variant.build_create_proto()
+        self.assertEqual(dict(proto.attribute_values.values), {"ATTR-a": "a-new", "ATTR-b": ""})
+
+    def test_new_attribute_and_new_variant_in_same_push(self):
+        new_variant = Variant(resource_id="VARIANTS-new", name="New Site")
+        current = {VariantAttribute: {"ATTR-a": self._attr("ATTR-a", {})}}
+        new = {
+            Variant: {"VARIANTS-new": new_variant},
+            VariantAttribute: {"ATTR-a": self._attr("ATTR-a", {"VARIANTS-new": "from-new"})},
+        }
+
+        prepush.default_new_variant_attributes(new, {}, current_resources=current)
+
+        self.assertEqual(
+            dict(new_variant.build_create_proto().attribute_values.values),
+            {"ATTR-a": "from-new"},
+        )
+
+    def test_without_local_values_falls_back_to_blank(self):
+        new_variant = Variant(resource_id="VARIANTS-new", name="New Site")
+        current = {VariantAttribute: {"ATTR-a": self._attr("ATTR-a", {"VARIANTS-default": "d"})}}
+
+        prepush.default_new_variant_attributes(
+            {Variant: {"VARIANTS-new": new_variant}}, {}, current_resources=current
+        )
+
+        self.assertEqual(
+            dict(new_variant.build_create_proto().attribute_values.values), {"ATTR-a": ""}
+        )
 
 
 if __name__ == "__main__":

--- a/src/poly/utils/prepush.py
+++ b/src/poly/utils/prepush.py
@@ -325,10 +325,25 @@ def default_new_variant_attributes(
     new_resources: ResourceMap,
     deleted_resources: ResourceMap,
     current_resources: ResourceMap,
+    updated_resources: ResourceMap | None = None,
 ) -> None:
-    """Give new variants all known (non-deleted) attributes as default values."""
-    # Add known attributes to any new variant to give it a default value
+    """Give new variants all known (non-deleted) attributes, with their local values.
+
+    A new variant is created with every known attribute. The value for each
+    attribute comes from the local variant_attributes.yaml (the new/updated
+    attribute resources being pushed, falling back to the current remote
+    ones), so the variant is created with its real values. Previously every
+    value was sent as "" and, because non-default variant updates are never
+    pushed, a variant created on a stale branch stayed blank and then won a
+    3-way merge against main's populated copy.
+    """
     deleted_attribute_ids = set(deleted_resources.get(VariantAttribute, {}).keys())
+    # Local attribute resources win over the remote snapshot: they carry the
+    # mappings for the variant being created, the remote ones cannot.
+    attribute_sources: dict[str, VariantAttribute] = {}
+    attribute_sources.update(current_resources.get(VariantAttribute, {}))
+    attribute_sources.update((updated_resources or {}).get(VariantAttribute, {}))
+    attribute_sources.update(new_resources.get(VariantAttribute, {}))
     for variant in new_resources.get(Variant, {}).values():
         if not isinstance(variant, Variant):
             raise TypeError(f"Variant is not a Variant: {variant}")
@@ -338,6 +353,11 @@ def default_new_variant_attributes(
             if aid not in deleted_attribute_ids
         ]
         variant.attribute_ids = attribute_ids
+        variant.attribute_values = {
+            aid: attribute_sources[aid].mappings.get(variant.resource_id, "")
+            for aid in attribute_ids
+            if aid in attribute_sources
+        }
 
 
 def filter_nondefault_variant_updates(updated_resources: ResourceMap) -> None:


### PR DESCRIPTION
## Summary

A variant that exists locally but not yet on the remote branch was created with every attribute value set to `""`. It is now created with the values from the local `variant_attributes.yaml`.

## Motivation

Non-default variant updates are never pushed (`filter_nondefault_variant_updates`), so a variant created blank stays blank on the branch. Real scenario: a branch is cut, a new variant (site) is added on main with values, then a push to the stale branch recreates that same variant locally-known-by-name as a new, blank variant (and `sync_ids_with_sandbox` recreates it blank again under main's id). A subsequent 3-way merge with a branch-wins resolution then replaces main's populated variant with the blank one, clearing every attribute value for that site in the published project.

## Changes

- `prepush.default_new_variant_attributes` now also resolves each new variant's attribute values from the local attribute resources (new/updated first, then current) and stores them on the variant; new optional `updated_resources` argument.
- `Variant.attribute_values` field; `Variant.build_create_proto` sends those values instead of `""`.
- `project._clean_resources_before_push` passes `updated_resources` through.
- Unit tests for the three cases (values from updated attributes, from new attributes, fallback to blank).

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1312 passed)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Before: `Variant_CreateVariant.attribute_values = {ATTR-a: "", ATTR-b: "", ...}` for every new variant.
After: `{ATTR-a: "<local value>", ATTR-b: "<local value>", ...}`.

https://claude.ai/code/session_013nH8byPh16YTfo1W9yKFUU