### PR TITLE
fix: accept flow functions in test case function call assertions

### DIFF
--- a/docs/docs/reference/resources/tests.md
+++ b/docs/docs/reference/resources/tests.md
@@ -162,11 +162,11 @@ prompt_assertions:
 
 ## Function call assertions
 
-Each function call assertion checks that a global function was called and, optionally, with specific argument values.
+Each function call assertion checks that a function was called and, optionally, with specific argument values.
 
 | Field | Description |
 |---|---|
-| `name` | Global function name. Must match a function in `functions/`. |
+| `name` | Function name. Must match a global function in `functions/` or a flow function in `flows/<flow>/functions/`. |
 | `arguments` | List of argument assertions. May be empty to check only that the function was called. |
 
 Argument assertion fields:
@@ -235,7 +235,7 @@ prompt_assertions:
 - `simulated_at`, if set, must be a valid ISO 8601 datetime
 - `caller_number`, if set, must be text — an unquoted number is rejected rather than converted
 - `integration_attributes` values must be text, numbers, `true`/`false`, `null`, lists, or nested maps; an unquoted date is rejected with the quoted form to use instead; keys must be text
-- each `function_call_assertions[*].name` must match a global function under `functions/`
+- each `function_call_assertions[*].name` must match a global function under `functions/` or a flow function under `flows/<flow>/functions/`
 - each argument's `value_type` must be one of `string`, `integer`, `number`, `boolean`
 - the filename must match the normalized `name`
 
@@ -292,7 +292,7 @@ Good coverage of a project usually includes:
 
     ---
 
-    Reference for the global functions named in function call assertions.
+    Reference for the functions named in function call assertions.
     [Open functions](./functions.md)
 
 -   **Variants**

--- a/src/poly/docs/tests.md
+++ b/src/poly/docs/tests.md
@@ -164,7 +164,7 @@ On `push`, each test case is validated:
 - **scenario** is required (cannot be empty).
 - **language** is required and must match a configured project language (default or additional).
 - **variant**, if specified, must match an existing variant in the project.
-- **function_call_assertions**: each function name must match a global function in the project, and each argument's `value_type` must be one of `string`, `integer`, `number`, or `boolean`.
+- **function_call_assertions**: each function name must match a global function (`functions/`) or a flow function (`flows/<flow>/functions/`) in the project, and each argument's `value_type` must be one of `string`, `integer`, `number`, or `boolean`.
 - **integration_attributes**: values must be text, numbers, `true`/`false`, `null`, lists or nested maps. An unquoted date is rejected with the quoted form to use instead, and keys must be text.
 
 ## Best practices

--- a/src/poly/resources/test_suite.py
+++ b/src/poly/resources/test_suite.py
@@ -703,16 +703,16 @@ class TestCase(YamlResource):
         # Integration attributes carry JSON types through to the agent
         _validate_attribute_value(self.integration_attributes.attributes, "integration_attributes")
 
-        # Function name is valid
-        known_global_functions = {
+        # `fn` is a global function, `ft` a flow function. Both are assertable.
+        known_functions = {
             resource.resource_name
             for resource in resource_mappings or []
-            if resource.resource_prefix == "fn"
+            if resource.resource_prefix in ("fn", "ft")
         }
         for function_call in self.assertions.function_calls:
             if not function_call.name:
                 raise ValueError("Function call assertion must have a name")
-            if known_global_functions and function_call.name not in known_global_functions:
+            if known_functions and function_call.name not in known_functions:
                 raise ValueError(f"Unknown function in assertion: {function_call.name}")
             for argument in function_call.arguments:
                 if argument.value_type not in ALLOWED_TYPES:

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -7357,6 +7357,72 @@ class TestCaseTests(unittest.TestCase):
             ]
         )
 
+    def _test_case_asserting_function(self, function_name: str) -> TestCase:
+        resource_id = "TEST-function_assertion"
+        return TestCase(
+            resource_id=resource_id,
+            name="Function assertion",
+            scenario="Give a phone number.",
+            channel="chat.polyai",
+            language="en-GB",
+            assertions=TestCaseAssertion(
+                resource_id=resource_id,
+                name="assertions",
+                prompts=[],
+                function_calls=[
+                    FunctionCallAssertion(
+                        name=function_name,
+                        arguments=[
+                            FunctionCallArgumentAssertion(
+                                parameter_name="phone_number",
+                                expected_value="123123",
+                                value_type="string",
+                            )
+                        ],
+                    )
+                ],
+            ),
+            tags=TestCaseTags(resource_id=resource_id, name="tags", tags=[]),
+        )
+
+    def _function_mappings(self) -> list[ResourceMapping]:
+        return [
+            ResourceMapping(
+                resource_id="fn-transfer",
+                resource_name="transfer_call",
+                resource_type=Function,
+                resource_prefix="fn",
+                file_path="functions/transfer_call.py",
+                flow_name=None,
+            ),
+            ResourceMapping(
+                resource_id="ft-register",
+                resource_name="register_phone_number",
+                resource_type=Function,
+                resource_prefix="ft",
+                file_path="flows/idnv/functions/register_phone_number.py",
+                flow_name="idnv",
+            ),
+        ]
+
+    def test_validate_accepts_global_function_assertion(self):
+        self._test_case_asserting_function("transfer_call").validate(
+            resource_mappings=self._function_mappings()
+        )
+
+    def test_validate_accepts_flow_function_assertion(self):
+        """A flow function is assertable: the platform accepts it, so the ADK must too."""
+        self._test_case_asserting_function("register_phone_number").validate(
+            resource_mappings=self._function_mappings()
+        )
+
+    def test_validate_rejects_unknown_function_assertion(self):
+        with self.assertRaises(ValueError) as cm:
+            self._test_case_asserting_function("register_phone_numbr").validate(
+                resource_mappings=self._function_mappings()
+            )
+        self.assertIn("Unknown function in assertion: register_phone_numbr", str(cm.exception))
+
     def test_get_new_updated_deleted_subresources(self):
         test_case = self._sample_test_case()
         new, updated, deleted = test_case.get_new_updated_deleted_subresources()


### PR DESCRIPTION
## Summary

`function_call_assertions` only accepted global functions, so an assertion naming a flow function was rejected as unknown. Agent Studio accepts either — the assertion can be created in the UI and read back by `poly pull` — so the ADK was rejecting files it had just written.

## Motivation

[DEVP-618](https://linear.app/poly-ai/issue/DEVP-618/allow-flow-functions-in-function-call-assertions)

~~~
Validation error in test_suite/dummy_test.yaml: Unknown function in assertion: register_phone_number
~~~

`register_phone_number` is at `flows/idnv/functions/`. Validation fails per project, so while such a test case exists `poly validate` fails for the whole project and CI goes red on any PR touching it.

## Changes

- `TestCase.validate` accepts both function prefixes: `fn` (global) and `ft` (flow). Unknown names still raise
- Update the docs that stated the global-only rule as intended

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

Three tests in `TestCaseTests` — global passes, flow passes, unknown still raises. Confirmed the flow test fails on `main` and passes here. Nothing covered this check before.

Also ran the patched validator over the real `adapthealth-usp` project offline (219 functions, 166 of them flow-local): the test case that triggered this now validates. Not pushed to Agent Studio.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1310 passed; 2 `posthog_test.py` failures are pre-existing on clean `main`)
- [x] No breaking changes — this only widens what validates
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Note for reviewers

Function steps and start/end functions have no prefix and stay rejected — they aren't LLM-callable. If the platform does accept assertions on them, covering that is harder: the empty prefix also covers every non-function resource, so unmapped names would stop being distinguishable from valid ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)