### PR TITLE
feat: gate api_mocks behind testify-v2-1 PostHog flag

### DIFF
--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -332,13 +332,17 @@ class AgentStudioInterface:
             self._handle_api_error(e)
 
     def pull_resources(
-        self, projection_json: Optional[dict[str, Any]] = None
+        self,
+        projection_json: Optional[dict[str, Any]] = None,
+        include_api_mocks: bool = False,
     ) -> tuple[dict[type[Resource], dict[str, Resource]], dict[str, Any]]:
         """Fetch all resources for the specific project.
 
         Args:
             projection_json (Optional[dict[str, Any]]): A dictionary containing the projection.
                 If provided, the projection will be used instead of fetching it from the API.
+            include_api_mocks (bool): If True, tell the platform to include test case
+                api_mocks in the returned projection (gated behind the api mock editor FF).
 
         Returns:
             dict[type[Resource], dict[str, Resource]]: A dictionary mapping resource types to
@@ -350,7 +354,7 @@ class AgentStudioInterface:
         if projection_json is not None:
             return load_resources_from_projection(projection_json), projection_json
         try:
-            projection = self.sync_client.pull_projection()
+            projection = self.sync_client.pull_projection(include_api_mocks=include_api_mocks)
             return load_resources_from_projection(projection), projection
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
@@ -678,6 +682,7 @@ class AgentStudioInterface:
         input_lang: Optional[str] = None,
         output_lang: Optional[str] = None,
         sip_headers: Optional[dict[str, str]] = None,
+        api_mock_editor: bool = False,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -689,6 +694,8 @@ class AgentStudioInterface:
             variant_id: Optional variant ID (e.g. 'Voice')
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
+            api_mock_editor: If True, tell the platform to intercept API integration
+                calls using the test case's api_mocks (gated behind the api mock editor FF)
 
         Returns:
             dict: The API response containing the conversation ID and initial greeting
@@ -703,6 +710,7 @@ class AgentStudioInterface:
             input_lang=input_lang,
             output_lang=output_lang,
             sip_headers=sip_headers,
+            api_mock_editor=api_mock_editor,
         )
 
     @staticmethod
@@ -770,6 +778,7 @@ class AgentStudioInterface:
         input_lang: str = None,
         output_lang: str = None,
         sip_headers: Optional[dict[str, str]] = None,
+        api_mock_editor: bool = False,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -782,6 +791,8 @@ class AgentStudioInterface:
             channel: The channel identifier (e.g. 'chat.polyai', 'webchat.polyai')
             variant_id: Optional variant ID (e.g. 'Voice')
             sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
+            api_mock_editor: If True, tell the platform to intercept API integration
+                calls using the test case's api_mocks (gated behind the api mock editor FF)
 
         Returns:
             dict: The API response containing the conversation ID and initial greeting
@@ -797,6 +808,7 @@ class AgentStudioInterface:
             input_lang=input_lang,
             output_lang=output_lang,
             sip_headers=sip_headers,
+            api_mock_editor=api_mock_editor,
         )
 
     @staticmethod

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -453,6 +453,7 @@ class PlatformAPIHandler:
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
         sip_headers: ty.Optional[dict[str, str]] = None,
+        api_mock_editor: bool = False,
     ) -> dict:
         """Create a new chat conversation.
 
@@ -466,6 +467,8 @@ class PlatformAPIHandler:
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response,
             sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
+            api_mock_editor: If True, tell the platform to intercept API integration
+                calls using the test case's api_mocks (gated behind the api mock editor FF)
 
         Returns:
             dict: The API response containing the conversation ID
@@ -483,6 +486,8 @@ class PlatformAPIHandler:
             data["tts_lang_code"] = output_lang
         if sip_headers:
             data["sip_headers"] = sip_headers
+        if api_mock_editor:
+            data["apiMockEditor"] = True
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod
@@ -567,6 +572,7 @@ class PlatformAPIHandler:
         input_lang: ty.Optional[str] = None,
         output_lang: ty.Optional[str] = None,
         sip_headers: ty.Optional[dict[str, str]] = None,
+        api_mock_editor: bool = False,
     ) -> dict:
         """Create a new chat conversation against a branch deployment.
 
@@ -581,6 +587,8 @@ class PlatformAPIHandler:
             input_lang: Optional language code of the input message, e.g. "en-GB" or "fr-FR"
             output_lang: Optional language code for the agent's response, e.g. "en-
             sip_headers: Optional simulated SIP headers exposed through conv.sip_headers
+            api_mock_editor: If True, tell the platform to intercept API integration
+                calls using the test case's api_mocks (gated behind the api mock editor FF)
 
         Returns:
             dict: The API response containing the conversation ID
@@ -599,6 +607,8 @@ class PlatformAPIHandler:
             data["tts_lang_code"] = output_lang
         if sip_headers:
             data["sip_headers"] = sip_headers
+        if api_mock_editor:
+            data["apiMockEditor"] = True
         return PlatformAPIHandler.make_request(region, endpoint, "POST", data=data)
 
     @staticmethod

--- a/src/poly/handlers/sdk.py
+++ b/src/poly/handlers/sdk.py
@@ -522,6 +522,7 @@ class SourcererSDK:
         force_refresh: bool = False,
         branch_id: Optional[str] = None,
         at_sequence: Optional[int] = None,
+        include_api_mocks: bool = False,
     ) -> dict[str, Any]:
         """Fetch the projection from the API.
 
@@ -531,6 +532,8 @@ class SourcererSDK:
                 When provided, caching is skipped entirely.
             at_sequence: Return the projection at this historical event-sequence
                 number. Implies *force_refresh* and skips caching.
+            include_api_mocks: If True, tell the platform to include test case
+                api_mocks in the projection (gated behind the api mock editor FF).
 
         Returns:
             The projection data as a dictionary.
@@ -550,6 +553,8 @@ class SourcererSDK:
         params: dict[str, Any] = {}
         if at_sequence is not None:
             params["atSequence"] = at_sequence
+        if include_api_mocks:
+            params["apiMockEditor"] = True
 
         try:
             response = self.session.get(url, params=params or None)

--- a/src/poly/handlers/sync_client.py
+++ b/src/poly/handlers/sync_client.py
@@ -111,13 +111,18 @@ class SyncClientHandler:
         return projection
 
     def pull_branch_projection(
-        self, branch_id: str, at_sequence: Optional[int] = None
+        self,
+        branch_id: str,
+        at_sequence: Optional[int] = None,
+        include_api_mocks: bool = False,
     ) -> dict[str, Any]:
         """Fetch projection for a specific branch, optionally at a historical sequence.
 
         Args:
             branch_id: The branch whose projection to fetch.
             at_sequence: When provided, fetches the projection at this sequence number.
+            include_api_mocks: If True, ask the platform to include test case
+                api_mocks in the projection (gated behind the api mock editor FF).
 
         Returns:
             The raw projection dict for the branch.
@@ -127,18 +132,27 @@ class SyncClientHandler:
             + (f" at sequence {at_sequence}" if at_sequence is not None else "")
         )
         projection = self.sdk.fetch_projection(
-            force_refresh=True, branch_id=branch_id, at_sequence=at_sequence
+            force_refresh=True,
+            branch_id=branch_id,
+            at_sequence=at_sequence,
+            include_api_mocks=include_api_mocks,
         )
         return projection
 
-    def pull_projection(self) -> dict[str, Any]:
+    def pull_projection(self, include_api_mocks: bool = False) -> dict[str, Any]:
         """Fetch the raw projection for the current branch.
+
+        Args:
+            include_api_mocks: If True, ask the platform to include test case
+                api_mocks in the projection (gated behind the api mock editor FF).
 
         Returns:
             The raw projection dict.
         """
         self.assert_branch_exists()
-        projection = self.pull_branch_projection(branch_id=self.sdk.branch_id)
+        projection = self.pull_branch_projection(
+            branch_id=self.sdk.branch_id, include_api_mocks=include_api_mocks
+        )
         logger.debug(f"Projection: {projection}")
         logger.info(
             f"Successfully fetched project data for project {self.project_id} "

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -50,6 +50,7 @@ from poly.resources.resource import (
     _parse_multi_resource_path,
     load_resources_from_projection,
 )
+from poly.resources.test_suite import TestCaseApiMocks
 from poly.utils import prepush
 
 logger = logging.getLogger(__name__)
@@ -361,7 +362,8 @@ class AgentStudioProject:
 
         try:
             project.resources, projection = project.api_handler.pull_resources(
-                projection_json=projection_json
+                projection_json=projection_json,
+                include_api_mocks=project.api_mock_editor_enabled,
             )
         except ValueError:
             if os.path.exists(project_path):
@@ -370,6 +372,7 @@ class AgentStudioProject:
                 shutil.rmtree(account_path)
             raise
 
+        project._strip_disabled_api_mocks(project.resources)
         project._check_no_duplicate_resource_paths(project.resources)
 
         resource_mappings: list[ResourceMapping] = project._make_resource_mappings(
@@ -448,7 +451,11 @@ class AgentStudioProject:
         Returns:
             A tuple of (resources dict, projection dict).
         """
-        resources, projection = self.api_handler.pull_resources(projection_json=projection_json)
+        resources, projection = self.api_handler.pull_resources(
+            projection_json=projection_json,
+            include_api_mocks=self.api_mock_editor_enabled,
+        )
+        self._strip_disabled_api_mocks(resources)
         self._check_no_duplicate_resource_paths(resources)
 
         self.resources = resources
@@ -562,12 +569,14 @@ class AgentStudioProject:
         # -------
 
         incoming_resources, projection = self.api_handler.pull_resources(
-            projection_json=projection_json
+            projection_json=projection_json,
+            include_api_mocks=self.api_mock_editor_enabled,
         )
         # Only update branch id if we used the API to pull the resources
         if projection_json is None:
             self.branch_id = self.api_handler.branch_id
 
+        self._strip_disabled_api_mocks(incoming_resources)
         self._check_no_duplicate_resource_paths(incoming_resources)
         # -------
         # Update resources
@@ -1248,6 +1257,8 @@ class AgentStudioProject:
                 resource_mapping.resource_id
             ] = local_resource
 
+        self._strip_disabled_api_mocks(new_state)
+
         # 3. Work out kept resources that have changed
         new_resources: ResourceMap = {}
         updated_resources: ResourceMap = {}
@@ -1768,7 +1779,10 @@ class AgentStudioProject:
                 self.region, self.account_id, self.project_id, branch_id
             )
             logger.info(f"Pulling resources from branch '{name}'...")
-            resources, _ = branch_api_handler.pull_resources()
+            resources, _ = branch_api_handler.pull_resources(
+                include_api_mocks=self.api_mock_editor_enabled
+            )
+            self._strip_disabled_api_mocks(resources)
             return resources
 
         # 3) Deployment version hash prefix -> deployment resources
@@ -2549,6 +2563,7 @@ class AgentStudioProject:
                 input_lang=input_lang,
                 output_lang=output_lang,
                 sip_headers=sip_headers,
+                api_mock_editor=self.api_mock_editor_enabled,
             )
 
         return AgentStudioInterface.create_chat(
@@ -2561,6 +2576,7 @@ class AgentStudioProject:
             input_lang=input_lang,
             output_lang=output_lang,
             sip_headers=sip_headers,
+            api_mock_editor=self.api_mock_editor_enabled,
         )
 
     def send_message(
@@ -3077,6 +3093,8 @@ class AgentStudioProject:
             )
 
             new_state.setdefault(mapping.resource_type, {})[mapping.resource_id] = local_resource
+
+        self._strip_disabled_api_mocks(new_state)
 
         # 3. Compare new_state vs self.resources by file_path -> new/deleted/updated
         deleted_resources: ResourceMap = {}
@@ -3888,3 +3906,24 @@ class AgentStudioProject:
         return live_head is not None and (
             sandbox_head is None or _parse_created_at(live_head) >= _parse_created_at(sandbox_head)
         )
+
+    @cached_property
+    def api_mock_editor_enabled(self) -> bool:
+        """Check if the API mock editor (test case `api_mocks`) feature is enabled."""
+        return self.api_handler.feature_flag_enabled(
+            key="testify-v2-1",
+            region=self.region,
+            project_id=self.project_id,
+            default=False,
+        )
+
+    def _strip_disabled_api_mocks(self, resources: "ResourceMap") -> None:
+        """Clear `TestCase.api_mocks` in-place while the api mock editor FF is off.
+
+        Keeps api_mocks dark end-to-end: never read from the platform, never
+        diffed against, and never pushed back up.
+        """
+        if self.api_mock_editor_enabled:
+            return
+        for test_case in resources.get(TestCase, {}).values():
+            test_case.api_mocks = TestCaseApiMocks()

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -85,6 +85,52 @@ class CreateChat(unittest.TestCase):
 
         self.assertEqual(mock_make_request.call_args.kwargs["data"]["sip_headers"], sip_headers)
 
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_standard_chat_requests_api_mock_editor_when_enabled(self, mock_make_request):
+        """api_mock_editor=True asks the platform to intercept API calls with the test mocks."""
+        PlatformAPIHandler.create_chat(
+            "uk-1",
+            "ACCOUNT-123",
+            "PROJECT-123",
+            api_mock_editor=True,
+        )
+
+        self.assertIs(mock_make_request.call_args.kwargs["data"]["apiMockEditor"], True)
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_standard_chat_omits_api_mock_editor_by_default(self, mock_make_request):
+        """The apiMockEditor key is left out entirely rather than sent as False."""
+        PlatformAPIHandler.create_chat("uk-1", "ACCOUNT-123", "PROJECT-123")
+
+        self.assertNotIn("apiMockEditor", mock_make_request.call_args.kwargs["data"])
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_draft_chat_requests_api_mock_editor_when_enabled(self, mock_make_request):
+        """api_mock_editor=True is forwarded on branch (draft) chats too."""
+        PlatformAPIHandler.create_draft_chat(
+            "uk-1",
+            "ACCOUNT-123",
+            "PROJECT-123",
+            "artifact-version",
+            "lambda-version",
+            api_mock_editor=True,
+        )
+
+        self.assertIs(mock_make_request.call_args.kwargs["data"]["apiMockEditor"], True)
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_draft_chat_omits_api_mock_editor_by_default(self, mock_make_request):
+        """The apiMockEditor key is left out entirely rather than sent as False."""
+        PlatformAPIHandler.create_draft_chat(
+            "uk-1",
+            "ACCOUNT-123",
+            "PROJECT-123",
+            "artifact-version",
+            "lambda-version",
+        )
+
+        self.assertNotIn("apiMockEditor", mock_make_request.call_args.kwargs["data"])
+
 
 class MakeRequest(unittest.TestCase):
     """Tests for PlatformAPIHandler.make_request HTTP behaviour."""

--- a/src/poly/tests/api/sdk_test.py
+++ b/src/poly/tests/api/sdk_test.py
@@ -93,6 +93,32 @@ class FetchProjection(unittest.TestCase):
 
         self.assertEqual(session.get.call_count, 2)
 
+    def test_include_api_mocks_sends_api_mock_editor_param(self):
+        """include_api_mocks=True asks the platform for test case api_mocks."""
+        sdk = build_sdk()
+        session = MagicMock()
+        session.get.return_value = make_mock_response(
+            200, json_body={"projection": {}, "lastKnownSequence": "1"}
+        )
+        sdk._session = session
+
+        sdk.fetch_projection(include_api_mocks=True)
+
+        self.assertEqual(session.get.call_args.kwargs["params"], {"apiMockEditor": True})
+
+    def test_api_mock_editor_param_omitted_when_api_mocks_not_requested(self):
+        """The apiMockEditor param is left off entirely rather than sent as False."""
+        sdk = build_sdk()
+        session = MagicMock()
+        session.get.return_value = make_mock_response(
+            200, json_body={"projection": {}, "lastKnownSequence": "1"}
+        )
+        sdk._session = session
+
+        sdk.fetch_projection(at_sequence=7, include_api_mocks=False)
+
+        self.assertEqual(session.get.call_args.kwargs["params"], {"atSequence": 7})
+
     def test_request_failure_raises_sourcerer_error(self):
         """A failing projection request raises SourcererAPIError."""
         sdk = build_sdk()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -58,6 +58,7 @@ from poly.resources.flows import (
 )
 from poly.resources.function import FunctionType
 from poly.resources.resource import MultiResourceYamlResource
+from poly.resources.test_suite import ApiResponse, ApiResponseRule, TestCaseApiMocks
 from poly.tests.testing_utils import mock_read_from_file
 
 DIR = os.path.dirname(os.path.abspath(__file__))
@@ -3661,6 +3662,112 @@ class ResolveTestsTest(unittest.TestCase):
             self.project.resolve_tests(files=["no_such_test.yaml"])
 
 
+class ApiMockEditorFeatureFlagTest(unittest.TestCase):
+    """Gating of test case `api_mocks` behind the api mock editor feature flag."""
+
+    def setUp(self):
+        self.mock_api_handler = patch.object(
+            AgentStudioProject, "api_handler", new_callable=MagicMock
+        ).start()
+        patch.object(AgentStudioProject, "save_config").start()
+
+    def tearDown(self):
+        patch.stopall()
+
+    def _test_case_with_mocks(self) -> TestCase:
+        """A test case carrying a single mocked API response."""
+        return TestCase(
+            resource_id="TEST-1",
+            name="Order lookup",
+            scenario="Caller asks about their order.",
+            channel="chat.polyai",
+            language="en-GB",
+            assertions=TestCaseAssertion(
+                resource_id="TEST-1", name="assertions", prompts=[], function_calls=[]
+            ),
+            tags=TestCaseTags(resource_id="TEST-1", name="tags", tags=[]),
+            api_mocks=TestCaseApiMocks(
+                mocks={
+                    "crm": {
+                        "get_customer": [
+                            ApiResponseRule(respond=ApiResponse(status=200, body={"id": 1}))
+                        ]
+                    }
+                }
+            ),
+        )
+
+    def test_flag_is_read_from_posthog_for_the_current_project(self):
+        """The cached property returns the PostHog value for the testify-v2-1 key."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.feature_flag_enabled.return_value = True
+
+        self.assertTrue(project.api_mock_editor_enabled)
+        self.mock_api_handler.feature_flag_enabled.assert_called_once_with(
+            key="testify-v2-1",
+            region=project.region,
+            project_id=project.project_id,
+            default=False,
+        )
+
+    def test_disabled_flag_clears_api_mocks_on_test_cases(self):
+        """With the flag off, api_mocks are emptied so they are never diffed or pushed."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.feature_flag_enabled.return_value = False
+        test_case = self._test_case_with_mocks()
+
+        project._strip_disabled_api_mocks({TestCase: {test_case.resource_id: test_case}})
+
+        self.assertEqual(test_case.api_mocks, TestCaseApiMocks())
+
+    def test_enabled_flag_leaves_api_mocks_untouched(self):
+        """With the flag on, stripping is a no-op and the mocks survive."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.feature_flag_enabled.return_value = True
+        test_case = self._test_case_with_mocks()
+
+        project._strip_disabled_api_mocks({TestCase: {test_case.resource_id: test_case}})
+
+        self.assertEqual(test_case.api_mocks.mocks["crm"]["get_customer"][0].respond.status, 200)
+
+    def test_load_project_drops_api_mocks_returned_by_the_platform_when_disabled(self):
+        """Even if the platform sends api_mocks back, a disabled flag strips them on load."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.feature_flag_enabled.return_value = False
+        test_case = self._test_case_with_mocks()
+        self.mock_api_handler.pull_resources.return_value = (
+            {TestCase: {test_case.resource_id: test_case}},
+            {},
+        )
+
+        resources, _ = project.load_project()
+
+        self.assertEqual(resources[TestCase]["TEST-1"].api_mocks, TestCaseApiMocks())
+        self.mock_api_handler.pull_resources.assert_called_once_with(
+            projection_json=None, include_api_mocks=False
+        )
+
+    def test_load_project_requests_api_mocks_from_the_platform_when_enabled(self):
+        """With the flag on, the pull asks the platform to include api_mocks."""
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.feature_flag_enabled.return_value = True
+        test_case = self._test_case_with_mocks()
+        self.mock_api_handler.pull_resources.return_value = (
+            {TestCase: {test_case.resource_id: test_case}},
+            {},
+        )
+
+        resources, _ = project.load_project()
+
+        self.assertEqual(
+            resources[TestCase]["TEST-1"].api_mocks.mocks["crm"]["get_customer"][0].respond.status,
+            200,
+        )
+        self.mock_api_handler.pull_resources.assert_called_once_with(
+            projection_json=None, include_api_mocks=True
+        )
+
+
 class FetchProjectTest(unittest.TestCase):
     """Tests for the fetch_project method."""
 
@@ -3669,6 +3776,7 @@ class FetchProjectTest(unittest.TestCase):
         self.mock_api_handler = patch.object(
             AgentStudioProject, "api_handler", new_callable=MagicMock
         ).start()
+        self.mock_api_handler.feature_flag_enabled.return_value = False
         self.mock_save_config = patch.object(AgentStudioProject, "save_config").start()
 
     def tearDown(self):
@@ -3690,7 +3798,9 @@ class FetchProjectTest(unittest.TestCase):
         self.assertEqual(projection, expected_projection)
         self.assertEqual(project.resources, expected_resources)
         self.assertEqual(project._not_loaded_resources, [])
-        self.mock_api_handler.pull_resources.assert_called_once_with(projection_json=None)
+        self.mock_api_handler.pull_resources.assert_called_once_with(
+            projection_json=None, include_api_mocks=False
+        )
 
     def test_fetch_without_branch_updates_branch_id_from_api(self):
         """When no projection_json, branch_id should be updated from api_handler."""
@@ -3748,7 +3858,7 @@ class FetchProjectTest(unittest.TestCase):
 
         self.assertEqual(project.branch_id, original_branch_id)
         self.mock_api_handler.pull_resources.assert_called_once_with(
-            projection_json={"cached": "projection"}
+            projection_json={"cached": "projection"}, include_api_mocks=False
         )
 
     def test_fetch_calls_save_config(self):
@@ -4090,6 +4200,7 @@ class MigrateFlowStepSettingsTest(unittest.TestCase):
         migrate_flow_step_settings(status_dict)
 
         self.assertNotIn("settings", status_dict["resources"]["flow_steps"]["FLOW-abc_step-1"])
+
 
 class SyncBranchProject(unittest.TestCase):
     """Tests for AgentStudioProject.sync_branch."""
@@ -5477,9 +5588,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         flow_id is translated the prefix and flow_id disagree and the flow id stays welded
         onto start_step exactly as it did in the unfixed case.
         """
-        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(
-            without_start_step=True
-        )
+        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(without_start_step=True)
 
         with patch.object(
             AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
@@ -5491,9 +5600,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
 
     def test_branch_only_step_is_rekeyed_onto_the_sandbox_flow_id(self):
         """A step added on the branch adopts the sandbox flow id in its composite id."""
-        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(
-            without_start_step=True
-        )
+        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(without_start_step=True)
 
         with patch.object(
             AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
@@ -5542,9 +5649,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
                 rekeyed[resource.resource_id] = resource
             sandbox[resource_type] = rekeyed
 
-        with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox
-        ):
+        with patch.object(AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
         self.assertEqual(


### PR DESCRIPTION
## Summary

Gates the whole API mock editor feature (test case `api_mocks`) behind the PostHog flag `testify-v2-1`, and tells the platform when it's enabled via an `apiMockEditor` payload flag.

## Motivation

The `api_mocks` support added on this branch needs to be dark-launched rather than immediately live for all users.

## Changes

- Added `AgentStudioProject.api_mock_editor_enabled` (`cached_property`), checking PostHog flag `testify-v2-1` — mirrors the existing `using_simplified_deployments` pattern.
- Added `AgentStudioProject._strip_disabled_api_mocks()`, called everywhere `TestCase` resources enter memory (pull, load, push, RTC sync) to clear `api_mocks` when the flag is off — keeps the feature dark end-to-end (never read, diffed, or pushed).
- Threaded `include_api_mocks` through `pull_resources` → `pull_projection` → `fetch_projection`; when enabled, sends `"apiMockEditor": true` as a query param on projection pull requests.
- Threaded `api_mock_editor` through `create_chat_session` → `create_chat`/`create_draft_chat`; when enabled, sends `"apiMockEditor": true` in the JSON body of chat/simulation creation requests.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)