### PR TITLE
fix: accept none reasoning effort in experimental config

### DIFF
--- a/src/poly/resources/experimental_config_schema.yaml
+++ b/src/poly/resources/experimental_config_schema.yaml
@@ -215,6 +215,7 @@ components:
         reasoning_effort:
           type: string
           enum:
+            - none
             - minimal
             - low
             - medium
@@ -222,6 +223,7 @@ components:
             - auto
           description: >
             LLM 'thinking time'. Supported values vary by model:
+            OpenAI GPT-5.6 models: `none`, `low`, `medium`, `high`.
             OpenAI reasoning models (GPT-5): `minimal`, `low`, `medium`, `high`.
             Raven 3.5: `auto` (model decides whether to reason, short verbosity) and `low` (always reasons, short verbosity).
             Raven v3: `low` only.


### PR DESCRIPTION
## Summary

Adds `none` to the `reasoning_effort` enum in the bundled experimental config schema, and documents which models take it.

## Motivation

The platform now accepts `reasoning_effort: none` — it is the supported low-latency value for OpenAI GPT-5.6 models, which do not accept the older GPT-5 `minimal`. The bundled schema is what `poly validate` / CI check an `experimental_config` against, so without this a project that legitimately sets `none` validates in Agent Studio but fails validation here, and the usual "remove it to pass CI" workaround silently reverts the setting on merge.

## Changes

- `src/poly/resources/experimental_config_schema.yaml`: add `none` to the `reasoning_effort` enum and a description line for the GPT-5.6 supported set (`none`, `low`, `medium`, `high`), keeping the existing per-model lines unchanged.

Out of scope: the flow-step `ReasoningEffort` enum in `resources/flows.py` is bound to proto ordinals, so a `none` member there needs the proto enum to carry one first. This PR only widens the experimental config schema.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Schema-only change; `pytest src/poly/tests/project_test.py` (the experimental config validation tests) passes — 233 passed.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass (no Python changed)
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface — this only widens what validates
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

N/A