### PR TITLE
ci: pin the release tooling instead of rebuilding it unpinned every run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,20 +35,35 @@ jobs:
         with:
           python-version: "3.14"
 
+      # python-semantic-release@v9 and publish-action@v9 are Docker actions whose image is
+      # rebuilt on every run, pip-installing their dependencies unpinned. GitPython 3.1.60
+      # removed Actor.name_email_regex, which semantic-release reads while parsing
+      # commit_author, so the actions started failing without any change on our side.
+      # Installing the tooling ourselves pins both halves. The gitpython pin can be dropped
+      # once upstream stops using the removed attribute.
+      - name: Install python-semantic-release
+        run: |
+          python -m venv /tmp/psr
+          /tmp/psr/bin/pip install --upgrade pip
+          /tmp/psr/bin/pip install \
+            "python-semantic-release==9.21.2" "gitpython==3.1.59"
+
       - name: Semantic release
         id: release
-        uses: python-semantic-release/python-semantic-release@v9
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          git_committer_name: github-actions[bot]
-          git_committer_email: "github-actions[bot]@users.noreply.github.com"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GIT_COMMIT_AUTHOR: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          export PATH="/tmp/psr/bin:$PATH"
+          semantic-release -v version
 
       - name: Publish to GitHub Releases
         if: steps.release.outputs.released == 'true'
-        uses: python-semantic-release/publish-action@v9
-        with:
-          github_token: ${{ steps.app-token.outputs.token }}
-          tag: ${{ steps.release.outputs.tag }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: /tmp/psr/bin/semantic-release -v publish --tag "${{ steps.release.outputs.tag }}"
 
       - name: Publish to PyPI
         if: steps.release.outputs.released == 'true'


### PR DESCRIPTION
## Summary

The `Release` workflow has been failing since 26 Aug because its semantic-release actions rebuild themselves with unpinned dependencies on every run. This installs the tooling ourselves with both `python-semantic-release` and `gitpython` pinned, unblocking the five commits currently stranded on `main`.

## Motivation

Two release runs failed in the **Semantic release** step with:

```
type object 'Actor' has no attribute 'name_email_regex'
```

Nothing in this repo caused it:

1. `python-semantic-release@v9` and `publish-action@v9` are **Docker actions whose image is rebuilt on every run**, pip-installing their dependencies unpinned. `@v9` pins the action's code, not its dependency tree.
2. **GitPython 3.1.60** was published 2026-08-25 18:33 UTC — between the last green run (25 Aug 10:24) and the first red one (26 Aug 10:50).
3. 3.1.60 removed the `Actor.name_email_regex` class attribute, which semantic-release reads **unconditionally** while validating `commit_author` (`cli/config.py:745`). Verified locally: present in 3.1.59, absent in 3.1.60.
4. **Upgrading the action to v10 would not help** — 10.6.1 contains the identical call at the same line and also resolves GitPython 3.1.60.

Verified working combination: `python-semantic-release==9.21.2` + `gitpython==3.1.59`.

## Changes

- Add an `Install python-semantic-release` step that builds a venv at `/tmp/psr` with both packages pinned.
- Run `semantic-release version` directly instead of `python-semantic-release@v9`.
- Run `semantic-release publish` directly instead of `publish-action@v9`, which has the identical unpinned install and would fail the same way.
- Leave the `on:`/`permissions:`/`concurrency:` blocks and the PyPI trusted-publishing step untouched.

Behaviour is preserved deliberately, each point checked against the pinned semantic-release source rather than assumed:

| Concern | Why it still works |
|---|---|
| `steps.release.outputs.released` / `.tag` | `semantic-release` writes `released`/`version`/`tag`/`is_prerelease` to `$GITHUB_OUTPUT` itself (`cli/github_actions_output.py`, registered via `ctx.call_on_close`) |
| Token, without the `github_token:` input | `GH_TOKEN` is the GitHub client's `DEFAULT_ENV_TOKEN_NAME` (`hvcs/github.py:85`) |
| Committer identity | `commit_author` is an `EnvConfigVar(env="GIT_COMMIT_AUTHOR")`; the value set matches the previous `git_committer_name`/`git_committer_email` inputs exactly |
| `build_command` | `pip install build && python -m build` needs a pip on PATH — `python -m venv` ships one, and the venv is prepended to PATH, as the action's container previously provided |
| Commit/tag/push/changelog | The action's `INPUT_COMMIT`/`INPUT_TAG`/`INPUT_PUSH`/`INPUT_CHANGELOG`/`INPUT_VCS_RELEASE` all defaulted true, matching bare `semantic-release version` defaults |

`/tmp/psr` is deliberately outside the workspace so the venv cannot be caught by `version_toml` globs or land in the built sdist.

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Verified locally by reproducing exactly what CI will install:

```
$ python3 -m venv psr-check
$ ./psr-check/bin/pip install "python-semantic-release==9.21.2" "gitpython==3.1.59"
$ ./psr-check/bin/python -c "from git import Actor; print(hasattr(Actor,'name_email_regex'))"
True
$ ./psr-check/bin/semantic-release --version
semantic-release, version 9.21.2
```

The workflow YAML was parsed and its step list confirmed.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass (no Python files changed)
- [x] `pytest` passes (no Python files changed)
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Merging this triggers the Release workflow (`release.yaml` is inside its own `paths:` filter), which should cut **0.45.0** — minor, because semantic-release takes the highest bump across everything since `v0.44.4`:

```
e8333c3  fix:  accept none reasoning effort (#292)   -> PATCH
42a5616  feat: API integration mocks (#284)          -> MINOR   <- dominates
038eed6  docs: auto-update (#287)                    -> NO_RELEASE
3940c12  fix:  handoff/review behavior (#279)        -> PATCH
8be0deb  fix:  document path casing (#281)           -> PATCH
```

One known risk: an earlier run (32985593610) is stuck `queued` and refuses both `gh run cancel` and the force-cancel API. The job declares `concurrency: release`, so if the post-merge run also sits queued without allocating a job, that zombie is holding the concurrency group.

The `gitpython` pin can be dropped once upstream stops using the removed attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)