### PR TITLE
feat: add persona to agent settings (DEVP-624)

### DIFF
--- a/docs/docs/development/resource-architecture.md
+++ b/docs/docs/development/resource-architecture.md
@@ -47,7 +47,7 @@ The last two are not peers of the first four. Agent configuration is the leaf la
 
 Rules are **always present in the prompt**, on every turn. They are not retrieved and not conditional, which makes them the right home for instructions that are unconditionally true — "always confirm the booking reference before making changes" — and the wrong home for facts, which would consume prompt space even when irrelevant to the current turn.
 
-`persona.txt` is narrower than rules: it accepts only `{{vrbl:}}` references. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
+`persona.txt` is narrower than rules: it accepts only `{{attr:}}` and `{{vrbl:}}` references. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
 
 See [agent settings](../reference/resources/agent_settings.md).
 

--- a/docs/docs/development/resource-architecture.md
+++ b/docs/docs/development/resource-architecture.md
@@ -43,12 +43,11 @@ The last two are not peers of the first four. Agent configuration is the leaf la
 | File | Holds |
 |---|---|
 | `rules.txt` | Global behavioral instructions |
-| `personality.yaml` | Tone and manner |
-| `role.yaml` | Who the agent is and what it is for |
+| `persona.txt` | Who the agent is, in free text |
 
 Rules are **always present in the prompt**, on every turn. They are not retrieved and not conditional, which makes them the right home for instructions that are unconditionally true — "always confirm the booking reference before making changes" — and the wrong home for facts, which would consume prompt space even when irrelevant to the current turn.
 
-`personality.yaml` and `role.yaml` are narrower than rules: they accept only `{{attr:}}` and `{{vrbl:}}` references. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
+`persona.txt` is narrower than rules: it accepts only `{{vrbl:}}` references. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
 
 See [agent settings](../reference/resources/agent_settings.md).
 
@@ -234,7 +233,7 @@ See [voice settings](../reference/resources/voice_settings.md), [chat settings](
 |---|---|
 | A new FAQ, policy, or factual answer | Topic (`topics/`) |
 | A global behavioral rule (always do X, never do Y) | `agent_settings/rules.txt` |
-| Agent identity and tone | `agent_settings/personality.yaml` and `role.yaml` |
+| Agent identity and tone | `agent_settings/persona.txt` |
 | A multi-step guided conversation | Flow (`flows/`) |
 | Structured data collection from the caller | Entity + flow |
 | Deterministic branching or routing logic | Function (`functions/`) |

--- a/docs/docs/development/working-locally.md
+++ b/docs/docs/development/working-locally.md
@@ -28,8 +28,7 @@ A typical project structure looks like this:
 ├── _gen/                               # Generated stubs - do not edit
 ├── agent_settings/                     # Agent identity and behavior
 │   ├── languages.yaml                  # Optional
-│   ├── personality.yaml
-│   ├── role.yaml
+│   ├── persona.txt
 │   ├── rules.txt
 │   ├── safety_filters.yaml             # Optional
 │   └── experimental_config.json        # Optional

--- a/docs/docs/reference/cli/docs.md
+++ b/docs/docs/reference/cli/docs.md
@@ -31,7 +31,7 @@ Available resource names:
 
 | Name | Description |
 |---|---|
-| `agent_settings` | Personality, role, rules |
+| `agent_settings` | Persona, rules |
 | `api_integrations` | External HTTP API definitions |
 | `chat_settings` | Chat greeting, style prompt |
 | `context` | Context files for agent knowledge |

--- a/docs/docs/reference/resources.md
+++ b/docs/docs/reference/resources.md
@@ -15,7 +15,7 @@ Every resource here follows the same sync process, including [permission-gated v
 
 | Resource | Configures | File |
 |---|---|---|
-| [Agent settings](./resources/agent_settings.md) | Personality, role, and global rules | `agent_settings/` |
+| [Agent settings](./resources/agent_settings.md) | Persona and global rules | `agent_settings/` |
 | [Languages](./resources/languages.md) | Supported languages for a multilingual agent | `agent_settings/languages.yaml` |
 | [Experimental config](./resources/experimental_config.md) | Opt-in experimental platform features | `agent_settings/experimental_config.json` |
 

--- a/docs/docs/reference/resources/CLAUDE.MD
+++ b/docs/docs/reference/resources/CLAUDE.MD
@@ -33,7 +33,7 @@ config/entities.yaml
 ## What a/an <resource> contains|controls|is for
 
 <The overview. Use grid cards when there are several sub-parts to introduce
-(e.g. agent settings has personality/role/rules); use plain prose when there's
+(e.g. agent settings has persona/rules); use plain prose when there's
 only one shape.>
 
 ### Fields

--- a/docs/docs/reference/resources/agent_settings.md
+++ b/docs/docs/reference/resources/agent_settings.md
@@ -1,17 +1,20 @@
 ---
 title: Agent settings
-description: Define the agent's identity, role, and behavioral rules in the PolyAI ADK.
+description: Define the agent's identity, persona, and behavioral rules in the PolyAI ADK.
 ---
 
 # Agent settings
 
 <p class="lead">
 Agent settings define the agent's identity and behavioral rules.
-They live in <code>agent_settings/</code> and are made up of personality, role, and rules resources.
+They live in <code>agent_settings/</code> and are made up of persona and rules resources.
 </p>
 
-!!! note "Personality and role are platform-provisioned — update only"
-    The personality and role resources are created automatically by the platform when a project is created. They always exist on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If these files appear in a project directory without matching entries in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](../cli/init.md) and [`poly pull`](../cli/pull.md) rather than copying an existing directory.
+!!! note "The persona is platform-provisioned — update only"
+    The persona resource is created automatically by the platform when a project is created. It always exists on any Agent Studio project and can be updated with `poly push`, but cannot be created from scratch via the ADK. If `persona.txt` appears in a project directory without a matching entry in `.agent_studio_config` — for example, after copying a directory from another project — the push will fail with a "Create operation not supported" error. Always start a new project with [`poly init`](../cli/init.md) and [`poly pull`](../cli/pull.md) rather than copying an existing directory.
+
+!!! warning "Personality and role have been removed"
+    The agent's identity used to be split across `personality.yaml` and `role.yaml`. Agent Studio replaced both with a single free-text persona, so the ADK no longer pulls or pushes them. A project last pulled with an older version still has the two files on disk; they are deleted the first time the project is loaded, and the ADK logs a warning telling you to run [`poly pull`](../cli/pull.md) to fetch `persona.txt`.
 
 These settings shape how the agent presents itself and how it should behave across the conversation.
 
@@ -22,8 +25,7 @@ Agent settings live under:
 ~~~text
 agent_settings/
 ├── languages.yaml                  # Optional
-├── personality.yaml
-├── role.yaml
+├── persona.txt
 ├── rules.txt
 ├── safety_filters.yaml             # Optional
 └── experimental_config.json        # Optional
@@ -33,17 +35,11 @@ agent_settings/
 
 <div class="grid cards" markdown>
 
--   **Personality**
+-   **Persona**
 
     ---
 
-    Controls the agent's tone and conversational style.
-
--   **Role**
-
-    ---
-
-    Defines what the agent is and what kind of job it performs.
+    Describes who the agent is, in free text.
 
 -   **Rules**
 
@@ -71,82 +67,29 @@ agent_settings/
 
 </div>
 
-## Personality
+## Persona
 
-The `personality.yaml` file controls the agent's conversational tone.
+The `persona.txt` file is a free-text description of who the agent is. It is the single field that defines the agent's identity, and it is what the **Role** field in Agent Studio edits.
 
-### Fields
+### Supported references
 
-| Field | Description |
+| Syntax | Meaning |
 |---|---|
-| `adjectives` | Map of personality traits to booleans |
-| `custom` | Free-text personality description |
+| `{{vrbl:variable_name}}` | [State variable](./variables.md) |
 
-### Adjectives
-
-Allowed adjective values are:
-
-- `Polite`
-- `Calm`
-- `Kind`
-- `Funny`
-- `Energetic`
-- `Thoughtful`
-- `Other`
-
-If `Other` is set to `true`, no other adjective can be selected.
-
-!!! info "Non-standard adjectives"
-
-    The platform may return adjectives not in the local allowed set (for example, deprecated or newly added adjectives). Validation only fails for adjectives that are **enabled** (`true`) and not in the allowed set. Disabled (`false`) non-standard adjectives pass validation and are silently excluded from the update payload when pushing.
-
-### `custom`
-
-The `custom` field is a free-text description of the personality.
-
-It supports:
-
-- `{{attr:...}}`
-- `{{vrbl:...}}`
+Variables are the only reference type the persona accepts. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
 
 ### Example
 
-~~~yaml
-adjectives:
-  Polite: true
-  Calm: true
-  Kind: true
-custom: ""
+~~~text
+You are a calm and polite concierge for {{vrbl:hotel_name}}. Keep answers short.
 ~~~
 
-## Role
+### Derived personas
 
-The `role.yaml` file defines what the agent is.
+A project that predates the persona and has never had one authored still pulls a `persona.txt`: the platform derives its content from the project's old personality and role settings, without storing it. Because `poly push` only sends resources whose contents have changed, an untouched file is never pushed back.
 
-This is usually the agent's role, title, or function in the business context.
-
-### Fields
-
-| Field | Description |
-|---|---|
-| `value` | Role name, such as `Customer Service Representative` |
-| `additional_info` | Extra context about the role |
-| `custom` | Free-text role description used when `value` is `other` |
-
-If `value` is set to `other`, the `custom` field is used instead.
-
-The `custom` field supports:
-
-- `{{attr:...}}`
-- `{{vrbl:...}}`
-
-### Example
-
-~~~yaml
-value: Customer Service Representative
-additional_info: Handles customer inquiries and bookings
-custom: ""
-~~~
+Editing `persona.txt` and pushing authors a real persona. From that point the content is fixed and no longer derived.
 
 ## Rules
 
@@ -231,7 +174,7 @@ See the [Safety filters reference](./safety_filters.md) for field descriptions, 
 
 - keep rules concise and actionable
 - use references instead of hard-coded values
-- use `custom` personality and role text only when you need more than the structured fields provide
+- keep the persona focused on who the agent is, and leave what it should do to the rules
 - treat rules as a global behavioral layer, not a place for detailed flow logic
 
 ## Related pages

--- a/docs/docs/reference/resources/agent_settings.md
+++ b/docs/docs/reference/resources/agent_settings.md
@@ -75,9 +75,14 @@ The `persona.txt` file is a free-text description of who the agent is. It is the
 
 | Syntax | Meaning |
 |---|---|
+| `{{attr:attribute_name}}` | [Variant attribute](./variants.md) |
 | `{{vrbl:variable_name}}` | [State variable](./variables.md) |
 
-Variables are the only reference type the persona accepts. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
+These are the same two the personality and role settings accepted, so the persona can vary per [variant](./variants.md) or per call. Behavioral references such as `{{fn:}}` and `{{ho:}}` belong in `rules.txt`.
+
+!!! warning "Attribute references are not tracked"
+
+    `PersonaReferences` carries a variables map and nothing else, so an `{{attr:}}` reference travels in the persona text but is not recorded as a reference on the resource. The personality and role settings behaved the same way. `poly push` still validates that the attribute exists.
 
 ### Example
 

--- a/docs/docs/reference/resources/chat_settings.md
+++ b/docs/docs/reference/resources/chat_settings.md
@@ -78,7 +78,7 @@ Use this for chat-specific guidance such as:
 - using bullet points for lists
 - adjusting formatting for readability
 
-This is separate from the agent's broader personality. Use it to control how the agent communicates specifically in web chat.
+This is separate from the agent's broader persona. Use it to control how the agent communicates specifically in web chat.
 
 ### Fields
 

--- a/docs/docs/reference/resources/languages.md
+++ b/docs/docs/reference/resources/languages.md
@@ -69,7 +69,7 @@ additional_languages:
 
     ---
 
-    See how `languages.yaml` fits alongside personality, role, and rules.
+    See how `languages.yaml` fits alongside the persona and rules.
     [Open agent settings](./agent_settings.md)
 
 -   **Voice settings**

--- a/docs/docs/reference/resources/safety_filters.md
+++ b/docs/docs/reference/resources/safety_filters.md
@@ -182,7 +182,7 @@ The same settings can be configured in the Agent Studio UI. The platform docs co
 
     ---
 
-    Configure personality, role, and rules alongside project-level safety filters.
+    Configure the persona and rules alongside project-level safety filters.
     [Open agent settings](./agent_settings.md)
 
 -   **Voice settings**

--- a/docs/docs/reference/resources/variants.md
+++ b/docs/docs/reference/resources/variants.md
@@ -129,8 +129,6 @@ Use `{{attr:attribute_name}}` in supported text fields such as:
 - rules (`rules.txt`)
 - greeting (`welcome_message`)
 - disclaimer message
-- personality `custom`
-- role `custom`
 
 ### Example
 

--- a/docs/docs/reference/resources/variants.md
+++ b/docs/docs/reference/resources/variants.md
@@ -127,6 +127,7 @@ Use `{{attr:attribute_name}}` in supported text fields such as:
 - flow step prompts
 - [topic](./topics.md) actions (not in `content` or `example_queries`)
 - rules (`rules.txt`)
+- persona (`persona.txt`)
 - greeting (`welcome_message`)
 - disclaimer message
 

--- a/docs/docs/reference/resources/voice_settings.md
+++ b/docs/docs/reference/resources/voice_settings.md
@@ -87,7 +87,7 @@ Use this for voice-specific guidance such as:
 - spoken tone
 - conversational pacing
 
-This is separate from the agent's broader personality. Use it to shape how the agent should sound specifically on phone calls.
+This is separate from the agent's broader persona. Use it to shape how the agent should sound specifically on phone calls.
 
 ### Fields
 

--- a/docs/docs/tooling/tooling.md
+++ b/docs/docs/tooling/tooling.md
@@ -111,7 +111,7 @@ Tooling slots into the standard [CLI workflow](../reference/cli.md): pull or ini
 
     ---
 
-    Configure personality, role, and rules that define agent behavior.
+    Configure the persona and rules that define agent behavior.
     [Open agent settings](../reference/resources/agent_settings.md)
 
 -   **Flows reference**

--- a/docs/docs/tutorials/build-an-agent.md
+++ b/docs/docs/tutorials/build-an-agent.md
@@ -152,7 +152,7 @@ Add or edit [knowledge-base topics](../reference/resources/topics.md) used for r
 
 #### Agent settings
 
-Update the [personality, role, and rules](../reference/resources/agent_settings.md) that define the agent's global behavior.
+Update the [persona and rules](../reference/resources/agent_settings.md) that define the agent's global behavior.
 
 #### Flows
 

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -89,7 +89,7 @@ You are polite, calm, and warm, and you keep answers short.
 
 !!! info "Supported references"
 
-    The persona accepts `{{vrbl:...}}` references only, so it can vary per call. Behavioral references such as `{{fn:...}}` and `{{ho:...}}` belong in `rules.txt`.
+    The persona accepts `{{attr:...}}` and `{{vrbl:...}}` references, so it can vary per [variant](../reference/resources/variants.md) or per call. Behavioral references such as `{{fn:...}}` and `{{ho:...}}` belong in `rules.txt`.
 
 ### Rules
 

--- a/docs/docs/tutorials/restaurant-booking-agent.md
+++ b/docs/docs/tutorials/restaurant-booking-agent.md
@@ -74,46 +74,22 @@ You are now on the `booking-flow` branch — pushes go here instead of `main`, l
 
 ## Part 2 — Define the agent
 
-### Personality
+### Persona
 
-Open `agent_settings/personality.yaml`. Adjust the adjectives to suit the Maison brand:
+Open `agent_settings/persona.txt` and describe who the agent is. This is the free-text field Agent Studio shows as **Role**:
 
-~~~yaml
-adjectives:
-  Polite: true
-  Calm: true
-  Kind: true
-custom: ""
+~~~text
+You are the reservations agent for Maison, an upscale French restaurant.
+You are polite, calm, and warm, and you keep answers short.
 ~~~
 
-The file has two fields:
+!!! tip "Keep identity and behavior separate"
 
-- **`adjectives`** — a map of preset tonal traits. Each is set to `true` or `false`; every selected trait is combined into the agent's personality.
-- **`custom`** — a free-text description that can extend or replace the adjectives. It accepts `{{attr:...}}` and `{{vrbl:...}}` references, so the personality can vary per [variant](../reference/resources/variants.md) or per call.
+    The persona says who the agent is. Standing instructions about what it should do belong in `rules.txt` below.
 
-!!! info "Allowed adjective values"
+!!! info "Supported references"
 
-    `adjectives` keys must come from a fixed set: `Polite`, `Calm`, `Kind`, `Funny`, `Energetic`, `Thoughtful`, and `Other`. Any other key causes `poly push` to fail with a validation error.
-
-!!! tip "How `Other` works"
-
-    `Other` is the "none of the above" switch. When you set `Other: true`, every other adjective must be `false` (or omitted) — combining `Other: true` with any other adjective set to `true` fails validation with:
-
-    ~~~text
-    Other adjective can only be set if no other adjectives are selected.
-    ~~~
-
-    Use `Other: true` together with the `custom` field when the six presets do not capture the tone you want and you would rather describe the personality entirely in free form. You do **not** need `Other: true` just to use `custom` — `custom` can always be added on top of preset adjectives to refine them further.
-
-### Role
-
-Open `agent_settings/role.yaml` and describe what the agent is:
-
-~~~yaml
-value: Restaurant Reservations Agent
-additional_info: Takes table reservations for Maison restaurant
-custom: ""
-~~~
+    The persona accepts `{{vrbl:...}}` references only, so it can vary per call. Behavioral references such as `{{fn:...}}` and `{{ho:...}}` belong in `rules.txt`.
 
 ### Rules
 

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -408,8 +408,6 @@ class PushCommand(BaseCommand):
                 "message": output,
                 "dry_run": dry_run,
             }
-            if project.push_warnings:
-                json_output["warnings"] = project.push_warnings
             if new_branch_name:
                 json_output["switched_to"] = new_branch_name
                 json_output["new_branch_id"] = project.branch_id
@@ -438,8 +436,6 @@ class PushCommand(BaseCommand):
 
         if new_branch_name:
             warning(f"Created and switched to new branch '{new_branch_name}'.")
-        for push_warning in project.push_warnings or []:
-            warning(push_warning)
         if push_ok:
             success(f"Pushed {project.account_id}/{project.project_id} to Agent Studio.")
         else:

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -408,6 +408,8 @@ class PushCommand(BaseCommand):
                 "message": output,
                 "dry_run": dry_run,
             }
+            if project.push_warnings:
+                json_output["warnings"] = project.push_warnings
             if new_branch_name:
                 json_output["switched_to"] = new_branch_name
                 json_output["new_branch_id"] = project.branch_id
@@ -436,6 +438,8 @@ class PushCommand(BaseCommand):
 
         if new_branch_name:
             warning(f"Created and switched to new branch '{new_branch_name}'.")
+        for push_warning in project.push_warnings or []:
+            warning(push_warning)
         if push_ok:
             success(f"Pushed {project.account_id}/{project.project_id} to Agent Studio.")
         else:

--- a/src/poly/docs/agent_settings.md
+++ b/src/poly/docs/agent_settings.md
@@ -2,16 +2,35 @@
 
 ## Overview
 
-Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of three resources: personality, role, and rules.
+Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of four resources: persona, personality, role, and rules.
 
 ## File structure
 ```
 agent_settings/
+├── persona.txt                # Optional — see below
 ├── personality.yaml
 ├── role.yaml
 ├── rules.txt
 └── experimental_config.json   # See experimental_config docs
 ```
+
+## Persona (`persona.txt`)
+
+Plain-text description of who the agent is. This is what the **Role** field in Agent Studio edits — not `role.yaml`.
+
+### Supported references
+- `{{vrbl:variable_name}}` — variables. No other reference type is allowed.
+
+### Example
+```text
+You are a calm and polite concierge for {{vrbl:hotel_name}}. Keep answers short.
+```
+
+### Notes
+- The file is only pulled for projects on the `enable-persona-prompt` feature flag. Projects without it have no `persona.txt`, and that is not an error.
+- For projects that have never authored a persona, the pulled content is **derived** from `personality.yaml` and `role.yaml`. Nothing is stored server-side until someone edits it, and `poly push` sends nothing while the file is untouched.
+- Editing `persona.txt` and pushing authors a real persona. From that point the content is fixed and no longer tracks `personality.yaml` / `role.yaml`.
+- `personality.yaml` and `role.yaml` still pull and push, but they no longer affect what the agent's Role field shows. `poly push` warns when you change them on a project that has a persona.
 
 ## Personality (`personality.yaml`)
 

--- a/src/poly/docs/agent_settings.md
+++ b/src/poly/docs/agent_settings.md
@@ -2,21 +2,21 @@
 
 ## Overview
 
-Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of four resources: persona, personality, role, and rules.
+Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of the persona and rules, plus the superseded personality and role settings.
 
 ## File structure
 ```
 agent_settings/
-├── persona.txt                # Optional — see below
-├── personality.yaml
-├── role.yaml
+├── persona.txt                # The agent's identity
+├── personality.yaml           # Superseded by persona.txt
+├── role.yaml                  # Superseded by persona.txt
 ├── rules.txt
 └── experimental_config.json   # See experimental_config docs
 ```
 
 ## Persona (`persona.txt`)
 
-Plain-text description of who the agent is. This is what the **Role** field in Agent Studio edits — not `role.yaml`.
+Free-text description of who the agent is, and the single field that defines the agent's identity. This is what the **Role** field in Agent Studio edits — it replaces `personality.yaml` and `role.yaml`, which are no longer surfaced to builders.
 
 ### Supported references
 - `{{vrbl:variable_name}}` — variables. No other reference type is allowed.
@@ -27,12 +27,12 @@ You are a calm and polite concierge for {{vrbl:hotel_name}}. Keep answers short.
 ```
 
 ### Notes
-- The file is only pulled for projects on the `enable-persona-prompt` feature flag. Projects without it have no `persona.txt`, and that is not an error.
-- For projects that have never authored a persona, the pulled content is **derived** from `personality.yaml` and `role.yaml`. Nothing is stored server-side until someone edits it, and `poly push` sends nothing while the file is untouched.
+- For projects that predate the persona and have never authored one, the pulled content is **derived** from `personality.yaml` and `role.yaml`. Nothing is stored server-side until someone edits it, and `poly push` sends nothing while the file is untouched.
 - Editing `persona.txt` and pushing authors a real persona. From that point the content is fixed and no longer tracks `personality.yaml` / `role.yaml`.
-- `personality.yaml` and `role.yaml` still pull and push, but they no longer affect what the agent's Role field shows. `poly push` warns when you change them on a project that has a persona.
 
 ## Personality (`personality.yaml`)
+
+**Superseded by `persona.txt`.** Kept for projects that predate the persona; it still pulls and pushes, but no longer affects the agent's identity. `poly push` warns when you change it on a project that has a persona.
 
 Controls the agent's conversational tone.
 
@@ -50,6 +50,8 @@ custom: ""
 ```
 
 ## Role (`role.yaml`)
+
+**Superseded by `persona.txt`.** Kept for projects that predate the persona; it still pulls and pushes, but no longer affects the agent's identity. `poly push` warns when you change it on a project that has a persona.
 
 Defines what the agent is (its job title / purpose).
 

--- a/src/poly/docs/agent_settings.md
+++ b/src/poly/docs/agent_settings.md
@@ -2,21 +2,19 @@
 
 ## Overview
 
-Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of the persona and rules, plus the superseded personality and role settings.
+Agent settings define the agent's identity and behavioral rules. They live in `agent_settings/` and consist of two resources: the persona and the rules.
 
 ## File structure
 ```
 agent_settings/
 ├── persona.txt                # The agent's identity
-├── personality.yaml           # Superseded by persona.txt
-├── role.yaml                  # Superseded by persona.txt
 ├── rules.txt
 └── experimental_config.json   # See experimental_config docs
 ```
 
 ## Persona (`persona.txt`)
 
-Free-text description of who the agent is, and the single field that defines the agent's identity. This is what the **Role** field in Agent Studio edits — it replaces `personality.yaml` and `role.yaml`, which are no longer surfaced to builders.
+Free-text description of who the agent is, and the single field that defines the agent's identity. This is what the **Role** field in Agent Studio edits.
 
 ### Supported references
 - `{{vrbl:variable_name}}` — variables. No other reference type is allowed.
@@ -27,45 +25,9 @@ You are a calm and polite concierge for {{vrbl:hotel_name}}. Keep answers short.
 ```
 
 ### Notes
-- For projects that predate the persona and have never authored one, the pulled content is **derived** from `personality.yaml` and `role.yaml`. Nothing is stored server-side until someone edits it, and `poly push` sends nothing while the file is untouched.
-- Editing `persona.txt` and pushing authors a real persona. From that point the content is fixed and no longer tracks `personality.yaml` / `role.yaml`.
-
-## Personality (`personality.yaml`)
-
-**Superseded by `persona.txt`.** Kept for projects that predate the persona; it still pulls and pushes, but no longer affects the agent's identity. `poly push` warns when you change it on a project that has a persona.
-
-Controls the agent's conversational tone.
-
-### Fields
-- **adjectives**: Map of personality traits to booleans. Allowed values: `Polite`, `Calm`, `Kind`, `Funny`, `Energetic`, `Thoughtful`, `Other`. If `Other` is `true`, no other adjective can be selected.
-- **custom**: Free-text personality description. Supports `{{attr:...}}` and `{{vrbl:...}}` references.
-
-### Example
-```yaml
-adjectives:
-  Polite: true
-  Calm: true
-  Kind: true
-custom: ""
-```
-
-## Role (`role.yaml`)
-
-**Superseded by `persona.txt`.** Kept for projects that predate the persona; it still pulls and pushes, but no longer affects the agent's identity. `poly push` warns when you change it on a project that has a persona.
-
-Defines what the agent is (its job title / purpose).
-
-### Fields
-- **value**: Role name (e.g. `Customer Service Representative`). If set to `other`, the `custom` field is used.
-- **additional_info**: Extra context about the role.
-- **custom**: Free-text role description, only valid when `value` is `other`. Supports `{{attr:...}}` and `{{vrbl:...}}` references.
-
-### Example
-```yaml
-value: Customer Service Representative
-additional_info: Handles customer inquiries and bookings
-custom: ""
-```
+- The persona replaced the older personality and role settings, which are no longer surfaced in Agent Studio and are no longer pulled or pushed. Any `personality.yaml` / `role.yaml` left in a project from an earlier version is deleted the next time the project is loaded.
+- For projects that predate the persona and have never authored one, the pulled content is **derived** server-side from the old personality and role. Nothing is stored until someone edits it, and `poly push` sends nothing while the file is untouched.
+- Editing `persona.txt` and pushing authors a real persona. From that point the content is fixed and no longer derived.
 
 ## Rules (`rules.txt`)
 

--- a/src/poly/docs/agent_settings.md
+++ b/src/poly/docs/agent_settings.md
@@ -17,7 +17,10 @@ agent_settings/
 Free-text description of who the agent is, and the single field that defines the agent's identity. This is what the **Role** field in Agent Studio edits.
 
 ### Supported references
-- `{{vrbl:variable_name}}` — variables. No other reference type is allowed.
+- `{{attr:attribute_name}}` — variant attributes
+- `{{vrbl:variable_name}}` — variables
+
+The same two the personality and role settings accepted. Behavioral references such as `{{fn:...}}` and `{{ho:...}}` belong in `rules.txt`.
 
 ### Example
 ```text

--- a/src/poly/docs/docs.md
+++ b/src/poly/docs/docs.md
@@ -13,6 +13,7 @@ Each project defines an AI voice or webchat agent. Resources in the project (flo
 ├── _gen/                               # Generated stubs - do not edit
 ├── agent_settings/                     # Agent identity and behavior
 │   ├── languages.yaml                  # Optional
+│   ├── persona.txt                     # Optional — the Agent Studio "Role" field
 │   ├── personality.yaml
 │   ├── role.yaml
 │   ├── rules.txt

--- a/src/poly/docs/docs.md
+++ b/src/poly/docs/docs.md
@@ -13,7 +13,7 @@ Each project defines an AI voice or webchat agent. Resources in the project (flo
 ├── _gen/                               # Generated stubs - do not edit
 ├── agent_settings/                     # Agent identity and behavior
 │   ├── languages.yaml                  # Optional
-│   ├── persona.txt                     # Optional — the Agent Studio "Role" field
+│   ├── persona.txt                     # The Agent Studio "Role" field
 │   ├── personality.yaml
 │   ├── role.yaml
 │   ├── rules.txt
@@ -118,7 +118,7 @@ Resource-specific documentation is available via `poly docs {resource} [resource
 
 | Name | Description |
 |------|-------------|
-| `agent_settings` | Personality, role, rules |
+| `agent_settings` | Persona, rules |
 | `api_integrations` | External HTTP API definitions |
 | `chat_settings` | Chat greeting, style prompt |
 | `context` | Context files for agent knowledge |

--- a/src/poly/docs/docs.md
+++ b/src/poly/docs/docs.md
@@ -14,8 +14,6 @@ Each project defines an AI voice or webchat agent. Resources in the project (flo
 ├── agent_settings/                     # Agent identity and behavior
 │   ├── languages.yaml                  # Optional
 │   ├── persona.txt                     # The Agent Studio "Role" field
-│   ├── personality.yaml
-│   ├── role.yaml
 │   ├── rules.txt
 │   ├── safety_filters.yaml
 │   └── experimental_config.json        # Optional
@@ -107,7 +105,7 @@ These placeholders can be used in prompts, rules, topics, and other text fields 
 | `{{fn:function_name}}` | Global function | Rules, topics (actions), advanced step prompts |
 | `{{ft:function_name}}` | Flow transition function | Advanced step prompts (same flow only) |
 | `{{entity:entity_name}}` | Collected entity value | Flow step prompts |
-| `{{attr:attribute_name}}` | Variant attribute | Rules, prompts, topics (actions), greeting, disclaimer, personality, role |
+| `{{attr:attribute_name}}` | Variant attribute | Rules, prompts, topics (actions), greeting, disclaimer |
 | `{{twilio_sms:template_name}}` | SMS template | Rules, topics (actions) |
 | `{{ho:handoff_name}}` | Handoff destination | Rules |
 | `{{vrbl:variable_name}}` (preferred) / `$variable_name` | State variable (interchangeable; `{{vrbl:...}}` is validated) | Prompts, topic actions, SMS templates |

--- a/src/poly/migration_utils.py
+++ b/src/poly/migration_utils.py
@@ -4,11 +4,14 @@ Tools to help with migrating from older versions of the Agent Development Kit to
 Copyright PolyAI Limited
 """
 
+import logging
 import os
 from copy import deepcopy
 from enum import Enum
 
 from poly.resources import resource_utils
+
+logger = logging.getLogger(__name__)
 
 
 class MigrationFlag(Enum):
@@ -20,6 +23,7 @@ class MigrationFlag(Enum):
     MIGRATED_LEGACY_TOPIC_FILES = "migrated_legacy_topic_files"
     MIGRATED_FLOW_STEP_RESOURCE_IDS = "migrated_flow_step_resource_ids"
     MIGRATED_FLOW_STEP_SETTINGS = "migrated_flow_step_settings"
+    REMOVED_PERSONALITY_AND_ROLE_FILES = "removed_personality_and_role_files"
 
 
 def load_migration_flags(flags: list[str]) -> set[MigrationFlag]:
@@ -81,7 +85,32 @@ def run_migrations(
         migrate_flow_step_settings(status_dict)
         new_flags.add(MigrationFlag.MIGRATED_FLOW_STEP_SETTINGS)
 
+    if MigrationFlag.REMOVED_PERSONALITY_AND_ROLE_FILES not in applied_migrations:
+        remove_personality_and_role_files(root_path)
+        new_flags.add(MigrationFlag.REMOVED_PERSONALITY_AND_ROLE_FILES)
+
     return new_flags
+
+
+def remove_personality_and_role_files(root_path: str) -> None:
+    """Delete the personality and role files, which are superseded by the persona.
+
+    Agent Studio replaced both settings with a single free-text persona, so the
+    files no longer describe anything the agent uses. They are removed rather
+    than left in place so a stale copy can't be edited and pushed.
+    """
+    removed = []
+    for file_name in ("personality.yaml", "role.yaml"):
+        file_path = os.path.join(root_path, "agent_settings", file_name)
+        if os.path.exists(file_path):
+            os.remove(file_path)
+            removed.append(os.path.join("agent_settings", file_name))
+
+    if removed:
+        logger.warning(
+            f"Removed {', '.join(removed)}: personality and role have been replaced by "
+            "agent_settings/persona.txt. Run 'poly pull' to fetch it."
+        )
 
 
 # Sub-config keys set internally by the config classes rather than accepted as __init__ args.

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -40,9 +40,6 @@ from poly.resources import (
     Pronunciation,
     Resource,
     ResourceMapping,
-    SettingsPersona,
-    SettingsPersonality,
-    SettingsRole,
     SubResource,
     TestCase,
     Topic,
@@ -123,8 +120,6 @@ class AgentStudioProject:
     # So they aren't considered locally deleted when pushing/pulling
     # before they are saved.
     _not_loaded_resources: list[ResourceType] = None
-
-    push_warnings: list[str] = None
 
     @property
     def all_resources(self) -> list[Resource]:
@@ -1204,8 +1199,6 @@ class AgentStudioProject:
                 - List of commands serialized to protobuf.
         """
 
-        self.push_warnings = []
-
         if not dry_run:
             # If force, load latest version of the project
             # to compare against
@@ -1293,19 +1286,6 @@ class AgentStudioProject:
         new_resources.update(subresource_changes.new)
         updated_resources.update(subresource_changes.updated)
         deleted_resources.update(subresource_changes.deleted)
-
-        if new_state.get(SettingsPersona):
-            shadowed = [
-                resource.file_path
-                for resource_type in (SettingsPersonality, SettingsRole)
-                for resource in updated_resources.get(resource_type, {}).values()
-            ]
-            if shadowed:
-                self.push_warnings.append(
-                    f"{', '.join(sorted(shadowed))} changed, but this project uses "
-                    f"{next(iter(new_state[SettingsPersona].values())).file_path} — "
-                    "personality and role no longer affect the Role field in Agent Studio."
-                )
 
         if not (updated_resources or new_resources or deleted_resources):
             return False, "No changes detected", []
@@ -1552,10 +1532,6 @@ class AgentStudioProject:
             current_resources=self.resources,
             queue_command=lambda command: self.api_handler.queue_command(command),
         )
-
-        # There is no create_persona command; authoring a persona is an update.
-        if new_personas := new_resources.pop(SettingsPersona, None):
-            updated_resources.setdefault(SettingsPersona, {}).update(new_personas)
 
         return PushPhaseChangeSet(
             main=ResourceChangeSet(

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -40,6 +40,9 @@ from poly.resources import (
     Pronunciation,
     Resource,
     ResourceMapping,
+    SettingsPersona,
+    SettingsPersonality,
+    SettingsRole,
     SubResource,
     TestCase,
     Topic,
@@ -120,6 +123,8 @@ class AgentStudioProject:
     # So they aren't considered locally deleted when pushing/pulling
     # before they are saved.
     _not_loaded_resources: list[ResourceType] = None
+
+    push_warnings: list[str] = None
 
     @property
     def all_resources(self) -> list[Resource]:
@@ -1199,6 +1204,8 @@ class AgentStudioProject:
                 - List of commands serialized to protobuf.
         """
 
+        self.push_warnings = []
+
         if not dry_run:
             # If force, load latest version of the project
             # to compare against
@@ -1286,6 +1293,19 @@ class AgentStudioProject:
         new_resources.update(subresource_changes.new)
         updated_resources.update(subresource_changes.updated)
         deleted_resources.update(subresource_changes.deleted)
+
+        if new_state.get(SettingsPersona):
+            shadowed = [
+                resource.file_path
+                for resource_type in (SettingsPersonality, SettingsRole)
+                for resource in updated_resources.get(resource_type, {}).values()
+            ]
+            if shadowed:
+                self.push_warnings.append(
+                    f"{', '.join(sorted(shadowed))} changed, but this project uses "
+                    f"{next(iter(new_state[SettingsPersona].values())).file_path} — "
+                    "personality and role no longer affect the Role field in Agent Studio."
+                )
 
         if not (updated_resources or new_resources or deleted_resources):
             return False, "No changes detected", []
@@ -1532,6 +1552,10 @@ class AgentStudioProject:
             current_resources=self.resources,
             queue_command=lambda command: self.api_handler.queue_command(command),
         )
+
+        # There is no create_persona command; authoring a persona is an update.
+        if new_personas := new_resources.pop(SettingsPersona, None):
+            updated_resources.setdefault(SettingsPersona, {}).update(new_personas)
 
         return PushPhaseChangeSet(
             main=ResourceChangeSet(

--- a/src/poly/resources/__init__.py
+++ b/src/poly/resources/__init__.py
@@ -1,5 +1,6 @@
 # Copyright PolyAI Limited
 from poly.resources.agent_settings import (
+    SettingsPersona,
     SettingsPersonality,
     SettingsRole,
     SettingsRules,

--- a/src/poly/resources/__init__.py
+++ b/src/poly/resources/__init__.py
@@ -1,8 +1,6 @@
 # Copyright PolyAI Limited
 from poly.resources.agent_settings import (
     SettingsPersona,
-    SettingsPersonality,
-    SettingsRole,
     SettingsRules,
 )
 from poly.resources.api_integration import (

--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -4,7 +4,7 @@ Copyright PolyAI Limited
 """
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import cached_property
 
 from google.protobuf.message import Message
@@ -12,15 +12,12 @@ from google.protobuf.message import Message
 import poly.resources.resource_utils as utils
 from poly.handlers.protobuf.agent_settings_pb2 import (
     Persona_UpdatePersona,
-    Personality_UpdatePersonality,
     PersonaReferences,
-    Role_UpdateRole,
     Rules_UpdateRules,
 )
 from poly.resources.resource import (
     Resource,
     ResourceMapping,
-    YamlResource,
     register_resource,
 )
 
@@ -33,251 +30,6 @@ ALLOWED_BEHAVIOUR_REFERENCES = [
     "translations",
 ]
 ALLOWED_PERSONA_REFERENCES = ["variables"]
-ALLOWED_ADJECTIVES = {
-    "Polite",
-    "Calm",
-    "Kind",
-    "Funny",
-    "Other",
-    "Energetic",
-    "Thoughtful",
-}
-
-
-@register_resource("personality")
-@dataclass
-class SettingsPersonality(YamlResource):
-    """Resource class for managing personality settings"""
-
-    custom: str
-    adjectives: dict[str, bool] = field(default_factory=dict)
-
-    @cached_property
-    def file_path(self) -> str:
-        """Get the file path for the Personality resource."""
-        return os.path.join("agent_settings", "personality.yaml")
-
-    def to_yaml_dict(self) -> dict:
-        """Convert the personality settings to a YAML-serializable dict."""
-        return {
-            "adjectives": {
-                adj: enabled for adj, enabled in sorted(self.adjectives.items()) if enabled
-            },
-            "custom": self.custom,
-        }
-
-    @classmethod
-    def to_pretty_dict(
-        cls, d: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> dict:
-        """Return the pretty dictionary."""
-        d["custom"] = utils.replace_resource_ids_with_names(d["custom"], resource_mappings or [])
-        return d
-
-    @classmethod
-    def from_yaml_dict(
-        cls, yaml_dict: dict, resource_id: str, name: str, **kwargs
-    ) -> "SettingsPersonality":
-        """Construct personality settings from YAML data and identity fields."""
-        return SettingsPersonality(
-            resource_id=resource_id,
-            name=name,
-            adjectives=yaml_dict.get("adjectives", {}),
-            custom=yaml_dict.get("custom", ""),
-        )
-
-    @classmethod
-    def from_projection(cls, projection: dict) -> dict[str, "SettingsPersonality"]:
-        """Parse personality settings from a projection dict."""
-        agent_settings = projection.get("agentSettings", {})
-        personality = agent_settings.get("personality", None)
-        if not personality:
-            return {}
-        return {
-            "personality": cls(
-                resource_id="personality",
-                name="personality",
-                adjectives=personality.get("adjectives", {}),
-                custom=personality.get("custom", ""),
-            )
-        }
-
-    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
-        """Validate the personality resource."""
-        # Other adjective can only be set if no other adjectives are selected
-        if self.adjectives.get("Other", False) and any(
-            v for k, v in self.adjectives.items() if k.lower() != "other"
-        ):
-            raise ValueError("Other adjective can only be set if no other adjectives are selected.")
-
-        # Adjectives must be from the allowed set
-        if any(
-            enabled and adj not in ALLOWED_ADJECTIVES for adj, enabled in self.adjectives.items()
-        ):
-            raise ValueError(
-                f"Enabled adjectives must be from the allowed set: {', '.join(ALLOWED_ADJECTIVES)}"
-            )
-
-        references = utils.get_references_from_prompt(
-            self.custom, ["attributes", "variables"], raise_on_invalid=True
-        )
-        valid, invalid_references = utils.validate_references(references, resource_mappings)
-        if not valid:
-            raise ValueError(f"Invalid references: {invalid_references}")
-
-    def build_update_proto(self) -> Personality_UpdatePersonality:
-        """Create a proto for updating the resource."""
-
-        return Personality_UpdatePersonality(
-            adjectives={
-                "values": {adj: self.adjectives.get(adj, False) for adj in ALLOWED_ADJECTIVES},
-            },
-            custom=self.custom,
-        )
-
-    def build_create_proto(self) -> Message:
-        """Create a proto for creating the resource."""
-        raise NotImplementedError("Create operation not supported for Personality settings.")
-
-    def build_delete_proto(self) -> Message:
-        """Create a proto for deleting the resource."""
-        raise NotImplementedError("Delete operation not supported for Personality settings.")
-
-    @property
-    def command_type(self) -> str:
-        """Get the update type for updating the resource."""
-        return "personality"
-
-    @staticmethod
-    def discover_resources(base_path: str) -> list[str]:
-        """Discover resources of this type in the given base path.
-
-        Args:
-            base_path (str): The base path to search for resources.
-
-        Returns:
-            list[str]: A list of file paths of discovered resources.
-        """
-        file_path = os.path.join(base_path, "agent_settings", "personality.yaml")
-
-        if not os.path.exists(file_path):
-            return []
-
-        return [file_path]
-
-
-@register_resource("role")
-@dataclass
-class SettingsRole(YamlResource):
-    """Resource class for managing role settings"""
-
-    value: str
-    additional_info: str
-    custom: str
-
-    @cached_property
-    def file_path(self) -> str:
-        """Get the file path for the Role resource."""
-        return os.path.join("agent_settings", "role.yaml")
-
-    def to_yaml_dict(self) -> dict:
-        """Convert the role settings to a YAML-serializable dict."""
-        return {
-            "value": self.value,
-            "additional_info": self.additional_info,
-            "custom": self.custom,
-        }
-
-    @classmethod
-    def to_pretty_dict(
-        cls, d: dict, resource_mappings: list[ResourceMapping] = None, **kwargs
-    ) -> dict:
-        """Return the pretty dictionary."""
-        d["custom"] = utils.replace_resource_ids_with_names(d["custom"], resource_mappings or [])
-        return d
-
-    @classmethod
-    def from_yaml_dict(
-        cls, yaml_dict: dict, resource_id: str, name: str, **kwargs
-    ) -> "SettingsRole":
-        """Construct role settings from YAML data and identity fields."""
-        return SettingsRole(
-            resource_id=resource_id,
-            name=name,
-            value=yaml_dict.get("value", ""),
-            additional_info=yaml_dict.get("additional_info", ""),
-            custom=yaml_dict.get("custom", ""),
-        )
-
-    @classmethod
-    def from_projection(cls, projection: dict) -> dict[str, "SettingsRole"]:
-        """Parse role settings from a projection dict."""
-        agent_settings = projection.get("agentSettings", {})
-        role = agent_settings.get("role", None)
-        if not role:
-            return {}
-        return {
-            "role": cls(
-                resource_id="role",
-                name="role",
-                value=role.get("value", ""),
-                additional_info=role.get("additionalInfo", ""),
-                custom=role.get("custom", ""),
-            )
-        }
-
-    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
-        """Validate the role resource."""
-        # Custom role can only exist if role is 'other'
-        if self.custom and self.value.lower() != "other":
-            raise ValueError("Custom role can only be set if role is 'other'.")
-
-        # Validate references
-        references = utils.get_references_from_prompt(
-            self.custom, ["attributes", "variables"], raise_on_invalid=True
-        )
-        valid, invalid_references = utils.validate_references(references, resource_mappings)
-        if not valid:
-            raise ValueError(f"Invalid references: {invalid_references}")
-
-    def build_update_proto(self) -> Role_UpdateRole:
-        """Create a proto for updating the resource."""
-
-        return Role_UpdateRole(
-            value=self.value,
-            additional_info=self.additional_info,
-            custom=self.custom,
-        )
-
-    def build_create_proto(self) -> Message:
-        """Create a proto for creating the resource."""
-        raise NotImplementedError("Create operation not supported for Role settings.")
-
-    def build_delete_proto(self) -> Message:
-        """Create a proto for deleting the resource."""
-        raise NotImplementedError("Delete operation not supported for Role settings.")
-
-    @property
-    def command_type(self) -> str:
-        """Get the update type for updating the resource."""
-        return "role"
-
-    @staticmethod
-    def discover_resources(base_path: str) -> list[str]:
-        """Discover resources of this type in the given base path.
-
-        Args:
-            base_path (str): The base path to search for resources.
-
-        Returns:
-            list[str]: A list of file paths of discovered resources.
-        """
-        file_path = os.path.join(base_path, "agent_settings", "role.yaml")
-
-        if not os.path.exists(file_path):
-            return []
-
-        return [file_path]
 
 
 @register_resource("persona")
@@ -286,8 +38,8 @@ class SettingsPersona(Resource):
     """Resource class for managing the persona setting.
 
     A single free-text description of who the agent is, edited as the "Role"
-    field in Agent Studio. It replaces the personality and role settings, which
-    remain on the wire but are no longer surfaced to builders.
+    field in Agent Studio. It replaced the personality and role settings, which
+    remain on the wire but are no longer surfaced to builders or handled here.
     """
 
     content: str

--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -11,7 +11,9 @@ from google.protobuf.message import Message
 
 import poly.resources.resource_utils as utils
 from poly.handlers.protobuf.agent_settings_pb2 import (
+    Persona_UpdatePersona,
     Personality_UpdatePersonality,
+    PersonaReferences,
     Role_UpdateRole,
     Rules_UpdateRules,
 )
@@ -30,6 +32,7 @@ ALLOWED_BEHAVIOUR_REFERENCES = [
     "variables",
     "translations",
 ]
+ALLOWED_PERSONA_REFERENCES = ["variables"]
 ALLOWED_ADJECTIVES = {
     "Polite",
     "Calm",
@@ -270,6 +273,125 @@ class SettingsRole(YamlResource):
             list[str]: A list of file paths of discovered resources.
         """
         file_path = os.path.join(base_path, "agent_settings", "role.yaml")
+
+        if not os.path.exists(file_path):
+            return []
+
+        return [file_path]
+
+
+@register_resource("persona")
+@dataclass
+class SettingsPersona(Resource):
+    """Resource class for managing the persona setting.
+
+    This is what the "Role" field in Agent Studio edits. It supersedes the
+    personality and role settings, which remain on the wire but are no longer
+    surfaced to builders.
+    """
+
+    content: str
+
+    @cached_property
+    def file_path(self) -> str:
+        """Get the file path for the Persona resource."""
+        return os.path.join("agent_settings", "persona.txt")
+
+    @property
+    def raw(self) -> str:
+        """Convert the resource to a raw format."""
+        return self.content
+
+    @staticmethod
+    def make_pretty(
+        contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace resource IDs with resource names in the provided contents."""
+        return utils.replace_resource_ids_with_names(contents, resource_mappings or [])
+
+    @classmethod
+    def from_pretty(
+        cls, contents: str, resource_mappings: list[ResourceMapping] = None, **kwargs
+    ) -> str:
+        """Replace resource names with resource IDs in the provided contents."""
+        return utils.replace_resource_names_with_ids(contents, resource_mappings or [])
+
+    def validate(self, resource_mappings: list[ResourceMapping] = None, **kwargs) -> None:
+        """Validate the persona resource."""
+        references = utils.get_references_from_prompt(
+            self.content, ALLOWED_PERSONA_REFERENCES, raise_on_invalid=True
+        )
+        valid, invalid_references = utils.validate_references(references, resource_mappings)
+        if not valid:
+            raise ValueError(f"Invalid references: {invalid_references}")
+
+    @classmethod
+    def from_projection(cls, projection: dict) -> dict[str, "SettingsPersona"]:
+        """Parse the persona setting from a projection dict.
+
+        A project without the persona feature flag still carries a persona object,
+        just without content, so absent content means the setting is not enabled
+        rather than that anything is wrong.
+        """
+        agent_settings = projection.get("agentSettings", {})
+        persona = agent_settings.get("persona") or {}
+        content = persona.get("content")
+        if content is None:
+            return {}
+        return {
+            "persona": cls(
+                resource_id="persona",
+                name="persona",
+                content=content,
+            )
+        }
+
+    @classmethod
+    def read_local_resource(
+        cls, file_path: str, resource_id: str, resource_name: str, **kwargs
+    ) -> "SettingsPersona":
+        """Read a local plain text resource from the given file path."""
+        content = cls.read_to_raw(file_path, **kwargs)
+        return SettingsPersona(
+            resource_id=resource_id,
+            name=resource_name,
+            content=content,
+        )
+
+    def build_update_proto(self) -> Persona_UpdatePersona:
+        """Create a proto for updating the resource."""
+
+        references = utils.get_references_from_prompt(self.content, ALLOWED_PERSONA_REFERENCES)
+
+        return Persona_UpdatePersona(
+            content=self.content,
+            references=PersonaReferences(variables=references.get("variables", {})),
+        )
+
+    def build_create_proto(self) -> Message:
+        """Create a proto for creating the resource."""
+        raise NotImplementedError("Create operation not supported for Persona settings.")
+
+    def build_delete_proto(self) -> Message:
+        """Create a proto for deleting the resource."""
+        raise NotImplementedError("Delete operation not supported for Persona settings.")
+
+    @property
+    def command_type(self) -> str:
+        """Get the update type for updating the resource."""
+        return "persona"
+
+    @staticmethod
+    def discover_resources(base_path: str) -> list[str]:
+        """Discover resources of this type in the given base path.
+
+        Args:
+            base_path (str): The base path to search for resources.
+
+        Returns:
+            list[str]: A list of file paths of discovered resources.
+        """
+        file_path = os.path.join(base_path, "agent_settings", "persona.txt")
 
         if not os.path.exists(file_path):
             return []

--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -29,7 +29,7 @@ ALLOWED_BEHAVIOUR_REFERENCES = [
     "variables",
     "translations",
 ]
-ALLOWED_PERSONA_REFERENCES = ["variables"]
+ALLOWED_PERSONA_REFERENCES = ["attributes", "variables"]
 
 
 @register_resource("persona")
@@ -111,7 +111,12 @@ class SettingsPersona(Resource):
         )
 
     def build_update_proto(self) -> Persona_UpdatePersona:
-        """Create a proto for updating the resource."""
+        """Create a proto for updating the resource.
+
+        PersonaReferences carries a variables map and nothing else, so attribute
+        references travel in the content and are not tracked. Personality and
+        role behaved the same way before the persona replaced them.
+        """
 
         references = utils.get_references_from_prompt(self.content, ALLOWED_PERSONA_REFERENCES)
 

--- a/src/poly/resources/agent_settings.py
+++ b/src/poly/resources/agent_settings.py
@@ -285,9 +285,9 @@ class SettingsRole(YamlResource):
 class SettingsPersona(Resource):
     """Resource class for managing the persona setting.
 
-    This is what the "Role" field in Agent Studio edits. It supersedes the
-    personality and role settings, which remain on the wire but are no longer
-    surfaced to builders.
+    A single free-text description of who the agent is, edited as the "Role"
+    field in Agent Studio. It replaces the personality and role settings, which
+    remain on the wire but are no longer surfaced to builders.
     """
 
     content: str
@@ -329,9 +329,9 @@ class SettingsPersona(Resource):
     def from_projection(cls, projection: dict) -> dict[str, "SettingsPersona"]:
         """Parse the persona setting from a projection dict.
 
-        A project without the persona feature flag still carries a persona object,
-        just without content, so absent content means the setting is not enabled
-        rather than that anything is wrong.
+        The projection carries a persona object whether or not any content was
+        ever authored, so read the content rather than the object: absent content
+        means there is nothing to write to disk, not that anything is wrong.
         """
         agent_settings = projection.get("agentSettings", {})
         persona = agent_settings.get("persona") or {}

--- a/src/poly/tests/migration_test.py
+++ b/src/poly/tests/migration_test.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 import unittest
 
-from poly.migration_utils import migrate_legacy_topic_files
+from poly.migration_utils import migrate_legacy_topic_files, remove_personality_and_role_files
 from poly.resources import resource_utils
 
 
@@ -130,3 +130,44 @@ class TestMigrateLegacyTopicFiles(unittest.TestCase):
                 data = resource_utils.load_yaml(f.read())
             self.assertEqual(data["name"], "Billing/Refunds")
             self.assertTrue(data["enabled"])
+
+
+class TestRemovePersonalityAndRoleFiles(unittest.TestCase):
+    """Tests for remove_personality_and_role_files."""
+
+    def _write_settings(self, root: str, *filenames: str) -> None:
+        settings_dir = os.path.join(root, "agent_settings")
+        os.makedirs(settings_dir, exist_ok=True)
+        for filename in filenames:
+            with open(os.path.join(settings_dir, filename), "w", encoding="utf-8") as f:
+                f.write("custom: ''\n")
+
+    def test_no_agent_settings_dir(self):
+        """Should be a no-op when agent_settings/ doesn't exist."""
+        with tempfile.TemporaryDirectory() as tmp:
+            remove_personality_and_role_files(tmp)
+            self.assertFalse(os.path.isdir(os.path.join(tmp, "agent_settings")))
+
+    def test_removes_both_files(self):
+        """Both superseded files should be deleted and the removal logged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_settings(tmp, "personality.yaml", "role.yaml")
+
+            with self.assertLogs("poly.migration_utils", level="WARNING") as logs:
+                remove_personality_and_role_files(tmp)
+
+            self.assertFalse(os.path.exists(os.path.join(tmp, "agent_settings", "personality.yaml")))
+            self.assertFalse(os.path.exists(os.path.join(tmp, "agent_settings", "role.yaml")))
+            self.assertIn("persona.txt", logs.output[0])
+            self.assertIn("poly pull", logs.output[0])
+
+    def test_leaves_other_settings_alone(self):
+        """Only personality and role are removed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._write_settings(tmp, "role.yaml", "rules.txt", "persona.txt")
+
+            remove_personality_and_role_files(tmp)
+
+            self.assertFalse(os.path.exists(os.path.join(tmp, "agent_settings", "role.yaml")))
+            self.assertTrue(os.path.exists(os.path.join(tmp, "agent_settings", "rules.txt")))
+            self.assertTrue(os.path.exists(os.path.join(tmp, "agent_settings", "persona.txt")))

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -32,6 +32,7 @@ from poly.resources import (
     Pronunciation,
     Resource,
     ResourceMapping,
+    SettingsPersona,
     SettingsPersonality,
     SettingsRole,
     SettingsRules,
@@ -310,6 +311,10 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertEqual(
             local_resources[SettingsRules],
             [os.path.join(TEST_DIR, "agent_settings", "rules.txt")],
+        )
+        self.assertEqual(
+            local_resources[SettingsPersona],
+            [os.path.join(TEST_DIR, "agent_settings", "persona.txt")],
         )
 
         # Finds all Functions and Flow Steps
@@ -2479,6 +2484,43 @@ class PushProjectTest(unittest.TestCase):
         self.mock_api_handler.queue_resources.assert_called_once()
         self.mock_api_handler.send_queued_commands.assert_not_called()
         self.mock_api_handler.clear_command_queue.assert_called_once()
+
+
+    def test_push_project_new_persona_is_pushed_as_an_update(self):
+        project_data = deepcopy(PROJECT_DATA)
+        project_data["resources"].pop("persona")
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+
+        success, _, _ = project.push_project(force=True)
+
+        self.assertTrue(success)
+        call_args = self.mock_api_handler.queue_resources.call_args
+        self.assertNotIn(SettingsPersona, call_args.kwargs["new_resources"])
+        personas = call_args.kwargs["updated_resources"][SettingsPersona]
+        self.assertEqual([r.name for r in personas.values()], ["persona"])
+
+    def test_push_project_warns_when_legacy_settings_are_shadowed(self):
+        project_data = deepcopy(PROJECT_DATA)
+        project_data["resources"]["personality"]["PERSONALITY-personality"]["custom"] = "stale"
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+
+        success, _, _ = project.push_project(force=True)
+
+        self.assertTrue(success)
+        self.assertEqual(len(project.push_warnings), 1)
+        self.assertIn("personality.yaml", project.push_warnings[0])
+        self.assertIn("persona.txt", project.push_warnings[0])
+
+    def test_push_project_does_not_warn_when_legacy_settings_are_untouched(self):
+        project_data = deepcopy(PROJECT_DATA)
+        project_data["resources"]["topics"].pop("TOPIC-Topic 1")
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+
+        success, _, _ = project.push_project(force=True)
+
+        self.assertTrue(success)
+        self.assertEqual(project.push_warnings, [])
+
 
 
 class ValidateProjectTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -33,8 +33,6 @@ from poly.resources import (
     Resource,
     ResourceMapping,
     SettingsPersona,
-    SettingsPersonality,
-    SettingsRole,
     SettingsRules,
     SMSTemplate,
     TestCase,
@@ -299,14 +297,6 @@ class DiscoverLocalResourcesTest(unittest.TestCase):
         self.assertEqual(
             local_resources[ChatStylePrompt],
             [os.path.join(TEST_DIR, "chat", "configuration.yaml", "style_prompt")],
-        )
-        self.assertEqual(
-            local_resources[SettingsPersonality],
-            [os.path.join(TEST_DIR, "agent_settings", "personality.yaml")],
-        )
-        self.assertEqual(
-            local_resources[SettingsRole],
-            [os.path.join(TEST_DIR, "agent_settings", "role.yaml")],
         )
         self.assertEqual(
             local_resources[SettingsRules],
@@ -2484,43 +2474,6 @@ class PushProjectTest(unittest.TestCase):
         self.mock_api_handler.queue_resources.assert_called_once()
         self.mock_api_handler.send_queued_commands.assert_not_called()
         self.mock_api_handler.clear_command_queue.assert_called_once()
-
-
-    def test_push_project_new_persona_is_pushed_as_an_update(self):
-        project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"].pop("persona")
-        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-
-        success, _, _ = project.push_project(force=True)
-
-        self.assertTrue(success)
-        call_args = self.mock_api_handler.queue_resources.call_args
-        self.assertNotIn(SettingsPersona, call_args.kwargs["new_resources"])
-        personas = call_args.kwargs["updated_resources"][SettingsPersona]
-        self.assertEqual([r.name for r in personas.values()], ["persona"])
-
-    def test_push_project_warns_when_legacy_settings_are_shadowed(self):
-        project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["personality"]["PERSONALITY-personality"]["custom"] = "stale"
-        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-
-        success, _, _ = project.push_project(force=True)
-
-        self.assertTrue(success)
-        self.assertEqual(len(project.push_warnings), 1)
-        self.assertIn("personality.yaml", project.push_warnings[0])
-        self.assertIn("persona.txt", project.push_warnings[0])
-
-    def test_push_project_does_not_warn_when_legacy_settings_are_untouched(self):
-        project_data = deepcopy(PROJECT_DATA)
-        project_data["resources"]["topics"].pop("TOPIC-Topic 1")
-        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
-
-        success, _, _ = project.push_project(force=True)
-
-        self.assertTrue(success)
-        self.assertEqual(project.push_warnings, [])
-
 
 
 class ValidateProjectTest(unittest.TestCase):

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -13,10 +13,7 @@ from jsonschema import ValidationError
 
 import poly.resources.resource_utils as resource_utils
 from poly.resources.agent_settings import (
-    ALLOWED_ADJECTIVES,
     SettingsPersona,
-    SettingsPersonality,
-    SettingsRole,
     SettingsRules,
 )
 from poly.resources.api_integration import (
@@ -1751,255 +1748,6 @@ class VoiceGreetingTests(unittest.TestCase):
             self.assertEqual(result.language_code, "en-GB")
 
 
-TEST_PERSONALITY = SettingsPersonality(
-    resource_id="personality_123",
-    name="personality",
-    adjectives={"Polite": True, "Calm": True, "Kind": False},
-    custom="",
-)
-
-PERSONALITY_RAW = """adjectives:
-  Calm: true
-  Polite: true
-custom: ''
-"""
-
-
-class SettingsPersonalityTests(unittest.TestCase):
-    def test_get_raw(self):
-        """Test that raw property returns correct YAML representation."""
-        self.assertEqual(TEST_PERSONALITY.raw, PERSONALITY_RAW)
-
-    def test_to_yaml_dict_strips_disabled_adjectives(self):
-        """Test that to_yaml_dict excludes adjectives set to False."""
-        yaml_dict = TEST_PERSONALITY.to_yaml_dict()
-        self.assertEqual(yaml_dict["adjectives"], {"Polite": True, "Calm": True})
-        self.assertNotIn("Kind", yaml_dict["adjectives"])
-
-    def test_to_yaml_dict_sorts_adjectives(self):
-        """Test that to_yaml_dict returns adjectives in sorted order."""
-        unsorted = SettingsPersonality(
-            resource_id="p1",
-            name="personality",
-            adjectives={"Polite": True, "Calm": True, "Energetic": True, "Kind": False},
-            custom="",
-        )
-        yaml_dict = unsorted.to_yaml_dict()
-        self.assertEqual(list(yaml_dict["adjectives"].keys()), ["Calm", "Energetic", "Polite"])
-
-    def test_to_yaml_dict_normalizes_empty_and_all_false(self):
-        """Test that both empty and all-false adjectives produce the same YAML dict."""
-        empty = SettingsPersonality(resource_id="p1", name="personality", adjectives={}, custom="")
-        all_false = SettingsPersonality(
-            resource_id="p2",
-            name="personality",
-            adjectives={"Polite": False, "Calm": False},
-            custom="",
-        )
-        self.assertEqual(empty.to_yaml_dict()["adjectives"], {})
-        self.assertEqual(all_false.to_yaml_dict()["adjectives"], {})
-
-    def test_to_pretty(self):
-        """Test converting personality to pretty format."""
-        pretty_content = TEST_PERSONALITY.to_pretty()
-        self.assertIn("Polite", pretty_content)
-
-    def test_convert_and_unconvert_personality(self):
-        """Test roundtrip conversion: to_pretty -> from_pretty."""
-        converted_personality = TEST_PERSONALITY.to_pretty()
-        reverted_personality = SettingsPersonality.from_pretty(converted_personality)
-        self.assertEqual(reverted_personality, TEST_PERSONALITY.raw)
-
-    def test_validate_personality_settings(self):
-        """Test validation of personality settings."""
-        self.assertIsNone(TEST_PERSONALITY.validate())
-
-        # Test with custom and other adjectives (invalid)
-        invalid_personality = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"Polite": True, "Other": True},
-            custom="Custom personality description",
-        )
-        with self.assertRaises(ValueError) as cm:
-            invalid_personality.validate()
-        self.assertIn(
-            "Other adjective can only be set if no other adjectives are selected.",
-            str(cm.exception),
-        )
-
-        # Test with invalid adjectives
-        invalid_personality = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"InvalidAdjective": True},
-            custom="",
-        )
-        with self.assertRaises(ValueError) as cm:
-            invalid_personality.validate()
-        self.assertIn("Enabled adjectives must be from the allowed set:", str(cm.exception))
-
-        # Test with disabled invalid adjective (valid — only enabled adjectives are checked)
-        personality_with_disabled_invalid = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"Polite": True, "InvalidAdjective": False},
-            custom="",
-        )
-        self.assertIsNone(personality_with_disabled_invalid.validate())
-
-        # Test with custom and 'Other' selected (valid case)
-        valid_personality = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"Other": True},
-            custom="Custom personality description",
-        )
-        self.assertIsNone(valid_personality.validate())
-
-        # Test with invalid function reference in custom field
-        invalid_personality = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"Other": True},
-            custom="Use {{fn:func-123}} in custom personality",
-        )
-        with self.assertRaises(ValueError) as cm:
-            invalid_personality.validate()
-        self.assertIn(
-            "Invalid reference type: global_functions is not a valid reference type for this resource.",
-            str(cm.exception),
-        )
-
-    def test_build_update_proto_sends_all_allowed_adjectives(self):
-        """Test that build_update_proto sends all allowed adjectives, defaulting unset to False."""
-        personality = SettingsPersonality(
-            resource_id="personality_123",
-            name="personality",
-            adjectives={"Polite": True, "InvalidAdjective": False, "Calm": True},
-            custom="",
-        )
-        proto = personality.build_update_proto()
-        adjective_values = proto.adjectives.values
-        self.assertNotIn("InvalidAdjective", adjective_values)
-        self.assertEqual(set(adjective_values.keys()), ALLOWED_ADJECTIVES)
-        self.assertTrue(adjective_values["Polite"])
-        self.assertTrue(adjective_values["Calm"])
-        self.assertFalse(adjective_values["Kind"])
-        self.assertFalse(adjective_values["Funny"])
-
-    def test_read_local_resource(self):
-        """Test reading a personality from a YAML file."""
-        test_file_pretty_content = """adjectives:
-  Polite: true
-  Calm: true
-custom: ''
-"""
-
-        with mock_read_from_file(test_file_pretty_content):
-            result = SettingsPersonality.read_local_resource(
-                file_path="agent_settings/personality.yaml",
-                resource_id="personality_123",
-                resource_name="personality",
-            )
-
-            self.assertEqual(result.resource_id, "personality_123")
-            self.assertEqual(result.name, "personality")
-            self.assertIn("Polite", result.adjectives)
-            self.assertEqual(result.custom, "")
-
-
-TEST_ROLE = SettingsRole(
-    resource_id="role_123",
-    name="role",
-    value="Customer Service Representative",
-    additional_info="Handles customer inquiries and support requests",
-    custom="",
-)
-
-ROLE_RAW = """value: Customer Service Representative
-additional_info: Handles customer inquiries and support requests
-custom: ''
-"""
-
-
-class SettingsRoleTests(unittest.TestCase):
-    def test_get_raw(self):
-        """Test that raw property returns correct YAML representation."""
-        self.assertEqual(TEST_ROLE.raw, ROLE_RAW)
-
-    def test_to_pretty(self):
-        """Test converting role to pretty format."""
-        pretty_content = TEST_ROLE.to_pretty()
-        self.assertIn("Customer Service Representative", pretty_content)
-
-    def test_convert_and_unconvert_role(self):
-        """Test roundtrip conversion: to_pretty -> from_pretty."""
-        converted_role = TEST_ROLE.to_pretty()
-        reverted_role = SettingsRole.from_pretty(converted_role)
-        self.assertEqual(reverted_role, TEST_ROLE.raw)
-
-    def test_validate_role_settings(self):
-        """Test validation of role settings."""
-        self.assertIsNone(TEST_ROLE.validate(resource_mappings=[]))
-
-        # Test with custom and non-other role (invalid)
-        invalid_role = SettingsRole(
-            resource_id="role_123",
-            name="role",
-            value="Customer Service Representative",
-            additional_info="",
-            custom="Custom role description",
-        )
-        with self.assertRaises(ValueError) as cm:
-            invalid_role.validate(resource_mappings=[])
-        self.assertIn("Custom role can only be set if role is 'other'.", str(cm.exception))
-
-        # Test with custom and 'other' role (valid case)
-        valid_role = SettingsRole(
-            resource_id="role_123",
-            name="role",
-            value="Other",
-            additional_info="",
-            custom="Custom role description",
-        )
-        self.assertIsNone(valid_role.validate(resource_mappings=[]))
-
-        # Test with invalid function reference in custom field
-        invalid_role = SettingsRole(
-            resource_id="role_123",
-            name="role",
-            value="Other",
-            additional_info="",
-            custom="Use {{fn:func-123}} in custom role",
-        )
-        with self.assertRaises(ValueError) as cm:
-            invalid_role.validate(resource_mappings=[])
-        self.assertIn(
-            "Invalid reference type: global_functions is not a valid reference type for this resource.",
-            str(cm.exception),
-        )
-
-    def test_read_local_resource(self):
-        """Test reading a role from a YAML file."""
-        test_file_pretty_content = """value: Customer Service Representative
-additional_info: Handles customer inquiries
-custom: ''
-"""
-
-        with mock_read_from_file(test_file_pretty_content):
-            result = SettingsRole.read_local_resource(
-                file_path="agent_settings/role.yaml",
-                resource_id="role_123",
-                resource_name="role",
-            )
-
-            self.assertEqual(result.resource_id, "role_123")
-            self.assertEqual(result.name, "role")
-            self.assertEqual(result.value, "Customer Service Representative")
-            self.assertEqual(result.additional_info, "Handles customer inquiries")
-
-
 TEST_RULES = SettingsRules(
     resource_id="rules_123",
     name="rules",
@@ -2204,10 +1952,7 @@ PERSONA_VARIABLE_MAPPING = [
 
 
 def _persona_projection(persona: dict | None) -> dict:
-    agent_settings = {
-        "personality": {"adjectives": {"Polite": True}, "custom": ""},
-        "role": {"value": "Consultant", "additionalInfo": "", "custom": ""},
-    }
+    agent_settings = {"rules": {"behaviour": "Be polite and helpful"}}
     if persona is not None:
         agent_settings["persona"] = persona
     return {"agentSettings": agent_settings}
@@ -2242,7 +1987,7 @@ class SettingsPersonaTests(unittest.TestCase):
         self.assertIn("Invalid references: ['variables: VAR-customer_name']", str(cm.exception))
 
     def test_validate_rejects_non_variable_references(self):
-        """Test that only variables may be referenced, unlike personality and role."""
+        """Test that only variables may be referenced."""
         persona_with_attr = SettingsPersona(
             resource_id="persona_123",
             name="persona",
@@ -9376,27 +9121,25 @@ class CheckYamlFieldTypesTest(unittest.TestCase):
         self.assertIn("bool", str(ctx.exception))
 
     def test_dict_value_wrong_type_raises(self):
-        """A dict[str, bool] field with a str value instead of bool should raise."""
-        personality = SettingsPersonality(
-            resource_id="P-1",
-            name="personality",
-            custom="fine",
-            adjectives={"Polite": "sure"},
+        """A dict[str, str] field with an int value instead of str should raise."""
+        translation = Translation(
+            resource_id="TN-1",
+            name="greeting",
+            translations={"en-GB": 1},
         )
         with self.assertRaises(ValueError) as ctx:
-            resource_utils.check_yaml_field_types(personality)
-        self.assertIn("adjectives", str(ctx.exception))
-        self.assertIn("should be bool but got str", str(ctx.exception))
+            resource_utils.check_yaml_field_types(translation)
+        self.assertIn("translations", str(ctx.exception))
+        self.assertIn("should be str but got int", str(ctx.exception))
 
     def test_dict_valid_types_passes(self):
-        """A dict[str, bool] field with correct types should not raise."""
-        personality = SettingsPersonality(
-            resource_id="P-1",
-            name="personality",
-            custom="fine",
-            adjectives={"Polite": True, "Calm": False},
+        """A dict[str, str] field with correct types should not raise."""
+        translation = Translation(
+            resource_id="TN-1",
+            name="greeting",
+            translations={"en-GB": "Hello", "fr-FR": "Bonjour"},
         )
-        resource_utils.check_yaml_field_types(personality)
+        resource_utils.check_yaml_field_types(translation)
 
     def test_int_accepted_for_float_field(self):
         """int values should be accepted where float is expected (YAML parses 500 as int)."""
@@ -10237,50 +9980,7 @@ class FunctionStepFromProjection(unittest.TestCase):
 
 
 class AgentSettingsFromProjection(unittest.TestCase):
-    """Tests for SettingsPersonality, SettingsRole, and SettingsRules from_projection."""
-
-    def test_personality_from_projection(self):
-        """Verify personality adjectives and custom text are parsed."""
-        projection = {
-            "agentSettings": {
-                "personality": {
-                    "adjectives": {"Friendly": True, "Professional": True},
-                    "custom": "Always be cheerful",
-                }
-            }
-        }
-        result = SettingsPersonality.from_projection(projection)
-        self.assertEqual(list(result), ["personality"])
-        personality = result["personality"]
-        self.assertIsInstance(personality, SettingsPersonality)
-        self.assertEqual(personality.adjectives, {"Friendly": True, "Professional": True})
-        self.assertEqual(personality.custom, "Always be cheerful")
-
-    def test_personality_empty_projection(self):
-        """An empty projection should return an empty dict."""
-        self.assertEqual(SettingsPersonality.from_projection({}), {})
-
-    def test_role_from_projection(self):
-        """Verify role value, additional_info, and custom are parsed."""
-        projection = {
-            "agentSettings": {
-                "role": {
-                    "value": "receptionist",
-                    "additionalInfo": "front desk",
-                    "custom": "",
-                }
-            }
-        }
-        result = SettingsRole.from_projection(projection)
-        self.assertEqual(list(result), ["role"])
-        role = result["role"]
-        self.assertIsInstance(role, SettingsRole)
-        self.assertEqual(role.value, "receptionist")
-        self.assertEqual(role.additional_info, "front desk")
-
-    def test_role_empty_projection(self):
-        """An empty projection should return an empty dict."""
-        self.assertEqual(SettingsRole.from_projection({}), {})
+    """Tests for SettingsRules from_projection."""
 
     def test_rules_from_projection(self):
         """Verify rules behaviour is parsed."""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1947,7 +1947,15 @@ PERSONA_VARIABLE_MAPPING = [
         file_path="variables/customer_name",
         resource_prefix="vrbl",
         flow_name=None,
-    )
+    ),
+    ResourceMapping(
+        resource_id="ATTR-brand_name",
+        resource_name="brand_name",
+        resource_type=VariantAttribute,
+        file_path="config/variant_attributes.yaml",
+        resource_prefix="attr",
+        flow_name=None,
+    ),
 ]
 
 
@@ -1986,16 +1994,43 @@ class SettingsPersonaTests(unittest.TestCase):
             TEST_PERSONA.validate(resource_mappings=[])
         self.assertIn("Invalid references: ['variables: VAR-customer_name']", str(cm.exception))
 
-    def test_validate_rejects_non_variable_references(self):
-        """Test that only variables may be referenced."""
+    def test_validate_attribute_reference(self):
+        """Test that attributes are accepted, as they were on personality and role."""
         persona_with_attr = SettingsPersona(
             resource_id="persona_123",
             name="persona",
-            content="You are a concierge for {{attr:customer-name}}.",
+            content="You are a concierge for {{attr:ATTR-brand_name}}.",
         )
+        self.assertIsNone(persona_with_attr.validate(resource_mappings=PERSONA_VARIABLE_MAPPING))
+
         with self.assertRaises(ValueError) as cm:
             persona_with_attr.validate(resource_mappings=[])
-        self.assertIn("Invalid reference type: attributes", str(cm.exception))
+        self.assertIn("Invalid references: ['attributes: ATTR-brand_name']", str(cm.exception))
+
+    def test_validate_rejects_behavioural_references(self):
+        """Test that behavioural references belong in rules.txt, not the persona."""
+        persona_with_fn = SettingsPersona(
+            resource_id="persona_123",
+            name="persona",
+            content="You are a concierge. Use {{fn:book_table}}.",
+        )
+        with self.assertRaises(ValueError) as cm:
+            persona_with_fn.validate(resource_mappings=[])
+        self.assertIn("Invalid reference type: global_functions", str(cm.exception))
+
+    def test_build_update_proto_omits_attribute_references(self):
+        """Test that attribute references stay in the content, untracked.
+
+        PersonaReferences has a variables map and nothing else — the same shape
+        PersonalityReferences and RoleReferences had.
+        """
+        proto = SettingsPersona(
+            resource_id="persona_123",
+            name="persona",
+            content="You are a concierge for {{attr:ATTR-brand_name}}.",
+        ).build_update_proto()
+        self.assertIn("{{attr:ATTR-brand_name}}", proto.content)
+        self.assertEqual(dict(proto.references.variables), {})
 
     def test_build_update_proto(self):
         """Test building the update proto, including variable references."""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -2294,7 +2294,7 @@ class SettingsPersonaTests(unittest.TestCase):
         )
 
     def test_from_projection_without_content(self):
-        """Test a project without the persona flag, where content is absent."""
+        """Test a persona object that carries no content."""
         self.assertEqual(
             SettingsPersona.from_projection(
                 _persona_projection(

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -14,6 +14,7 @@ from jsonschema import ValidationError
 import poly.resources.resource_utils as resource_utils
 from poly.resources.agent_settings import (
     ALLOWED_ADJECTIVES,
+    SettingsPersona,
     SettingsPersonality,
     SettingsRole,
     SettingsRules,
@@ -2183,6 +2184,135 @@ TEST_FLOW_CONFIG = FlowConfig(
     description="A test flow description",
     start_step="step-1",
 )
+
+TEST_PERSONA = SettingsPersona(
+    resource_id="persona_123",
+    name="persona",
+    content="You are a calm concierge. Greet {{vrbl:VAR-customer_name}} by name.",
+)
+
+PERSONA_VARIABLE_MAPPING = [
+    ResourceMapping(
+        resource_id="VAR-customer_name",
+        resource_name="customer_name",
+        resource_type=Variable,
+        file_path="variables/customer_name",
+        resource_prefix="vrbl",
+        flow_name=None,
+    )
+]
+
+
+def _persona_projection(persona: dict | None) -> dict:
+    agent_settings = {
+        "personality": {"adjectives": {"Polite": True}, "custom": ""},
+        "role": {"value": "Consultant", "additionalInfo": "", "custom": ""},
+    }
+    if persona is not None:
+        agent_settings["persona"] = persona
+    return {"agentSettings": agent_settings}
+
+
+class SettingsPersonaTests(unittest.TestCase):
+    def test_get_raw(self):
+        """Test that raw property returns the content string."""
+        self.assertEqual(TEST_PERSONA.raw, TEST_PERSONA.content)
+
+    def test_file_path(self):
+        """Test that the persona is stored as plain text next to the other settings."""
+        self.assertEqual(TEST_PERSONA.file_path, os.path.join("agent_settings", "persona.txt"))
+
+    def test_convert_and_unconvert_persona(self):
+        """Test roundtrip conversion: to_pretty -> from_pretty."""
+        pretty_content = TEST_PERSONA.to_pretty(resource_mappings=PERSONA_VARIABLE_MAPPING)
+        self.assertIn("{{vrbl:customer_name}}", pretty_content)
+        self.assertNotIn("{{vrbl:VAR-customer_name}}", pretty_content)
+
+        reverted = SettingsPersona.from_pretty(
+            pretty_content, resource_mappings=PERSONA_VARIABLE_MAPPING
+        )
+        self.assertEqual(reverted, TEST_PERSONA.raw)
+
+    def test_validate_variable_reference(self):
+        """Test validation accepts a known variable and rejects an unknown one."""
+        self.assertIsNone(TEST_PERSONA.validate(resource_mappings=PERSONA_VARIABLE_MAPPING))
+
+        with self.assertRaises(ValueError) as cm:
+            TEST_PERSONA.validate(resource_mappings=[])
+        self.assertIn("Invalid references: ['variables: VAR-customer_name']", str(cm.exception))
+
+    def test_validate_rejects_non_variable_references(self):
+        """Test that only variables may be referenced, unlike personality and role."""
+        persona_with_attr = SettingsPersona(
+            resource_id="persona_123",
+            name="persona",
+            content="You are a concierge for {{attr:customer-name}}.",
+        )
+        with self.assertRaises(ValueError) as cm:
+            persona_with_attr.validate(resource_mappings=[])
+        self.assertIn("Invalid reference type: attributes", str(cm.exception))
+
+    def test_build_update_proto(self):
+        """Test building the update proto, including variable references."""
+        proto = TEST_PERSONA.build_update_proto()
+        self.assertEqual(proto.content, TEST_PERSONA.content)
+        self.assertEqual(dict(proto.references.variables), {"VAR-customer_name": True})
+
+    def test_build_update_proto_without_references(self):
+        """Test that references are always sent, even when empty."""
+        proto = SettingsPersona(
+            resource_id="persona_123",
+            name="persona",
+            content="You are a calm concierge.",
+        ).build_update_proto()
+        self.assertEqual(dict(proto.references.variables), {})
+
+    def test_command_type(self):
+        """Test that pushing a persona sends update_persona."""
+        self.assertEqual(TEST_PERSONA.command_type, "persona")
+        self.assertEqual(TEST_PERSONA.update_command_type, "update_persona")
+
+    def test_create_and_delete_not_supported(self):
+        """Test that the platform offers no create or delete for the persona."""
+        with self.assertRaises(NotImplementedError):
+            TEST_PERSONA.build_create_proto()
+        with self.assertRaises(NotImplementedError):
+            TEST_PERSONA.build_delete_proto()
+
+    def test_from_projection(self):
+        """Test that persona content becomes a SettingsPersona resource."""
+        resources = SettingsPersona.from_projection(
+            _persona_projection({"content": "You are a calm Consultant."})
+        )
+        self.assertEqual(
+            resources["persona"],
+            SettingsPersona(
+                resource_id="persona",
+                name="persona",
+                content="You are a calm Consultant.",
+            ),
+        )
+
+    def test_from_projection_without_content(self):
+        """Test a project without the persona flag, where content is absent."""
+        self.assertEqual(
+            SettingsPersona.from_projection(
+                _persona_projection(
+                    {"createdAt": "", "createdBy": "", "references": {"variables": {}}}
+                )
+            ),
+            {},
+        )
+
+    def test_from_projection_without_persona(self):
+        """Test a projection with no persona key at all."""
+        self.assertEqual(SettingsPersona.from_projection(_persona_projection(None)), {})
+
+    def test_from_projection_with_empty_content(self):
+        """Test that an authored but empty persona is still a resource."""
+        resources = SettingsPersona.from_projection(_persona_projection({"content": ""}))
+        self.assertEqual(resources["persona"].content, "")
+
 
 FLOW_CONFIG_RAW = """name: Test Flow
 description: A test flow description

--- a/src/poly/tests/test_projects/test_project/agent_settings/persona.txt
+++ b/src/poly/tests/test_projects/test_project/agent_settings/persona.txt
@@ -1,0 +1,2 @@
+You are a calm and polite concierge.
+Greet the caller by name using {{vrbl:customer_name}}.

--- a/src/poly/tests/test_projects/test_project/agent_settings/personality.yaml
+++ b/src/poly/tests/test_projects/test_project/agent_settings/personality.yaml
@@ -1,6 +1,0 @@
-adjectives:
-  Polite: true
-  Calm: true
-  Kind: true
-custom: ""
-

--- a/src/poly/tests/test_projects/test_project/agent_settings/role.yaml
+++ b/src/poly/tests/test_projects/test_project/agent_settings/role.yaml
@@ -1,4 +1,0 @@
-value: Customer Service Representative
-additional_info: Handles customer inquiries and bookings
-custom: ""
-

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -435,6 +435,13 @@
         "custom": ""
       }
     },
+    "persona": {
+      "PERSONA-persona": {
+        "resource_id": "PERSONA-persona",
+        "name": "persona",
+        "content": "You are a calm and polite concierge.\nGreet the caller by name using {{vrbl:VAR-customer_name}}.\n"
+      }
+    },
     "rules": {
       "RULES-rules": {
         "resource_id": "RULES-rules",

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -414,27 +414,6 @@
         "prompt": "You are a helpful and professional web chat assistant."
       }
     },
-    "personality": {
-      "PERSONALITY-personality": {
-        "resource_id": "PERSONALITY-personality",
-        "name": "personality",
-        "adjectives": {
-          "Polite": true,
-          "Calm": true,
-          "Kind": true
-        },
-        "custom": ""
-      }
-    },
-    "role": {
-      "ROLE-role": {
-        "resource_id": "ROLE-role",
-        "name": "role",
-        "value": "Customer Service Representative",
-        "additional_info": "Handles customer inquiries and bookings",
-        "custom": ""
-      }
-    },
     "persona": {
       "PERSONA-persona": {
         "resource_id": "PERSONA-persona",


### PR DESCRIPTION
## Summary

Replaces the separate Personality and Role settings in ADK with the single free-text `persona` resource that superseded them in Agent Studio. `agent_settings/persona.txt` now pulls, pushes and diffs; `personality.yaml` and `role.yaml` are gone, and a migration deletes them from existing project directories.

## Motivation

[DEVP-624](https://linear.app/poly-ai/issue/DEVP-624/add-persona-to-agent-settings-adk-is-blind-to-the-new-merged-role)

On the wire the merged Role field is a new `persona` component on `agentSettings`. ADK had no persona resource at all, so `pull` dropped the field builders actually author, `push` could only write the dead settings, and `diff` across environments silently ignored the primary identity field.

## Changes

- `SettingsPersona` in `resources/agent_settings.py` — plain-text `agent_settings/persona.txt`, modelled on `SettingsRules`, registered via `@register_resource("persona")`
- References validated against `{{attr:}}` and `{{vrbl:}}` — the same two the personality and role `custom` fields accepted. Attribute references travel in the content and are not tracked on the resource, since `PersonaReferences` is variables-only; so were `PersonalityReferences` and `RoleReferences`, so this is not new
- `update_persona` always carries a `variables` map (possibly empty) — the backend schema requires the key whenever `references` is sent
- `from_projection` reads `persona.content`, not the `persona` object — the projection always carries the object, so absent content just means there is nothing to write to disk. An authored empty string is a real persona and is kept
- **`SettingsPersonality` and `SettingsRole` deleted.** They still exist on the wire but nothing surfaces them, so keeping them registered only leaves two files that pull, push and validate while affecting nothing
- **Migration `removed_personality_and_role_files`** deletes `agent_settings/personality.yaml` and `role.yaml` the first time a project is loaded, logging what it removed and telling the builder to pull to get `persona.txt`. `file_structure_info` is recomputed from the loaded resources on every load, so the stale status entries drop out on their own
- Docs: the packaged `docs/agent_settings.md` + `docs/docs.md`, and the mkdocs site — the resource reference, architecture guide, working-locally tree, tooling/CLI tables and the restaurant tutorial all walked builders through `personality.yaml` and `role.yaml`

### On the compiled backfill

For a project that has never authored a persona, the content the projection returns is derived server-side from the old `personality` + `role` and stored nowhere. This is deliberately left as-is rather than detected and skipped: `push_project` only sends resources whose on-disk hash differs from the pulled snapshot, so an untouched `persona.txt` is never pushed back, and editing the file authors a real persona — which is the intent. Documented in `docs/agent_settings.md`.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly docs agent_settings`)
- [ ] Tested against a live Agent Studio project

New coverage: `SettingsPersonaTests` (15 cases — raw/pretty roundtrip, attribute and variable validation, `{{fn:}}` rejection, update proto with and without references, `from_projection` for present / absent-content / absent-object / empty-string) and `TestRemovePersonalityAndRoleFiles` for the migration (no-op without `agent_settings/`, both files removed with the warning logged, other settings files untouched).

Also verified offline that a `Command(type="update_persona", ...)` builds, serialises and round-trips with `references.variables` populated.

Not yet run against a live project — `poly pull` / `poly push` on a real project is still outstanding.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1352 passed, 112 subtests)
- [x] No breaking changes to the `poly` CLI interface
- [x] Commit messages follow conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)

