### PR TITLE
feat(types): add CxOne stubs so conv.cxone resolves in projects

### DIFF
--- a/scripts/sync_runtime_stubs.py
+++ b/scripts/sync_runtime_stubs.py
@@ -44,6 +44,7 @@ STUB_FILES = [
     "agentic_dial.py",
     "emails.py",
     "entity_validator.py",
+    "cxone.py",
 ]
 
 

--- a/src/poly/types/conversation.py
+++ b/src/poly/types/conversation.py
@@ -7,6 +7,7 @@
 from typing import Any, Literal, NewType
 from .external_events import GenericExternalEvent, SMSReceived
 from .agentic_dial import AgenticDialData
+from .cxone import CxOne
 from .entity_validator import EntityValidationResult
 from .history import AgentResponse, UserInput
 from .integrations.integrations import Integrations
@@ -586,6 +587,10 @@ class Conversation:
     @property
     def sip_headers(self) -> dict[str, str]:
         """Dict mapping header names to values"""
+
+    @property
+    def cxone(self) -> CxOne:
+        """NICE CXone Signal API, for handing the call back to CXone"""
 
     @property
     def integration_attributes(self) -> dict[str, Any] | None:

--- a/src/poly/types/cxone.py
+++ b/src/poly/types/cxone.py
@@ -1,0 +1,108 @@
+# Copyright PolyAI Limited
+# flake8: noqa
+# ruff: noqa
+# type: ignore
+
+
+from typing import Any
+
+
+__all__ = [
+    "CxOne",
+    "CxOneError",
+    "CxOneMissingContactId",
+    "CxOneSecretError",
+    "CxOneSignalError",
+    "CxOneTokenError",
+]
+
+DEFAULT_TOKEN_URL = "https://cxone.niceincontact.com/auth/token"
+DEFAULT_REGION = "na1"
+DEFAULT_DOMAIN = "niceincontact"
+DEFAULT_VERSION = "v24.0"
+DEFAULT_TIMEOUT_SECONDS = 10.0
+UNAUTHORIZED = 401
+CONTACT_ID_HEADERS = ("X-InContact-ContactId", "X-inc-master-id")
+MAX_SIGNAL_PARAMETERS = 9
+
+
+class CxOneError(Exception):
+    """Base class for CXone errors."""
+
+
+class CxOneMissingContactId(CxOneError):
+    """No CXone contact ID was given and none could be read from SIP headers."""
+
+    def __init__(self, headers: tuple[str, ...] = ...): ...
+
+
+class CxOneSecretError(CxOneError):
+    """The CXone credentials secret is missing, inaccessible or malformed."""
+
+    def __init__(self, secret_name: str, reason: str): ...
+
+
+class CxOneTokenError(CxOneError):
+    """CXone rejected the request for an access token."""
+
+    def __init__(self, status_code: int, detail: str): ...
+
+
+class CxOneSignalError(CxOneError):
+    """The CXone Signal API returned an error."""
+
+    def __init__(self, status_code: int, detail: str): ...
+
+
+class CxOne:
+    """CXone Signal API interface, exposed to functions as ``conv.cxone``."""
+
+    def __init__(self, conv: Any):
+        """init"""
+
+    @property
+    def default_secret_name(self) -> str:
+        """Name of the CXone credentials secret used when none is given."""
+
+    @property
+    def contact_id(self) -> str | None:
+        """The CXone contact ID from the inbound SIP headers, if present."""
+
+    def handoff(
+        self,
+        reason: str | None = ...,
+        params: dict[str, Any] | list[Any] | None = ...,
+        contact_id: str | None = ...,
+        destination: str | None = ...,
+        utterance: str | None = ...,
+        region: str = ...,
+        domain: str = ...,
+        version: str = ...,
+        secret_name: str | None = ...,
+        token_url: str = ...,
+        timeout: float = ...,
+    ) -> None:
+        """Hand the caller back to CXone and end PolyAI's leg of the call."""
+
+    def signal(
+        self,
+        params: dict[str, Any] | list[Any] | None = ...,
+        contact_id: str | None = ...,
+        region: str = ...,
+        domain: str = ...,
+        version: str = ...,
+        secret_name: str | None = ...,
+        token_url: str = ...,
+        timeout: float = ...,
+    ) -> None:
+        """Send a signal to the CXone Studio script without ending the call."""
+
+
+__all__ = [
+    "CxOne",
+    "CxOneError",
+    "CxOneMissingContactId",
+    "CxOneSecretError",
+    "CxOneSignalError",
+    "CxOneTokenError",
+]


### PR DESCRIPTION
## Summary

Companion to [genai_lambda_runtime#116](https://github.com/PolyAI-LDN/genai_lambda_runtime/pull/116), which adds `conv.cxone` for NICE CXone Signal API handoffs. Without these stubs `conv.cxone` doesn't exist in `_gen`, so builders get no autocomplete and a project function that catches `CxOneSignalError` fails its local tests.

Adds `cxone.py` to `STUB_FILES`, the generated `src/poly/types/cxone.py`, and the `cxone` property on the `Conversation` stub.

## Deliberately not a full resync

Scoped to the CXone delta rather than running `sync_runtime_stubs.py` wholesale, because **a full resync is currently broken**:

`STUB_FILES` is missing `clock.py`, `knowledge_base.py` and `verified_context.py`, but the current runtime `conversation.py` imports all three. A full run therefore emits a `conversation.py` stub importing three modules that never get generated — the resulting `_gen` package raises `ModuleNotFoundError` on import, which would break every project. That's pre-existing and worth fixing, but not in a CXone change. Happy to raise it separately.

(A full run also picks up genuine additive drift that's accumulated since the last sync — `AgenticDial.unsubscribe_from_destination`, `XaiVoice`/`GradiumVoice`, `BackgroundTrack`, `Attachment.chart_spec`, `EntityValidationResult.details`, new `prompt_llm` models. All safe, all missing from the committed stubs, all better handled in a dedicated resync PR once the three missing modules are added.)

## Circular-import note

`runtime/cxone.py` deliberately does **not** import `Conversation`, not even under `TYPE_CHECKING`. The generator promotes `TYPE_CHECKING` imports to unconditional ones, and `conversation.py` imports `CxOne`, so the pair would be circular and `_gen` unimportable. `flow.py` uses the same annotate-against-`Conversation` pattern safely only because nothing imports `flow` back. There's a comment on the runtime side so nobody re-adds it.

## Testing

- Verified the generated package actually imports and resolves, rather than just eyeballing the stub:
  ```
  _gen imported OK
  CxOne exports: ['CxOne', 'CxOneError', 'CxOneMissingContactId', 'CxOneSecretError', 'CxOneSignalError', 'CxOneTokenError']
  Conversation.cxone is a property: True
  CxOne attrs: ['handoff', 'signal', 'contact_id', 'default_secret_name']
  cxone -> return annotation: <class '_gen.cxone.CxOne'>
  ```
- `1352 passed, 112 subtests passed`
- `ruff check` / `ruff format --check` clean

## Ticket

https://poly-ai.atlassian.net/browse/HSP-16548

🤖 Generated with [Claude Code](https://claude.com/claude-code)