### PR TITLE
feat: keep withheld resources as slim reference mappings

### DIFF
--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -24,7 +24,8 @@ from poly.resources import (
     Function,
     FunctionStep,
     Handoff,
-    Resource,
+    ResourceMap,
+    ResourceMapping,
     SMSTemplate,
     Variable,
     Variant,
@@ -261,7 +262,7 @@ class AgentStudioInterface:
     @staticmethod
     def get_template_resources(
         template_id: str, region: str
-    ) -> dict[type[Resource], dict[str, Resource]]:
+    ) -> tuple[ResourceMap, list[ResourceMapping]]:
         """Fetch a template and return its resources.
 
         Combines projection fetching and resource conversion in one call.
@@ -271,7 +272,9 @@ class AgentStudioInterface:
             region: The region to query.
 
         Returns:
-            dict mapping resource types to their resources.
+            tuple[ResourceMap, list[ResourceMapping]]: A tuple containing:
+                1. A dictionary mapping resource types to their resources.
+                2. A list of slim resources.
         """
         from poly.resources.resource import load_resources_from_projection
 
@@ -312,15 +315,17 @@ class AgentStudioInterface:
 
     def pull_deployment_resources(
         self, deployment_id: str
-    ) -> dict[type[Resource], dict[str, Resource]]:
+    ) -> tuple[ResourceMap, list[ResourceMapping]]:
         """Fetch all resources for a specific deployment of a project.
 
         Args:
             deployment_id (str): The deployment ID
 
         Returns:
-            dict[type[Resource], dict[str, Resource]]: A dictionary mapping resource types to
-                their resources
+            tuple[ResourceMap, list[ResourceMapping]]: A tuple containing:
+                1. A dictionary mapping resource types to their resources.
+                2. A list of slim resources.
+
         """
         from poly.resources.resource import load_resources_from_projection
 
@@ -332,7 +337,7 @@ class AgentStudioInterface:
 
     def pull_resources(
         self, projection_json: Optional[dict[str, Any]] = None
-    ) -> tuple[dict[type[Resource], dict[str, Resource]], dict[str, Any]]:
+    ) -> tuple[ResourceMap, list[ResourceMapping], dict[str, Any]]:
         """Fetch all resources for the specific project.
 
         Args:
@@ -340,17 +345,20 @@ class AgentStudioInterface:
                 If provided, the projection will be used instead of fetching it from the API.
 
         Returns:
-            dict[type[Resource], dict[str, Resource]]: A dictionary mapping resource types to
-                their resources
-            dict[str, Any]: The projection data
+            tuple[ResourceMap, list[ResourceMapping], dict[str, Any]]: A tuple containing:
+                1. A dictionary mapping resource types to their resources.
+                2. A list of slim resources.
+                3. The projection JSON.
         """
         from poly.resources.resource import load_resources_from_projection
 
         if projection_json is not None:
-            return load_resources_from_projection(projection_json), projection_json
+            resources, slim_resources = load_resources_from_projection(projection_json)
+            return resources, slim_resources, projection_json
         try:
             projection = self.sync_client.pull_projection()
-            return load_resources_from_projection(projection), projection
+            resources, slim_resources = load_resources_from_projection(projection)
+            return resources, slim_resources, projection
         except (requests.HTTPError, SourcererAPIError) as e:
             self._handle_api_error(e)
 
@@ -635,7 +643,7 @@ class AgentStudioInterface:
 
     def pull_branch_resources(
         self, branch_id: str, at_sequence: Optional[int] = None
-    ) -> dict[type, dict[str, Any]]:
+    ) -> tuple[ResourceMap, list[ResourceMapping]]:
         """Fetch resources for a branch, optionally at a historical sequence.
 
         Args:
@@ -643,7 +651,9 @@ class AgentStudioInterface:
             at_sequence: When provided, fetches the projection at this sequence number.
 
         Returns:
-            A ResourceMap of the branch's resources.
+            tuple[ResourceMap, list[ResourceMapping]]: A tuple containing:
+                1. A dictionary mapping resource types to their resources.
+                2. A list of slim resources.
         """
         from poly.resources.resource import load_resources_from_projection
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -10,7 +10,7 @@ import os
 import shutil
 import uuid
 from collections.abc import Callable
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 from datetime import datetime
 from enum import Enum
 from functools import cached_property
@@ -39,8 +39,10 @@ from poly.resources import (
     MultiResourceYamlResource,
     Pronunciation,
     Resource,
+    ResourceMap,
     ResourceMapping,
-    SubResource,
+    ResourceType,
+    SubResourceMap,
     TestCase,
     Topic,
 )
@@ -61,10 +63,6 @@ STATUS_FILE = os.path.join("_gen", ".agent_studio_config")
 
 DECORATORS = ["func_parameter", "func_description", "func_latency_control"]
 
-ResourceType: TypeAlias = type[Resource]
-ResourceMap: TypeAlias = dict[ResourceType, dict[str, Resource]]
-SubResourceType: TypeAlias = type[SubResource]
-SubResourceMap: TypeAlias = dict[SubResourceType, dict[str, SubResource]]
 DiscoveredResourcePaths: TypeAlias = dict[ResourceType, list[str]]
 ResourceUpdatePair: TypeAlias = tuple[ResourceMap, ResourceMap]
 
@@ -108,6 +106,7 @@ class AgentStudioProject:
     root_path: str
     resources: ResourceMap
     last_updated: datetime
+    slim_resources: list[ResourceMapping] = field(default_factory=list)
     branch_id: str = None
     project_name: Optional[str] = None
     account_name: Optional[str] = None
@@ -120,7 +119,7 @@ class AgentStudioProject:
     # Store resources that were not loaded from the status file
     # So they aren't considered locally deleted when pushing/pulling
     # before they are saved.
-    _not_loaded_resources: list[ResourceType] = None
+    _not_loaded_resources: list[ResourceType] = field(default_factory=list)
 
     @property
     def all_resources(self) -> list[Resource]:
@@ -161,9 +160,10 @@ class AgentStudioProject:
     @classmethod
     def _load_resources_from_status_dict(
         cls, status_dict: dict
-    ) -> tuple[ResourceMap, list[ResourceType]]:
+    ) -> tuple[ResourceMap, list[ResourceType], list[ResourceMapping]]:
         resources: ResourceMap = {}
         not_loaded_resources: list[ResourceType] = []
+        slim_resources: list[ResourceMapping] = []
         for resource_name, resource_class in RESOURCE_NAME_TO_CLASS.items():
             resource_dicts: Optional[dict[str, dict[str, Any]]] = status_dict.get(
                 "resources", {}
@@ -180,7 +180,12 @@ class AgentStudioProject:
                 )
                 for resource_id, resource_dict in resource_dicts.items()
             }
-        return resources, not_loaded_resources
+        for slim_resource_dict in status_dict.get("slim_resources", []):
+            resource_mapping = ResourceMapping.from_dict(slim_resource_dict)
+            if resource_mapping is not None:
+                slim_resources.append(resource_mapping)
+
+        return resources, not_loaded_resources, slim_resources
 
     @classmethod
     def from_file_path(cls, root_path: str) -> "AgentStudioProject":
@@ -211,7 +216,9 @@ class AgentStudioProject:
         migration_flags = run_migrations(root_path, migration_flags, status_dict=status_dict)
 
         # Load resources
-        resources, not_loaded_resources = cls._load_resources_from_status_dict(status_dict)
+        resources, not_loaded_resources, slim_resources = cls._load_resources_from_status_dict(
+            status_dict
+        )
 
         last_updated_str = status_dict.get("last_updated")
         if last_updated_str:
@@ -227,6 +234,7 @@ class AgentStudioProject:
             root_path=root_path,
             last_updated=last_updated,
             file_structure_info={},
+            slim_resources=slim_resources,
             branch_id=status_dict.get("branch_id", "main"),
             project_name=config_dict.get("project_name") or status_dict.get("project_name"),
             account_name=config_dict.get("account_name") or status_dict.get("account_name"),
@@ -247,6 +255,7 @@ class AgentStudioProject:
                 }
                 for rt, rs in self.resources.items()
             },
+            "slim_resources": [r.to_dict() for r in self.slim_resources or []],
             "last_updated": (self.last_updated.isoformat() if self.last_updated else None),
             "file_structure_info": self.file_structure_info,
             "branch_id": self.branch_id,
@@ -264,7 +273,7 @@ class AgentStudioProject:
         migration_flags = load_migration_flags(data.get("migration_flags", []))
         migration_flags = run_migrations(root_path, migration_flags, status_dict=data)
 
-        resources, not_loaded_resources = cls._load_resources_from_status_dict(data)
+        resources, not_loaded_resources, slim_resources = cls._load_resources_from_status_dict(data)
 
         file_structure_info = cls.compute_file_structure_info(resources)
 
@@ -281,6 +290,7 @@ class AgentStudioProject:
             account_name=data.get("account_name"),
             _migration_flags=migration_flags,
             _not_loaded_resources=not_loaded_resources,
+            slim_resources=slim_resources,
             rtc_metadata=data.get("rtc_metadata"),
         )
 
@@ -361,7 +371,7 @@ class AgentStudioProject:
         )
 
         try:
-            project.resources, projection = project.api_handler.pull_resources(
+            project.resources, slim_resources, projection = project.api_handler.pull_resources(
                 projection_json=projection_json
             )
         except ValueError:
@@ -373,8 +383,8 @@ class AgentStudioProject:
 
         project._check_no_duplicate_resource_paths(project.resources)
 
-        resource_mappings: list[ResourceMapping] = project._make_resource_mappings(
-            project.resources
+        resource_mappings: list[ResourceMapping] = (
+            project._make_resource_mappings(project.resources) + slim_resources
         )
 
         all_resources = project.all_resources
@@ -449,10 +459,13 @@ class AgentStudioProject:
         Returns:
             A tuple of (resources dict, projection dict).
         """
-        resources, projection = self.api_handler.pull_resources(projection_json=projection_json)
+        resources, slim_resources, projection = self.api_handler.pull_resources(
+            projection_json=projection_json
+        )
         self._check_no_duplicate_resource_paths(resources)
 
         self.resources = resources
+        self.slim_resources = slim_resources
         self.file_structure_info = self.compute_file_structure_info(resources)
         if not preserve_not_loaded_resources:
             self._not_loaded_resources = []
@@ -511,9 +524,12 @@ class AgentStudioProject:
         Writes template resources to disk without updating the tracked state,
         so the next ``poly push`` detects the template files as changes.
         """
-        template_resources = AgentStudioInterface.get_template_resources(template_id, region)
+        template_resources, template_slim_resources = AgentStudioInterface.get_template_resources(
+            template_id, region
+        )
 
         self._not_loaded_resources = []
+        self.slim_resources = template_slim_resources
         self.save_config()
 
         # Delete only ADK-managed resource files, leaving non-ADK files intact.
@@ -562,12 +578,15 @@ class AgentStudioProject:
         # Pull resources
         # -------
 
-        incoming_resources, projection = self.api_handler.pull_resources(
+        incoming_resources, slim_resources, projection = self.api_handler.pull_resources(
             projection_json=projection_json
         )
         # Only update branch id if we used the API to pull the resources
         if projection_json is None:
             self.branch_id = self.api_handler.branch_id
+
+        # Update slim resources in memory
+        self.slim_resources = slim_resources
 
         self._check_no_duplicate_resource_paths(incoming_resources)
         # -------
@@ -622,9 +641,10 @@ class AgentStudioProject:
         Returns:
             list[str]: Always empty (force overwrite produces no conflicts).
         """
-        incoming_resources = self.get_remote_resources_by_name(env)
+        incoming_resources, slim_resources = self.get_remote_resources_by_name(env)
         if not incoming_resources:
             raise ValueError(f"No resources returned from environment '{env}'.")
+        self.slim_resources = slim_resources
         self.branch_id = self.api_handler.branch_id
 
         self._check_no_duplicate_resource_paths(incoming_resources)
@@ -942,13 +962,13 @@ class AgentStudioProject:
         files_with_conflicts = []
 
         # Generate resource mappings
-        incoming_resource_mappings: list[ResourceMapping] = self._make_resource_mappings(
-            incoming_resources
+        incoming_resource_mappings: list[ResourceMapping] = (
+            self._make_resource_mappings(incoming_resources) + self.slim_resources
         )
 
         # If not force, compare with original and local changes
-        original_resource_mappings: list[ResourceMapping] = self._make_resource_mappings(
-            original_resources
+        original_resource_mappings: list[ResourceMapping] = (
+            self._make_resource_mappings(original_resources) + self.slim_resources
         )
 
         # Merging is done on a per file basis.
@@ -1234,12 +1254,16 @@ class AgentStudioProject:
                         [],
                     )
 
-                # Push Algorithm
+        # Push Algorithm
         # 1. Get new/kept/deleted resources
         new_resource_mappings, kept_resource_mappings, deleted_resource_mappings = (
             self.find_new_kept_deleted(self.discover_local_resources())
         )
         local_resource_mappings = new_resource_mappings + kept_resource_mappings
+        # Slim resources have no file to read - they exist only so that references
+        # to them still resolve to a name. Keep them out of the list we iterate,
+        # and only in the list we resolve references against.
+        resource_mappings = local_resource_mappings + self.slim_resources
 
         if format:
             # format all local resources before pushing
@@ -1256,7 +1280,7 @@ class AgentStudioProject:
         for resource_mapping in local_resource_mappings:
             local_resource = self.read_local_resource(
                 resource=resource_mapping,
-                resource_mappings=local_resource_mappings,
+                resource_mappings=resource_mappings,
             )
             new_state.setdefault(resource_mapping.resource_type, {})[
                 resource_mapping.resource_id
@@ -1307,7 +1331,7 @@ class AgentStudioProject:
         # 4. Validate all resources with new state
         if not skip_validation:
             validation_errors = self.validate_resources(
-                resources_dict=new_state, resource_mappings=local_resource_mappings
+                resources_dict=new_state, resource_mappings=resource_mappings
             )
             if validation_errors:
                 error_messages = "\n".join(validation_errors)
@@ -1338,7 +1362,6 @@ class AgentStudioProject:
         if dry_run:
             return True, "Dry run completed. No changes were pushed.", commands
         else:
-            # Update local state
             self.resources = new_state
             self.file_structure_info = self.compute_file_structure_info(self.resources)
             self.save_config()
@@ -1591,6 +1614,7 @@ class AgentStudioProject:
         deleted_files = [resource.file_path for resource in deleted_resources_mappings]
 
         local_resources_mappings = new_resources_mappings + kept_resources_mappings
+        local_resources_mappings.extend(self.slim_resources)
 
         for kept_local_resource_mapping in kept_resources_mappings:
             original_hash = self.file_structure_info.get(
@@ -1650,6 +1674,7 @@ class AgentStudioProject:
             self.find_new_kept_deleted(self.discover_local_resources())
         )
         local_resources_mappings = new_resources_mappings + kept_resources_mappings
+        local_resources_mappings.extend(self.slim_resources)
 
         for local_resource_mapping in kept_resources_mappings:
             if not all_files and file_paths and local_resource_mapping.file_path not in file_paths:
@@ -1747,7 +1772,7 @@ class AgentStudioProject:
 
         return deployments, active_deployment_hashes
 
-    def get_remote_resources_by_name(self, name: str) -> ResourceMap:
+    def get_remote_resources_by_name(self, name: str) -> tuple[ResourceMap, list[ResourceMapping]]:
         """Resolve and fetch a remote project state by name.
         Supports:
         - **Environments**: sandbox / pre-release / live (active deployments)
@@ -1767,7 +1792,7 @@ class AgentStudioProject:
             deployment_id = (deployments.get(name) or {}).get("deployment_id")
             if not deployment_id:
                 logger.error(f"No active deployment found for environment '{name}'.")
-                return {}
+                return {}, []
             logger.info(f"Pulling resources from deployment '{deployment_id}' ({name})...")
             return self.api_handler.pull_deployment_resources(deployment_id)
 
@@ -1779,8 +1804,8 @@ class AgentStudioProject:
                 self.region, self.account_id, self.project_id, branch_id
             )
             logger.info(f"Pulling resources from branch '{name}'...")
-            resources, _ = branch_api_handler.pull_resources()
-            return resources
+            resources, branch_slim_resources, _ = branch_api_handler.pull_resources()
+            return resources, branch_slim_resources
 
         # 3) Deployment version hash prefix -> deployment resources
         version_hash = (name or "")[:9].lower()
@@ -1802,25 +1827,28 @@ class AgentStudioProject:
                 self.discover_local_resources()
             )
             local_resources_mappings = new_resources_mappings + kept_resources_mappings
+            # Slim resources have no file to read - resolve references against
+            # them, but never iterate them looking for one.
+            resource_mappings = local_resources_mappings + self.slim_resources
             resources: ResourceMap = {}
             for resource_mapping in local_resources_mappings:
                 resource = self.read_local_resource(
-                    resource=resource_mapping, resource_mappings=local_resources_mappings
+                    resource=resource_mapping, resource_mappings=resource_mappings
                 )
                 resources.setdefault(resource_mapping.resource_type, {})[
                     resource_mapping.resource_id
                 ] = resource
-            return resources
+            return resources, self.slim_resources
 
         logger.error(f"Name '{name}' not found in environments, branches, or deployments.")
-        return {}
+        return {}, []
 
     def diff_remote_named_versions(
         self, before_name: str, after_name: str
     ) -> Optional[dict[str, str]]:
         """Compute diffs between two remote project states (branches / envs / deployments)."""
-        before_resources = self.get_remote_resources_by_name(before_name)
-        after_resources = self.get_remote_resources_by_name(after_name)
+        before_resources, before_slim_resources = self.get_remote_resources_by_name(before_name)
+        after_resources, after_slim_resources = self.get_remote_resources_by_name(after_name)
 
         if not before_resources or not after_resources:
             logger.error(
@@ -1829,7 +1857,9 @@ class AgentStudioProject:
             )
             return None
 
-        diffs = self.diff_resource_maps(before_resources, after_resources)
+        diffs = self.diff_resource_maps(
+            before_resources, before_slim_resources, after_resources, after_slim_resources
+        )
         if diffs is None:
             logger.info(
                 f"No differences detected between names '{before_name}' and '{after_name}'."
@@ -1843,12 +1873,21 @@ class AgentStudioProject:
 
         Empty projections are valid (e.g. diffing a branch against an empty main).
         """
-        before_resources = load_resources_from_projection(before_projection)
-        after_resources = load_resources_from_projection(after_projection)
-        return self.diff_resource_maps(before_resources, after_resources)
+        before_resources, before_slim_resources = load_resources_from_projection(before_projection)
+        after_resources, after_slim_resources = load_resources_from_projection(after_projection)
+        return self.diff_resource_maps(
+            before_resources,
+            before_slim_resources,
+            after_resources,
+            after_slim_resources,
+        )
 
     def diff_resource_maps(
-        self, before_resources: ResourceMap, after_resources: ResourceMap
+        self,
+        before_resources: ResourceMap,
+        before_resource_slim_mappings: list[ResourceMapping],
+        after_resources: ResourceMap,
+        after_resource_slim_mappings: list[ResourceMapping],
     ) -> Optional[dict[str, str]]:
         """Compute per-file diffs between two in-memory resource maps.
 
@@ -1864,17 +1903,13 @@ class AgentStudioProject:
         for resource_type, resources_dict in after_resources.items():
             for resource_id, resource in resources_dict.items():
                 after_resources_by_path[(resource_type, resource.file_path)] = resource
-        # Combine both resource sets to create comprehensive resource_mappings
-        # This ensures all resource references can be properly converted to pretty names
-        combined_resources: ResourceMap = {}
-        for resource_type, resources_dict in before_resources.items():
-            combined_resources[resource_type] = combined_resources.get(resource_type, {})
-            combined_resources[resource_type].update(resources_dict)
-        for resource_type, resources_dict in after_resources.items():
-            combined_resources[resource_type] = combined_resources.get(resource_type, {})
-            combined_resources[resource_type].update(resources_dict)
 
-        resource_mappings = self._make_resource_mappings(combined_resources)
+        before_resource_mappings = (
+            self._make_resource_mappings(before_resources) + before_resource_slim_mappings
+        )
+        after_resource_mappings = (
+            self._make_resource_mappings(after_resources) + after_resource_slim_mappings
+        )
 
         diffs: dict[str, str] = {}
 
@@ -1887,17 +1922,21 @@ class AgentStudioProject:
             after_resource = after_resources_by_path.get(resource_key)
 
             if before_resource and after_resource:
-                before_pretty = before_resource.to_pretty(resource_mappings=resource_mappings)
-                after_pretty = after_resource.to_pretty(resource_mappings=resource_mappings)
+                before_pretty = before_resource.to_pretty(
+                    resource_mappings=before_resource_mappings
+                )
+                after_pretty = after_resource.to_pretty(resource_mappings=after_resource_mappings)
                 if before_pretty != after_pretty:
                     diffs[before_resource.file_path] = resource_utils.get_diff(
                         before_pretty, after_pretty
                     )
             elif before_resource and not after_resource:
-                before_pretty = before_resource.to_pretty(resource_mappings=resource_mappings)
+                before_pretty = before_resource.to_pretty(
+                    resource_mappings=before_resource_mappings
+                )
                 diffs[before_resource.file_path] = resource_utils.get_diff(before_pretty, "")
             elif not before_resource and after_resource:
-                after_pretty = after_resource.to_pretty(resource_mappings=resource_mappings)
+                after_pretty = after_resource.to_pretty(resource_mappings=after_resource_mappings)
                 diffs[after_resource.file_path] = resource_utils.get_diff("", after_pretty)
 
         if not diffs:
@@ -1907,14 +1946,19 @@ class AgentStudioProject:
 
     def _resolve_branch_fork_point(
         self, branch_name: Optional[str] = None
-    ) -> tuple[ResourceMap, ResourceMap]:
+    ) -> tuple[ResourceMap, list[ResourceMapping], ResourceMap, list[ResourceMapping]]:
         """Fetch parent (at fork point) and branch (latest) resource maps.
 
         Args:
             branch_name: Name of the branch. Defaults to the current branch.
 
         Returns:
-            (parent_resources, branch_resources) tuple.
+            tuple[ResourceMap, list[ResourceMapping], ResourceMap, list[ResourceMapping]]:
+                A tuple containing:
+                1. The parent's resources at the fork point.
+                2. The parent's slim resources.
+                3. The branch's latest resources.
+                4. The branch's slim resources.
 
         Raises:
             ValueError: If on main with no branch specified, or the branch
@@ -1953,10 +1997,12 @@ class AgentStudioProject:
             )
 
         parent_id = parent_branch_id or "main"
-        parent_resources = self.api_handler.pull_branch_resources(parent_id, parent_at_sequence)
-        branch_resources = self.api_handler.pull_branch_resources(branch_id)
+        parent_resources, parent_slim_resources = self.api_handler.pull_branch_resources(
+            parent_id, parent_at_sequence
+        )
+        branch_resources, branch_slim_resources = self.api_handler.pull_branch_resources(branch_id)
 
-        return parent_resources, branch_resources
+        return parent_resources, parent_slim_resources, branch_resources, branch_slim_resources
 
     def diff_branch(
         self,
@@ -1977,8 +2023,12 @@ class AgentStudioProject:
             ValueError: If on main with no branch specified, or the branch
                 does not exist.
         """
-        parent_resources, branch_resources = self._resolve_branch_fork_point(branch_name)
-        diffs = self.diff_resource_maps(parent_resources, branch_resources)
+        parent_resources, parent_slim_resources, branch_resources, branch_slim_resources = (
+            self._resolve_branch_fork_point(branch_name)
+        )
+        diffs = self.diff_resource_maps(
+            parent_resources, parent_slim_resources, branch_resources, branch_slim_resources
+        )
 
         if diffs and file_paths:
             diffs = {fp: d for fp, d in diffs.items() if fp in file_paths}
@@ -2002,7 +2052,9 @@ class AgentStudioProject:
             ValueError: If on main with no branch specified, or the branch
                 does not exist.
         """
-        parent_resources, branch_resources = self._resolve_branch_fork_point(branch_name)
+        parent_resources, parent_slim_resources, branch_resources, branch_slim_resources = (
+            self._resolve_branch_fork_point(branch_name)
+        )
 
         parent_by_path: dict[tuple, Resource] = {}
         for resources_dict in parent_resources.values():
@@ -2014,14 +2066,12 @@ class AgentStudioProject:
             for resource in resources_dict.values():
                 branch_by_path[(type(resource), resource.file_path)] = resource
 
-        combined: ResourceMap = {}
-        for rt, rd in parent_resources.items():
-            combined[rt] = combined.get(rt, {})
-            combined[rt].update(rd)
-        for rt, rd in branch_resources.items():
-            combined[rt] = combined.get(rt, {})
-            combined[rt].update(rd)
-        resource_mappings = self._make_resource_mappings(combined)
+        before_resource_mappings = (
+            self._make_resource_mappings(parent_resources) + parent_slim_resources
+        )
+        after_resource_mappings = (
+            self._make_resource_mappings(branch_resources) + branch_slim_resources
+        )
 
         new_files: list[str] = []
         modified_files: list[str] = []
@@ -2033,9 +2083,9 @@ class AgentStudioProject:
             branch_r = branch_by_path.get(key)
 
             if parent_r and branch_r:
-                if parent_r.to_pretty(resource_mappings=resource_mappings) != branch_r.to_pretty(
-                    resource_mappings=resource_mappings
-                ):
+                if parent_r.to_pretty(
+                    resource_mappings=before_resource_mappings
+                ) != branch_r.to_pretty(resource_mappings=after_resource_mappings):
                     modified_files.append(branch_r.file_path)
             elif branch_r and not parent_r:
                 new_files.append(branch_r.file_path)
@@ -2326,6 +2376,7 @@ class AgentStudioProject:
                 and resource_type in self._not_loaded_resources
             ):
                 continue
+
             resource_id = resource_info["resource_id"]
             resource_mapping = ResourceMapping(
                 resource_id=resource_id,
@@ -2705,7 +2756,7 @@ class AgentStudioProject:
             self.discover_local_resources()
         )
         all_mappings = new_resources_mappings + kept_resources_mappings
-        resource_mappings: list[ResourceMapping] = [
+        filtered_resource_mappings: list[ResourceMapping] = [
             m
             for m in all_mappings
             if not files
@@ -2715,7 +2766,7 @@ class AgentStudioProject:
                 and _parse_multi_resource_path(m.file_path)[0] in files
             )
         ]
-        return self._format_resources(resource_mappings, check_only=check_only)
+        return self._format_resources(filtered_resource_mappings, check_only=check_only)
 
     def _format_resources(
         self, resource_mappings: list[ResourceMapping], check_only: bool = False
@@ -2790,11 +2841,13 @@ class AgentStudioProject:
         )
         local_resource_mappings = new_resource_mappings + kept_resource_mappings
 
+        resource_mappings = local_resource_mappings + self.slim_resources
+
         resources: ResourceMap = {}
         for resource_mapping in local_resource_mappings:
             local_resource = self.read_local_resource(
                 resource=resource_mapping,
-                resource_mappings=local_resource_mappings,
+                resource_mappings=resource_mappings,
             )
             resources.setdefault(resource_mapping.resource_type, {})[
                 resource_mapping.resource_id
@@ -2802,7 +2855,7 @@ class AgentStudioProject:
 
         return self.validate_resources(
             resources_dict=resources,
-            resource_mappings=local_resource_mappings,
+            resource_mappings=resource_mappings,
         )
 
     @staticmethod
@@ -2994,7 +3047,9 @@ class AgentStudioProject:
         if self.get_diffs():
             raise ValueError("Cannot sync ids due to uncommitted changes.")
 
-        sandbox_resources = self.get_remote_resources_by_name("main")
+        # Sandbox slim mappings describe what main withheld; local files resolve their
+        # references against this branch's own slim mappings, so they are not needed here.
+        sandbox_resources, _ = self.get_remote_resources_by_name("main")
         # Build lookup by file path -> Resource
         sandbox_resource_lookup: dict[str, Resource] = {}
         for resources_dict in sandbox_resources.values():
@@ -3075,6 +3130,7 @@ class AgentStudioProject:
                 path = resource.file_path
                 branch_by_path[path] = (resource_type, resource_id, resource)
 
+        slim_mappings = self.slim_resources
         new_state: ResourceMap = {}
         for mapping in sync_mappings:
             relative_file_path = os.path.relpath(mapping.file_path, self.root_path)
@@ -3083,7 +3139,7 @@ class AgentStudioProject:
             sandbox_resource = sandbox_resource_lookup.get(relative_file_path, branch_resource)
             local_resource = self.read_local_resource(
                 resource=mapping,
-                resource_mappings=sync_mappings,
+                resource_mappings=[*slim_mappings, *sync_mappings],
                 original_resource=sandbox_resource,
             )
 

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -546,6 +546,8 @@ class AgentStudioProject:
             original_resources=empty_resources,
             incoming_resources=template_resources,
             force=True,
+            original_slim_resources=[],
+            incoming_slim_resources=template_slim_resources,
         )
 
     def pull_project(
@@ -585,9 +587,6 @@ class AgentStudioProject:
         if projection_json is None:
             self.branch_id = self.api_handler.branch_id
 
-        # Update slim resources in memory
-        self.slim_resources = slim_resources
-
         self._check_no_duplicate_resource_paths(incoming_resources)
         # -------
         # Update resources
@@ -599,6 +598,8 @@ class AgentStudioProject:
             force=force,
             format=format,
             on_save=on_save,
+            original_slim_resources=self.slim_resources,
+            incoming_slim_resources=slim_resources,
         )
 
         # -------
@@ -611,6 +612,7 @@ class AgentStudioProject:
 
         # Save the updated project configuration
         self.resources = incoming_resources
+        self.slim_resources = slim_resources
 
         # Update file_structure_info
         self.file_structure_info = self.compute_file_structure_info(incoming_resources)
@@ -644,7 +646,6 @@ class AgentStudioProject:
         incoming_resources, slim_resources = self.get_remote_resources_by_name(env)
         if not incoming_resources:
             raise ValueError(f"No resources returned from environment '{env}'.")
-        self.slim_resources = slim_resources
         self.branch_id = self.api_handler.branch_id
 
         self._check_no_duplicate_resource_paths(incoming_resources)
@@ -657,7 +658,10 @@ class AgentStudioProject:
             force=True,
             format=format,
             on_save=None,
+            original_slim_resources=self.slim_resources,
+            incoming_slim_resources=slim_resources,
         )
+        self.slim_resources = slim_resources
 
         utils.export_decorators(DECORATORS, self.root_path)
         utils.save_imports(self.root_path)
@@ -958,17 +962,20 @@ class AgentStudioProject:
         force: bool,
         format: bool = False,
         on_save: Callable[[int, int], None] | None = None,
+        *,
+        original_slim_resources: list[ResourceMapping],
+        incoming_slim_resources: list[ResourceMapping],
     ) -> list[str]:
         files_with_conflicts = []
 
         # Generate resource mappings
         incoming_resource_mappings: list[ResourceMapping] = (
-            self._make_resource_mappings(incoming_resources) + self.slim_resources
+            self._make_resource_mappings(incoming_resources) + incoming_slim_resources
         )
 
         # If not force, compare with original and local changes
         original_resource_mappings: list[ResourceMapping] = (
-            self._make_resource_mappings(original_resources) + self.slim_resources
+            self._make_resource_mappings(original_resources) + original_slim_resources
         )
 
         # Merging is done on a per file basis.

--- a/src/poly/resources/__init__.py
+++ b/src/poly/resources/__init__.py
@@ -55,8 +55,12 @@ from poly.resources.resource import (
     BaseResource,
     MultiResourceYamlResource,
     Resource,
+    ResourceMap,
     ResourceMapping,
+    ResourceType,
     SubResource,
+    SubResourceMap,
+    SubResourceType,
     load_resources_from_projection,
     register_resource,
 )

--- a/src/poly/resources/entities.py
+++ b/src/poly/resources/entities.py
@@ -93,9 +93,10 @@ class Entity(MultiResourceYamlResource):
         *,
         resource_id: str,
         name: str,
-        entity_type: str | EntityType,
+        entity_type: str | EntityType | None = None,
         description: str = "",
         config: dict | None = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
@@ -106,17 +107,29 @@ class Entity(MultiResourceYamlResource):
             else entity_type
         )
         self.config = utils.convert_keys_to_snake_case(config or {})
+        self.slim = slim
 
     @classmethod
     def from_projection(cls, projection: dict) -> dict[str, "Entity"]:
         """Parse entities from a projection dict."""
         entities = {}
         entities_projection = projection.get("entities", {}).get("entities", {}).get("entities", {})
-        if "entities" not in projection or any(
-            "type" not in entity for entity in entities_projection.values()
-        ):
+        if "entities" not in projection:
             logger.debug("No read access to entities - they will not be pulled.")
             return {}
+
+        # Auth-filtered: keep id and name only, so {{entity:<id>}} in a readable
+        # topic or flow step still renders as a name rather than a raw id.
+        if any("type" not in entity for entity in entities_projection.values()):
+            logger.debug("No read access to entities - keeping names for references only.")
+            return {
+                entity_id: cls(
+                    resource_id=entity_id,
+                    name=entity_data.get("name", ""),
+                    slim=True,
+                )
+                for entity_id, entity_data in entities_projection.items()
+            }
 
         for entity_id, entity_data in entities_projection.items():
             entities[entity_id] = cls(

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -237,14 +237,15 @@ class Function(Resource):
         *,
         resource_id: str,
         name: str,
-        description: str,
-        code: str,
-        parameters: list[FunctionParameters],
-        latency_control: dict | FunctionLatencyControl,
-        function_type: FunctionType,
+        description: str = "",
+        code: str = "",
+        parameters: list[FunctionParameters] | None = None,
+        latency_control: dict | FunctionLatencyControl | None = None,
+        function_type: FunctionType | None = None,
         flow_id: str | None = None,
         flow_name: str | None = None,
         variable_references: dict | None = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
@@ -258,6 +259,7 @@ class Function(Resource):
         self.flow_name = flow_name
         self.function_type = function_type
         self.variable_references = variable_references
+        self.slim = slim
 
     @staticmethod
     def _parse_latency_control(value) -> FunctionLatencyControl:
@@ -364,10 +366,23 @@ class Function(Resource):
                 )
 
         global_functions = projection.get("functions", {}).get("functions", {}).get("entities", {})
-        if "functions" not in projection or any(
-            "code" not in func for func in global_functions.values()
-        ):
+        if "functions" not in projection:
             logger.debug("No read access to functions - they will not be pulled.")
+            global_functions = {}
+        elif any("code" not in func for func in global_functions.values()):
+            # Auth-filtered: keep id and name only, so {{fn:<id>}} in a readable
+            # topic (or a phrase filter's function) still renders as a name rather
+            # than a raw id. flow_id/flow_name stay None so the stub keeps the
+            # global function's path and "fn" prefix, not a transition's "ft".
+            # Archived functions are stubbed too, since we can't tell them apart.
+            logger.debug("No read access to functions - keeping names for references only.")
+            for func_id, func in global_functions.items():
+                functions[func_id] = cls(
+                    resource_id=func_id,
+                    name=func.get("name", ""),
+                    function_type=FunctionType.GLOBAL,
+                    slim=True,
+                )
             global_functions = {}
 
         for func_id, func in global_functions.items():

--- a/src/poly/resources/handoff.py
+++ b/src/poly/resources/handoff.py
@@ -86,11 +86,13 @@ class Handoff(MultiResourceYamlResource):
         is_default: bool = False,
         sip_config: HandoffSipConfig | dict | None = None,
         sip_headers: list | None = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
         self.description = description
         self.is_default = is_default
+        self.slim = slim
 
         if sip_config is None:
             sip_config = {}
@@ -110,13 +112,24 @@ class Handoff(MultiResourceYamlResource):
         """Parse handoffs from a projection dict."""
         handoffs_projection = projection.get("handoff", {}).get("handoffs", {}).get("entities", {})
         handoffs = {}
-        # Read access is checked before "active": an auth-filtered handoff has no
-        # "active" field, and must not be mistaken for a deactivated one.
-        if "handoff" not in projection or any(
-            "active" not in handoff for handoff in handoffs_projection.values()
-        ):
+        if "handoff" not in projection:
             logger.debug("No read access to handoffs - they will not be pulled.")
             return {}
+
+        # Read access is checked before "active": an auth-filtered handoff has no
+        # "active" field, and must not be mistaken for a deactivated one. Inactive
+        # handoffs are stubbed too, since we can't tell them apart here - harmless,
+        # as an inactive handoff's id is never referenced.
+        if any("active" not in handoff for handoff in handoffs_projection.values()):
+            logger.debug("No read access to handoffs - keeping names for references only.")
+            return {
+                handoff_id: cls(
+                    resource_id=handoff_id,
+                    name=handoff_data.get("name", ""),
+                    slim=True,
+                )
+                for handoff_id, handoff_data in handoffs_projection.items()
+            }
 
         for handoff_id, handoff_data in handoffs_projection.items():
             if not handoff_data.get("active", False):

--- a/src/poly/resources/languages.py
+++ b/src/poly/resources/languages.py
@@ -242,6 +242,9 @@ class AdditionalLanguage(MultiResourceYamlResource):
         self, base_path: str, format: bool = False, save_to_cache: bool = False, **kwargs
     ) -> None:
         """Save this language into the additional_languages list."""
+        # No-op for slim resources, which are not saved to disk.
+        if self.slim:
+            return
         true_file_path = os.path.join(base_path, LANGUAGES_FILE)
         _ensure_languages_file(type(self), true_file_path, save_to_cache)
         top_level = self._get_top_level_data(true_file_path)

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -730,17 +730,19 @@ def register_resource(name: str) -> callable:
 
 
 def _filter_slim_resources(all_resources: ResourceMap) -> tuple[ResourceMap, list[ResourceMapping]]:
+    # Imported here: both modules import from this one at module level.
+    from poly.resources.function import Function
+    from poly.resources.variable import Variable
+
     slim_resources: list[ResourceMapping] = []
     resources: ResourceMap = {}
 
     # Variables are slim if functions are slim
-    functions_slim = any(
-        r.slim for r in all_resources.get(RESOURCE_NAME_TO_CLASS.get("functions"), {}).values()
-    )
+    functions_slim = any(r.slim for r in all_resources.get(Function, {}).values())
 
     for resources_dict in all_resources.values():
         for resource in resources_dict.values():
-            if isinstance(resource, RESOURCE_NAME_TO_CLASS.get("variables")):
+            if isinstance(resource, Variable):
                 resource.slim = functions_slim
 
             if not resource.slim:

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -5,8 +5,8 @@ Copyright PolyAI Limited
 
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import ClassVar, Optional
+from dataclasses import dataclass, field
+from typing import ClassVar, Optional, TypeAlias
 
 from google.protobuf.message import Message
 
@@ -24,6 +24,41 @@ class ResourceMapping:
     flow_name: Optional[str]
     resource_prefix: Optional[str]
     flow_id: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        """Convert the mapping to a JSON serializable dictionary.
+
+        resource_type is stored by its registered name, as the class itself
+        cannot be serialized.
+        """
+        return {
+            "resource_id": self.resource_id,
+            "resource_type": RESOURCE_CLASS_TO_NAME[self.resource_type],
+            "resource_name": self.resource_name,
+            "file_path": self.file_path,
+            "flow_name": self.flow_name,
+            "resource_prefix": self.resource_prefix,
+            "flow_id": self.flow_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Optional["ResourceMapping"]:
+        """Rebuild a mapping from its serialized form.
+
+        Args:
+            data: A dictionary as produced by to_dict().
+
+        Returns:
+            The mapping, or None if the resource type is no longer registered.
+        """
+        mapping_data = dict(data)
+        resource_type = mapping_data.get("resource_type")
+        if isinstance(resource_type, str):
+            resource_type = RESOURCE_NAME_TO_CLASS.get(resource_type)
+        if resource_type is None:
+            return None
+        mapping_data["resource_type"] = resource_type
+        return cls(**mapping_data)
 
 
 @dataclass
@@ -75,6 +110,7 @@ class Resource(BaseResource, ABC):
 
     resource_id: str
     name: str
+    slim: bool = field(default=False, repr=False, init=False)
 
     @staticmethod
     def get_resource_prefix(**kwargs) -> str:
@@ -668,6 +704,12 @@ RESOURCE_CLASS_TO_NAME: dict[type[Resource], str] = {}
 PROJECTION_REGISTRY: list[type[Resource]] = []
 
 
+ResourceType: TypeAlias = type[Resource]
+ResourceMap: TypeAlias = dict[ResourceType, dict[str, Resource]]
+SubResourceType: TypeAlias = type[SubResource]
+SubResourceMap: TypeAlias = dict[SubResourceType, dict[str, SubResource]]
+
+
 def register_resource(name: str) -> callable:
     """Class decorator to register a resource type.
 
@@ -687,9 +729,48 @@ def register_resource(name: str) -> callable:
     return decorator
 
 
+def _filter_slim_resources(all_resources: ResourceMap) -> tuple[ResourceMap, list[ResourceMapping]]:
+    slim_resources: list[ResourceMapping] = []
+    resources: ResourceMap = {}
+
+    # Variables are slim if functions are slim
+    functions_slim = any(
+        r.slim for r in all_resources.get(RESOURCE_NAME_TO_CLASS.get("functions"), {}).values()
+    )
+
+    for resources_dict in all_resources.values():
+        for resource in resources_dict.values():
+            if isinstance(resource, RESOURCE_NAME_TO_CLASS.get("variables")):
+                resource.slim = functions_slim
+
+            if not resource.slim:
+                resources.setdefault(type(resource), {})[resource.resource_id] = resource
+                continue
+            slim_resources.append(
+                ResourceMapping(
+                    resource_id=resource.resource_id,
+                    resource_type=type(resource),
+                    resource_name=resource.name,
+                    file_path=resource.file_path,
+                    flow_name=(
+                        resource.name
+                        if type(resource).__name__ == "FlowConfig"
+                        else getattr(resource, "flow_name", None)
+                    ),
+                    resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
+                    flow_id=(
+                        resource.resource_id
+                        if type(resource).__name__ == "FlowConfig"
+                        else getattr(resource, "flow_id", None)
+                    ),
+                )
+            )
+    return resources, slim_resources
+
+
 def load_resources_from_projection(
     projection: dict,
-) -> dict[type[Resource], dict[str, Resource]]:
+) -> tuple[ResourceMap, list[ResourceMapping]]:
     """Parse a projection dict into typed Resources.
 
     Iterates all registered resource classes and calls their from_projection()
@@ -699,11 +780,16 @@ def load_resources_from_projection(
         projection: Raw projection dict from the Sourcerer API or a local file.
 
     Returns:
-        A dictionary mapping resource types to {resource_id: Resource}.
+        A tuple containing:
+        1. A dictionary mapping resource types to {resource_id: Resource}.
+        2. A list of ResourceMapping objects for slim resources.
     """
     result: dict[type[Resource], dict[str, Resource]] = {}
     for resource_cls in PROJECTION_REGISTRY:
         resources = resource_cls.from_projection(projection)
         if resources:
             result[resource_cls] = resources
-    return result
+
+    filtered_resources, slim_resources = _filter_slim_resources(result)
+
+    return filtered_resources, slim_resources

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -737,7 +737,10 @@ def _filter_slim_resources(all_resources: ResourceMap) -> tuple[ResourceMap, lis
     slim_resources: list[ResourceMapping] = []
     resources: ResourceMap = {}
 
-    # Variables are slim if functions are slim
+    # Variables are slim whenever functions are. Variables have no file of their
+    # own - they exist as a reference graph derived from function code - and
+    # variableUpdate is gated on jupiter_flows rather than functions, so the API
+    # would accept a graph rebuilt from functions the user cannot read.
     functions_slim = any(r.slim for r in all_resources.get(Function, {}).values())
 
     for resources_dict in all_resources.values():

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -754,17 +754,9 @@ def _filter_slim_resources(all_resources: ResourceMap) -> tuple[ResourceMap, lis
                     resource_type=type(resource),
                     resource_name=resource.name,
                     file_path=resource.file_path,
-                    flow_name=(
-                        resource.name
-                        if type(resource).__name__ == "FlowConfig"
-                        else getattr(resource, "flow_name", None)
-                    ),
+                    flow_name=getattr(resource, "flow_name", None),
                     resource_prefix=resource.get_resource_prefix(file_path=resource.file_path),
-                    flow_id=(
-                        resource.resource_id
-                        if type(resource).__name__ == "FlowConfig"
-                        else getattr(resource, "flow_id", None)
-                    ),
+                    flow_id=getattr(resource, "flow_id", None),
                 )
             )
     return resources, slim_resources

--- a/src/poly/resources/resource.py
+++ b/src/poly/resources/resource.py
@@ -5,7 +5,7 @@ Copyright PolyAI Limited
 
 import os
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from typing import ClassVar, Optional, TypeAlias
 
 from google.protobuf.message import Message
@@ -49,16 +49,24 @@ class ResourceMapping:
             data: A dictionary as produced by to_dict().
 
         Returns:
-            The mapping, or None if the resource type is no longer registered.
+            The mapping, or None if the resource type is no longer registered or
+            the data does not fit the mapping shape. The status file outlives any
+            one ADK version, so unknown data is dropped rather than raised on.
         """
-        mapping_data = dict(data)
+        field_names = {f.name for f in fields(cls)}
+        # Ignore keys a newer ADK (or a hand edit) may have added.
+        mapping_data = {key: value for key, value in data.items() if key in field_names}
         resource_type = mapping_data.get("resource_type")
         if isinstance(resource_type, str):
             resource_type = RESOURCE_NAME_TO_CLASS.get(resource_type)
         if resource_type is None:
             return None
         mapping_data["resource_type"] = resource_type
-        return cls(**mapping_data)
+        try:
+            return cls(**mapping_data)
+        except TypeError:
+            # Missing required fields - drop the one mapping, not the command.
+            return None
 
 
 @dataclass

--- a/src/poly/resources/sms.py
+++ b/src/poly/resources/sms.py
@@ -50,12 +50,14 @@ class SMSTemplate(MultiResourceYamlResource):
         *,
         resource_id: str,
         name: str,
-        text: str,
+        text: str = "",
         env_phone_numbers: EnvPhoneNumbers | dict | None = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
         self.text = text
+        self.slim = slim
         if env_phone_numbers is None:
             self.env_phone_numbers = None
         elif isinstance(env_phone_numbers, EnvPhoneNumbers):
@@ -75,13 +77,24 @@ class SMSTemplate(MultiResourceYamlResource):
             projection.get("sms", {}).get("templates", {}).get("entities", {})
         )
         sms_templates = {}
-        # Read access is checked before "active": an auth-filtered template has no
-        # "active" field, and must not be mistaken for a deactivated one.
-        if "sms" not in projection or any(
-            "active" not in template for template in sms_templates_projection.values()
-        ):
+        if "sms" not in projection:
             logger.debug("No read access to SMS templates - they will not be pulled.")
             return {}
+
+        # Read access is checked before "active": an auth-filtered template has no
+        # "active" field, and must not be mistaken for a deactivated one. Inactive
+        # templates are stubbed too, since we can't tell them apart here - harmless,
+        # as an inactive template's id is never referenced.
+        if any("active" not in template for template in sms_templates_projection.values()):
+            logger.debug("No read access to SMS templates - keeping names for references only.")
+            return {
+                template_id: cls(
+                    resource_id=template_id,
+                    name=template_data.get("name", ""),
+                    slim=True,
+                )
+                for template_id, template_data in sms_templates_projection.items()
+            }
 
         for sms_template_id, sms_template_data in sms_templates_projection.items():
             if not sms_template_data.get("active", False):

--- a/src/poly/resources/translations.py
+++ b/src/poly/resources/translations.py
@@ -43,12 +43,21 @@ class Translation(MultiResourceYamlResource):
         if not translations_data:
             return {}
 
+        # Auth-filtered: keep id and translation key only, so {{tn:<id>}} in a
+        # readable topic or behaviour rule still renders as a key, not a raw id.
         if any(
             "translations" not in translation_data
             for translation_data in translations_data.values()
         ):
-            logger.debug("No read access to translations - they will not be pulled.")
-            return {}
+            logger.debug("No read access to translations - keeping keys for references only.")
+            return {
+                translation_id: cls(
+                    resource_id=translation_id,
+                    name=translation_data.get("translationKey", ""),
+                    slim=True,
+                )
+                for translation_id, translation_data in translations_data.items()
+            }
 
         translations = {}
         for translation_id, translation_data in translations_data.items():
@@ -68,10 +77,12 @@ class Translation(MultiResourceYamlResource):
         resource_id: Optional[str] = None,
         name: str = "",
         translations: dict[str, str] = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name or ""
         self.translations = translations if translations is not None else {}
+        self.slim = slim
 
     @property
     def file_path(self) -> str:

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -39,10 +39,12 @@ class Variant(MultiResourceYamlResource):
         resource_id: str,
         name: str,
         is_default: bool = False,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
         self.is_default = is_default
+        self.slim = slim
         self.attribute_ids = []
 
     def to_yaml_dict(self) -> dict:
@@ -68,14 +70,23 @@ class Variant(MultiResourceYamlResource):
         variants_projection = (
             projection.get("variantManagement", {}).get("variants", {}).get("entities", {})
         )
+        if "variantManagement" not in projection:
+            logger.debug("No read access to variants - they will not be pulled.")
+            return {}
+
         # Guard on "isDefault", not "name": names are deliberately exposed to
         # filtered readers so test cases can resolve their variant, so a name
         # no longer distinguishes a readable variant from a withheld one.
-        if "variantManagement" not in projection or any(
-            "isDefault" not in variant for variant in variants_projection.values()
-        ):
-            logger.debug("No read access to variants - they will not be pulled.")
-            return {}
+        if any("isDefault" not in variant for variant in variants_projection.values()):
+            logger.debug("No read access to variants - keeping names for references only.")
+            return {
+                variant_id: cls(
+                    resource_id=variant_id,
+                    name=variant_data.get("name", ""),
+                    slim=True,
+                )
+                for variant_id, variant_data in variants_projection.items()
+            }
 
         for variant_id, variant_data in variants_projection.items():
             variants[variant_id] = cls(
@@ -191,11 +202,13 @@ class VariantAttribute(MultiResourceYamlResource):
         *,
         resource_id: str,
         name: str,
-        mappings: dict[str, str],
+        mappings: dict[str, str] | None = None,
+        slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
-        self.mappings = mappings
+        self.mappings = mappings if mappings is not None else {}
+        self.slim = slim
 
     def to_yaml_dict(self) -> dict:
         return {
@@ -232,13 +245,27 @@ class VariantAttribute(MultiResourceYamlResource):
         attributes_projection = (
             projection.get("variantManagement", {}).get("attributes", {}).get("entities", {})
         )
-        # "archived" is optional in the API schema, so it can't distinguish an
-        # auth-filtered attribute from an unarchived one. "type" always is.
-        if "variantManagement" not in projection or any(
-            "type" not in attribute for attribute in attributes_projection.values()
-        ):
+        if "variantManagement" not in projection:
             logger.debug("No read access to variant attributes - they will not be pulled.")
             return {}
+
+        # "archived" is optional in the API schema, so it can't distinguish an
+        # auth-filtered attribute from an unarchived one. "type" always is.
+        # Auth-filtered: keep id and name only, so {{attr:<id>}} in a readable
+        # topic or prompt still renders as a name rather than a raw id. Archived
+        # attributes are stubbed too, since we can't tell them apart here.
+        if any("type" not in attribute for attribute in attributes_projection.values()):
+            logger.debug(
+                "No read access to variant attributes - keeping names for references only."
+            )
+            return {
+                attribute_id: cls(
+                    resource_id=attribute_id,
+                    name=attribute_data.get("name", ""),
+                    slim=True,
+                )
+                for attribute_id, attribute_data in attributes_projection.items()
+            }
 
         for attribute_id, attribute_data in attributes_projection.items():
             if attribute_data.get("archived"):

--- a/src/poly/tests/api/interface_test.py
+++ b/src/poly/tests/api/interface_test.py
@@ -125,12 +125,15 @@ class PullResourcesWithProjection(unittest.TestCase):
         """Passing projection_json bypasses the sync client and loads locally."""
         interface = AgentStudioInterface()
         interface.sync_client = MagicMock()
-        mock_loader.return_value = {"loaded": "resources"}
+        mock_loader.return_value = ({"loaded": "resources"}, ["slim"])
         projection = {"knowledgeBase": {}}
 
-        resources, returned_projection = interface.pull_resources(projection_json=projection)
+        resources, slim_resources, returned_projection = interface.pull_resources(
+            projection_json=projection
+        )
 
         self.assertEqual(resources, {"loaded": "resources"})
+        self.assertEqual(slim_resources, ["slim"])
         self.assertIs(returned_projection, projection)
         mock_loader.assert_called_once_with(projection)
         interface.sync_client.pull_projection.assert_not_called()

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -105,6 +105,7 @@ class InitProjectOnSaveTest(unittest.TestCase):
         """on_save should be called once per resource with (current, total)"""
         self.mock_api_handler.pull_resources.return_value = (
             AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR).resources,
+            [],
             {},
         )
         on_save = MagicMock()
@@ -126,6 +127,7 @@ class InitProjectOnSaveTest(unittest.TestCase):
         """init_project without on_save should work without errors"""
         self.mock_api_handler.pull_resources.return_value = (
             AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR).resources,
+            [],
             {},
         )
 
@@ -2705,7 +2707,7 @@ class PullProjectTest(unittest.TestCase):
         # Incoming resources are the same as project.resources
         # Use the actual resources from the project to ensure they match
         original_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (original_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (original_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
         self.assertEqual(files_with_conflicts, [])
@@ -2732,7 +2734,7 @@ class PullProjectTest(unittest.TestCase):
         # Simulate pull: incoming has variant_attributes from remote
         full_project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         incoming_resources = full_project.resources
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         with mock_read_from_file(
             {os.path.join(TEST_DIR, "config", "variant_attributes.yaml"): "{}\n"}
@@ -2762,7 +2764,7 @@ class PullProjectTest(unittest.TestCase):
             example_queries=["New query"],
         )
         incoming_resources.setdefault(Topic, {})["TOPIC-new_topic"] = new_topic
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
         self.assertEqual(files_with_conflicts, [])
@@ -2778,7 +2780,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         if Topic in incoming_resources and "TOPIC-Topic 1" in incoming_resources[Topic]:
             del incoming_resources[Topic]["TOPIC-Topic 1"]
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
 
@@ -2797,7 +2799,7 @@ class PullProjectTest(unittest.TestCase):
         modified_func = deepcopy(incoming_resources[Function][func_id])
         modified_func.code = 'def test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Modified"\n'
         incoming_resources[Function][func_id] = modified_func
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
         self.assertEqual(files_with_conflicts, [])
@@ -2815,7 +2817,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[Function][
             "FUNCTION-test_function"
         ].code = 'def test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Remote change"\n'
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         with mock_read_from_file(
             {
@@ -2855,7 +2857,7 @@ class PullProjectTest(unittest.TestCase):
         modified_flow_config = deepcopy(incoming_resources[FlowConfig][flow_config_id])
         modified_flow_config.description = "Modified remotely - new description"
         incoming_resources[FlowConfig][flow_config_id] = modified_flow_config
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         # Mock local file with different changes
         flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
@@ -2906,7 +2908,7 @@ class PullProjectTest(unittest.TestCase):
         modified_flow_config = deepcopy(incoming_resources[FlowConfig][flow_config_id])
         modified_flow_config.description = "Modified remotely"
         incoming_resources[FlowConfig][flow_config_id] = modified_flow_config
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         flow_config_path = os.path.join(TEST_DIR, "flows", "test_flow", "flow_config.yaml")
         # Local file: same semantic content as original but with trailing whitespace
@@ -2939,7 +2941,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[Function][
             "FUNCTION-test_function"
         ].code = 'def test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Remote change"\n'
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         with mock_read_from_file(
             {
@@ -2976,7 +2978,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources[Function][
             "FUNCTION-test_function"
         ].code = 'def test_function(conv: Conversation):\n    """Modified remotely."""\n    return "Remote change"\n'
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         with mock_read_from_file(
             {
@@ -3001,7 +3003,7 @@ class PullProjectTest(unittest.TestCase):
         full_project_resources = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR).resources
         incoming_resources = deepcopy(full_project_resources)
 
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
         files_with_conflicts, _ = project.pull_project(force=False, format=True)
         self.assertEqual(files_with_conflicts, [])
         # Verify resource is updated in project resources
@@ -3028,7 +3030,7 @@ class PullProjectTest(unittest.TestCase):
             "FUNCTION-test_function_with_parameters"
         ].code = 'def test_function_with_parameters(conv: Conversation):\n    """Test function with parameters."""\n    return "Test function with parameters"\n'
 
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
         files_with_conflicts, _ = project.pull_project(force=False)
         self.assertEqual(len(files_with_conflicts), 1)
 
@@ -3046,7 +3048,7 @@ class PullProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(project_data, TEST_DIR)
         incoming_resources = deepcopy(project.resources)
 
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
         files_with_conflicts, _ = project.pull_project(force=False)
         self.assertEqual(files_with_conflicts, [])
 
@@ -3074,7 +3076,7 @@ class PullProjectTest(unittest.TestCase):
         # Rename the topic (this changes the file path)
         renamed_topic.name = "renamed_topic"
 
-        self.mock_api_handler.pull_resources.return_value = (original_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (original_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
 
@@ -3091,7 +3093,7 @@ class PullProjectTest(unittest.TestCase):
         """Test that empty flow folders are deleted after pull"""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         original_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (original_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (original_resources, [], {})
 
         # Mock os.listdir and os.rmdir to verify empty folder deletion
         empty_flow_path = os.path.join(TEST_DIR, "flows", "test_flow")
@@ -3157,7 +3159,7 @@ class PullProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         incoming_resources = deepcopy(project.resources)
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         # dump_yaml format produced by MultiResourceYamlResource.save(save_to_cache=True)
@@ -3202,7 +3204,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         # Remote: PolyAI level maximum → boosted
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         original_kp_content = (
@@ -3259,7 +3261,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         # Remote: PolyAI level maximum → boosted
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
         original_kp_content = (
@@ -3312,7 +3314,7 @@ class PullProjectTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         # Remote: PolyAI level maximum → boosted
         incoming_resources[KeyphraseBoosting]["KEYPHRASE_BOOSTING-polyai"].level = "boosted"
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         kp_path = os.path.join(TEST_DIR, "voice", "speech_recognition", "keyphrase_boosting.yaml")
 
@@ -3338,7 +3340,7 @@ class PullProjectTest(unittest.TestCase):
         """on_save should be called during pull with correct final progress"""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         incoming_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         on_save = MagicMock()
         files_with_conflicts, _ = project.pull_project(on_save=on_save)
@@ -3353,7 +3355,7 @@ class PullProjectTest(unittest.TestCase):
         """pull_project without on_save should work without errors"""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         incoming_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project()
         self.assertEqual(files_with_conflicts, [])
@@ -3370,7 +3372,7 @@ class PullProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
         incoming_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         # Local file has mixed-case level values (not yet normalised)
         local_keyphrases_yaml = (
@@ -3422,7 +3424,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
 
     def test_raises_when_no_active_deployment(self):
         """Empty resource map (e.g. live not yet deployed) raises with a clear message."""
-        self.mock_get_remote.return_value = {}
+        self.mock_get_remote.return_value = ({}, [])
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
         with self.assertRaises(ValueError) as ctx:
@@ -3434,7 +3436,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
 
     def test_raises_for_pre_release_when_not_deployed(self):
         """Same guard applies for pre-release, not just live."""
-        self.mock_get_remote.return_value = {}
+        self.mock_get_remote.return_value = ({}, [])
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
         with self.assertRaises(ValueError) as ctx:
@@ -3449,7 +3451,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
     def test_calls_get_remote_with_correct_env(self):
         """get_remote_resources_by_name is invoked with the exact env string passed in."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-        self.mock_get_remote.return_value = deepcopy(project.resources)
+        self.mock_get_remote.return_value = (deepcopy(project.resources), [])
 
         project.pull_project_from_env(env="pre-release")
 
@@ -3464,7 +3466,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         original_resources = deepcopy(project.resources)
         incoming_resources = deepcopy(project.resources)
-        self.mock_get_remote.return_value = incoming_resources
+        self.mock_get_remote.return_value = (incoming_resources, [])
 
         files_with_conflicts = project.pull_project_from_env(env="live")
 
@@ -3482,7 +3484,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
         modified_func = deepcopy(incoming_resources[Function][func_id])
         modified_func.code = 'def test_function(conv: Conversation):\n    """Modified in live."""\n    return "Live"\n'
         incoming_resources[Function][func_id] = modified_func
-        self.mock_get_remote.return_value = incoming_resources
+        self.mock_get_remote.return_value = (incoming_resources, [])
 
         files_with_conflicts = project.pull_project_from_env(env="live")
 
@@ -3503,7 +3505,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
             example_queries=["live query"],
         )
         incoming_resources.setdefault(Topic, {})["TOPIC-live_only_topic"] = new_topic
-        self.mock_get_remote.return_value = incoming_resources
+        self.mock_get_remote.return_value = (incoming_resources, [])
 
         files_with_conflicts = project.pull_project_from_env(env="live")
 
@@ -3525,7 +3527,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
         incoming_resources[Function][
             func_id
         ].code = 'def test_function(conv: Conversation):\n    return "From live"\n'
-        self.mock_get_remote.return_value = incoming_resources
+        self.mock_get_remote.return_value = (incoming_resources, [])
 
         files_with_conflicts = project.pull_project_from_env(env="pre-release")
 
@@ -3540,7 +3542,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
         incoming_resources = deepcopy(project.resources)
         if Topic in incoming_resources and "TOPIC-Topic 1" in incoming_resources[Topic]:
             del incoming_resources[Topic]["TOPIC-Topic 1"]
-        self.mock_get_remote.return_value = incoming_resources
+        self.mock_get_remote.return_value = (incoming_resources, [])
 
         files_with_conflicts = project.pull_project_from_env(env="live")
 
@@ -3556,7 +3558,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
     def test_save_config_not_called_and_imports_saved_on_success(self):
         """save_config must NOT be called (env changes are local); save_imports is called."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
-        self.mock_get_remote.return_value = deepcopy(project.resources)
+        self.mock_get_remote.return_value = (deepcopy(project.resources), [])
 
         project.pull_project_from_env(env="live")
 
@@ -3565,7 +3567,7 @@ class PullProjectFromEnvTest(unittest.TestCase):
 
     def test_save_config_not_called_when_no_deployment(self):
         """save_config must not be called if the deployment lookup fails."""
-        self.mock_get_remote.return_value = {}
+        self.mock_get_remote.return_value = ({}, [])
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
         with self.assertRaises(ValueError):
@@ -3688,18 +3690,41 @@ class GetRemoteResourcesByNameLocalTest(unittest.TestCase):
         """'local' should resolve to the current local filesystem state."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
-        result = project.get_remote_resources_by_name("local")
+        result, slim_resources = project.get_remote_resources_by_name("local")
 
         self.assertIsInstance(result, dict)
         self.assertGreater(len(result), 0)
+        self.assertEqual(slim_resources, project.slim_resources)
 
     def test_local_resources_match_project_resources(self):
         """Resources returned for 'local' should have the same resource types as project.resources."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
 
-        result = project.get_remote_resources_by_name("local")
+        result, _ = project.get_remote_resources_by_name("local")
 
         self.assertEqual(set(result.keys()), set(project.resources.keys()))
+
+    def test_every_resolution_mode_returns_a_resources_and_slim_pair(self):
+        """The return shape has to be the same whichever name resolves.
+
+        Callers unpack two values, so a branch of this method that returns a bare
+        resource map raises far from the cause - and the branch path is the one that
+        no other test exercises.
+        """
+        project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
+        self.mock_api_handler.get_branches.return_value = {"dev": {"branchId": "BRANCH-1"}}
+        self.mock_api_handler.pull_deployment_resources.return_value = ({}, [])
+        self.mock_api_handler.get_active_deployments.return_value = {
+            "sandbox": {"deployment_id": "dep-1"}
+        }
+
+        with patch("poly.project.AgentStudioInterface") as mock_interface:
+            mock_interface.return_value.pull_resources.return_value = ({}, [], {})
+            for name in ("sandbox", "dev", "abc123456", "local", "nothing-matches-this"):
+                with self.subTest(name=name):
+                    resources, slim_resources = project.get_remote_resources_by_name(name)
+                    self.assertIsInstance(resources, dict)
+                    self.assertIsInstance(slim_resources, list)
 
     def test_hash_lookup_tolerates_none_version_hash(self):
         """A deployment record with version_hash=None should not raise TypeError during hash lookup."""
@@ -3834,6 +3859,7 @@ class FetchProjectTest(unittest.TestCase):
         expected_projection = {"some": "projection"}
         self.mock_api_handler.pull_resources.return_value = (
             expected_resources,
+            [],
             expected_projection,
         )
         self.mock_api_handler.branch_id = "remote-branch-id"
@@ -3850,6 +3876,7 @@ class FetchProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {},
         )
         self.mock_api_handler.branch_id = "api-branch-42"
@@ -3867,6 +3894,7 @@ class FetchProjectTest(unittest.TestCase):
         }
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {},
         )
         self.mock_api_handler.branch_id = "branch-2"
@@ -3893,6 +3921,7 @@ class FetchProjectTest(unittest.TestCase):
         original_branch_id = project.branch_id
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {"cached": True},
         )
         self.mock_api_handler.branch_id = "should-not-be-used"
@@ -3909,6 +3938,7 @@ class FetchProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {},
         )
         self.mock_api_handler.branch_id = "b"
@@ -3925,6 +3955,7 @@ class FetchProjectTest(unittest.TestCase):
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {},
         )
         self.mock_api_handler.branch_id = "b"
@@ -3938,7 +3969,7 @@ class FetchProjectTest(unittest.TestCase):
         """fetch_project should recompute file_structure_info from the new resources."""
         project = AgentStudioProject.from_dict(PROJECT_DATA, TEST_DIR)
         new_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (new_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (new_resources, [], {})
         self.mock_api_handler.branch_id = "b"
 
         project.fetch_project()
@@ -3952,6 +3983,7 @@ class FetchProjectTest(unittest.TestCase):
         self.mock_api_handler.get_branches.return_value = {"staging": {"branchId": "staging-id"}}
         self.mock_api_handler.pull_resources.return_value = (
             deepcopy(project.resources),
+            [],
             {},
         )
         # After pull, the api_handler.branch_id may differ from the branch dict value
@@ -3993,7 +4025,7 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
 
         # Remove Topics entirely from incoming — simulates remote having deleted all topics
         del incoming_resources[Topic]
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
 
@@ -4020,7 +4052,7 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
 
         # Remove Entities entirely from incoming — simulates remote having deleted all entities
         del incoming_resources[Entity]
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         MultiResourceYamlResource._file_cache.clear()
         with patch.object(Entity, "delete_resource") as mock_delete:
@@ -4049,7 +4081,7 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
         self.assertGreater(len(entity_names), 0)
 
         del incoming_resources[Entity]
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         MultiResourceYamlResource._file_cache.clear()
         project.pull_project(force=False)
@@ -4086,7 +4118,7 @@ class UpdatePulledResourcesDeleteAbsentTypesTest(unittest.TestCase):
         # Incoming also doesn't have VariantAttribute — but since it's "not loaded",
         # we should NOT delete local files for it
         incoming_resources = deepcopy(project.resources)
-        self.mock_api_handler.pull_resources.return_value = (incoming_resources, {})
+        self.mock_api_handler.pull_resources.return_value = (incoming_resources, [], {})
 
         files_with_conflicts, _ = project.pull_project(force=False)
 
@@ -4277,6 +4309,7 @@ class MigrateFlowStepSettingsTest(unittest.TestCase):
         migrate_flow_step_settings(status_dict)
 
         self.assertNotIn("settings", status_dict["resources"]["flow_steps"]["FLOW-abc_step-1"])
+
 
 class SyncBranchProject(unittest.TestCase):
     """Tests for AgentStudioProject.sync_branch."""
@@ -4629,8 +4662,8 @@ class DiffBranchTest(unittest.TestCase):
         branch_resources = {Topic: {"TOPIC-1": branch_topic}}
 
         self.mock_api.pull_branch_resources.side_effect = [
-            parent_resources,
-            branch_resources,
+            (parent_resources, []),
+            (branch_resources, []),
         ]
 
         diffs = self.project.diff_branch(branch_name="feature-x")
@@ -4664,8 +4697,8 @@ class DiffBranchTest(unittest.TestCase):
         identical_resources = {Topic: {"TOPIC-1": topic}}
 
         self.mock_api.pull_branch_resources.side_effect = [
-            identical_resources,
-            deepcopy(identical_resources),
+            (identical_resources, []),
+            (deepcopy(identical_resources), []),
         ]
 
         result = self.project.diff_branch(branch_name="feature-y")
@@ -4686,8 +4719,8 @@ class DiffBranchTest(unittest.TestCase):
 
         topic = self._make_topic("TOPIC-1", "Hours", "9am-5pm")
         self.mock_api.pull_branch_resources.side_effect = [
-            {Topic: {"TOPIC-1": topic}},
-            {Topic: {"TOPIC-1": deepcopy(topic)}},
+            ({Topic: {"TOPIC-1": topic}}, []),
+            ({Topic: {"TOPIC-1": deepcopy(topic)}}, []),
         ]
 
         self.project.diff_branch(branch_name="feature-z")
@@ -4723,8 +4756,8 @@ class DiffBranchTest(unittest.TestCase):
         }
 
         self.mock_api.pull_branch_resources.side_effect = [
-            parent_resources,
-            branch_resources,
+            (parent_resources, []),
+            (branch_resources, []),
         ]
 
         topic_a_path = os.path.join("topics", "topic_a.yaml")
@@ -4752,8 +4785,8 @@ class DiffBranchTest(unittest.TestCase):
         topic_new = self._make_topic("TOPIC-1", "Hours", "new")
 
         self.mock_api.pull_branch_resources.side_effect = [
-            {Topic: {"TOPIC-1": topic}},
-            {Topic: {"TOPIC-1": topic_new}},
+            ({Topic: {"TOPIC-1": topic}}, []),
+            ({Topic: {"TOPIC-1": topic_new}}, []),
         ]
 
         result = self.project.diff_branch(
@@ -4779,8 +4812,8 @@ class DiffBranchTest(unittest.TestCase):
 
         topic = self._make_topic("TOPIC-1", "FAQ", "same")
         self.mock_api.pull_branch_resources.side_effect = [
-            {Topic: {"TOPIC-1": topic}},
-            {Topic: {"TOPIC-1": deepcopy(topic)}},
+            ({Topic: {"TOPIC-1": topic}}, []),
+            ({Topic: {"TOPIC-1": deepcopy(topic)}}, []),
         ]
 
         result = self.project.diff_branch()
@@ -5650,7 +5683,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         sandbox_resources = self._sandbox_resources_with_reassigned_flow_id()
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox_resources, [])
         ):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
@@ -5664,12 +5697,10 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         flow_id is translated the prefix and flow_id disagree and the flow id stays welded
         onto start_step exactly as it did in the unfixed case.
         """
-        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(
-            without_start_step=True
-        )
+        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(without_start_step=True)
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox_resources, [])
         ):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
@@ -5678,12 +5709,10 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
 
     def test_branch_only_step_is_rekeyed_onto_the_sandbox_flow_id(self):
         """A step added on the branch adopts the sandbox flow id in its composite id."""
-        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(
-            without_start_step=True
-        )
+        sandbox_resources = self._sandbox_resources_with_reassigned_flow_id(without_start_step=True)
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox_resources, [])
         ):
             self.project.sync_ids_with_sandbox()
 
@@ -5730,7 +5759,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
             sandbox[resource_type] = rekeyed
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox, [])
         ):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
@@ -5764,7 +5793,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         self.assertTrue(flow_scoped_function_ids, "fixture must have flow-scoped functions")
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox_resources, [])
         ):
             self.project.sync_ids_with_sandbox()
 
@@ -5780,7 +5809,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         sandbox_resources = self._sandbox_resources_with_reassigned_flow_id()
 
         with patch.object(
-            AgentStudioProject, "get_remote_resources_by_name", return_value=sandbox_resources
+            AgentStudioProject, "get_remote_resources_by_name", return_value=(sandbox_resources, [])
         ):
             self.project.sync_ids_with_sandbox()
 
@@ -5795,7 +5824,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         with patch.object(
             AgentStudioProject,
             "get_remote_resources_by_name",
-            return_value=deepcopy(self.project.resources),
+            return_value=(deepcopy(self.project.resources), []),
         ):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
@@ -5813,7 +5842,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         with patch.object(
             AgentStudioProject,
             "get_remote_resources_by_name",
-            return_value=deepcopy(self.project.resources),
+            return_value=(deepcopy(self.project.resources), []),
         ):
             self.assertTrue(self.project.sync_ids_with_sandbox())
 
@@ -5834,7 +5863,7 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
             patch.object(
                 AgentStudioProject,
                 "get_remote_resources_by_name",
-                return_value=deepcopy(self.project.resources),
+                return_value=(deepcopy(self.project.resources), []),
             ),
             patch.object(
                 AgentStudioProject,

--- a/src/poly/tests/slim_projection_test.py
+++ b/src/poly/tests/slim_projection_test.py
@@ -396,6 +396,21 @@ class SlimResourcesSurviveTheStatusFile(unittest.TestCase):
 
         self.assertEqual(reloaded_names, names)
 
+    def test_from_dict_ignores_keys_from_a_newer_adk(self):
+        """The status file outlives any one ADK version.
+
+        A field added by a newer version (or a hand edit) must not turn every
+        later command into a TypeError.
+        """
+        mapping = next(iter(self._project().slim_resources))
+        data = {**mapping.to_dict(), "added_in_a_newer_version": True}
+
+        self.assertEqual(ResourceMapping.from_dict(data), mapping)
+
+    def test_from_dict_drops_a_mapping_missing_required_fields(self):
+        """A truncated entry loses that one mapping, not the whole command."""
+        self.assertIsNone(ResourceMapping.from_dict({"resource_type": "entities"}))
+
     def test_slim_resources_are_absent_from_file_structure_info(self):
         """No file on disk means no baseline entry.
 

--- a/src/poly/tests/slim_projection_test.py
+++ b/src/poly/tests/slim_projection_test.py
@@ -9,13 +9,27 @@ delete, which is honest, since from that user's vantage point it does not exist.
 Copyright PolyAI Limited
 """
 
+import os
+import tempfile
 import unittest
+from datetime import datetime
+from unittest.mock import MagicMock, patch
 
 import poly.resources  # noqa: F401  - triggers resource registration
+import poly.resources.resource_utils as resource_utils
+from poly.project import AgentStudioProject
+from poly.resources.entities import Entity
 from poly.resources.function import Function
-from poly.resources.resource import PROJECTION_REGISTRY, RESOURCE_CLASS_TO_NAME
+from poly.resources.resource import (
+    PROJECTION_REGISTRY,
+    RESOURCE_CLASS_TO_NAME,
+    MultiResourceYamlResource,
+    load_resources_from_projection,
+)
 from poly.resources.sms import SMSTemplate
 from poly.resources.topic import Topic
+from poly.resources.variable import Variable
+from poly.utils.prepush import fix_orphaned_variables
 
 # A projection where every slice came back auth-filtered, built from the fields
 # each slice declares in its alwaysPresentJsonPaths allow-list. Slices whose
@@ -132,31 +146,50 @@ SKELETON_PROJECTION = {
 
 # Variables and their names are the whole of the Variable resource, and the
 # variables slice keeps both, so a filtered slice is indistinguishable from - and
-# just as usable as - a full one. Nothing else should survive.
+# just as usable as - a full one.
 TYPES_READABLE_FROM_SKELETON = {"variables"}
+
+# Types whose ids appear inside a resource gated on a *different* permission.
+# These are kept as identity-only stubs so those references still resolve to a
+# name; everything else withheld is dropped entirely.
+TYPES_KEPT_AS_SLIM = {
+    "entities",
+    "functions",
+    "handoffs",
+    "sms_templates",
+    "translations",
+    "variant_attributes",
+    "variants",
+}
 
 
 class SkeletonProjectionParsing(unittest.TestCase):
     """Every registered resource must tolerate an auth-filtered projection."""
+
+    @staticmethod
+    def _parse(resource_cls):
+        return resource_cls.from_projection(SKELETON_PROJECTION)
 
     def test_no_resource_type_raises(self):
         """A slim projection must never abort the pull."""
         for resource_cls in PROJECTION_REGISTRY:
             name = RESOURCE_CLASS_TO_NAME[resource_cls]
             with self.subTest(resource=name):
-                resource_cls.from_projection(SKELETON_PROJECTION)
+                self._parse(resource_cls)
 
-    def test_only_fully_readable_types_are_represented(self):
-        """Anything the user cannot read is hidden rather than partly built."""
-        represented = {
-            RESOURCE_CLASS_TO_NAME[cls]
-            for cls in PROJECTION_REGISTRY
-            if cls.from_projection(SKELETON_PROJECTION)
-        }
-        self.assertEqual(represented, TYPES_READABLE_FROM_SKELETON)
+    def test_only_referenced_types_survive_as_slim(self):
+        """Withheld resources are dropped unless something else points at them."""
+        real, slim = set(), set()
+        for resource_cls in PROJECTION_REGISTRY:
+            name = RESOURCE_CLASS_TO_NAME[resource_cls]
+            for resource in self._parse(resource_cls).values():
+                (slim if resource.slim else real).add(name)
 
-    def test_represented_resources_survive_downstream_operations(self):
-        """Whatever is kept must be usable, not a half-built object.
+        self.assertEqual(real, TYPES_READABLE_FROM_SKELETON)
+        self.assertEqual(slim, TYPES_KEPT_AS_SLIM)
+
+    def test_readable_resources_survive_downstream_operations(self):
+        """Whatever is kept in full must be usable, not a half-built object.
 
         compute_hash and file_path run on every pull and push, so a resource
         that parses but blows up here fails far from the cause - which is how
@@ -164,10 +197,30 @@ class SkeletonProjectionParsing(unittest.TestCase):
         """
         for resource_cls in PROJECTION_REGISTRY:
             name = RESOURCE_CLASS_TO_NAME[resource_cls]
-            for resource in resource_cls.from_projection(SKELETON_PROJECTION).values():
+            for resource in self._parse(resource_cls).values():
+                if resource.slim:
+                    continue
                 with self.subTest(resource=name):
                     resource.compute_hash()
                     resource.validate()
+
+    def test_slim_resources_can_be_turned_into_mappings(self):
+        """A stub's only job is to feed the id<->name lookup.
+
+        file_path and get_resource_prefix are what _make_resource_mapping needs,
+        and both are derived from fields the skeleton actually provides. Nothing
+        else is required of a stub - notably not compute_hash or validate, which
+        would be operating on absent data.
+        """
+        for resource_cls in PROJECTION_REGISTRY:
+            name = RESOURCE_CLASS_TO_NAME[resource_cls]
+            for resource in self._parse(resource_cls).values():
+                if not resource.slim:
+                    continue
+                with self.subTest(resource=name):
+                    self.assertTrue(resource.resource_id)
+                    self.assertTrue(resource.name)
+                    resource.get_resource_prefix(file_path=resource.file_path)
 
 
 class FalsyGuardValuesAreReadable(unittest.TestCase):
@@ -250,7 +303,12 @@ class FunctionSliceIndependence(unittest.TestCase):
             },
         }
         functions = Function.from_projection(projection)
-        self.assertEqual(list(functions), ["TF-1"])
+        # The global function is referenced by topics and phrase filters, so it
+        # is kept as a stub rather than dropped - but only the readable one is
+        # a real, file-backed resource.
+        self.assertEqual(
+            {f_id: f.slim for f_id, f in functions.items()}, {"TF-1": False, "FN-1": True}
+        )
 
 
 class WithheldSlicesAreReported(unittest.TestCase):
@@ -265,6 +323,219 @@ class WithheldSlicesAreReported(unittest.TestCase):
         projection = {"knowledgeBase": {"topics": {"entities": {}}}}
         with self.assertNoLogs("poly.resources.topic", level="DEBUG"):
             self.assertEqual(Topic.from_projection(projection), {})
+
+
+class PrepushDerivationsAreInertWhenHidden(unittest.TestCase):
+    """Why the prepush derivations need no read-access handling of their own.
+
+    They compare the baseline against local files, and a slim pull empties both
+    together - it rewrites the manifest and deletes the files in one go. So a
+    hidden resource is absent from both sides and no derivation can see a delta.
+    fix_orphaned_variables is the one that would corrupt server state if it did:
+    variableUpdate is gated on jupiter_flows, not functions, so the API would
+    accept a reference graph rebuilt from functions the user cannot see.
+    """
+
+    def test_no_variable_commands_when_functions_are_hidden(self):
+        variable = Variable(resource_id="VAR-1", name="order_id")
+        visible = {Variable: {"VAR-1": variable}, Function: {}}
+        new, updated, deleted = {}, {}, {}
+
+        fix_orphaned_variables(visible, new, updated, deleted, visible, lambda _: [])
+
+        self.assertEqual((new, updated, deleted), ({}, {}, {}))
+
+
+class SlimResourcesSurviveTheStatusFile(unittest.TestCase):
+    """Slim resources have to outlive the process that pulled them.
+
+    Every command other than pull rehydrates from _gen/.agent_studio_config, so
+    a slim resource that is not written there is gone by the next command - and
+    with it the id<->name mapping, which makes every reference to a withheld
+    resource read back as a raw id and the file look locally modified.
+    """
+
+    def _project(self) -> AgentStudioProject:
+        resources, slim_resources = load_resources_from_projection(SKELETON_PROJECTION)
+        project = AgentStudioProject(
+            region="local",
+            account_id="ACCOUNT-1",
+            project_id="PROJECT-1",
+            root_path="/tmp/does-not-need-to-exist",
+            resources=resources,
+            slim_resources=slim_resources,
+            last_updated=datetime(2026, 1, 1),
+        )
+        project.file_structure_info = project.compute_file_structure_info(project.resources)
+        return project
+
+    @staticmethod
+    def _slim_ids(project: AgentStudioProject) -> set[tuple[str, str]]:
+        return {
+            (RESOURCE_CLASS_TO_NAME[mapping.resource_type], mapping.resource_id)
+            for mapping in project.slim_resources
+        }
+
+    def test_slim_resources_round_trip_through_to_dict(self):
+        project = self._project()
+        self.assertTrue(self._slim_ids(project), "fixture should produce slim resources")
+
+        reloaded = AgentStudioProject.from_dict(project.to_dict(), project.root_path)
+
+        self.assertEqual(self._slim_ids(reloaded), self._slim_ids(project))
+
+    def test_slim_resources_keep_their_names_when_reloaded(self):
+        """The name is the whole point - an id alone resolves nothing."""
+        project = self._project()
+        names = {m.resource_id: m.resource_name for m in project.slim_resources}
+        self.assertTrue(names, "fixture should produce slim resources")
+
+        reloaded = AgentStudioProject.from_dict(project.to_dict(), project.root_path)
+        reloaded_names = {m.resource_id: m.resource_name for m in reloaded.slim_resources}
+
+        self.assertEqual(reloaded_names, names)
+
+    def test_slim_resources_are_absent_from_file_structure_info(self):
+        """No file on disk means no baseline entry.
+
+        Otherwise find_new_kept_deleted sees a known file that discovery can
+        never turn up, and reports it deleted on every run.
+        """
+        project = self._project()
+        slim_paths = {m.file_path for m in project.slim_resources}
+        self.assertTrue(slim_paths)
+
+        self.assertEqual(slim_paths & set(project.file_structure_info), set())
+
+    def test_slim_resources_are_absent_from_the_resource_map(self):
+        """Slim resources are mappings, not resources.
+
+        Leaving them in resources means push tries to serialize a resource
+        whose substantive fields were never sent, and save writes a file for
+        something the user cannot read.
+        """
+        project = self._project()
+        self.assertTrue(project.slim_resources, "fixture should produce slim resources")
+
+        self.assertEqual(
+            [r for resources in project.resources.values() for r in resources.values() if r.slim],
+            [],
+        )
+
+    def test_slim_resources_are_carried_past_a_rebuild_from_disk(self):
+        """A push replaces resources with state re-read from local files.
+
+        Slim resources have no file, so they cannot be in that state - they
+        have to survive on slim_resources or they are lost from the status
+        file on every push.
+        """
+        project = self._project()
+        expected = self._slim_ids(project)
+        self.assertTrue(expected, "fixture should produce slim resources")
+
+        # What push does: swap in state rebuilt from the local files.
+        project.resources = {
+            resource_type: dict(resources) for resource_type, resources in project.resources.items()
+        }
+
+        reloaded = AgentStudioProject.from_dict(project.to_dict(), project.root_path)
+        self.assertEqual(self._slim_ids(reloaded), expected)
+
+
+class WithheldTypeIsRemovedFromDisk(unittest.TestCase):
+    """A type readable on one pull and withheld on the next must leave no file behind.
+
+    Withheld types are absent from incoming_resources entirely, so the local file is
+    only removed by the "entire type absent from incoming" pass. That pass batches its
+    deletions into the file cache, and a cached entry carries the pre-write mtime - so
+    if the cache is not flushed, the deletions never reach disk *and* every later read
+    in the same process sees a file state that is not on disk. The visible symptom is
+    a force pull that needs running twice before `poly diff` comes back clean.
+    """
+
+    READABLE_ENTITIES = {
+        "entities": {
+            "entities": {
+                "ids": ["ENTITY-1"],
+                "entities": {
+                    "ENTITY-1": {
+                        "id": "ENTITY-1",
+                        "name": "account_number",
+                        "description": "The caller's account number.",
+                        "type": "alphanumeric",
+                        "config": {"value": {}},
+                    }
+                },
+            }
+        }
+    }
+
+    def setUp(self):
+        self.root_path = tempfile.mkdtemp()
+        self.addCleanup(patch.stopall)
+        MultiResourceYamlResource._file_cache.clear()
+        self.addCleanup(MultiResourceYamlResource._file_cache.clear)
+
+    def _project_with_readable_entities(self) -> AgentStudioProject:
+        resources, slim_resources = load_resources_from_projection(self.READABLE_ENTITIES)
+        project = AgentStudioProject(
+            region="us-1",
+            account_id="ACCOUNT-1",
+            project_id="PROJECT-1",
+            root_path=self.root_path,
+            resources=resources,
+            slim_resources=slim_resources,
+            last_updated=datetime(2026, 1, 1),
+        )
+        for entity in resources[Entity].values():
+            entity.save(self.root_path, resource_name=entity.name, resource_mappings=[])
+        project.file_structure_info = project.compute_file_structure_info(project.resources)
+        MultiResourceYamlResource._file_cache.clear()
+        return project
+
+    @property
+    def _entities_file(self) -> str:
+        return os.path.join(self.root_path, "config", "entities.yaml")
+
+    def test_one_force_pull_clears_a_type_that_became_withheld(self):
+        project = self._project_with_readable_entities()
+        self.assertIn("account_number", open(self._entities_file).read())
+
+        withheld, slim_resources = load_resources_from_projection(SKELETON_PROJECTION)
+        mock_api = patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock).start()
+        mock_api.pull_resources.return_value = (withheld, slim_resources, {})
+        patch.object(AgentStudioProject, "save_config").start()
+
+        project.pull_project(force=True)
+
+        self.assertNotIn(
+            "account_number",
+            open(self._entities_file).read(),
+            "one force pull should remove the withheld entity from disk",
+        )
+
+    def test_the_file_cache_never_disagrees_with_disk(self):
+        """A cache entry that was never flushed hides the real file from everything after it.
+
+        The entry is stamped with the file's pre-write mtime, so the mtime check that is
+        supposed to catch staleness reads it as fresh and hands back content that is not
+        on disk - which is how discovery came to miss files that were still there.
+        """
+        project = self._project_with_readable_entities()
+
+        withheld, slim_resources = load_resources_from_projection(SKELETON_PROJECTION)
+        mock_api = patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock).start()
+        mock_api.pull_resources.return_value = (withheld, slim_resources, {})
+        patch.object(AgentStudioProject, "save_config").start()
+
+        project.pull_project(force=True)
+
+        for file_path, (_, cached_dict) in MultiResourceYamlResource._file_cache.items():
+            self.assertEqual(
+                resource_utils.load_yaml(open(file_path).read()) or {},
+                cached_dict,
+                f"cached content for {file_path} does not match what is on disk",
+            )
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/slim_projection_test.py
+++ b/src/poly/tests/slim_projection_test.py
@@ -24,6 +24,7 @@ from poly.resources.resource import (
     PROJECTION_REGISTRY,
     RESOURCE_CLASS_TO_NAME,
     MultiResourceYamlResource,
+    ResourceMapping,
     load_resources_from_projection,
 )
 from poly.resources.sms import SMSTemplate
@@ -440,6 +441,58 @@ class SlimResourcesSurviveTheStatusFile(unittest.TestCase):
 
         reloaded = AgentStudioProject.from_dict(project.to_dict(), project.root_path)
         self.assertEqual(self._slim_ids(reloaded), expected)
+
+
+class PullBaselineKeepsOriginalSlimMappings(unittest.TestCase):
+    """The merge baseline must use the slim mappings recorded with it.
+
+    pull_project swaps self.slim_resources for the incoming list before the
+    merge runs. If the baseline then resolves references against the incoming
+    mappings, a withheld resource renamed remotely renders the baseline with the
+    new name while the disk file still carries the old one - a phantom local
+    change, surfacing exactly when merge output matters most.
+    """
+
+    @staticmethod
+    def _mapping(name: str) -> ResourceMapping:
+        return ResourceMapping(
+            resource_id="ENTITY-1",
+            resource_type=Entity,
+            resource_name=name,
+            file_path=os.path.join("config", "entities.yaml", "entities", name),
+            flow_name=None,
+            resource_prefix="entity",
+            flow_id=None,
+        )
+
+    def test_pull_passes_original_and_incoming_slim_lists_separately(self):
+        original = [self._mapping("old_name")]
+        incoming = [self._mapping("new_name")]
+
+        project = AgentStudioProject(
+            region="local",
+            account_id="ACCOUNT-1",
+            project_id="PROJECT-1",
+            root_path=tempfile.mkdtemp(),
+            resources={},
+            slim_resources=original,
+            last_updated=datetime(2026, 1, 1),
+        )
+
+        self.addCleanup(patch.stopall)
+        mock_api = patch.object(AgentStudioProject, "api_handler", new_callable=MagicMock).start()
+        mock_api.pull_resources.return_value = ({}, incoming, {})
+        patch.object(AgentStudioProject, "save_config").start()
+        mock_update = patch.object(
+            AgentStudioProject, "_update_pulled_resources", return_value=[]
+        ).start()
+
+        project.pull_project(force=False)
+
+        kwargs = mock_update.call_args.kwargs
+        self.assertEqual(kwargs["original_slim_resources"], original)
+        self.assertEqual(kwargs["incoming_slim_resources"], incoming)
+        self.assertEqual(project.slim_resources, incoming)
 
 
 class WithheldTypeIsRemovedFromDisk(unittest.TestCase):


### PR DESCRIPTION
## Summary

Withheld resources whose ids appear inside resources gated on a *different* permission
are kept as identity-only mappings rather than dropped, so `{{entity:...}}`-style
references to them still resolve to a name. They live in `slim_resources`, a list of
`ResourceMapping` that resolves references but is never iterated for a file, saved, or
pushed.

## Motivation

With #299 alone, a restricted reader's pull succeeds but every reference to a withheld
resource renders as a raw id — and because the id round-trips differently than the name,
the file looks locally modified on every command. The mapping also has to survive in the
status file: every command other than pull rehydrates from it, so a slim resource not
written there is gone by the next command.

## Changes

- `from_projection` for entities, functions, handoffs, SMS templates, translations,
  variants and variant attributes returns identity-only stubs (`slim=True`) for
  auth-filtered slices; `load_resources_from_projection` separates them out of the
  resource map into a list of `ResourceMapping`.
- Variables are treated as slim when functions are slim: `variableUpdate` is gated on a
  different permission than functions, so the API would accept a reference graph rebuilt
  from functions the user cannot see.
- `ResourceMapping` gained `to_dict`/`from_dict`, storing `resource_type` by its
  registered name so slim mappings persist in the status file. An unregistered type is
  dropped on read rather than raising.
- Slim resources are excluded from `file_structure_info` — they have no file on disk, so
  a baseline entry would make `find_new_kept_deleted` report them deleted on every run.
- `pull_resources`, `pull_deployment_resources`, `pull_branch_resources`,
  `get_template_resources`, `get_remote_resources_by_name` and
  `_resolve_branch_fork_point` all return their slim mappings alongside the resource
  map, and every caller (pull, push, status, diff, branch diff, validate, sync-ids) was
  updated to resolve references against them.
- Tests covering status-file round-trips, force-pull removal of a type that became
  withheld, and cache/disk agreement after a pull.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1453 passed, 165 subtests)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
