### PR TITLE
fix: catch duplicate keyphrases before pushing

### DIFF
--- a/src/poly/resources/keyphrase_boosting.py
+++ b/src/poly/resources/keyphrase_boosting.py
@@ -21,6 +21,29 @@ logger = logging.getLogger(__name__)
 VALID_LEVELS = ("default", "boosted", "maximum")
 
 
+def normalize_keyphrase(keyphrase: str) -> str:
+    """Normalize a keyphrase for uniqueness comparison.
+
+    Mirrors Agent Studio's `normalizeKeyphrase` (trim + lowercase). The platform
+    rejects a whole command batch when two keyphrases normalize the same, so the
+    ADK has to agree about what counts as a duplicate.
+    """
+    return keyphrase.strip().lower()
+
+
+def _group_by_normalized(
+    keyphrases: list[str],
+) -> dict[str, list[str]]:
+    """Group keyphrases by their normalized form, preserving original spellings."""
+    groups: dict[str, list[str]] = {}
+    for keyphrase in keyphrases:
+        normalized = normalize_keyphrase(keyphrase)
+        if not normalized:
+            continue
+        groups.setdefault(normalized, []).append(keyphrase)
+    return groups
+
+
 @register_resource("keyphrase_boosting")
 @dataclass
 class KeyphraseBoosting(MultiResourceYamlResource):
@@ -64,7 +87,28 @@ class KeyphraseBoosting(MultiResourceYamlResource):
                 keyphrase=kp_data.get("keyphrase", ""),
                 level=kp_data.get("level", "default"),
             )
+
+        cls._warn_about_duplicates(keyphrases)
         return keyphrases
+
+    @classmethod
+    def _warn_about_duplicates(cls, keyphrases: dict[str, "KeyphraseBoosting"]) -> None:
+        """Warn about keyphrases that normalize to the same phrase.
+
+        Projects created before Agent Studio enforced uniqueness can still hold
+        colliding entries. Pulling one must not fail, but the next push will, so
+        flag them here while the original spellings are still visible.
+        """
+        for _, spellings in sorted(
+            _group_by_normalized([k.keyphrase for k in keyphrases.values()]).items()
+        ):
+            if len(spellings) > 1:
+                logger.warning(
+                    "Keyphrases %s differ only by case or surrounding whitespace. "
+                    "Agent Studio treats them as one phrase and will reject a push "
+                    "that keeps both - remove the duplicates.",
+                    " / ".join(repr(s) for s in sorted(spellings)),
+                )
 
     @property
     def file_path(self) -> str:
@@ -124,6 +168,33 @@ class KeyphraseBoosting(MultiResourceYamlResource):
             raise ValueError(
                 f"Invalid level '{self.level}'. Must be one of: {', '.join(VALID_LEVELS)}"
             )
+
+    @classmethod
+    def validate_collection(
+        cls,
+        resources: dict[str, "KeyphraseBoosting"],
+        **kwargs,
+    ) -> None:
+        """Reject keyphrases that collide once trimmed and lowercased.
+
+        Agent Studio enforces this server-side and fails the entire push with an
+        opaque entity id, so catch it here where the offending phrase can be named.
+        """
+        groups = _group_by_normalized([r.keyphrase for r in resources.values()])
+        duplicates = {
+            normalized: spellings for normalized, spellings in groups.items() if len(spellings) > 1
+        }
+        if not duplicates:
+            return
+
+        described = "; ".join(
+            " / ".join(repr(s) for s in sorted(spellings))
+            for _, spellings in sorted(duplicates.items())
+        )
+        raise ValueError(
+            "Duplicate keyphrases (compared case-insensitively, ignoring surrounding "
+            f"whitespace): {described}. Keep one entry per phrase."
+        )
 
     @staticmethod
     def discover_resources(base_path: str) -> list[str]:

--- a/src/poly/resources/keyphrase_boosting.py
+++ b/src/poly/resources/keyphrase_boosting.py
@@ -21,6 +21,20 @@ logger = logging.getLogger(__name__)
 VALID_LEVELS = ("default", "boosted", "maximum")
 
 
+def _as_text(value: object) -> str:
+    """Coerce a resolved YAML scalar back to the text the author wrote.
+
+    The loader follows YAML 1.2, so a bare `true`/`false` resolves to a bool and
+    a bare `2024` to an int. Boosting digits or years is a reasonable thing to
+    want, and either type breaks the string handling below.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return value if isinstance(value, str) else str(value)
+
+
 def normalize_keyphrase(keyphrase: str) -> str:
     """Normalize a keyphrase for uniqueness comparison.
 
@@ -63,8 +77,8 @@ class KeyphraseBoosting(MultiResourceYamlResource):
         level: str = "default",
     ):
         self.resource_id = resource_id
-        self.name = name
-        self.keyphrase = keyphrase
+        self.name = _as_text(name)
+        self.keyphrase = _as_text(keyphrase)
         self.level = level.lower()
 
     @classmethod
@@ -215,7 +229,7 @@ class KeyphraseBoosting(MultiResourceYamlResource):
         keyphrases: list[dict] = yaml_dict.get("keyphrases", []) if yaml_dict else []
 
         for kp in keyphrases:
-            name = kp.get(KeyphraseBoosting.resource_key)
+            name = _as_text(kp.get(KeyphraseBoosting.resource_key))
             if not name:
                 continue
             path_safe_name = utils.clean_name(name, lowercase=False)

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -6595,6 +6595,68 @@ class KeyphraseBoostingTests(unittest.TestCase):
         )
         k.validate()
 
+    @staticmethod
+    def _collection(*keyphrases: str) -> dict[str, KeyphraseBoosting]:
+        return {
+            f"kp-{i}": KeyphraseBoosting(
+                resource_id=f"kp-{i}",
+                name=keyphrase,
+                keyphrase=keyphrase,
+                level="default",
+            )
+            for i, keyphrase in enumerate(keyphrases)
+        }
+
+    def test_validate_collection_passes_for_distinct_keyphrases(self):
+        """Phrases that only share a prefix or a stem are not duplicates."""
+        KeyphraseBoosting.validate_collection(
+            self._collection("sensor", "sensors", "Pap", "C Pap", "Acme Health")
+        )
+
+    def test_validate_collection_rejects_case_only_duplicates(self):
+        """Agent Studio matches case-insensitively, so these collide."""
+        with self.assertRaises(ValueError) as cm:
+            KeyphraseBoosting.validate_collection(
+                self._collection("Infusion Sets", "infusion sets")
+            )
+        message = str(cm.exception)
+        self.assertIn("Duplicate keyphrases", message)
+        self.assertIn("'Infusion Sets'", message)
+        self.assertIn("'infusion sets'", message)
+
+    def test_validate_collection_rejects_whitespace_only_duplicates(self):
+        """Agent Studio trims before comparing, so surrounding space is not a difference."""
+        with self.assertRaises(ValueError) as cm:
+            KeyphraseBoosting.validate_collection(self._collection("Acme", " Acme "))
+        self.assertIn("Duplicate keyphrases", str(cm.exception))
+
+    def test_validate_collection_reports_every_colliding_group(self):
+        """All colliding groups are named, not just the first."""
+        with self.assertRaises(ValueError) as cm:
+            KeyphraseBoosting.validate_collection(
+                self._collection("Acme", "acme", "Infusion Sets", "infusion sets")
+            )
+        message = str(cm.exception)
+        self.assertIn("'Acme'", message)
+        self.assertIn("'Infusion Sets'", message)
+
+    def test_from_projection_warns_on_pre_existing_duplicates(self):
+        """Pulling a project that predates the uniqueness rule warns instead of failing."""
+        projection = {
+            "keyphraseBoosting": {
+                "keyphraseBoosting": {
+                    "entities": {
+                        "KEYPHRASE-1": {"keyphrase": "Acme", "level": "default"},
+                        "KEYPHRASE-2": {"keyphrase": "acme", "level": "default"},
+                    }
+                }
+            }
+        }
+        with self.assertLogs("poly.resources.keyphrase_boosting", level="WARNING") as logs:
+            keyphrases = KeyphraseBoosting.from_projection(projection)
+        self.assertEqual(len(keyphrases), 2)
+        self.assertIn("differ only by case", "".join(logs.output))
+
     def test_read_local_resource(self):
         """read_local_resource correctly parses a keyphrase from the multi-resource YAML."""
         yaml_content = """keyphrases:

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -6657,6 +6657,34 @@ class KeyphraseBoostingTests(unittest.TestCase):
         self.assertEqual(len(keyphrases), 2)
         self.assertIn("differ only by case", "".join(logs.output))
 
+    def test_yaml_resolved_scalars_are_read_as_text(self):
+        """A bare `true` or `2024` in YAML resolves to a bool/int, not a string."""
+        for raw, expected in ((True, "true"), (False, "false"), (2024, "2024"), (None, "")):
+            with self.subTest(raw=raw):
+                k = KeyphraseBoosting.from_yaml_dict(
+                    {"keyphrase": raw, "level": "boosted"}, "kp-1", "kp-1"
+                )
+                self.assertEqual(k.keyphrase, expected)
+                self.assertEqual(k.name, expected)
+
+    def test_validate_collection_handles_resolved_scalars(self):
+        """A bare `true` and a quoted 'true' are the same phrase to Agent Studio."""
+        collection = {
+            "kp-0": KeyphraseBoosting(resource_id="kp-0", name="x", keyphrase=True),
+            "kp-1": KeyphraseBoosting(resource_id="kp-1", name="y", keyphrase="True"),
+        }
+        with self.assertRaises(ValueError) as cm:
+            KeyphraseBoosting.validate_collection(collection)
+        self.assertIn("Duplicate keyphrases", str(cm.exception))
+
+    def test_numeric_keyphrase_validates(self):
+        """Boosting a bare number is legitimate and must not fail validation."""
+        k = KeyphraseBoosting.from_yaml_dict(
+            {"keyphrase": 2024, "level": "maximum"}, "kp-1", "kp-1"
+        )
+        k.validate()
+        self.assertEqual(k.to_yaml_dict(), {"keyphrase": "2024", "level": "maximum"})
+
     def test_read_local_resource(self):
         """read_local_resource correctly parses a keyphrase from the multi-resource YAML."""
         yaml_content = """keyphrases:


### PR DESCRIPTION
## Summary

Agent Studio normalizes keyphrases (trim + lowercase) and enforces uniqueness server-side. When two entries collide it rejects the whole command batch with an opaque entity id. This validates the same rule locally so the offending phrase is named up front.

## Motivation

A push containing two keyphrases that differ only by case or surrounding whitespace fails on the platform with an error that points at an entity id rather than the phrase, leaving no clear way to find which entry to fix. The ADK can apply the same normalization and fail early with the actual spellings.

## Changes

- Add `normalize_keyphrase` mirroring Agent Studio's `normalizeKeyphrase` (trim + lowercase)
- Add `KeyphraseBoosting.validate_collection`, rejecting keyphrases that normalize to the same value and naming every colliding group with its original spellings
- Warn (rather than fail) on pull when a projection already contains colliding entries, so existing projects that predate the uniqueness rule can still be pulled

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

Unit tests cover distinct phrases that merely share a prefix or stem, case-only collisions, whitespace-only collisions, multiple colliding groups in one collection, and the pull-path warning.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Validation error raised on push:

```
Validation error: Duplicate keyphrases (compared case-insensitively, ignoring
surrounding whitespace): 'Infusion Sets' / 'infusion sets'. Keep one entry per phrase.
```

Warning emitted on pull:

```
Keyphrases 'Acme' / 'acme' differ only by case or surrounding whitespace. Agent Studio
treats them as one phrase and will reject a push that keeps both - remove the duplicates.
```