### PR TITLE
feat: add AI agent skills suite

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,25 @@
+# PolyAI ADK Skills
+
+Agent skills for building [Agent Studio](https://studio.poly.ai) dialog agents with the [PolyAI ADK](https://polyai.github.io/adk/). They teach any coding agent — Claude Code, Cursor, Codex, or others — the `poly` CLI workflow: pull a project, edit resources on a branch, validate, push, test, and merge.
+
+Install into your coding agent via [`npx skills`](https://github.com/vercel-labs/skills):
+
+```bash
+npx -y skills add https://github.com/polyai/adk -y
+```
+
+## Skills
+
+| Skill | Description |
+|-------|-------------|
+| `poly-adk-workflow` | **Entrypoint** — install and auth, project setup, resource-choice guidance, the core edit → validate → push → test → merge loop |
+| `poly-adk-testing` | Verification — `poly validate`, scripted `poly chat`, the `test_suite/` simulated conversation tests, running functions in isolation |
+| `poly-adk-branching` | Branch management, the three-way merge model, non-interactive conflict resolution, review gists |
+| `poly-adk-conversations` | Inspecting real calls with `poly conversations`, instrumenting functions with `conv.log` and metrics |
+| `poly-adk-rtc` | Per-environment Real-Time Configuration — pull/push cycle, drift protection, live-environment safety |
+
+`poly-adk-workflow` is the always-relevant entrypoint; the others load on demand for their task and point back to it. Resource schemas are deliberately **not** duplicated in the skills — the `poly docs` command ships them with the installed CLI, so they can never drift from the release in use.
+
+## Versioning
+
+Each skill's `metadata.version` tracks the `polyai-adk` release it was written against. Update the skills alongside CLI releases that change command surfaces or workflows.

--- a/skills/poly-adk-branching/SKILL.md
+++ b/skills/poly-adk-branching/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: poly-adk-branching
+description: >
+  This skill should be used when the user wants to "resolve merge conflicts", "merge a branch",
+  "fix conflict markers", "create a hotfix branch", "share changes for review", or manage
+  branches in a PolyAI ADK project — or when poly pull or poly branch merge reports conflicts.
+  Covers branch management, the three-way merge model, non-interactive conflict resolution,
+  and review gists. Part of the PolyAI ADK skills suite. Do NOT use for the everyday
+  edit-push loop (use poly-adk-workflow).
+metadata:
+  author: PolyAI
+  license: Apache-2.0
+  version: 0.53.1
+  requires:
+    bins:
+      - poly
+    install: "uv tool install polyai-adk"
+---
+
+# Branching, Merging, and Conflicts
+
+Load `poly-adk-workflow` first for where branching sits in the build loop. The one rule that shapes everything: **you cannot work on `main`** — `branch diff`, `merge`, `sync`, `tag`, and `untag` all refuse to run there.
+
+## Branch management
+
+```bash
+poly branch list                   # all branches (--archived for soft-deleted ones)
+poly branch current                # current branch + its parent
+poly branch create <name>          # create + switch; branches from main's latest state
+poly branch switch <name>          # requires a clean tree (--force discards local changes)
+poly branch rename <new-name>
+poly branch delete [<name>]        # main cannot be deleted
+poly branch restore <branch_id>    # un-archive; IDs from poly branch list --archived
+poly branch history                # branches merged into the current branch
+```
+
+Semantics that matter:
+
+- **`create` carries uncommitted local work onto the new branch; `switch` refuses to move with uncommitted changes** and replaces local files with the target branch's state. Started editing on `main` by accident? `branch create` alone recovers it — nothing is lost.
+- Branches exist **on the platform**, not just locally — teammates can switch to yours, and the web UI can edit it while you work.
+- `poly status`/`poly diff` show unpushed local edits; `poly branch status`/`poly branch diff` show everything since the branch was created. Use the branch-level pair before merging. `poly branch status` also says whether the branch has diverged — i.e. whether it will merge cleanly.
+
+### Hotfix branches from a deployed environment
+
+`poly branch create my-hotfix --env live` snapshots the deployed environment into a fresh branch (also `sandbox`, `pre-release`). **Use with caution**: it overwrites your local project with the deployed state, and merging that branch back to main can roll back changes made after the snapshot. It fails on uncommitted local changes unless `--force`.
+
+## How pull merges
+
+`poly pull` never blind-overwrites. It three-way merges, line by line, between **base** (state at your last pull/push, tracked in `_gen/.agent_studio_config`), **local** (your disk, including uncommitted edits), and **incoming** (the remote branch). Files are re-serialized to canonical form first, so formatting and key-order differences never conflict — only real content changes do. A file deleted locally stays deleted.
+
+Conflicts are written into files with **unlabelled** markers — unlike Git, there are no branch names:
+
+```text
+<<<<<<<
+your local version
+=======
+the incoming remote version
+>>>>>>>
+```
+
+**While any marker remains, `status`, `diff`, `validate`, and `push` all refuse to run.** `poly pull` lists every conflicted file; edit each to the content you want, delete the markers, then continue. Escape hatches: `poly pull -f` discards all local work and takes the remote (confirm with the user first — it also deletes local resources missing from the remote); `poly pull --format` formats all three sides first to reduce spurious conflicts.
+
+## Merging a branch
+
+```bash
+poly branch merge 'Merge message'       # message required when merging into main
+```
+
+A clean merge completes immediately and switches your checkout to the parent branch. Merging into `main` deploys to `sandbox` automatically. The web UI's **Merge** button hits the same endpoint — identical result.
+
+### Resolving merge conflicts
+
+On conflict the command exits non-zero and prints a table per conflicting field: **Path** (e.g. `topics > Booking > content`), **Base / Ours / Theirs** values, the **auto-merged value**, and whether it's auto-mergeable. Two resolution routes:
+
+- `--interactive` / `-i` — walks each conflict: accept the auto-merge, pick ours (parent) / theirs (branch) / base, or edit in `$EDITOR`. Terminal-only; incompatible with `--json`.
+- `--resolutions <source>` — **the non-interactive route, so the one to use as an agent.** A JSON array (file path, inline string, or `-` for stdin):
+
+```json
+[
+  { "path": ["topics", "Booking", "content"], "strategy": "theirs" },
+  { "path": ["agent_settings", "rules", "value"], "strategy": "theirs", "value": "Custom resolved content" },
+  { "path": ["flows", "main_flow", "steps", "greet", "prompt"], "strategy": "ours" }
+]
+```
+
+`path` matches the conflict table's Path column; `strategy` is `"ours"`, `"theirs"`, or `"base"`; a custom `value` is only honored with `"theirs"`. Workflow: run `poly branch merge --json` once to surface the conflicts, build a resolutions file covering each path, re-run with `--resolutions`. Confirm resolution choices with the user when the right answer isn't obvious — both sides are real work.
+
+## Sharing changes for review
+
+Both review commands publish a private GitHub Gist (one `.diff` file per changed resource) so reviewers don't need filesystem access. Requires a GitHub token in the environment.
+
+```bash
+poly branch review                                  # this branch since creation
+poly review create                                  # local vs remote
+poly review create --before main --after my-feature # any two branches/versions
+poly review list                                    # open past gists
+poly review delete --id <gist_id>
+```
+
+## Habits that avoid trouble
+
+- Pull before starting work so your base is recent and conflicts stay small.
+- Keep branches small and single-purpose — easier to review and merge.
+- Keep resource names stable; references point at resources by name.
+- Check `poly branch status` before merging to know in advance whether it's clean.

--- a/skills/poly-adk-conversations/SKILL.md
+++ b/skills/poly-adk-conversations/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: poly-adk-conversations
+description: >
+  This skill should be used when the user wants to "see what happened on a call",
+  "review real conversations", "download a call recording", "debug a production call",
+  or "add logging/metrics" to a PolyAI agent. Covers poly conversations and instrumenting
+  functions with conv.log and metrics. Part of the PolyAI ADK skills suite. Do NOT use
+  for simulated test conversations (use poly-adk-testing).
+metadata:
+  author: PolyAI
+  license: Apache-2.0
+  version: 0.53.1
+  requires:
+    bins:
+      - poly
+    install: "uv tool install polyai-adk"
+---
+
+# Reviewing Real Conversations
+
+Load `poly-adk-workflow` first for the build loop this feeds back into. Once an agent handles real calls, the question becomes "what happened on that call?" — and answering it depends on instrumentation added *while building*. Logs and metrics are not available retroactively.
+
+## Inspecting conversations
+
+```bash
+poly conversations list                        # recent conversations: ID, start, duration, caller, channel, variant, handoff, summary
+poly conversations list --limit 20 --offset 10
+poly conversations get <conversation_id>       # full metadata + turn-by-turn transcript
+poly conversations get-audio <conversation_id> -o recording.wav
+```
+
+- `get` includes channel, language, duration, handoff, tags, PolyScore, summary, and every turn — use `--json` when analyzing programmatically.
+- `get-audio` downloads the WAV for a voice call; `--direction user|agent|combined` picks the track, `--redacted` fetches the redacted version.
+- The CLI reads individual conversations. Aggregate views — containment, CSAT, handle time, flagged transcripts — live in Agent Studio, not the CLI.
+
+Treat what you find as input to development: a surprising real conversation is the raw material for the next `test_suite/` case (see `poly-adk-testing`). What callers actually say is reliably different from what you imagined.
+
+## Instrumenting functions
+
+See `poly docs functions` for the full `conv.log` and metrics APIs.
+
+**Logging** — record meaningful outcomes, not every step:
+
+```python
+conv.log.info("Booking confirmed", reference=booking_ref)
+conv.log.warning("Availability API slow, using cached slots")
+conv.log.error("Payment provider returned 500")
+```
+
+Log around the things that can fail — API calls, validation, any branch you'd want to explain later. **Never swallow an external failure silently**: a bare `except` with no log turns a broken integration into a mysteriously unhelpful agent with nothing in the transcript to explain it.
+
+**Metrics** — count outcomes you'll aggregate across calls (flow completions, handoffs fired, API fallbacks). The common mistake is inflation: a metric emitted in a loop or on every turn counts nothing useful. Use `write_once=True` for once-per-conversation events, and emit on the outcome you actually want to count.
+
+The test for both: would this line help answer a question you can imagine being asked — "how often do callers abandon at payment?", "did that transfer actually fire?" If not, it's noise.
+
+## When debugging a specific call
+
+1. `poly conversations get <id>` — read the transcript and logs turn by turn.
+2. If the wording is right but the *audio* is wrong, it's a channel-settings problem, not a prompt problem: mishearing → `voice/speech_recognition/` (keyphrase boosting, transcript corrections); mispronunciation → `voice/response_control/` (pronunciations). See `poly docs speech_recognition response_control`.
+3. Reproduce with `poly chat` (simulate SIP headers, variant, language — see `poly-adk-testing`), then encode the fix's verification as a test case.

--- a/skills/poly-adk-rtc/SKILL.md
+++ b/skills/poly-adk-rtc/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: poly-adk-rtc
+description: >
+  This skill should be used when the user wants to "change real-time configuration",
+  "update RTC", "edit per-environment config", or work with the real_time_configuration/
+  directory of a PolyAI ADK project. Covers poly rtc pull/push/edit/diff/validate, drift
+  protection, and the live-environment hazard. Part of the PolyAI ADK skills suite.
+  Do NOT use for resources that deploy through branches (use poly-adk-workflow).
+metadata:
+  author: PolyAI
+  license: Apache-2.0
+  version: 0.53.1
+  requires:
+    bins:
+      - poly
+    install: "uv tool install polyai-adk"
+---
+
+# Real-Time Configuration (RTC)
+
+Load `poly-adk-workflow` first for the resource workflow RTC sits *outside* of. RTC is per-environment configuration that takes effect **without a deployment** — it is not branched, not versioned with resources, and not promoted through the sandbox → pre-release → live ladder. You pull and push it per environment, and there is no promotion between environments: changing a value everywhere means pushing to each one.
+
+**`poly rtc push --env live` writes straight to production, effective immediately — no branch, review, or promotion step.** Never push to `live` (or `pre-release`) unless the user explicitly asks. Verify in `sandbox` first.
+
+## Local layout
+
+Each environment holds a **schema** (`schema.json`, the shape) and **data** (`data.json`, the values):
+
+```text
+real_time_configuration/
+├── draft_and_sandbox/     # the sandbox environment (note the directory name)
+│   ├── schema.json
+│   └── data.json
+├── pre_release/
+└── live/
+```
+
+## The cycle
+
+```bash
+poly rtc pull                  # all environments by default (--env to narrow)
+# edit schema.json / data.json
+poly rtc diff                  # local vs remote, per environment
+poly rtc validate              # data.json against schema.json
+poly rtc push --env sandbox    # --env is REQUIRED on push — no default, so no wrong-env accidents
+```
+
+- `--schema` / `--data` on pull and push operate on just one half (mutually exclusive).
+- `poly rtc push` runs the same validation as `poly rtc validate` unless `--skip-validation`.
+- `poly rtc edit --env <env>` does pull → open in `$EDITOR` → validate → push in one step. It is inherently interactive (no `--json`), so as an agent prefer the pull/edit-files/push cycle.
+
+## Drift protection
+
+Each `poly rtc pull` stores a base copy. On push, if the remote moved since your last pull (usually someone editing in the Agent Studio UI), the config has **drifted**. Default behavior is a three-way merge — **per key**, unlike resource files which merge per line: a key changed on one side applies cleanly; a key changed differently on both sides is a conflict and aborts the push.
+
+- `--no-merge` — fail on any drift instead of merging.
+- `--force` — skip the drift check and overwrite the remote. Confirm with the user first; someone's UI edits may be on the other side.
+- **Drift protection only works if you pulled first** — push without a prior pull and the check is silently skipped. Always `poly rtc pull` before editing.

--- a/skills/poly-adk-testing/SKILL.md
+++ b/skills/poly-adk-testing/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: poly-adk-testing
+description: >
+  This skill should be used when the user wants to "test the agent", "chat with the agent",
+  "run the test suite", "write a test case", "check why a test failed", or "run a function"
+  built with the PolyAI ADK. Covers poly validate, scripted poly chat, the test_suite/
+  simulated conversation tests, and executing functions in isolation. Part of the PolyAI
+  ADK skills suite. Do NOT use for inspecting real production calls (use
+  poly-adk-conversations) or the general build workflow (use poly-adk-workflow).
+metadata:
+  author: PolyAI
+  license: Apache-2.0
+  version: 0.53.1
+  requires:
+    bins:
+      - poly
+    install: "uv tool install polyai-adk"
+---
+
+# Testing a PolyAI Agent
+
+Load `poly-adk-workflow` first for the overall build loop these commands fit into.
+
+Four layers of verification, catching different problems:
+
+| Command | Catches | Runs against |
+|---|---|---|
+| `poly validate` | Invalid resources, missing values, broken references | Local files |
+| `poly chat` | Conversational behavior, judged by reading | Last **pushed** state |
+| `poly test run` | Regressions, repeatably | Last **pushed** state |
+| `poly conversations` | What happened on real calls (see `poly-adk-conversations`) | Live traffic |
+
+**`poly chat` and `poly test run` run against the last pushed state, not local files.** Push first, or pass `--push` to push-and-run in one step. Both target the current branch by default; `-e sandbox|pre-release|live` targets a deployed environment instead.
+
+## 1. Validate while editing
+
+`poly validate` checks local files without contacting the platform — malformed resources, missing required values, and `{{prefix:name}}` references that don't resolve. Run it as you edit, not just before pushing; `poly push` runs the same validation and rejects anything validate rejects.
+
+## 2. Chat with the agent
+
+As an agent, always use the non-interactive modes:
+
+```bash
+poly chat --push -m 'Hello' -m 'I want to book a table' --json
+poly chat --input-file ./script.txt          # one message per line; - for stdin
+poly chat --metadata                          # show function calls, active flow/step, and state changes per turn
+poly chat --conv-id <id> -m 'Follow-up'       # resume an existing conversation
+```
+
+Useful flags for reproducing specific situations:
+
+- `--channel voice|webchat` — which channel's settings apply (default `voice`)
+- `--sip-header X-Customer-ID=12345` — simulate SIP headers, exposed to project functions via `conv.sip_headers` (repeatable; test-only, no real SIP call)
+- `--variant <name>` — chat as a specific variant
+- `--lang` / `--input-lang` / `--output-lang` — multilingual agents
+
+With `--json`, output is a `conversations` array with per-turn detail mirroring the `--functions`/`--flows`/`--state` flags you enabled.
+
+Chat is for judging whether a conversation *feels* right. Anything worth checking twice belongs in the test suite instead.
+
+## 3. Simulated conversation tests
+
+Test cases live in `test_suite/` and assert what the agent should say and which functions it should call. They are the only repeatable layer — the thing that stops a fixed bug coming back. Run `poly docs tests` for the file format and available assertions before writing cases.
+
+```bash
+poly test run                    # all tests, polls until complete, non-zero exit on failure
+poly test run --tag smoke        # only tagged tests (multiple tags OR-match)
+poly test run --files test_suite/greeting_flow_test.yaml
+poly test run --dry-run          # preview which tests would run
+poly test run --dont-poll        # trigger and exit; check later with poly test show
+poly test list                   # past runs
+poly test show <run_id>                    # run summary + per-test table
+poly test show <run_id> <test_case_id>     # assertion results, function failures, full transcript
+```
+
+Statuses: `pending`, `in_progress`, `passed`, `failed` (assertion failed), `errored`, `timed_out`. After a run, failures are summarized with assertion reasons and conversation IDs.
+
+Write cases for the paths that are tedious to reach by hand — an unavailable API, a caller changing their mind, variant-specific behavior. For the API case, `api_mocks` forces a named API integration operation to return a fixed response so the test is deterministic (see `poly docs tests`).
+
+## 4. Execute a function in isolation
+
+To debug one function without a conversation:
+
+```bash
+poly functions execute <function_name> --args '{"x": 1}' --json   # returns body, logs, runtime
+poly functions validate                                            # syntax errors + orphaned flow-step references
+```
+
+Limitations: builds a fresh `conv` from the branch config — no live caller, `conv.state` starts empty and is not persisted, and `conv.say`/`conv.goto_flow`/`conv.call_handoff` have no channel to act on. Covers global functions only, not flow transition functions or function steps. There is no way to attach to a real call.
+
+Both subcommands accept `--region --project_id --branch_id` (all three together) to run headlessly without a local checkout.
+
+## Where each layer fits
+
+Validation and chat belong in the edit loop; the test suite belongs before merging; and after promoting to an environment, re-run chat and tests against it with `-e`. A surprising real conversation found via `poly-adk-conversations` is the raw material for the next test case.

--- a/skills/poly-adk-workflow/SKILL.md
+++ b/skills/poly-adk-workflow/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: poly-adk-workflow
+description: >
+  This skill should be used when the user wants to "build an agent", "update an agent",
+  "create a PolyAI project", "push changes to Agent Studio", or work with the PolyAI ADK
+  (`poly`) in any way. Entrypoint for the PolyAI ADK skills suite — covers setup, project
+  structure, resource choice, and the core edit/validate/push/test/merge workflow, and
+  routes to the task-specific skills (testing, branching, conversations, rtc).
+metadata:
+  author: PolyAI
+  license: Apache-2.0
+  version: 0.53.1
+  requires:
+    bins:
+      - poly
+    install: "uv tool install polyai-adk"
+---
+
+# PolyAI ADK workflow
+
+The PolyAI ADK (`poly`) is a CLI for building dialog agents on the Agent Studio platform. It gives you a Git-like local workflow: agent resources (flows, functions, topics, entities, settings) live on disk as YAML, text, and Python files, and you `pull`, `push`, `branch`, and `merge` them against the platform.
+
+Use `poly <command> --help` as the source of truth for flags. Almost every command accepts `--json` (a single JSON object on stdout, exit code 0 on success) — prefer it when you need to parse output.
+
+## Task-specific skills
+
+This skill covers setup and the core loop. Load the matching skill when the task goes deeper:
+
+| Task | Skill |
+|---|---|
+| Testing the agent — scripted chat, running the test suite, writing test cases | `poly-adk-testing` |
+| Merge conflicts, branch management, sharing reviews | `poly-adk-branching` |
+| Inspecting real conversations, logging and metrics | `poly-adk-conversations` |
+| Per-environment real-time configuration | `poly-adk-rtc` |
+
+## 1. Installing and updating
+
+Assume `poly` is installed. If a command fails because it isn't:
+
+- **Install** → `uv tool install polyai-adk` (install `uv` first if needed: `curl -LsSf https://astral.sh/uv/install.sh | sh`)
+- **Update to latest** → `uv tool upgrade polyai-adk`
+
+## 2. Authentication
+
+Assume the user is already logged in — do not check credentials up front. Only if a command fails with an authentication error, ask the user to run `poly login` — it opens a browser to sign in, so they must complete it themselves. Regions: `studio` for self-serve accounts, `us-1` / `euw-1` / `uk-1` for enterprise workspaces. Self-serve users can alternatively run `poly start`, which signs up and optionally creates a project and pulls it locally in one step.
+
+Credentials are resolved in this order: `~/.poly/credentials.json` (written by `poly login`), then a region-scoped env var (`POLY_ADK_KEY_US` / `POLY_ADK_KEY_EUW` / `POLY_ADK_KEY_UK` / `POLY_ADK_KEY_STUDIO`), then `POLY_ADK_KEY` — useful when debugging why the CLI is using the wrong account or region.
+
+## 3. Load the resource documentation
+
+Before creating or editing any resource, load the built-in docs — they define each resource type's exact schema, valid values, and conventions:
+
+```bash
+poly docs # For the top level overview of all resource types
+poly docs {resource name} # For a specific resource type, e.g. flows, functions, topics, etc.
+poly docs flows functions topics # For multiple resource types at once
+```
+
+Read the relevant sections before writing files. Do not guess at resource schemas — `poly docs` is authoritative for the installed version.
+
+### Choosing the right resource type
+
+The three that overlap most are rules, topics, and functions. The test: if an instruction is **always true**, it belongs in `agent_settings/rules.txt`; if it's only relevant **when a subject comes up**, it belongs in a topic; if it needs a **comparison, calculation, or API call**, it belongs in a Python function. Prompts are for collecting and presenting information; Python is for branching, routing, and validation — never write "if X then Y" conditionals in prompt text.
+
+Resources reference each other by name with `{{prefix:name}}` placeholders (`{{fn:}}` functions, `{{entity:}}` entities, `{{ho:}}` handoffs, `{{attr:}}` variant attributes, `{{vrbl:}}` state variables, `{{twilio_sms:}}` SMS templates, `{{tn:}}` translations). `poly validate` checks every reference resolves.
+
+## 4. Set up or connect a project
+
+```bash
+poly project create   # create a new Agent Studio project and pull it locally
+poly init             # connect to an existing project (interactive pickers)
+poly template list    # optional: start from a pre-built template
+poly template load <name>
+```
+
+Projects land in a `<account_id>/<project_id>/` directory. **Run all `poly` commands from inside the project directory**, or pass `--path`.
+
+A project looks like:
+
+```text
+<account>/<project>/
+├── _gen/                    # Generated stubs — NEVER edit
+├── agent_settings/          # persona.txt, rules.txt, guardrails, languages
+├── config/                  # entities, handoffs, sms_templates, api_integrations, variants, translations
+├── context/                 # background docs for Studio Assistant
+├── voice/                   # voice channel config, speech_recognition/, response_control/
+├── chat/                    # webchat channel config
+├── flows/                   # multi-step guided conversations
+├── functions/               # Python functions (deterministic logic, lifecycle hooks)
+├── topics/                  # knowledge base entries
+├── test_suite/              # simulated conversation tests
+├── real_time_configuration/ # per-environment RTC (see poly-adk-rtc)
+└── project.yaml             # project metadata
+```
+
+## 5. The core development loop
+
+**You cannot work on `main`.** Every change goes on a branch. The branch you are on determines what `poly push` writes to and what `poly chat` talks to.
+
+```bash
+poly pull                        # 1. start from the latest state on main
+poly branch create <name>        # 2. create + switch to a branch (keeps local edits)
+# 3. edit resource files on disk
+poly status                      # 4. see unpushed local changes
+poly diff                        #    inspect them in detail
+poly validate                    # 5. catch structural errors locally, before pushing
+poly push                        # 6. push to the branch
+poly chat --push                 # 7. test interactively (see poly-adk-testing)
+poly test run                    #    and/or run the simulated test suite
+# 8. iterate: repeat 3–7
+poly branch diff                 # 9. review everything on the branch since creation
+poly branch merge '<message>'    # 10. merge into main (deploys to sandbox automatically)
+```
+
+Key distinctions:
+
+- `poly status` / `poly diff` show **unpushed local edits**; `poly branch status` / `poly branch diff` show **everything on the branch** since it was created. Use the branch-level commands before merging.
+- `poly revert` discards local changes; `poly format` normalizes resource files.
+- `poly pull` three-way merges rather than overwriting, and `poly branch merge` can conflict — if either reports conflicts, load `poly-adk-branching` for the resolution workflow.
+
+## 6. Testing
+
+Four layers, catching different problems — load `poly-adk-testing` for the details of each:
+
+| Command | Catches | Runs against |
+|---|---|---|
+| `poly validate` | Invalid resources, missing values, broken references | Local files |
+| `poly chat` | Conversational behavior, judged by reading | Last **pushed** state |
+| `poly test run` | Regressions, repeatably | Last **pushed** state |
+| `poly conversations` | What happened on real calls | Live traffic |
+
+`poly chat` and `poly test run` run against the last pushed state, **not** local files — push first, or use `poly chat --push` / `poly test run --push`.
+
+## 7. Deployment
+
+Merging into `main` deploys to `sandbox` automatically. From there, promotion is one step at a time up the ladder — `sandbox` → `pre-release` → `live`:
+
+```bash
+poly deployments promote --from sandbox --to pre-release --dry-run
+poly deployments list             # what is deployed where
+```
+
+**Never promote to `pre-release` or `live` unless the user explicitly asks** — `live` is production. Use `--dry-run` first to preview, and re-run tests against each environment after promoting. See `poly deployments --help` for the full surface, including rollback.
+
+## Rules and gotchas
+
+- Never edit anything under `_gen/` — generated stubs.
+- Never work on `main`; check `poly branch current` if unsure.
+- Run `poly validate` before every push — push runs the same validation and rejects what validate rejects.
+- Python functions callable by the model need `@func_description` and `@func_parameter` decorators; without them the platform creates the function with no parameters and calls fail at runtime. Lifecycle functions and function steps don't need them.
+- Keep resource names stable — resources reference each other by name (`{{prefix:name}}` syntax).
+- Keep branches small and focused; pull before starting work so conflicts stay small.
+- The web UI edits the same branches — someone may change the branch in Agent Studio while you work; `poly pull` reconciles.


### PR DESCRIPTION
## Summary

Adds a `skills/` directory with five agent skills that teach AI coding agents (Claude Code, Cursor, Codex, etc.) the `poly` CLI workflow, plus a README describing the suite. Installable via `npx skills add`.

First PR of a three-part stack: #305 adds `poly setup`, which installs these skills, and #303 makes `poly update` keep them current.

## Motivation

AI coding agents working on ADK projects currently have no contextual knowledge of the `poly` workflow — resource schemas, the no-`main` rule, pushed-state testing semantics, or conflict resolution. These skills provide that context on demand, structured after Google's `agents-cli` skills suite: a workflow entrypoint plus task-specific skills that load only when relevant.

## Changes

- `skills/poly-adk-workflow/SKILL.md` — entrypoint: install/update, auth, `poly docs` habit, resource-choice guidance, project structure, the core edit → validate → push → test → merge loop, and a routing table to the task skills
- `skills/poly-adk-testing/SKILL.md` — `poly validate`, scripted `poly chat`, `test_suite/` authoring with `api_mocks`, `poly functions execute/validate`
- `skills/poly-adk-branching/SKILL.md` — branch semantics, three-way merge model, conflict markers, non-interactive `merge --resolutions`, review gists
- `skills/poly-adk-conversations/SKILL.md` — `poly conversations`, instrumenting with `conv.log` and metrics, real-call → test-case loop
- `skills/poly-adk-rtc/SKILL.md` — RTC pull/push cycle, drift protection, live-environment safety
- `skills/README.md` — suite overview and install instructions

Resource schemas are deliberately not duplicated — skills instruct agents to run `poly docs`, which ships schemas with the installed CLI. Skill `metadata.version` is pinned to the current release (0.53.1).

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

Markdown-only change. Skills were installed locally via `npx skills add` (frontmatter validated by the tool) and exercised in Claude Code sessions against a real project. All CLI commands and flags referenced were cross-checked against `docs/` and, where relevant, the source.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
