### PR TITLE
feat: support typed variant attributes

### DIFF
--- a/docs/docs/reference/resources/variants.md
+++ b/docs/docs/reference/resources/variants.md
@@ -46,9 +46,56 @@ Each attribute includes:
 | Field | Description |
 |---|---|
 | `name` | Attribute identifier, ideally in snake_case |
-| `values` | Map from variant name to string value |
+| `kind` | Optional. The attribute's type: `string` (default), `number`, `boolean`, `enum`, or `object` |
+| `config` | Optional. Type-specific configuration. Only `enum` takes one: `config.values` lists the allowed values |
+| `values` | Map from variant name to value |
 
-Every attribute must provide a value for every defined variant, even if that value is an empty string.
+Every attribute must provide a value for every defined variant, even if that value is blank.
+
+## Attribute types
+
+An attribute with no `kind` is a string attribute, which is how every attribute behaved before types existed — existing files need no change.
+
+Declaring a `kind` does two things: values are checked against it when you push, so a typo is caught at authoring time rather than on a live call, and the agent receives the value in its real type. A `number` attribute arrives as `3`, not `"3"`, and a `boolean` as `true`, not `"True"`.
+
+| `kind` | Written in `values` as | Example |
+|---|---|---|
+| `string` | Text | `London Office` |
+| `number` | A number | `"3"`, `"2.5"` |
+| `boolean` | `"true"` or `"false"` | `"true"` |
+| `enum` | One of `config.values` | `premium` |
+| `object` | A JSON object or array | `'{"currency":"USD"}'` |
+
+A blank value is allowed for every kind and means the attribute is not set for that variant yet.
+
+!!! note "Values are stored as text"
+
+    `values` always holds strings on disk, and `kind` says how to read them. That keeps the file readable by an ADK released before typed attributes, which would otherwise fail on a bare `3` or `true`.
+
+    You can still write values naturally by hand — `max_retries: 3` and `max_retries: "3"` are the same attribute, and neither shows as a change against the other. `poly pull` rewrites them in the quoted form.
+
+Changing an attribute's `kind` does not convert its existing values. Update the values in the same change, or the push is rejected with the variants whose values no longer fit.
+
+### Blank values at runtime
+
+A blank value behaves differently depending on the kind, and the difference only shows up on a live call:
+
+- A blank **`string`** attribute substitutes an empty string, so `{{attr:name}}` resolves to nothing.
+- A blank attribute of **any other kind** is left out of the deployed agent entirely, so `{{attr:name}}` stays unresolved and is reported as a configuration gap.
+
+If a prompt depends on a typed attribute, give it a value for every variant rather than leaving one blank.
+
+### Types that Agent Studio shows but does not store
+
+Agent Studio's type picker offers three types that have no equivalent here, because the platform stores them as one of the five kinds above:
+
+| Agent Studio type | Stored as | Value shape in `values` |
+|---|---|---|
+| Date & time | `string` | `2026-09-03 14:30` |
+| Opening hours | `string` | `Mon: 09:00-17:00; Tue: 09:00-17:00; Wed: Closed; Thu: ...` — all seven days, `Mon` to `Sun`, separated by `; ` |
+| Voice | `enum` | A voice ID, from `config.values` |
+
+They are editor choices, not stored types. Agent Studio re-detects "Date & time" and "Opening hours" by matching the value's exact shape, so editing one of those values here into a different shape silently drops the attribute back to a plain text editor in the UI. The value itself still works. "Voice" is indistinguishable from any other `enum` once saved.
 
 ## Example
 
@@ -86,6 +133,29 @@ attributes:
       london: |-
         This call may be recorded in accordance with UK regulations.
       tokyo: ""
+
+  - name: max_retries
+    kind: number
+    values:
+      new_york: "3"
+      london: "5"
+      tokyo: "3"
+
+  - name: serves_alcohol
+    kind: boolean
+    values:
+      new_york: "true"
+      london: "true"
+      tokyo: "false"
+
+  - name: tier
+    kind: enum
+    config:
+      values: [basic, premium]
+    values:
+      new_york: premium
+      london: premium
+      tokyo: basic
 ~~~
 
 ## Why variants are useful
@@ -163,7 +233,7 @@ Common uses include:
 | Branding | greeting name, company name |
 | Contact | phone numbers, addresses, office hours |
 | IDs | location ID, region code |
-| Feature flags | `"True"` / `"False"` strings, checked in Python |
+| Feature flags | `kind: boolean` (`true` / `false`) |
 | URLs | portal links, payment links |
 | Environment | timezone, `is_live` |
 
@@ -176,12 +246,15 @@ Common uses include:
 
 - Exactly one variant must have `is_default: true` — validation fails if zero or more than one variant is marked default.
 - Every variant must have a value in every attribute's `values` map — a missing variant fails validation.
+- Every value must match its attribute's declared `kind` — a value of the wrong type fails validation, naming the variant it came from.
+- An `enum` attribute must declare a non-empty `config.values` list, with no duplicates.
 
 ## Best practices
 
 - keep variant names stable over time
 - set exactly one default variant
-- provide a value or `""` for every variant in every attribute
+- provide a value, or a blank one, for every variant in every attribute
+- declare a `kind` whenever the value is not text, so mistakes surface at push time
 - prefer `{{attr:...}}` over hard-coded strings when values vary by location or environment
 - use multi-line YAML for disclaimers, instructions, or longer text values
 

--- a/docs/docs/reference/resources/variants.md
+++ b/docs/docs/reference/resources/variants.md
@@ -45,7 +45,7 @@ Each attribute includes:
 
 | Field | Description |
 |---|---|
-| `name` | Attribute identifier, ideally in snake_case |
+| `name` | Attribute identifier. Must be a valid Python identifier, since it is read in code as `conv.variant.<name>` |
 | `kind` | Optional. The attribute's type: `string` (default), `number`, `boolean`, `enum`, or `object` |
 | `config` | Optional. Type-specific configuration. Only `enum` takes one: `config.values` lists the allowed values |
 | `values` | Map from variant name to value |
@@ -61,18 +61,18 @@ Declaring a `kind` does two things: values are checked against it when you push,
 | `kind` | Written in `values` as | Example |
 |---|---|---|
 | `string` | Text | `London Office` |
-| `number` | A number | `"3"`, `"2.5"` |
-| `boolean` | `"true"` or `"false"` | `"true"` |
+| `number` | A number | `3`, `2.5` |
+| `boolean` | `true` or `false` | `true` |
 | `enum` | One of `config.values` | `premium` |
-| `object` | A JSON object or array | `'{"currency":"USD"}'` |
+| `object` | A map or list | `{currency: USD}` |
+
+Values are written in their declared type. A quoted value is still read correctly — `max_retries: 3` and `max_retries: "3"` are the same attribute, and neither shows as a change against the other — but `poly pull` writes the native form.
 
 A blank value is allowed for every kind and means the attribute is not set for that variant yet.
 
-!!! note "Values are stored as text"
+!!! info "`config` is per-kind"
 
-    `values` always holds strings on disk, and `kind` says how to read them. That keeps the file readable by an ADK released before typed attributes, which would otherwise fail on a bare `3` or `true`.
-
-    You can still write values naturally by hand — `max_retries: 3` and `max_retries: "3"` are the same attribute, and neither shows as a change against the other. `poly pull` rewrites them in the quoted form.
+    Only `enum` takes a `config` today. It is nested rather than a top-level `enum_values` so a future kind can carry its own settings without every other kind growing a field it ignores — and because `values` at the top level is already the per-variant value map.
 
 Changing an attribute's `kind` does not convert its existing values. Update the values in the same change, or the push is rejected with the variants whose values no longer fit.
 
@@ -137,16 +137,16 @@ attributes:
   - name: max_retries
     kind: number
     values:
-      new_york: "3"
-      london: "5"
-      tokyo: "3"
+      new_york: 3
+      london: 5
+      tokyo: 3
 
   - name: serves_alcohol
     kind: boolean
     values:
-      new_york: "true"
-      london: "true"
-      tokyo: "false"
+      new_york: true
+      london: true
+      tokyo: false
 
   - name: tier
     kind: enum
@@ -246,6 +246,7 @@ Common uses include:
 
 - Exactly one variant must have `is_default: true` — validation fails if zero or more than one variant is marked default.
 - Every variant must have a value in every attribute's `values` map — a missing variant fails validation.
+- Every attribute name must be a valid Python identifier — a letter or underscore followed by letters, digits or underscores — and not a Python reserved word. `customer-name` and `class` both fail.
 - Every value must match its attribute's declared `kind` — a value of the wrong type fails validation, naming the variant it came from.
 - An `enum` attribute must declare a non-empty `config.values` list, with no duplicates.
 

--- a/src/poly/docs/variants.md
+++ b/src/poly/docs/variants.md
@@ -18,7 +18,27 @@ The file has two top-level keys:
 
 ### `attributes` - List of attributes
 - **name**: Attribute identifier (snake_case recommended), e.g. `greeting_name`, `support_phone_number`.
-- **values**: Map from **variant name** to string value. Must have one entry per variant. Values can be `""`, a single line, or multi-line (`|-`).
+- **kind** (optional): The attribute's type — one of `string`, `number`, `boolean`, `enum`, `object`. Defaults to `string` when omitted.
+- **config** (optional): Type-specific configuration. Only `enum` takes one: `config.values` lists the allowed values.
+- **values**: Map from **variant name** to value. Must have one entry per variant. Leave a value blank for any kind to mean "not set yet".
+
+Typed values reach the agent as their real type: a `number` attribute arrives as `3`, not `"3"`. A `string` attribute behaves exactly as it always has, which is why untyped attributes need no change.
+
+`values` always holds strings on disk, and `kind` says how to read them — that keeps the file readable by an ADK released before typed attributes, which would fail on a bare `3` or `true`. You can still write values naturally by hand: `max_retries: 3` and `max_retries: "3"` are the same attribute, and `poly pull` rewrites them in the quoted form.
+
+### Blank values at runtime
+A blank `string` attribute substitutes an empty string, so `{{attr:name}}` resolves to nothing. A blank attribute of any other kind is left out of the deployed agent entirely, so `{{attr:name}}` stays unresolved and is reported as a configuration gap. Give typed attributes a value for every variant if a prompt depends on them.
+
+### Types Agent Studio shows but does not store
+Agent Studio's type picker offers three types with no equivalent here, because the platform stores them as one of the five kinds:
+
+| Agent Studio type | Stored as | Value shape |
+|---|---|---|
+| Date & time | `string` | `2026-09-03 14:30` |
+| Opening hours | `string` | `Mon: 09:00-17:00; Tue: Closed; ...` — all seven days, `Mon` to `Sun`, separated by `; ` |
+| Voice | `enum` | A voice ID, from `config.values` |
+
+Agent Studio re-detects "Date & time" and "Opening hours" by matching the value's exact shape, so editing one into a different shape drops the attribute back to a plain text editor in the UI. The value still works. "Voice" is indistinguishable from any other `enum` once saved.
 
 ## Example
 ```yaml
@@ -54,6 +74,40 @@ attributes:
       tokyo: ""
 ```
 
+### Typed attributes
+```yaml
+attributes:
+  - name: max_retries
+    kind: number
+    values:
+      new_york: "3"
+      london: "5"
+      tokyo: "3"
+
+  - name: serves_alcohol
+    kind: boolean
+    values:
+      new_york: "true"
+      london: "true"
+      tokyo: "false"
+
+  - name: tier
+    kind: enum
+    config:
+      values: [basic, premium]
+    values:
+      new_york: premium
+      london: premium
+      tokyo: basic
+
+  - name: menu_config
+    kind: object
+    values:
+      new_york: '{"categories":["pizza","pasta"],"currency":"USD"}'
+      london: '{"categories":["pizza"],"currency":"GBP"}'
+      tokyo: '{"categories":["pasta"],"currency":"JPY"}'
+```
+
 Ensure the YAML is formatted correctly, for example variant names with special characters (e.g. `&`, parentheses) must be quoted.
 
 ## Usage
@@ -84,13 +138,15 @@ Use the same attribute names as defined in `variant_attributes.yaml`.
 - **Branding**: greeting name, company name
 - **Contact**: phone numbers, addresses, office hours
 - **IDs**: location_id, region code
-- **Feature flags**: `"True"` / `"False"` strings (check in Python)
+- **Feature flags**: `kind: boolean` (`true` / `false`)
 - **URLs**: portal link, payment link
 - **Environment**: timezone, is_live
 
 ## Best practices
 - Keep variant names stable; quote them when they contain special characters.
 - Set exactly **one** `is_default` variant.
-- Provide a value (or `""`) for every variant in each attribute's `values` map. Validation will fail if a variant is missing.
+- Provide a value (or a blank one) for every variant in each attribute's `values` map. Validation will fail if a variant is missing.
+- Declare a `kind` when the value is not text. A `boolean` attribute is checked at push time and reaches the agent as a real boolean, where a `"True"` string is neither.
+- Changing an attribute's `kind` does not convert its existing values — update them in the same change, or the push is rejected.
 - Prefer `{{attr:...}}` over hard-coded strings for anything that varies by location/environment.
 - Use `|-` for multi-line values (disclaimers, hours, instructions).

--- a/src/poly/docs/variants.md
+++ b/src/poly/docs/variants.md
@@ -17,14 +17,14 @@ The file has two top-level keys:
 - **is_default** (optional): Exactly one variant must have `is_default: true`. Used when no variant is resolved at runtime.
 
 ### `attributes` - List of attributes
-- **name**: Attribute identifier (snake_case recommended), e.g. `greeting_name`, `support_phone_number`.
+- **name**: Attribute identifier. Must be a valid Python identifier (a letter or underscore followed by letters, digits or underscores) and not a Python reserved word, since it is read in code as `conv.variant.<name>`. e.g. `greeting_name`, `support_phone_number`.
 - **kind** (optional): The attribute's type — one of `string`, `number`, `boolean`, `enum`, `object`. Defaults to `string` when omitted.
 - **config** (optional): Type-specific configuration. Only `enum` takes one: `config.values` lists the allowed values.
 - **values**: Map from **variant name** to value. Must have one entry per variant. Leave a value blank for any kind to mean "not set yet".
 
 Typed values reach the agent as their real type: a `number` attribute arrives as `3`, not `"3"`. A `string` attribute behaves exactly as it always has, which is why untyped attributes need no change.
 
-`values` always holds strings on disk, and `kind` says how to read them — that keeps the file readable by an ADK released before typed attributes, which would fail on a bare `3` or `true`. You can still write values naturally by hand: `max_retries: 3` and `max_retries: "3"` are the same attribute, and `poly pull` rewrites them in the quoted form.
+Values are written in their declared type. A quoted value is still read correctly — `max_retries: 3` and `max_retries: "3"` are the same attribute — but `poly pull` writes the native form. Only `enum` takes a `config`; it is nested rather than a top-level `enum_values` so a future kind can carry its own settings, and because `values` at the top level is already the per-variant value map.
 
 ### Blank values at runtime
 A blank `string` attribute substitutes an empty string, so `{{attr:name}}` resolves to nothing. A blank attribute of any other kind is left out of the deployed agent entirely, so `{{attr:name}}` stays unresolved and is reported as a configuration gap. Give typed attributes a value for every variant if a prompt depends on them.
@@ -80,16 +80,16 @@ attributes:
   - name: max_retries
     kind: number
     values:
-      new_york: "3"
-      london: "5"
-      tokyo: "3"
+      new_york: 3
+      london: 5
+      tokyo: 3
 
   - name: serves_alcohol
     kind: boolean
     values:
-      new_york: "true"
-      london: "true"
-      tokyo: "false"
+      new_york: true
+      london: true
+      tokyo: false
 
   - name: tier
     kind: enum
@@ -103,9 +103,15 @@ attributes:
   - name: menu_config
     kind: object
     values:
-      new_york: '{"categories":["pizza","pasta"],"currency":"USD"}'
-      london: '{"categories":["pizza"],"currency":"GBP"}'
-      tokyo: '{"categories":["pasta"],"currency":"JPY"}'
+      new_york:
+        categories: [pizza, pasta]
+        currency: USD
+      london:
+        categories: [pizza]
+        currency: GBP
+      tokyo:
+        categories: [pasta]
+        currency: JPY
 ```
 
 Ensure the YAML is formatted correctly, for example variant names with special characters (e.g. `&`, parentheses) must be quoted.
@@ -146,6 +152,7 @@ Use the same attribute names as defined in `variant_attributes.yaml`.
 - Keep variant names stable; quote them when they contain special characters.
 - Set exactly **one** `is_default` variant.
 - Provide a value (or a blank one) for every variant in each attribute's `values` map. Validation will fail if a variant is missing.
+- Name attributes as Python identifiers — `customer_name`, not `customer-name`. The platform rejects anything else.
 - Declare a `kind` when the value is not text. A `boolean` attribute is checked at push time and reaches the agent as a real boolean, where a `"True"` string is neither.
 - Changing an attribute's `kind` does not convert its existing values — update them in the same change, or the push is rejected.
 - Prefer `{{attr:...}}` over hard-coded strings for anything that varies by location/environment.

--- a/src/poly/resources/__init__.py
+++ b/src/poly/resources/__init__.py
@@ -83,4 +83,4 @@ from poly.resources.topic import Topic
 from poly.resources.transcript_correction import RegularExpressionRule, TranscriptCorrection
 from poly.resources.translations import Translation
 from poly.resources.variable import Variable
-from poly.resources.variant_attributes import Variant, VariantAttribute
+from poly.resources.variant_attributes import AttributeKind, Variant, VariantAttribute

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -3,14 +3,21 @@
 Copyright PolyAI Limited
 """
 
+import json
 import logging
+import math
 import os
 from dataclasses import dataclass, field
-from typing import ClassVar
+from enum import Enum
+from typing import Any, ClassVar
+
+from google.protobuf.struct_pb2 import Struct
 
 import poly.resources.resource_utils as utils
 from poly.handlers.protobuf.variant_pb2 import (
+    AttributeType,
     AttributeValues,
+    EnumConfig,
     Variant_CreateAttribute,
     Variant_CreateVariant,
     Variant_DeleteAttribute,
@@ -24,6 +31,175 @@ from poly.resources.resource import MultiResourceYamlResource, ResourceMapping, 
 logger = logging.getLogger(__name__)
 
 
+class AttributeKind(str, Enum):
+    """Enum representing the declared type of a variant attribute."""
+
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    ENUM = "enum"
+    OBJECT = "object"
+
+
+# Ordinal mapping for the proto AttributeKind enum, which projections send as a raw int
+# rather than the string values used in YAML.
+ATTRIBUTE_KIND_FROM_PROTO_INT: dict[int, AttributeKind] = {
+    0: AttributeKind.STRING,
+    1: AttributeKind.NUMBER,
+    2: AttributeKind.BOOLEAN,
+    3: AttributeKind.ENUM,
+    4: AttributeKind.OBJECT,
+}
+
+ATTRIBUTE_KIND_TO_PROTO_INT: dict[AttributeKind, int] = {
+    kind: value for value, kind in ATTRIBUTE_KIND_FROM_PROTO_INT.items()
+}
+
+
+def _normalise_number(value: Any) -> Any:
+    """Collapse whole floats to int so YAML and the platform agree on `3` vs `3.0`.
+
+    Values cross the wire in a protobuf Struct, which holds every number as a double.
+    Without this, an attribute written as `3` locally would read back as `3.0` and show
+    up as a phantom diff on every status/push.
+    """
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value
+
+
+def parse_attribute_value(value: Any, kind: "AttributeKind", enum_values: list[str]) -> Any:
+    """Coerce a value read from YAML or a projection into its declared native type.
+
+    Mirrors the platform's `parseValueForKind`. Values are stored as strings on disk
+    (see `to_yaml_dict`), so this is the inverse of `stringify_attribute_value` — but a
+    value that is already native is passed straight through, so a hand-written `3` or
+    `true` works as naturally as the quoted form ADK writes.
+
+    A value that cannot be read as its kind is returned untouched rather than raising,
+    so `validate` can report it against its variant instead of blowing up mid-parse.
+    """
+    if isinstance(value, str):
+        value = value.strip()
+    if is_unset_attribute_value(value):
+        return None if kind != AttributeKind.STRING else value
+
+    match kind:
+        case AttributeKind.NUMBER:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, (int, float)):
+                return _normalise_number(value)
+            try:
+                parsed = float(value)
+            except (TypeError, ValueError):
+                return value
+            # Reject nan/inf: their JSON form is null, so they would not round-trip.
+            return _normalise_number(parsed) if math.isfinite(parsed) else value
+        case AttributeKind.BOOLEAN:
+            if isinstance(value, bool):
+                return value
+            if isinstance(value, str) and value.lower() in ("true", "false"):
+                return value.lower() == "true"
+            return value
+        case AttributeKind.OBJECT:
+            if isinstance(value, (dict, list)):
+                return value
+            try:
+                parsed = json.loads(value)
+            except (TypeError, ValueError):
+                return value
+            return parsed if isinstance(parsed, (dict, list)) else value
+        case _:
+            # STRING and ENUM are both stored as-is; an unquoted scalar becomes its
+            # text so an older or hand-written file reads without complaint.
+            if isinstance(value, bool) or isinstance(value, (int, float)):
+                return stringify_attribute_value(value)
+            return value
+
+
+def is_unset_attribute_value(value: Any) -> bool:
+    """Whether a stored attribute value means "unset".
+
+    Mirrors the platform's `isUnsetVariantValue`: `''` is the legacy marker written into
+    the string `values` map, `None` the one written into `typed_values` for a typed
+    attribute. Both mean the author has not given this variant a value.
+    """
+    return value is None or value == ""
+
+
+def stringify_attribute_value(value: Any) -> str:
+    """Stringify a native value for the legacy `values` map.
+
+    Mirrors the platform's `stringifyValue`: objects and lists are JSON, everything
+    else is `str(value)`, and unset is the empty string.
+    """
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (dict, list)):
+        return json.dumps(value, separators=(",", ":"))
+    return str(value)
+
+
+def _build_struct(values: dict[str, Any]) -> Struct:
+    """Build a protobuf Struct from native Python values, preserving nulls."""
+    struct = Struct()
+    struct.update(values)
+    return struct
+
+
+def _merge_variant_values(variant_attribute_values: dict) -> dict[str, Any]:
+    """Merge one variant's legacy string values with its native `typedValues`.
+
+    Mirrors the platform's `safeMergeVariantValues`: the native value wins per key, but
+    a `typedValues` that is not a mapping (corrupted or pre-typed data) is discarded
+    rather than merged, since spreading it would silently produce a partial result.
+    """
+    values = variant_attribute_values.get("values") or {}
+    typed_values = variant_attribute_values.get("typedValues")
+    if not isinstance(typed_values, dict):
+        return dict(values)
+    return {**values, **typed_values}
+
+
+def _read_attribute_type(type_data: dict | None) -> tuple[AttributeKind, dict]:
+    """Parse an attribute's declared type out of a projection.
+
+    Returns the kind and its flattened config. Projections carry `kind` as the proto
+    ordinal and wrap the `config` oneof the way ts-proto does — `{"$case": "enumConfig",
+    "value": {...}}` — which is flattened here to the plain config dict used in YAML.
+    Data written before typed attributes existed has no `type` at all and reads as STRING.
+    """
+    if not isinstance(type_data, dict):
+        return AttributeKind.STRING, {}
+
+    raw_kind = type_data.get("kind", 0)
+    if isinstance(raw_kind, str):
+        # The platform keeps `kind` numeric end to end; a token is only ever seen from
+        # a hand-written or legacy payload. Accept it rather than silently reading an
+        # ENUM as a STRING, which would drop the type on the next push. An unrecognised
+        # token falls back like an unrecognised ordinal does — one odd attribute must
+        # not fail the whole pull, which is the tolerance #299 established here.
+        try:
+            kind = AttributeKind(raw_kind.removeprefix("ATTRIBUTE_KIND_").strip().lower())
+        except ValueError:
+            logger.debug("Unknown variant attribute kind %r, reading as string.", raw_kind)
+            kind = AttributeKind.STRING
+    else:
+        kind = ATTRIBUTE_KIND_FROM_PROTO_INT.get(raw_kind, AttributeKind.STRING)
+
+    config = type_data.get("config")
+    if isinstance(config, dict):
+        # ts-proto oneof wrapper; older payloads set the member directly.
+        config = config.get("value", config)
+    if not isinstance(config, dict):
+        config = type_data.get("enum_config") or type_data.get("enumConfig") or {}
+
+    return kind, utils.convert_keys_to_snake_case(config or {})
+
+
 @register_resource("variants")
 @dataclass
 class Variant(MultiResourceYamlResource):
@@ -31,7 +207,10 @@ class Variant(MultiResourceYamlResource):
 
     is_default: bool = False
     top_level_name: ClassVar[str] = "variants"
-    attribute_ids: list[str] = field(default_factory=list, repr=False, init=False)
+    # Seed values for the attributes a newly created variant must carry, as
+    # {attribute_id: unset marker}. Filled in at push time by
+    # prepush.default_new_variant_attributes; never read from or written to YAML.
+    attribute_values: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     def __init__(
         self,
@@ -45,7 +224,7 @@ class Variant(MultiResourceYamlResource):
         self.name = name
         self.is_default = is_default
         self.slim = slim
-        self.attribute_ids = []
+        self.attribute_values = {}
 
     def to_yaml_dict(self) -> dict:
         yaml_dict = {
@@ -131,11 +310,21 @@ class Variant(MultiResourceYamlResource):
         )
 
     def build_create_proto(self) -> Variant_CreateVariant:
+        # A new variant must carry an entry for every attribute, but has no values of
+        # its own yet — the real values arrive with the attribute updates that follow.
+        # A typed attribute cannot hold "", so its seed is a native null in
+        # typed_values; the string map keeps "" so legacy readers see what they always did.
+        typed_seeds = {
+            attribute_id: value
+            for attribute_id, value in self.attribute_values.items()
+            if value is None
+        }
         return Variant_CreateVariant(
             id=self.resource_id,
             name=self.name,
             attribute_values=AttributeValues(
-                values={attribute_id: "" for attribute_id in self.attribute_ids}
+                values={attribute_id: "" for attribute_id in self.attribute_values},
+                typed_values=_build_struct(typed_seeds),
             ),
         )
 
@@ -194,7 +383,9 @@ class Variant(MultiResourceYamlResource):
 class VariantAttribute(MultiResourceYamlResource):
     """Dataclass representing a variant attribute"""
 
-    mappings: dict[str, str]
+    mappings: dict[str, Any]
+    kind: AttributeKind = AttributeKind.STRING
+    config: dict = field(default_factory=dict)
     top_level_name: ClassVar[str] = "attributes"
 
     def __init__(
@@ -202,19 +393,47 @@ class VariantAttribute(MultiResourceYamlResource):
         *,
         resource_id: str,
         name: str,
-        mappings: dict[str, str] | None = None,
+        mappings: dict[str, Any] | None = None,
+        kind: str | AttributeKind = AttributeKind.STRING,
+        config: dict | None = None,
         slim: bool = False,
     ):
         self.resource_id = resource_id
         self.name = name
-        self.mappings = mappings if mappings is not None else {}
         self.slim = slim
+        # kind and config first: parsing each value needs the declared type.
+        self.kind = AttributeKind(kind) if isinstance(kind, str) else kind
+        self.config = utils.convert_keys_to_snake_case(config or {})
+        self.mappings = {
+            variant_id: parse_attribute_value(value, self.kind, self.enum_values)
+            for variant_id, value in (mappings or {}).items()
+        }
+
+    @property
+    def enum_values(self) -> list[str]:
+        """Allowed values for an ENUM attribute; empty for every other kind."""
+        values = self.config.get("values") if self.kind == AttributeKind.ENUM else None
+        return list(values) if isinstance(values, list) else []
 
     def to_yaml_dict(self) -> dict:
-        return {
-            "name": self.name,
-            "values": dict(self.mappings),
+        yaml_dict: dict[str, Any] = {"name": self.name}
+        # An untyped attribute is a string one, so a STRING attribute is left
+        # un-annotated: `kind: string` carries no information, and writing it would
+        # rewrite the file for every project that has never used a type.
+        if self.kind != AttributeKind.STRING:
+            yaml_dict["kind"] = self.kind.value
+        if self.config:
+            yaml_dict["config"] = dict(self.config)
+        # Values are written as strings — the same strings the platform keeps in its
+        # legacy `values` map, with `kind` saying how to read them. Writing them
+        # natively would be prettier, but an ADK released before typed attributes
+        # calls .strip() on every value and would die on an int, bool or nested map
+        # the moment it read a file a newer ADK had written.
+        yaml_dict["values"] = {
+            variant_id: stringify_attribute_value(value)
+            for variant_id, value in self.mappings.items()
         }
+        return yaml_dict
 
     @property
     def file_path(self) -> str:
@@ -231,11 +450,21 @@ class VariantAttribute(MultiResourceYamlResource):
     def from_yaml_dict(
         cls, yaml_dict: dict, resource_id: str, name: str = "", **kwargs
     ) -> "VariantAttribute":
-        clean_mapping = {key: value.strip() for key, value in yaml_dict.get("values", {}).items()}
+        kind = yaml_dict.get("kind") or AttributeKind.STRING
+        if isinstance(kind, str):
+            try:
+                kind = AttributeKind(kind.strip().lower())
+            except ValueError:
+                raise ValueError(
+                    f"Unknown attribute kind '{kind}'. "
+                    f"Expected one of: {', '.join(k.value for k in AttributeKind)}"
+                ) from None
         return cls(
             resource_id=resource_id,
             name=yaml_dict.get("name") or name,
-            mappings=clean_mapping,
+            mappings=yaml_dict.get("values") or {},
+            kind=kind,
+            config=yaml_dict.get("config") or {},
         )
 
     @classmethod
@@ -270,8 +499,13 @@ class VariantAttribute(MultiResourceYamlResource):
         for attribute_id, attribute_data in attributes_projection.items():
             if attribute_data.get("archived"):
                 continue
+            kind, config = _read_attribute_type(attribute_data.get("type"))
             variant_attributes[attribute_id] = cls(
-                resource_id=attribute_id, name=attribute_data["name"], mappings={}
+                resource_id=attribute_id,
+                name=attribute_data["name"],
+                mappings={},
+                kind=kind,
+                config=config,
             )
         if not variant_attributes:
             return {}
@@ -282,9 +516,16 @@ class VariantAttribute(MultiResourceYamlResource):
             .get("entities", {})
             .items()
         ):
-            for attribute_id, attribute_value in variant_attribute_values.get("values", {}).items():
+            for attribute_id, attribute_value in _merge_variant_values(
+                variant_attribute_values
+            ).items():
                 if attribute_id in variant_attributes:
-                    variant_attributes[attribute_id].mappings[variant_id] = attribute_value
+                    attribute = variant_attributes[attribute_id]
+                    # A legacy value arrives only in the string map; parsing it against
+                    # the declared kind gives the same native value a typed one has.
+                    attribute.mappings[variant_id] = parse_attribute_value(
+                        attribute_value, attribute.kind, attribute.enum_values
+                    )
 
         return variant_attributes
 
@@ -301,9 +542,12 @@ class VariantAttribute(MultiResourceYamlResource):
             for resource in resource_mappings or []
             if resource.resource_type == Variant
         }
+        # `values:` with nothing under it parses as None, not {}. Tolerate it here so
+        # the empty attribute reaches validate() and fails with "Mappings are required"
+        # rather than an AttributeError from the pretty path.
         new_mapping = {
             variant_ids_to_names.get(variant_id, variant_id): variant_value
-            for variant_id, variant_value in d.get("values", {}).items()
+            for variant_id, variant_value in (d.get("values") or {}).items()
         }
         d["values"] = new_mapping
         return d
@@ -323,7 +567,7 @@ class VariantAttribute(MultiResourceYamlResource):
         }
 
         new_mapping = {}
-        for variant_name, variant_value in yaml_dict.get("values", {}).items():
+        for variant_name, variant_value in (yaml_dict.get("values") or {}).items():
             new_mapping[variant_names_to_ids.get(variant_name, variant_name)] = variant_value
 
         yaml_dict["values"] = new_mapping
@@ -345,9 +589,35 @@ class VariantAttribute(MultiResourceYamlResource):
     def update_command_type(self) -> str:
         return "variant_update_attribute"
 
+    def build_type_proto(self) -> AttributeType:
+        """Build the declared type, with its config for the kinds that have one."""
+        if self.kind == AttributeKind.ENUM:
+            return AttributeType(
+                kind=ATTRIBUTE_KIND_TO_PROTO_INT[self.kind],
+                enum_config=EnumConfig(values=self.enum_values),
+            )
+        return AttributeType(kind=ATTRIBUTE_KIND_TO_PROTO_INT[self.kind])
+
+    def build_variant_values_proto(self) -> VariantValues:
+        """Dual-write the per-variant values: stringified for legacy readers, native for typed ones.
+
+        A STRING attribute writes only the string map — it is what it has always
+        written, and `typed_values` would add nothing.
+        """
+        values = {
+            variant_id: stringify_attribute_value(value)
+            for variant_id, value in self.mappings.items()
+        }
+        if self.kind == AttributeKind.STRING:
+            return VariantValues(values=values)
+        return VariantValues(values=values, typed_values=_build_struct(dict(self.mappings)))
+
     def build_update_proto(self) -> Variant_UpdateAttribute:
         return Variant_UpdateAttribute(
-            id=self.resource_id, name=self.name, variant_values=VariantValues(values=self.mappings)
+            id=self.resource_id,
+            name=self.name,
+            variant_values=self.build_variant_values_proto(),
+            type=self.build_type_proto(),
         )
 
     def build_delete_proto(self) -> Variant_DeleteAttribute:
@@ -359,7 +629,8 @@ class VariantAttribute(MultiResourceYamlResource):
         return Variant_CreateAttribute(
             id=self.resource_id,
             name=self.name,
-            variant_values=VariantValues(values=self.mappings),
+            variant_values=self.build_variant_values_proto(),
+            type=self.build_type_proto(),
             references={},
         )
 
@@ -384,6 +655,66 @@ class VariantAttribute(MultiResourceYamlResource):
             raise ValueError(
                 f"Missing variants for variant attribute: {[known_variant_id_to_name[variant_id] for variant_id in missing_variants]}"
             )
+
+        self._validate_config()
+        for variant_id, value in self.mappings.items():
+            if not self._value_matches_kind(value):
+                variant_name = known_variant_id_to_name.get(variant_id, variant_id)
+                raise ValueError(
+                    f"Value for variant '{variant_name}' does not match the declared "
+                    f"type of attribute '{self.name}': expected {self._describe_kind()}, "
+                    f"got {value!r}"
+                )
+
+    def _describe_kind(self) -> str:
+        """Human-readable form of the declared type, for validation messages."""
+        if self.kind == AttributeKind.ENUM:
+            return f"enum ({', '.join(self.enum_values)})"
+        return self.kind.value
+
+    def _validate_config(self) -> None:
+        """Check the type's config is well formed for its kind."""
+        if self.kind != AttributeKind.ENUM:
+            if self.config:
+                raise ValueError(f"Attribute kind '{self.kind.value}' does not take a config")
+            return
+
+        values = self.config.get("values")
+        if not isinstance(values, list) or not values:
+            raise ValueError("An enum attribute needs a non-empty 'config.values' list")
+        if any(not isinstance(value, str) for value in values):
+            raise ValueError("Enum values must be strings")
+        if len(set(values)) != len(values):
+            raise ValueError(f"Duplicate enum values for attribute '{self.name}': {values}")
+
+    def _value_matches_kind(self, value: Any) -> bool:
+        """Whether one value is valid for the declared type.
+
+        Mirrors the platform's `validateValueMatchesType`, including its treatment of
+        unset: a blank value is valid for every kind, so an attribute can be added
+        before every variant has been given a value.
+        """
+        if is_unset_attribute_value(value):
+            return True
+        match self.kind:
+            case AttributeKind.NUMBER:
+                # bool is an int subclass in Python, but is not a number here.
+                # The platform checks Number.isFinite, so a YAML `.inf` or `.nan`
+                # has to fail here rather than at push time — neither survives the
+                # JSON round trip through typed_values anyway.
+                return (
+                    isinstance(value, (int, float))
+                    and not isinstance(value, bool)
+                    and math.isfinite(value)
+                )
+            case AttributeKind.BOOLEAN:
+                return isinstance(value, bool)
+            case AttributeKind.ENUM:
+                return isinstance(value, str) and value in self.enum_values
+            case AttributeKind.OBJECT:
+                return isinstance(value, (dict, list))
+            case _:
+                return isinstance(value, str)
 
     @staticmethod
     def discover_resources(base_path: str) -> list[str]:

--- a/src/poly/resources/variant_attributes.py
+++ b/src/poly/resources/variant_attributes.py
@@ -4,9 +4,11 @@ Copyright PolyAI Limited
 """
 
 import json
+import keyword
 import logging
 import math
 import os
+import re
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, ClassVar
@@ -41,8 +43,6 @@ class AttributeKind(str, Enum):
     OBJECT = "object"
 
 
-# Ordinal mapping for the proto AttributeKind enum, which projections send as a raw int
-# rather than the string values used in YAML.
 ATTRIBUTE_KIND_FROM_PROTO_INT: dict[int, AttributeKind] = {
     0: AttributeKind.STRING,
     1: AttributeKind.NUMBER,
@@ -57,27 +57,17 @@ ATTRIBUTE_KIND_TO_PROTO_INT: dict[AttributeKind, int] = {
 
 
 def _normalise_number(value: Any) -> Any:
-    """Collapse whole floats to int so YAML and the platform agree on `3` vs `3.0`.
-
-    Values cross the wire in a protobuf Struct, which holds every number as a double.
-    Without this, an attribute written as `3` locally would read back as `3.0` and show
-    up as a phantom diff on every status/push.
-    """
+    """Collapse whole floats to int, so a Struct's `3.0` doesn't diff against `3`."""
     if isinstance(value, float) and value.is_integer():
         return int(value)
     return value
 
 
 def parse_attribute_value(value: Any, kind: "AttributeKind", enum_values: list[str]) -> Any:
-    """Coerce a value read from YAML or a projection into its declared native type.
+    """Coerce a value into its declared native type, mirroring `parseValueForKind`.
 
-    Mirrors the platform's `parseValueForKind`. Values are stored as strings on disk
-    (see `to_yaml_dict`), so this is the inverse of `stringify_attribute_value` — but a
-    value that is already native is passed straight through, so a hand-written `3` or
-    `true` works as naturally as the quoted form ADK writes.
-
-    A value that cannot be read as its kind is returned untouched rather than raising,
-    so `validate` can report it against its variant instead of blowing up mid-parse.
+    A value that can't be read as its kind is returned untouched, so `validate` reports
+    it against its variant rather than this raising mid-parse.
     """
     if isinstance(value, str):
         value = value.strip()
@@ -94,7 +84,6 @@ def parse_attribute_value(value: Any, kind: "AttributeKind", enum_values: list[s
                 parsed = float(value)
             except (TypeError, ValueError):
                 return value
-            # Reject nan/inf: their JSON form is null, so they would not round-trip.
             return _normalise_number(parsed) if math.isfinite(parsed) else value
         case AttributeKind.BOOLEAN:
             if isinstance(value, bool):
@@ -111,29 +100,21 @@ def parse_attribute_value(value: Any, kind: "AttributeKind", enum_values: list[s
                 return value
             return parsed if isinstance(parsed, (dict, list)) else value
         case _:
-            # STRING and ENUM are both stored as-is; an unquoted scalar becomes its
-            # text so an older or hand-written file reads without complaint.
             if isinstance(value, bool) or isinstance(value, (int, float)):
                 return stringify_attribute_value(value)
             return value
 
 
 def is_unset_attribute_value(value: Any) -> bool:
-    """Whether a stored attribute value means "unset".
+    """Whether a value means "unset", mirroring `isUnsetVariantValue`.
 
-    Mirrors the platform's `isUnsetVariantValue`: `''` is the legacy marker written into
-    the string `values` map, `None` the one written into `typed_values` for a typed
-    attribute. Both mean the author has not given this variant a value.
+    `''` is the marker in the string map, `None` the one in `typed_values`.
     """
     return value is None or value == ""
 
 
 def stringify_attribute_value(value: Any) -> str:
-    """Stringify a native value for the legacy `values` map.
-
-    Mirrors the platform's `stringifyValue`: objects and lists are JSON, everything
-    else is `str(value)`, and unset is the empty string.
-    """
+    """Stringify a native value for the legacy `values` map, mirroring `stringifyValue`."""
     if value is None:
         return ""
     if isinstance(value, bool):
@@ -141,6 +122,24 @@ def stringify_attribute_value(value: Any) -> str:
     if isinstance(value, (dict, list)):
         return json.dumps(value, separators=(",", ":"))
     return str(value)
+
+
+# Not str.isidentifier(): that accepts non-ASCII names the platform's regex rejects.
+_PYTHONIC_NAME = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*")
+
+
+def _validate_attribute_name(name: str) -> None:
+    """Reject a name the platform would reject on push.
+
+    Names are read as `conv.variant.<name>`, so they must be Python identifiers.
+    """
+    if not _PYTHONIC_NAME.fullmatch(name):
+        raise ValueError(
+            f"Attribute name '{name}' must be a valid Python identifier: a letter or "
+            "underscore followed by letters, digits or underscores"
+        )
+    if keyword.iskeyword(name):
+        raise ValueError(f"Attribute name '{name}' is a reserved word in Python")
 
 
 def _build_struct(values: dict[str, Any]) -> Struct:
@@ -151,10 +150,9 @@ def _build_struct(values: dict[str, Any]) -> Struct:
 
 
 def _merge_variant_values(variant_attribute_values: dict) -> dict[str, Any]:
-    """Merge one variant's legacy string values with its native `typedValues`.
+    """Merge a variant's string values with its `typedValues`, per `safeMergeVariantValues`.
 
-    Mirrors the platform's `safeMergeVariantValues`: the native value wins per key, but
-    a `typedValues` that is not a mapping (corrupted or pre-typed data) is discarded
+    The native value wins per key. A `typedValues` that isn't a mapping is discarded
     rather than merged, since spreading it would silently produce a partial result.
     """
     values = variant_attribute_values.get("values") or {}
@@ -167,21 +165,15 @@ def _merge_variant_values(variant_attribute_values: dict) -> dict[str, Any]:
 def _read_attribute_type(type_data: dict | None) -> tuple[AttributeKind, dict]:
     """Parse an attribute's declared type out of a projection.
 
-    Returns the kind and its flattened config. Projections carry `kind` as the proto
-    ordinal and wrap the `config` oneof the way ts-proto does — `{"$case": "enumConfig",
-    "value": {...}}` — which is flattened here to the plain config dict used in YAML.
-    Data written before typed attributes existed has no `type` at all and reads as STRING.
+    ts-proto wraps the `config` oneof as `{"$case": ..., "value": {...}}`; this returns
+    the flattened config used in YAML. A missing `type` reads as STRING.
     """
     if not isinstance(type_data, dict):
         return AttributeKind.STRING, {}
 
     raw_kind = type_data.get("kind", 0)
     if isinstance(raw_kind, str):
-        # The platform keeps `kind` numeric end to end; a token is only ever seen from
-        # a hand-written or legacy payload. Accept it rather than silently reading an
-        # ENUM as a STRING, which would drop the type on the next push. An unrecognised
-        # token falls back like an unrecognised ordinal does — one odd attribute must
-        # not fail the whole pull, which is the tolerance #299 established here.
+        # A token only turns up in hand-written data; an unknown one must not fail the pull.
         try:
             kind = AttributeKind(raw_kind.removeprefix("ATTRIBUTE_KIND_").strip().lower())
         except ValueError:
@@ -190,9 +182,13 @@ def _read_attribute_type(type_data: dict | None) -> tuple[AttributeKind, dict]:
     else:
         kind = ATTRIBUTE_KIND_FROM_PROTO_INT.get(raw_kind, AttributeKind.STRING)
 
+    # Changing an attribute away from enum leaves its enum_config on the platform.
+    # Reading that back would give a kind a config it can't have, failing the next push.
+    if kind != AttributeKind.ENUM:
+        return kind, {}
+
     config = type_data.get("config")
     if isinstance(config, dict):
-        # ts-proto oneof wrapper; older payloads set the member directly.
         config = config.get("value", config)
     if not isinstance(config, dict):
         config = type_data.get("enum_config") or type_data.get("enumConfig") or {}
@@ -207,9 +203,7 @@ class Variant(MultiResourceYamlResource):
 
     is_default: bool = False
     top_level_name: ClassVar[str] = "variants"
-    # Seed values for the attributes a newly created variant must carry, as
-    # {attribute_id: unset marker}. Filled in at push time by
-    # prepush.default_new_variant_attributes; never read from or written to YAML.
+    # Push-time only, set by prepush.default_new_variant_attributes. Never in YAML.
     attribute_values: dict[str, Any] = field(default_factory=dict, repr=False, init=False)
 
     def __init__(
@@ -310,10 +304,7 @@ class Variant(MultiResourceYamlResource):
         )
 
     def build_create_proto(self) -> Variant_CreateVariant:
-        # A new variant must carry an entry for every attribute, but has no values of
-        # its own yet — the real values arrive with the attribute updates that follow.
-        # A typed attribute cannot hold "", so its seed is a native null in
-        # typed_values; the string map keeps "" so legacy readers see what they always did.
+        # Every attribute needs an entry; a typed one can't hold "", so it seeds null.
         typed_seeds = {
             attribute_id: value
             for attribute_id, value in self.attribute_values.items()
@@ -417,22 +408,11 @@ class VariantAttribute(MultiResourceYamlResource):
 
     def to_yaml_dict(self) -> dict:
         yaml_dict: dict[str, Any] = {"name": self.name}
-        # An untyped attribute is a string one, so a STRING attribute is left
-        # un-annotated: `kind: string` carries no information, and writing it would
-        # rewrite the file for every project that has never used a type.
         if self.kind != AttributeKind.STRING:
             yaml_dict["kind"] = self.kind.value
         if self.config:
             yaml_dict["config"] = dict(self.config)
-        # Values are written as strings — the same strings the platform keeps in its
-        # legacy `values` map, with `kind` saying how to read them. Writing them
-        # natively would be prettier, but an ADK released before typed attributes
-        # calls .strip() on every value and would die on an int, bool or nested map
-        # the moment it read a file a newer ADK had written.
-        yaml_dict["values"] = {
-            variant_id: stringify_attribute_value(value)
-            for variant_id, value in self.mappings.items()
-        }
+        yaml_dict["values"] = dict(self.mappings)
         return yaml_dict
 
     @property
@@ -521,8 +501,6 @@ class VariantAttribute(MultiResourceYamlResource):
             ).items():
                 if attribute_id in variant_attributes:
                     attribute = variant_attributes[attribute_id]
-                    # A legacy value arrives only in the string map; parsing it against
-                    # the declared kind gives the same native value a typed one has.
                     attribute.mappings[variant_id] = parse_attribute_value(
                         attribute_value, attribute.kind, attribute.enum_values
                     )
@@ -542,9 +520,8 @@ class VariantAttribute(MultiResourceYamlResource):
             for resource in resource_mappings or []
             if resource.resource_type == Variant
         }
-        # `values:` with nothing under it parses as None, not {}. Tolerate it here so
-        # the empty attribute reaches validate() and fails with "Mappings are required"
-        # rather than an AttributeError from the pretty path.
+        # `values:` with nothing under it parses as None, not {}. Let it reach
+        # validate() rather than raising AttributeError from the pretty path.
         new_mapping = {
             variant_ids_to_names.get(variant_id, variant_id): variant_value
             for variant_id, variant_value in (d.get("values") or {}).items()
@@ -599,10 +576,9 @@ class VariantAttribute(MultiResourceYamlResource):
         return AttributeType(kind=ATTRIBUTE_KIND_TO_PROTO_INT[self.kind])
 
     def build_variant_values_proto(self) -> VariantValues:
-        """Dual-write the per-variant values: stringified for legacy readers, native for typed ones.
+        """Dual-write the values: stringified for legacy readers, native for typed ones.
 
-        A STRING attribute writes only the string map — it is what it has always
-        written, and `typed_values` would add nothing.
+        STRING writes only the string map; `typed_values` would add nothing.
         """
         values = {
             variant_id: stringify_attribute_value(value)
@@ -637,6 +613,7 @@ class VariantAttribute(MultiResourceYamlResource):
     def validate(self, resource_mappings: list[ResourceMapping], **kwargs):
         if not self.name:
             raise ValueError("Name is required")
+        _validate_attribute_name(self.name)
         if not self.mappings:
             raise ValueError("Mappings are required")
 
@@ -690,18 +667,13 @@ class VariantAttribute(MultiResourceYamlResource):
     def _value_matches_kind(self, value: Any) -> bool:
         """Whether one value is valid for the declared type.
 
-        Mirrors the platform's `validateValueMatchesType`, including its treatment of
-        unset: a blank value is valid for every kind, so an attribute can be added
-        before every variant has been given a value.
+        Mirrors `validateValueMatchesType`: unset is valid for every kind.
         """
         if is_unset_attribute_value(value):
             return True
         match self.kind:
             case AttributeKind.NUMBER:
-                # bool is an int subclass in Python, but is not a number here.
-                # The platform checks Number.isFinite, so a YAML `.inf` or `.nan`
-                # has to fail here rather than at push time — neither survives the
-                # JSON round trip through typed_values anyway.
+                # bool is an int subclass; the platform also rejects non-finite.
                 return (
                     isinstance(value, (int, float))
                     and not isinstance(value, bool)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -20,6 +20,7 @@ from poly.handlers.protobuf.commands_pb2 import Command
 from poly.project import AgentStudioProject, DeploymentMode
 from poly.resources import (
     AsrSettings,
+    AttributeKind,
     ChatGreeting,
     ChatSafetyFilters,
     ChatStylePrompt,
@@ -2042,7 +2043,54 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             deleted_resources,
         )
 
-        self.assertEqual(new_variant.attribute_ids, ["VARIANT_ATTRIBUTES-keep"])
+        self.assertEqual(new_variant.attribute_values, {"VARIANT_ATTRIBUTES-keep": ""})
+
+    def test_new_variant_seeds_typed_attributes_with_null(self):
+        """A typed attribute cannot hold "", so a new variant seeds it as null instead."""
+        string_attr = VariantAttribute(
+            resource_id="VARIANT_ATTRIBUTES-greeting",
+            name="greeting_name",
+            mappings={"v1": "Hello"},
+        )
+        number_attr = VariantAttribute(
+            resource_id="VARIANT_ATTRIBUTES-retries",
+            name="max_retries",
+            mappings={"v1": 3},
+            kind=AttributeKind.NUMBER,
+        )
+        self.project.resources[VariantAttribute] = {
+            "VARIANT_ATTRIBUTES-greeting": string_attr,
+            "VARIANT_ATTRIBUTES-retries": number_attr,
+        }
+
+        new_variant = Variant(
+            resource_id="VARIANTS-new",
+            name="New Variant",
+            is_default=False,
+        )
+
+        self.project._clean_resources_before_push(
+            {},
+            {Variant: {"VARIANTS-new": new_variant}},
+            {},
+            {},
+        )
+
+        self.assertEqual(
+            new_variant.attribute_values,
+            {"VARIANT_ATTRIBUTES-greeting": "", "VARIANT_ATTRIBUTES-retries": None},
+        )
+
+        # Both seeds reach the wire: "" in the legacy string map for every attribute,
+        # and a native null in typed_values for the typed one.
+        proto = new_variant.build_create_proto()
+        self.assertEqual(
+            dict(proto.attribute_values.values),
+            {"VARIANT_ATTRIBUTES-greeting": "", "VARIANT_ATTRIBUTES-retries": ""},
+        )
+        self.assertEqual(
+            dict(proto.attribute_values.typed_values), {"VARIANT_ATTRIBUTES-retries": None}
+        )
 
     def test_non_default_variant_update_is_kept(self):
         """A renamed non-default variant must still be pushed as an update."""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -1480,20 +1480,20 @@ class TopicTests(unittest.TestCase):
         topic_with_attr = Topic(
             resource_id="789",
             name="topic_with_attr",
-            actions="Check {{attr:attr-customer-name}} status",
+            actions="Check {{attr:attr-customer_name}} status",
             content="Attribute reference",
             example_queries=["Test query"],
         )
         with self.assertRaises(ValueError) as cm:
             topic_with_attr.validate(resource_mappings=[])
-        self.assertIn("Invalid references: ['attributes: attr-customer-name']", str(cm.exception))
+        self.assertIn("Invalid references: ['attributes: attr-customer_name']", str(cm.exception))
 
         valid_mapping = [
             ResourceMapping(
-                resource_id="attr-customer-name",
-                resource_name="customer-name",
+                resource_id="attr-customer_name",
+                resource_name="customer_name",
                 resource_type=VariantAttribute,
-                file_path="config/variant_attributes.yaml/variant_attributes/customer-name",
+                file_path="config/variant_attributes.yaml/variant_attributes/customer_name",
                 flow_name=None,
                 resource_prefix="attr",
             )
@@ -2341,10 +2341,10 @@ class VoiceDisclaimerMessageTests(unittest.TestCase):
         # Valid attr reference
         valid_attr_mapping = [
             ResourceMapping(
-                resource_id="attr-customer-name",
-                resource_name="customer-name",
+                resource_id="attr-customer_name",
+                resource_name="customer_name",
                 resource_type=VariantAttribute,
-                file_path="config/variant_attributes.yaml/variant_attributes/customer-name",
+                file_path="config/variant_attributes.yaml/variant_attributes/customer_name",
                 flow_name=None,
                 resource_prefix="attr",
             )
@@ -2352,7 +2352,7 @@ class VoiceDisclaimerMessageTests(unittest.TestCase):
         valid_attr_disclaimer = VoiceDisclaimerMessage(
             resource_id="disclaimer_123",
             name="disclaimer_message",
-            message="Your status is {{attr:attr-customer-name}}.",
+            message="Your status is {{attr:attr-customer_name}}.",
             enabled=True,
             language_code="en-GB",
         )
@@ -4974,8 +4974,8 @@ class SMSTemplateTests(unittest.TestCase):
 TEST_VARIANT = Variant(resource_id="VARIANT-default", name="default")
 TEST_VARIANT_DEFAULT = Variant(resource_id="VARIANT-default", name="default", is_default=True)
 TEST_VARIANT_ATTRIBUTE = VariantAttribute(
-    resource_id="attr-customer-name",
-    name="customer-name",
+    resource_id="attr-customer_name",
+    name="customer_name",
     mappings={"VARIANT-default": "value"},
 )
 
@@ -5127,7 +5127,7 @@ class VariantTests(unittest.TestCase):
         rejected. Variant updates must therefore never populate it.
         """
         variant = Variant(resource_id="VARIANT-default", name="default")
-        variant.attribute_ids = ["attr-customer-name"]
+        variant.attribute_ids = ["attr-customer_name"]
 
         proto = variant.build_update_proto()
 
@@ -5143,18 +5143,18 @@ class VariantAttributeTests(unittest.TestCase):
     def test_to_yaml_dict(self):
         """Test converting variant attribute to YAML dictionary."""
         yaml_dict = TEST_VARIANT_ATTRIBUTE.to_yaml_dict()
-        self.assertEqual(yaml_dict["name"], "customer-name")
+        self.assertEqual(yaml_dict["name"], "customer_name")
         self.assertEqual(yaml_dict["values"], {"VARIANT-default": "value"})
 
     def test_from_yaml(self):
         """Test creating variant attribute from YAML dictionary."""
         yaml_dict = {
-            "name": "email-address",
+            "name": "email_address",
             "values": {"VARIANT-default": "user@example.com"},
         }
-        attr = VariantAttribute.from_yaml_dict(yaml_dict, "attr-email-address")
-        self.assertEqual(attr.resource_id, "attr-email-address")
-        self.assertEqual(attr.name, "email-address")
+        attr = VariantAttribute.from_yaml_dict(yaml_dict, "attr-email_address")
+        self.assertEqual(attr.resource_id, "attr-email_address")
+        self.assertEqual(attr.name, "email_address")
         self.assertEqual(attr.mappings, {"VARIANT-default": "user@example.com"})
 
     def test_file_path(self):
@@ -5169,10 +5169,10 @@ class VariantAttributeTests(unittest.TestCase):
         test_file_content = """variants:
   - default
 attributes:
-  - name: customer-name
+  - name: customer_name
     values:
       VARIANT-default: ""
-  - name: email-address
+  - name: email_address
     values:
       VARIANT-default: ""
 """
@@ -5194,10 +5194,10 @@ attributes:
         test_file_content = """variants:
   - default
 attributes:
-  - name: customer-name
+  - name: customer_name
     values:
       VARIANT-default: "test value"
-  - name: email-address
+  - name: email_address
     values:
       VARIANT-default: ""
 """
@@ -5213,13 +5213,13 @@ attributes:
         with mock_variant_attributes_file(test_file_content):
             result = VariantAttribute.read_local_resource(
                 file_path="config/variant_attributes.yaml/attributes/customer_name",
-                resource_id="attr-customer-name",
-                resource_name="customer-name",
+                resource_id="attr-customer_name",
+                resource_name="customer_name",
                 resource_mappings=[variant_mapping],
             )
 
-        self.assertEqual(result.resource_id, "attr-customer-name")
-        self.assertEqual(result.name, "customer-name")
+        self.assertEqual(result.resource_id, "attr-customer_name")
+        self.assertEqual(result.name, "customer_name")
         self.assertEqual(result.mappings, {"VARIANT-default": "test value"})
 
     def test_validate_empty_name(self):
@@ -5237,7 +5237,7 @@ attributes:
         """Test validation fails when mappings are empty."""
         attr = VariantAttribute(
             resource_id="attr-test",
-            name="test-attr",
+            name="test_attr",
             mappings={},
         )
         variant_mapping = ResourceMapping(
@@ -5256,7 +5256,7 @@ attributes:
         """Test validation fails when attribute is missing values for some variants."""
         attr = VariantAttribute(
             resource_id="attr-test",
-            name="test-attr",
+            name="test_attr",
             mappings={"VARIANT-default": ""},
         )
         variant_mappings = [
@@ -5285,7 +5285,7 @@ attributes:
         """Test validation fails when attribute has values for unknown variants."""
         attr = VariantAttribute(
             resource_id="attr-test",
-            name="test-attr",
+            name="test_attr",
             mappings={"VARIANT-default": "", "VARIANT-unknown": ""},
         )
         variant_mapping = ResourceMapping(
@@ -5314,7 +5314,7 @@ attributes:
 
     def test_make_pretty_replaces_variant_ids_with_names(self):
         """Test make_pretty replaces variant IDs with names in values."""
-        raw_content = "name: customer-name\nvalues:\n  VARIANT-default: hello\n"
+        raw_content = "name: customer_name\nvalues:\n  VARIANT-default: hello\n"
         variant_mapping = ResourceMapping(
             resource_id="VARIANT-default",
             resource_type=Variant,
@@ -5332,7 +5332,7 @@ attributes:
 
     def test_from_pretty_replaces_variant_names_with_ids(self):
         """Test from_pretty replaces variant names with IDs in values."""
-        pretty_content = "name: customer-name\nvalues:\n  default: hello\n"
+        pretty_content = "name: customer_name\nvalues:\n  default: hello\n"
         variant_mapping = ResourceMapping(
             resource_id="VARIANT-default",
             resource_type=Variant,
@@ -5365,7 +5365,7 @@ class TypedVariantAttributeTests(unittest.TestCase):
         )
 
     @staticmethod
-    def _attribute(kind, value, config=None, name="test-attr"):
+    def _attribute(kind, value, config=None, name="test_attr"):
         return VariantAttribute(
             resource_id="attr-test",
             name=name,
@@ -5386,7 +5386,7 @@ class TypedVariantAttributeTests(unittest.TestCase):
         """A string attribute serializes exactly as it did before types existed."""
         attr = self._attribute(AttributeKind.STRING, "hello")
         self.assertEqual(
-            attr.to_yaml_dict(), {"name": "test-attr", "values": {"VARIANT-default": "hello"}}
+            attr.to_yaml_dict(), {"name": "test_attr", "values": {"VARIANT-default": "hello"}}
         )
 
     def test_yaml_round_trip_preserves_kind_and_native_values(self):
@@ -5501,7 +5501,7 @@ class TypedVariantAttributeTests(unittest.TestCase):
             "VARIANT-d": "0123",
             "VARIANT-e": "1.0",
         }
-        attr = VariantAttribute(resource_id="attr-test", name="test-attr", mappings=values)
+        attr = VariantAttribute(resource_id="attr-test", name="test_attr", mappings=values)
 
         read_back = VariantAttribute.from_yaml_dict(
             resource_utils.load_yaml(resource_utils.dump_yaml(attr.to_yaml_dict())), "attr-test"
@@ -5521,6 +5521,33 @@ class TypedVariantAttributeTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             attr.validate(resource_mappings=[self.variant_mapping])
         self.assertIn("Mappings are required", str(cm.exception))
+
+    def test_validate_rejects_a_name_the_platform_would_reject(self):
+        """Attribute names are read as `conv.variant.<name>`, so they must be identifiers.
+
+        The platform rejects these with a ZodValidationError on push; catching it here
+        names the attribute and the rule instead.
+        """
+        for name, expected in [
+            ("customer-name", "valid Python identifier"),
+            ("1st_choice", "valid Python identifier"),
+            ("has space", "valid Python identifier"),
+            ("café", "valid Python identifier"),
+            ("class", "reserved word"),
+            ("lambda", "reserved word"),
+        ]:
+            with self.subTest(name=name):
+                attr = self._attribute(AttributeKind.STRING, "x", name=name)
+                with self.assertRaises(ValueError) as cm:
+                    attr.validate(resource_mappings=[self.variant_mapping])
+                self.assertIn(expected, str(cm.exception))
+
+    def test_validate_accepts_identifier_names(self):
+        """Anything Python would accept as a plain ASCII identifier is fine."""
+        for name in ("customer_name", "_private", "x1", "lambda_ok", "CamelCase"):
+            with self.subTest(name=name):
+                attr = self._attribute(AttributeKind.STRING, "x", name=name)
+                self.assertIsNone(attr.validate(resource_mappings=[self.variant_mapping]))
 
     def test_validate_rejects_config_on_a_kind_that_takes_none(self):
         """Only enum takes a config; a config anywhere else is a mistake worth surfacing."""
@@ -5579,84 +5606,68 @@ class TypedVariantAttributeTests(unittest.TestCase):
         self.assertEqual(dict(proto.variant_values.typed_values), {"VARIANT-default": True})
 
 
-class TypedVariantAttributeBackCompatTests(unittest.TestCase):
-    """Tests that a file written by this ADK stays readable by one released before types."""
+class TypedVariantAttributeYamlTests(unittest.TestCase):
+    """Tests for how typed values are written to and read back from YAML."""
 
     ALL_KINDS = [
-        (AttributeKind.STRING, "hello", None, "hello"),
-        (AttributeKind.NUMBER, 3, None, "3"),
-        (AttributeKind.NUMBER, 2.5, None, "2.5"),
-        (AttributeKind.BOOLEAN, True, None, "true"),
-        (AttributeKind.BOOLEAN, False, None, "false"),
-        (AttributeKind.ENUM, "premium", {"values": ["basic", "premium"]}, "premium"),
-        (AttributeKind.OBJECT, {"a": [1, 2]}, None, '{"a":[1,2]}'),
-        (AttributeKind.NUMBER, None, None, ""),
+        (AttributeKind.STRING, "hello", None),
+        (AttributeKind.NUMBER, 3, None),
+        (AttributeKind.NUMBER, 2.5, None),
+        (AttributeKind.BOOLEAN, True, None),
+        (AttributeKind.BOOLEAN, False, None),
+        (AttributeKind.ENUM, "premium", {"values": ["basic", "premium"]}),
+        (AttributeKind.OBJECT, {"a": [1, 2]}, None),
+        (AttributeKind.NUMBER, None, None),
     ]
 
     @staticmethod
-    def _read_the_way_old_adk_did(yaml_dict: dict) -> dict:
-        """The pre-types reader, verbatim.
+    def _attribute(kind, value, config):
+        return VariantAttribute(
+            resource_id="attr-test",
+            name="test_attr",
+            mappings={"VARIANT-default": value},
+            kind=kind,
+            config=config,
+        )
 
-        An ADK released before typed attributes parsed values with exactly this
-        comprehension. A native int, bool or nested map raises AttributeError here,
-        which is the failure this encoding exists to prevent.
-        """
-        return {key: value.strip() for key, value in yaml_dict.get("values", {}).items()}
-
-    def test_written_values_are_always_strings(self):
-        """Whatever the kind, what lands on disk is a string."""
-        for kind, value, config, expected in self.ALL_KINDS:
+    def test_values_are_written_in_their_declared_type(self):
+        """A number is written as a number, not as text."""
+        for kind, value, config in self.ALL_KINDS:
             with self.subTest(kind=kind, value=value):
-                attr = VariantAttribute(
-                    resource_id="attr-test",
-                    name="test-attr",
-                    mappings={"VARIANT-default": value},
-                    kind=kind,
-                    config=config,
-                )
-                written = attr.to_yaml_dict()["values"]["VARIANT-default"]
-                self.assertIsInstance(written, str)
-                self.assertEqual(written, expected)
+                written = self._attribute(kind, value, config).to_yaml_dict()["values"]
+                self.assertEqual(written["VARIANT-default"], value)
 
-    def test_an_older_adk_can_still_read_every_kind(self):
-        """The old reader survives a file this ADK wrote, for every kind."""
-        for kind, value, config, expected in self.ALL_KINDS:
+    def test_round_trip_through_yaml_preserves_every_kind(self):
+        """Dump then load gives back the same native value and the same hash."""
+        for kind, value, config in self.ALL_KINDS:
             with self.subTest(kind=kind, value=value):
-                attr = VariantAttribute(
-                    resource_id="attr-test",
-                    name="test-attr",
-                    mappings={"VARIANT-default": value},
-                    kind=kind,
-                    config=config,
+                attribute = self._attribute(kind, value, config)
+                read_back = VariantAttribute.from_yaml_dict(
+                    resource_utils.load_yaml(
+                        resource_utils.dump_yaml(attribute.to_yaml_dict())
+                    ),
+                    "attr-test",
                 )
-                on_disk = resource_utils.load_yaml(resource_utils.dump_yaml(attr.to_yaml_dict()))
-                self.assertEqual(
-                    self._read_the_way_old_adk_did(on_disk), {"VARIANT-default": expected}
-                )
+                self.assertEqual(read_back.mappings, attribute.mappings)
+                self.assertEqual(read_back.kind, attribute.kind)
+                self.assertEqual(read_back.compute_hash(), attribute.compute_hash())
 
-    def test_the_old_reader_would_have_died_on_native_values(self):
-        """Guards the guard: the old reader really does break on a native value."""
-        for native in (3, True, {"a": 1}):
-            with self.subTest(native=native):
-                with self.assertRaises(AttributeError):
-                    self._read_the_way_old_adk_did({"values": {"VARIANT-default": native}})
-
-    def test_natively_written_values_are_still_accepted(self):
-        """A hand-written `3` or `true` reads the same as the quoted form ADK writes."""
+    def test_quoted_values_are_still_accepted(self):
+        """A hand-written or legacy quoted value reads as its declared type."""
         cases = [
-            (AttributeKind.NUMBER, 3, None, 3),
             (AttributeKind.NUMBER, "3", None, 3),
-            (AttributeKind.BOOLEAN, True, None, True),
+            (AttributeKind.NUMBER, 3, None, 3),
             (AttributeKind.BOOLEAN, "true", None, True),
-            (AttributeKind.OBJECT, {"a": 1}, None, {"a": 1}),
+            (AttributeKind.BOOLEAN, True, None, True),
             (AttributeKind.OBJECT, '{"a":1}', None, {"a": 1}),
+            (AttributeKind.OBJECT, {"a": 1}, None, {"a": 1}),
             # An unquoted scalar under a string attribute reads as its text rather
-            # than failing, which is how a pre-types file with `port: 8080` behaves.
+            # than failing validation for being a number.
             (AttributeKind.STRING, 8080, None, "8080"),
         ]
         for kind, written, config, expected in cases:
             with self.subTest(kind=kind, written=written):
-                attr = VariantAttribute.from_yaml_dict(
+                attribute = VariantAttribute.from_yaml_dict(
                     {
                         "name": "x",
                         "kind": kind.value,
@@ -5665,10 +5676,10 @@ class TypedVariantAttributeBackCompatTests(unittest.TestCase):
                     },
                     "attr-x",
                 )
-                self.assertEqual(attr.mappings["VARIANT-default"], expected)
+                self.assertEqual(attribute.mappings["VARIANT-default"], expected)
 
     def test_both_spellings_hash_the_same(self):
-        """`3` and `"3"` are the same attribute, so neither shows as a diff against the other."""
+        """`3` and `"3"` are the same attribute, so neither shows as a diff."""
         native = VariantAttribute.from_yaml_dict(
             {"name": "x", "kind": "number", "values": {"v": 3}}, "attr-x"
         )
@@ -5677,15 +5688,41 @@ class TypedVariantAttributeBackCompatTests(unittest.TestCase):
         )
         self.assertEqual(native.compute_hash(), quoted.compute_hash())
 
-    def test_an_untyped_file_is_written_exactly_as_before(self):
+    def test_string_values_that_look_like_scalars_stay_strings(self):
+        """A string attribute holding "3" or "true" must not be re-read as a number or bool.
+
+        Otherwise every project with a numeric-looking ID or phone number would start
+        failing type validation the first time it round-tripped through YAML.
+        """
+        values = {
+            "VARIANT-default": "3",
+            "VARIANT-b": "true",
+            "VARIANT-c": "+12125551234",
+            "VARIANT-d": "0123",
+            "VARIANT-e": "1.0",
+        }
+        attribute = VariantAttribute(
+            resource_id="attr-test", name="test_attr", mappings=values
+        )
+
+        read_back = VariantAttribute.from_yaml_dict(
+            resource_utils.load_yaml(resource_utils.dump_yaml(attribute.to_yaml_dict())),
+            "attr-test",
+        )
+
+        self.assertEqual(read_back.mappings, values)
+        for value in read_back.mappings.values():
+            self.assertIsInstance(value, str)
+
+    def test_an_untyped_attribute_is_written_exactly_as_before(self):
         """A project that never adopts a type sees no change to its file at all."""
-        attr = VariantAttribute(
+        attribute = VariantAttribute(
             resource_id="attr-test",
             name="office_phone",
             mappings={"VARIANT-default": "+12125551234", "VARIANT-b": ""},
         )
         self.assertEqual(
-            attr.to_yaml_dict(),
+            attribute.to_yaml_dict(),
             {
                 "name": "office_phone",
                 "values": {"VARIANT-default": "+12125551234", "VARIANT-b": ""},
@@ -5696,12 +5733,21 @@ class TypedVariantAttributeBackCompatTests(unittest.TestCase):
 class TypedVariantAttributeProjectionTests(unittest.TestCase):
     """Tests for reading typed variant attributes out of a projection."""
 
+    variant_mapping = ResourceMapping(
+        resource_id="VARIANT-default",
+        resource_type=Variant,
+        resource_name="default",
+        file_path="",
+        flow_name=None,
+        resource_prefix=None,
+    )
+
     @staticmethod
     def _projection(attribute_type, values, typed_values=None):
         variant_values = {"id": "VARIANT-default", "values": values}
         if typed_values is not None:
             variant_values["typedValues"] = typed_values
-        attribute = {"name": "test-attr", "archived": False}
+        attribute = {"name": "test_attr", "archived": False}
         if attribute_type is not None:
             attribute["type"] = attribute_type
         return {
@@ -5747,6 +5793,46 @@ class TypedVariantAttributeProjectionTests(unittest.TestCase):
                 self.assertEqual(
                     _read_attribute_type(type_data), (AttributeKind.STRING, {})
                 )
+
+    def test_stale_enum_config_is_dropped_when_the_kind_is_not_enum(self):
+        """Changing an attribute away from enum leaves its old config on the platform.
+
+        The kind is what the attribute is; a config that no longer belongs to it is
+        stale data. Reading it back would write a config the kind can't have into the
+        YAML, and the next push would fail its own validation.
+        """
+        for kind in (0, 1, 2, 4):
+            with self.subTest(kind=kind):
+                attributes = VariantAttribute.from_projection(
+                    self._projection(
+                        {
+                            "kind": kind,
+                            "config": {
+                                "$case": "enumConfig",
+                                "value": {"values": ["basic", "premium"]},
+                            },
+                        },
+                        {"attr-test": ""},
+                    )
+                )
+                attribute = attributes["attr-test"]
+                self.assertEqual(attribute.config, {})
+                self.assertNotIn("config", attribute.to_yaml_dict())
+                self.assertIsNone(attribute.validate(resource_mappings=[self.variant_mapping]))
+
+    def test_enum_config_is_still_read_for_an_enum(self):
+        """The drop above must not take the config an enum actually needs with it."""
+        attributes = VariantAttribute.from_projection(
+            self._projection(
+                {
+                    "kind": 3,
+                    "config": {"$case": "enumConfig", "value": {"values": ["basic"]}},
+                },
+                {"attr-test": "basic"},
+            )
+        )
+        self.assertEqual(attributes["attr-test"].config, {"values": ["basic"]})
+        self.assertEqual(attributes["attr-test"].enum_values, ["basic"])
 
     def test_kind_is_read_from_either_spelling(self):
         """`kind` is numeric on the wire, but a written-out token is accepted too."""

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -106,7 +106,12 @@ from poly.resources.topic import (
 from poly.resources.transcript_correction import RegularExpressionRule, TranscriptCorrection
 from poly.resources.translations import Translation
 from poly.resources.variable import Variable
-from poly.resources.variant_attributes import Variant, VariantAttribute
+from poly.resources.variant_attributes import (
+    AttributeKind,
+    Variant,
+    VariantAttribute,
+    _read_attribute_type,
+)
 from poly.tests.testing_utils import mock_read_from_file, mock_variant_attributes_file
 
 TEST_CODE = """import random
@@ -5343,6 +5348,595 @@ attributes:
         self.assertIn("VARIANT-default:", raw)
         # Values dict should use variant ID as key, not name
         self.assertIn("VARIANT-default: hello", raw)
+
+
+class TypedVariantAttributeTests(unittest.TestCase):
+    """Tests for typed variant attributes (kind + config)."""
+
+    def setUp(self):
+        MultiResourceYamlResource._file_cache.clear()
+        self.variant_mapping = ResourceMapping(
+            resource_id="VARIANT-default",
+            resource_type=Variant,
+            resource_name="default",
+            file_path="",
+            flow_name=None,
+            resource_prefix=None,
+        )
+
+    @staticmethod
+    def _attribute(kind, value, config=None, name="test-attr"):
+        return VariantAttribute(
+            resource_id="attr-test",
+            name=name,
+            mappings={"VARIANT-default": value},
+            kind=kind,
+            config=config,
+        )
+
+    def test_defaults_to_string_kind(self):
+        """An attribute with no declared kind is a string attribute."""
+        attr = VariantAttribute.from_yaml_dict(
+            {"name": "greeting", "values": {"VARIANT-default": "hello"}}, "attr-greeting"
+        )
+        self.assertEqual(attr.kind, AttributeKind.STRING)
+        self.assertEqual(attr.config, {})
+
+    def test_string_attribute_omits_kind_from_yaml(self):
+        """A string attribute serializes exactly as it did before types existed."""
+        attr = self._attribute(AttributeKind.STRING, "hello")
+        self.assertEqual(
+            attr.to_yaml_dict(), {"name": "test-attr", "values": {"VARIANT-default": "hello"}}
+        )
+
+    def test_yaml_round_trip_preserves_kind_and_native_values(self):
+        """Each kind survives to_yaml_dict -> from_yaml_dict with its value's type intact."""
+        cases = [
+            (AttributeKind.NUMBER, 3, None),
+            (AttributeKind.NUMBER, 2.5, None),
+            (AttributeKind.BOOLEAN, True, None),
+            (AttributeKind.BOOLEAN, False, None),
+            (AttributeKind.ENUM, "premium", {"values": ["basic", "premium"]}),
+            (AttributeKind.OBJECT, {"currency": "USD"}, None),
+        ]
+        for kind, value, config in cases:
+            with self.subTest(kind=kind, value=value):
+                attr = self._attribute(kind, value, config)
+                yaml_dict = attr.to_yaml_dict()
+                self.assertEqual(yaml_dict["kind"], kind.value)
+
+                round_tripped = VariantAttribute.from_yaml_dict(yaml_dict, "attr-test")
+                self.assertEqual(round_tripped.kind, kind)
+                self.assertEqual(round_tripped.config, attr.config)
+                self.assertEqual(round_tripped.mappings["VARIANT-default"], value)
+
+    def test_unknown_kind_is_rejected(self):
+        """A kind that isn't one of the five is a validation error, not a silent string."""
+        with self.assertRaises(ValueError) as cm:
+            VariantAttribute.from_yaml_dict(
+                {"name": "x", "kind": "integer", "values": {}}, "attr-x"
+            )
+        self.assertIn("Unknown attribute kind 'integer'", str(cm.exception))
+
+    def test_whole_floats_collapse_to_int(self):
+        """3.0 off the wire matches 3 in YAML, so a typed number doesn't diff every push."""
+        attr = self._attribute(AttributeKind.NUMBER, 3.0)
+        self.assertEqual(attr.mappings["VARIANT-default"], 3)
+        self.assertNotIsInstance(attr.mappings["VARIANT-default"], float)
+        self.assertEqual(self._attribute(AttributeKind.NUMBER, 2.5).mappings["VARIANT-default"], 2.5)
+
+    def test_validate_accepts_matching_values(self):
+        """A value of the declared type passes validation."""
+        cases = [
+            (AttributeKind.STRING, "hello", None),
+            (AttributeKind.NUMBER, 3, None),
+            (AttributeKind.NUMBER, 2.5, None),
+            (AttributeKind.BOOLEAN, False, None),
+            (AttributeKind.ENUM, "basic", {"values": ["basic", "premium"]}),
+            (AttributeKind.OBJECT, {"a": 1}, None),
+            (AttributeKind.OBJECT, [1, 2], None),
+        ]
+        for kind, value, config in cases:
+            with self.subTest(kind=kind, value=value):
+                attr = self._attribute(kind, value, config)
+                self.assertIsNone(attr.validate(resource_mappings=[self.variant_mapping]))
+
+    def test_validate_rejects_mismatched_values(self):
+        """A value of the wrong type fails validation, naming the variant it came from."""
+        cases = [
+            (AttributeKind.NUMBER, "banana", None),
+            # bool is an int subclass in Python, but is not a number here.
+            (AttributeKind.NUMBER, True, None),
+            (AttributeKind.BOOLEAN, "yes", None),
+            (AttributeKind.BOOLEAN, 1, None),
+            (AttributeKind.ENUM, "gold", {"values": ["basic", "premium"]}),
+            (AttributeKind.OBJECT, "not an object", None),
+            # The platform checks Number.isFinite, and neither survives JSON.
+            (AttributeKind.NUMBER, float("inf"), None),
+            (AttributeKind.NUMBER, float("nan"), None),
+        ]
+        for kind, value, config in cases:
+            with self.subTest(kind=kind, value=value):
+                attr = self._attribute(kind, value, config)
+                with self.assertRaises(ValueError) as cm:
+                    attr.validate(resource_mappings=[self.variant_mapping])
+                self.assertIn("does not match the declared type", str(cm.exception))
+                self.assertIn("default", str(cm.exception))
+
+    def test_validate_accepts_unset_value_for_every_kind(self):
+        """A blank value means "not set yet" and is valid for every kind."""
+        for kind in AttributeKind:
+            for unset in (None, ""):
+                with self.subTest(kind=kind, unset=unset):
+                    config = {"values": ["basic"]} if kind == AttributeKind.ENUM else None
+                    attr = self._attribute(kind, unset, config)
+                    self.assertIsNone(attr.validate(resource_mappings=[self.variant_mapping]))
+
+    def test_validate_rejects_malformed_enum_config(self):
+        """An enum needs a non-empty list of unique string values."""
+        cases = [
+            (None, "non-empty 'config.values' list"),
+            ({"values": []}, "non-empty 'config.values' list"),
+            ({"values": "basic"}, "non-empty 'config.values' list"),
+            ({"values": [1, 2]}, "Enum values must be strings"),
+            ({"values": ["a", "a"]}, "Duplicate enum values"),
+        ]
+        for config, message in cases:
+            with self.subTest(config=config):
+                attr = self._attribute(AttributeKind.ENUM, None, config)
+                with self.assertRaises(ValueError) as cm:
+                    attr.validate(resource_mappings=[self.variant_mapping])
+                self.assertIn(message, str(cm.exception))
+
+    def test_string_values_that_look_like_scalars_stay_strings(self):
+        """A string attribute holding "3" or "true" must not be re-read as a number or bool.
+
+        Otherwise every project with a numeric-looking ID or phone number would start
+        failing type validation the first time it round-tripped through YAML.
+        """
+        values = {
+            "VARIANT-default": "3",
+            "VARIANT-b": "true",
+            "VARIANT-c": "+12125551234",
+            "VARIANT-d": "0123",
+            "VARIANT-e": "1.0",
+        }
+        attr = VariantAttribute(resource_id="attr-test", name="test-attr", mappings=values)
+
+        read_back = VariantAttribute.from_yaml_dict(
+            resource_utils.load_yaml(resource_utils.dump_yaml(attr.to_yaml_dict())), "attr-test"
+        )
+
+        self.assertEqual(read_back.mappings, values)
+        for value in read_back.mappings.values():
+            self.assertIsInstance(value, str)
+
+    def test_empty_values_key_reaches_validation(self):
+        """`values:` with nothing under it parses as None, and must not crash the pretty path."""
+        self.assertEqual(
+            VariantAttribute.make_pretty("name: x\nvalues:\n", resource_mappings=[]).strip(),
+            "name: x\nvalues: {}",
+        )
+        attr = VariantAttribute.from_yaml_dict({"name": "x", "values": None}, "attr-x")
+        with self.assertRaises(ValueError) as cm:
+            attr.validate(resource_mappings=[self.variant_mapping])
+        self.assertIn("Mappings are required", str(cm.exception))
+
+    def test_validate_rejects_config_on_a_kind_that_takes_none(self):
+        """Only enum takes a config; a config anywhere else is a mistake worth surfacing."""
+        attr = self._attribute(AttributeKind.NUMBER, 3, {"values": ["a"]})
+        with self.assertRaises(ValueError) as cm:
+            attr.validate(resource_mappings=[self.variant_mapping])
+        self.assertIn("does not take a config", str(cm.exception))
+
+    def test_build_create_proto_dual_writes_values(self):
+        """A typed attribute writes both the stringified legacy map and the native one."""
+        attr = self._attribute(AttributeKind.NUMBER, 3)
+        proto = attr.build_create_proto()
+
+        self.assertEqual(proto.type.kind, 1)
+        self.assertEqual(dict(proto.variant_values.values), {"VARIANT-default": "3"})
+        self.assertEqual(dict(proto.variant_values.typed_values), {"VARIANT-default": 3})
+
+    def test_build_proto_stringifies_each_kind_for_legacy_readers(self):
+        """The legacy string map mirrors the platform's stringifyValue."""
+        cases = [
+            (AttributeKind.BOOLEAN, True, None, "true"),
+            (AttributeKind.BOOLEAN, False, None, "false"),
+            (AttributeKind.NUMBER, 2.5, None, "2.5"),
+            (AttributeKind.ENUM, "basic", {"values": ["basic"]}, "basic"),
+            (AttributeKind.OBJECT, {"a": 1}, None, '{"a":1}'),
+            (AttributeKind.NUMBER, None, None, ""),
+        ]
+        for kind, value, config, expected in cases:
+            with self.subTest(kind=kind, value=value):
+                proto = self._attribute(kind, value, config).build_create_proto()
+                self.assertEqual(dict(proto.variant_values.values), {"VARIANT-default": expected})
+
+    def test_build_create_proto_carries_enum_config(self):
+        """An enum's allowed values reach the wire so the backend can validate against them."""
+        attr = self._attribute(AttributeKind.ENUM, "premium", {"values": ["basic", "premium"]})
+        proto = attr.build_create_proto()
+
+        self.assertEqual(proto.type.kind, 3)
+        self.assertEqual(list(proto.type.enum_config.values), ["basic", "premium"])
+
+    def test_string_attribute_writes_no_typed_values(self):
+        """A string attribute sends exactly what it always sent."""
+        proto = self._attribute(AttributeKind.STRING, "hello").build_create_proto()
+
+        self.assertEqual(proto.type.kind, 0)
+        self.assertEqual(dict(proto.variant_values.values), {"VARIANT-default": "hello"})
+        self.assertFalse(proto.variant_values.HasField("typed_values"))
+
+    def test_update_proto_carries_type_and_values(self):
+        """An update pushes the declared type alongside the values."""
+        attr = self._attribute(AttributeKind.BOOLEAN, True)
+        proto = attr.build_update_proto()
+
+        self.assertEqual(proto.type.kind, 2)
+        self.assertEqual(dict(proto.variant_values.values), {"VARIANT-default": "true"})
+        self.assertEqual(dict(proto.variant_values.typed_values), {"VARIANT-default": True})
+
+
+class TypedVariantAttributeBackCompatTests(unittest.TestCase):
+    """Tests that a file written by this ADK stays readable by one released before types."""
+
+    ALL_KINDS = [
+        (AttributeKind.STRING, "hello", None, "hello"),
+        (AttributeKind.NUMBER, 3, None, "3"),
+        (AttributeKind.NUMBER, 2.5, None, "2.5"),
+        (AttributeKind.BOOLEAN, True, None, "true"),
+        (AttributeKind.BOOLEAN, False, None, "false"),
+        (AttributeKind.ENUM, "premium", {"values": ["basic", "premium"]}, "premium"),
+        (AttributeKind.OBJECT, {"a": [1, 2]}, None, '{"a":[1,2]}'),
+        (AttributeKind.NUMBER, None, None, ""),
+    ]
+
+    @staticmethod
+    def _read_the_way_old_adk_did(yaml_dict: dict) -> dict:
+        """The pre-types reader, verbatim.
+
+        An ADK released before typed attributes parsed values with exactly this
+        comprehension. A native int, bool or nested map raises AttributeError here,
+        which is the failure this encoding exists to prevent.
+        """
+        return {key: value.strip() for key, value in yaml_dict.get("values", {}).items()}
+
+    def test_written_values_are_always_strings(self):
+        """Whatever the kind, what lands on disk is a string."""
+        for kind, value, config, expected in self.ALL_KINDS:
+            with self.subTest(kind=kind, value=value):
+                attr = VariantAttribute(
+                    resource_id="attr-test",
+                    name="test-attr",
+                    mappings={"VARIANT-default": value},
+                    kind=kind,
+                    config=config,
+                )
+                written = attr.to_yaml_dict()["values"]["VARIANT-default"]
+                self.assertIsInstance(written, str)
+                self.assertEqual(written, expected)
+
+    def test_an_older_adk_can_still_read_every_kind(self):
+        """The old reader survives a file this ADK wrote, for every kind."""
+        for kind, value, config, expected in self.ALL_KINDS:
+            with self.subTest(kind=kind, value=value):
+                attr = VariantAttribute(
+                    resource_id="attr-test",
+                    name="test-attr",
+                    mappings={"VARIANT-default": value},
+                    kind=kind,
+                    config=config,
+                )
+                on_disk = resource_utils.load_yaml(resource_utils.dump_yaml(attr.to_yaml_dict()))
+                self.assertEqual(
+                    self._read_the_way_old_adk_did(on_disk), {"VARIANT-default": expected}
+                )
+
+    def test_the_old_reader_would_have_died_on_native_values(self):
+        """Guards the guard: the old reader really does break on a native value."""
+        for native in (3, True, {"a": 1}):
+            with self.subTest(native=native):
+                with self.assertRaises(AttributeError):
+                    self._read_the_way_old_adk_did({"values": {"VARIANT-default": native}})
+
+    def test_natively_written_values_are_still_accepted(self):
+        """A hand-written `3` or `true` reads the same as the quoted form ADK writes."""
+        cases = [
+            (AttributeKind.NUMBER, 3, None, 3),
+            (AttributeKind.NUMBER, "3", None, 3),
+            (AttributeKind.BOOLEAN, True, None, True),
+            (AttributeKind.BOOLEAN, "true", None, True),
+            (AttributeKind.OBJECT, {"a": 1}, None, {"a": 1}),
+            (AttributeKind.OBJECT, '{"a":1}', None, {"a": 1}),
+            # An unquoted scalar under a string attribute reads as its text rather
+            # than failing, which is how a pre-types file with `port: 8080` behaves.
+            (AttributeKind.STRING, 8080, None, "8080"),
+        ]
+        for kind, written, config, expected in cases:
+            with self.subTest(kind=kind, written=written):
+                attr = VariantAttribute.from_yaml_dict(
+                    {
+                        "name": "x",
+                        "kind": kind.value,
+                        "config": config,
+                        "values": {"VARIANT-default": written},
+                    },
+                    "attr-x",
+                )
+                self.assertEqual(attr.mappings["VARIANT-default"], expected)
+
+    def test_both_spellings_hash_the_same(self):
+        """`3` and `"3"` are the same attribute, so neither shows as a diff against the other."""
+        native = VariantAttribute.from_yaml_dict(
+            {"name": "x", "kind": "number", "values": {"v": 3}}, "attr-x"
+        )
+        quoted = VariantAttribute.from_yaml_dict(
+            {"name": "x", "kind": "number", "values": {"v": "3"}}, "attr-x"
+        )
+        self.assertEqual(native.compute_hash(), quoted.compute_hash())
+
+    def test_an_untyped_file_is_written_exactly_as_before(self):
+        """A project that never adopts a type sees no change to its file at all."""
+        attr = VariantAttribute(
+            resource_id="attr-test",
+            name="office_phone",
+            mappings={"VARIANT-default": "+12125551234", "VARIANT-b": ""},
+        )
+        self.assertEqual(
+            attr.to_yaml_dict(),
+            {
+                "name": "office_phone",
+                "values": {"VARIANT-default": "+12125551234", "VARIANT-b": ""},
+            },
+        )
+
+
+class TypedVariantAttributeProjectionTests(unittest.TestCase):
+    """Tests for reading typed variant attributes out of a projection."""
+
+    @staticmethod
+    def _projection(attribute_type, values, typed_values=None):
+        variant_values = {"id": "VARIANT-default", "values": values}
+        if typed_values is not None:
+            variant_values["typedValues"] = typed_values
+        attribute = {"name": "test-attr", "archived": False}
+        if attribute_type is not None:
+            attribute["type"] = attribute_type
+        return {
+            "variantManagement": {
+                "attributes": {"entities": {"attr-test": attribute}},
+                "variantAttributeValues": {"entities": {"VARIANT-default": variant_values}},
+            }
+        }
+
+    def test_untyped_attribute_reads_as_string(self):
+        """An attribute that predates types carries the schema's default and reads as STRING.
+
+        `type` is never actually absent from a projection — the API schema defaults it to
+        `{kind: STRING}`, which is also why `from_projection` can use a missing `type` as
+        its auth-filtered sentinel. So a pre-types attribute arrives as kind 0, not as no
+        type at all.
+        """
+        attributes = VariantAttribute.from_projection(
+            self._projection({"kind": 0}, {"attr-test": "hello"})
+        )
+        attribute = attributes["attr-test"]
+        self.assertEqual(attribute.kind, AttributeKind.STRING)
+        self.assertEqual(attribute.mappings, {"VARIANT-default": "hello"})
+
+    def test_attribute_with_no_type_is_withheld_not_untyped(self):
+        """A missing `type` means auth-filtered, so the attribute is stubbed for references.
+
+        Pins the boundary between this change and the auth-filtering in #299/#300: a
+        missing `type` must not be read as "untyped", or a withheld attribute would come
+        back as an empty STRING one and get pushed as a real edit.
+        """
+        attributes = VariantAttribute.from_projection(
+            self._projection(None, {"attr-test": "hello"})
+        )
+        attribute = attributes["attr-test"]
+        self.assertTrue(attribute.slim)
+        self.assertEqual(attribute.mappings, {})
+
+    def test_read_attribute_type_defaults_to_string(self):
+        """The parser itself still tolerates a missing or malformed type."""
+        for type_data in (None, {}, "nonsense"):
+            with self.subTest(type_data=type_data):
+                self.assertEqual(
+                    _read_attribute_type(type_data), (AttributeKind.STRING, {})
+                )
+
+    def test_kind_is_read_from_either_spelling(self):
+        """`kind` is numeric on the wire, but a written-out token is accepted too."""
+        for raw_kind in (3, "enum", "ENUM", "ATTRIBUTE_KIND_ENUM"):
+            with self.subTest(raw_kind=raw_kind):
+                kind, _ = _read_attribute_type({"kind": raw_kind})
+                self.assertEqual(kind, AttributeKind.ENUM)
+
+    def test_unknown_kind_falls_back_instead_of_failing_the_pull(self):
+        """An unrecognised kind reads as string, whichever way it is spelled.
+
+        Both spellings have to degrade the same way: a pull covers every attribute in
+        the project, so raising here would fail the whole pull over one odd value —
+        the crash-on-odd-projection-data that #299 removed from this read path.
+        """
+        for raw_kind in (99, -1, "garbage", "ATTRIBUTE_KIND_NONSENSE", ""):
+            with self.subTest(raw_kind=raw_kind):
+                self.assertEqual(
+                    _read_attribute_type({"kind": raw_kind}), (AttributeKind.STRING, {})
+                )
+
+    def test_typed_values_win_over_the_legacy_string_map(self):
+        """The native value is the source of truth when the two disagree."""
+        attributes = VariantAttribute.from_projection(
+            self._projection({"kind": 1}, {"attr-test": "3"}, {"attr-test": 7})
+        )
+        attribute = attributes["attr-test"]
+        self.assertEqual(attribute.kind, AttributeKind.NUMBER)
+        self.assertEqual(attribute.mappings, {"VARIANT-default": 7})
+
+    def test_falls_back_to_the_string_map_when_typed_values_are_malformed(self):
+        """A typedValues that isn't a mapping is discarded rather than merged.
+
+        The fallback still reads as its declared kind — the legacy string map is the
+        only place a pre-types project ever stored a value.
+        """
+        attributes = VariantAttribute.from_projection(
+            self._projection({"kind": 1}, {"attr-test": "3"}, ["not", "a", "mapping"])
+        )
+        self.assertEqual(attributes["attr-test"].mappings, {"VARIANT-default": 3})
+
+    def test_legacy_values_parse_against_the_declared_kind(self):
+        """An attribute typed in the UI but never re-saved has values only in the string map."""
+        cases = [
+            ({"kind": 1}, "3", 3),
+            ({"kind": 1}, "2.5", 2.5),
+            ({"kind": 2}, "true", True),
+            ({"kind": 2}, "false", False),
+            ({"kind": 4}, '{"a":1}', {"a": 1}),
+        ]
+        for attribute_type, stored, expected in cases:
+            with self.subTest(stored=stored):
+                attributes = VariantAttribute.from_projection(
+                    self._projection(attribute_type, {"attr-test": stored})
+                )
+                self.assertEqual(attributes["attr-test"].mappings["VARIANT-default"], expected)
+
+    def test_reads_every_kind(self):
+        """Each proto ordinal maps to its kind."""
+        for ordinal, kind in enumerate(
+            [
+                AttributeKind.STRING,
+                AttributeKind.NUMBER,
+                AttributeKind.BOOLEAN,
+                AttributeKind.ENUM,
+                AttributeKind.OBJECT,
+            ]
+        ):
+            with self.subTest(kind=kind):
+                attributes = VariantAttribute.from_projection(
+                    self._projection({"kind": ordinal}, {"attr-test": ""})
+                )
+                self.assertEqual(attributes["attr-test"].kind, kind)
+
+    def test_reads_enum_config_from_the_oneof_wrapper(self):
+        """Projections wrap the config oneof the way ts-proto does; it is flattened here."""
+        attributes = VariantAttribute.from_projection(
+            self._projection(
+                {"kind": 3, "config": {"$case": "enumConfig", "value": {"values": ["a", "b"]}}},
+                {"attr-test": "a"},
+            )
+        )
+        attribute = attributes["attr-test"]
+        self.assertEqual(attribute.kind, AttributeKind.ENUM)
+        self.assertEqual(attribute.config, {"values": ["a", "b"]})
+        self.assertEqual(attribute.enum_values, ["a", "b"])
+
+    def test_reads_a_kind_given_as_a_token(self):
+        """A token kind is accepted rather than silently read as STRING."""
+        for token in ("ENUM", "enum", "ATTRIBUTE_KIND_ENUM"):
+            with self.subTest(token=token):
+                attributes = VariantAttribute.from_projection(
+                    self._projection(
+                        {"kind": token, "enumConfig": {"values": ["a"]}}, {"attr-test": "a"}
+                    )
+                )
+                self.assertEqual(attributes["attr-test"].kind, AttributeKind.ENUM)
+
+    def test_reads_enum_config_set_directly(self):
+        """An older payload that sets the oneof member directly is still understood."""
+        attributes = VariantAttribute.from_projection(
+            self._projection({"kind": 3, "enumConfig": {"values": ["a"]}}, {"attr-test": "a"})
+        )
+        self.assertEqual(attributes["attr-test"].config, {"values": ["a"]})
+
+    def test_whole_numbers_off_the_wire_stay_ints(self):
+        """A Struct holds every number as a double; 3.0 must read back as 3."""
+        attributes = VariantAttribute.from_projection(
+            self._projection({"kind": 1}, {"attr-test": "3"}, {"attr-test": 3.0})
+        )
+        self.assertEqual(attributes["attr-test"].mappings["VARIANT-default"], 3)
+
+    def test_save_and_read_round_trips_every_kind_through_a_real_file(self):
+        """Every kind survives save -> disk -> read_local_resource with its type intact."""
+        import tempfile
+
+        mapping = ResourceMapping(
+            resource_id="VARIANT-default",
+            resource_type=Variant,
+            resource_name="default",
+            file_path="",
+            flow_name=None,
+            resource_prefix=None,
+        )
+        attributes = [
+            VariantAttribute(
+                resource_id="attr-retries",
+                name="max_retries",
+                mappings={"VARIANT-default": 3},
+                kind=AttributeKind.NUMBER,
+            ),
+            VariantAttribute(
+                resource_id="attr-alcohol",
+                name="serves_alcohol",
+                mappings={"VARIANT-default": True},
+                kind=AttributeKind.BOOLEAN,
+            ),
+            VariantAttribute(
+                resource_id="attr-tier",
+                name="tier",
+                mappings={"VARIANT-default": "premium"},
+                kind=AttributeKind.ENUM,
+                config={"values": ["basic", "premium"]},
+            ),
+            VariantAttribute(
+                resource_id="attr-menu",
+                name="menu",
+                mappings={"VARIANT-default": {"categories": ["pizza"], "currency": "USD"}},
+                kind=AttributeKind.OBJECT,
+            ),
+            VariantAttribute(
+                resource_id="attr-greeting",
+                name="greeting",
+                mappings={"VARIANT-default": "hello"},
+            ),
+        ]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            MultiResourceYamlResource._file_cache.clear()
+            for attribute in attributes:
+                attribute.save(tmpdir, resource_mappings=[mapping])
+
+            MultiResourceYamlResource._file_cache.clear()
+            for attribute in attributes:
+                with self.subTest(kind=attribute.kind):
+                    read_back = VariantAttribute.read_local_resource(
+                        file_path=os.path.join(tmpdir, attribute.file_path),
+                        resource_id=attribute.resource_id,
+                        resource_name=attribute.name,
+                        resource_mappings=[mapping],
+                    )
+                    self.assertEqual(read_back.kind, attribute.kind)
+                    self.assertEqual(read_back.mappings, attribute.mappings)
+                    self.assertEqual(read_back.config, attribute.config)
+                    # Equal hashes mean a pulled project shows no phantom diff on status.
+                    self.assertEqual(read_back.compute_hash(), attribute.compute_hash())
+                    read_back.validate(resource_mappings=[mapping])
+
+    def test_projection_round_trips_through_yaml_without_diffing(self):
+        """A typed attribute pulled and re-read produces the same hash, so status stays clean."""
+        attributes = VariantAttribute.from_projection(
+            self._projection(
+                {"kind": 3, "config": {"$case": "enumConfig", "value": {"values": ["a", "b"]}}},
+                {"attr-test": "a"},
+                {"attr-test": "a"},
+            )
+        )
+        pulled = attributes["attr-test"]
+        reloaded = VariantAttribute.from_yaml_dict(pulled.to_yaml_dict(), "attr-test")
+        self.assertEqual(pulled.compute_hash(), reloaded.compute_hash())
 
 
 class MultiResourceYamlResourceCacheTests(unittest.TestCase):

--- a/src/poly/tests/test_projects/test_project/agent_settings/rules.txt
+++ b/src/poly/tests/test_projects/test_project/agent_settings/rules.txt
@@ -1,7 +1,7 @@
 Be helpful and professional at all times.
 Use {{fn:test_function}} when appropriate.
 Always validate inputs using {{fn:validate_email}} when dealing with email addresses.
-Access customer information from {{attr:customer-name}} and {{attr:email-address}}.
+Access customer information from {{attr:customer_name}} and {{attr:email_address}}.
 For complex issues, use {{ho:handoff-1}} to transfer to a specialist.
 Send important notifications via {{twilio_sms:test_template_1}} or {{twilio_sms:test_template_2}} as appropriate.
 Follow the guidelines provided.

--- a/src/poly/tests/test_projects/test_project/chat/configuration.yaml
+++ b/src/poly/tests/test_projects/test_project/chat/configuration.yaml
@@ -1,5 +1,5 @@
 greeting:
-  welcome_message: Hello! Welcome to our web chat. Your account shows {{attr:member-status}}. How can
+  welcome_message: Hello! Welcome to our web chat. Your account shows {{attr:member_status}}. How can
     I assist you today?
   language_code: en-GB
 style_prompt:

--- a/src/poly/tests/test_projects/test_project/child_topics/spanish/spanish_only_topic.yaml
+++ b/src/poly/tests/test_projects/test_project/child_topics/spanish/spanish_only_topic.yaml
@@ -1,6 +1,6 @@
 name: Spanish Only Topic
 enabled: true
-actions: Handle this request in Spanish using {{fn:test_function}} and {{attr:customer-name}}.
+actions: Handle this request in Spanish using {{fn:test_function}} and {{attr:customer_name}}.
 content: This topic only applies when the Spanish variant is active.
 example_queries:
 - How can I help you?

--- a/src/poly/tests/test_projects/test_project/config/variant_attributes.yaml
+++ b/src/poly/tests/test_projects/test_project/config/variant_attributes.yaml
@@ -3,19 +3,50 @@ variants:
     is_default: true
   - name: spanish
 attributes:
-  - name: customer-name
+  - name: customer_name
     values:
       default: "value-1"
       spanish: "valor-1"
-  - name: email-address
+  - name: email_address
     values:
       default: "value-2"
       spanish: "valor-2"
-  - name: member-status
+  - name: member_status
     values:
       default: "value-3"
       spanish: "valor-3"
-  - name: booking-status
+  - name: booking_status
     values:
       default: "value-4"
       spanish: "valor-4"
+  - name: max_retries
+    kind: number
+    values:
+      default: 3
+      spanish: 5
+  - name: serves_alcohol
+    kind: boolean
+    values:
+      default: true
+      spanish: false
+  - name: tier
+    kind: enum
+    config:
+      values:
+        - basic
+        - premium
+    values:
+      default: premium
+      spanish: basic
+  - name: menu_config
+    kind: object
+    values:
+      default:
+        categories:
+          - pizza
+          - pasta
+        currency: USD
+      spanish:
+        categories:
+          - paella
+        currency: EUR

--- a/src/poly/tests/test_projects/test_project/flows/test_flow/steps/confirm_details.yaml
+++ b/src/poly/tests/test_projects/test_project/flows/test_flow/steps/confirm_details.yaml
@@ -1,6 +1,6 @@
 step_type: advanced_step
 name: confirm_details
-prompt: Let me confirm your details using {{fn:format_date}} and {{ft:process_data}}. Your name is {{attr:customer-name}}. Is this correct?
+prompt: Let me confirm your details using {{fn:format_date}} and {{ft:process_data}}. Your name is {{attr:customer_name}}. Is this correct?
 asr_biasing:
   is_enabled: true
   numeric: true

--- a/src/poly/tests/test_projects/test_project/flows/test_flow_with_punctuation/steps/collect_email.yaml
+++ b/src/poly/tests/test_projects/test_project/flows/test_flow_with_punctuation/steps/collect_email.yaml
@@ -1,6 +1,6 @@
 step_type: advanced_step
 name: collect_email
-prompt: Please provide your email. I'll validate it using {{fn:validate_email}} and process with {{ft:calculate_total}}. Your current status is {{attr:booking-status}}. I can send updates via {{twilio_sms:test_template_2}}.
+prompt: Please provide your email. I'll validate it using {{fn:validate_email}} and process with {{ft:calculate_total}}. Your current status is {{attr:booking_status}}. I can send updates via {{twilio_sms:test_template_2}}.
 asr_biasing:
   is_enabled: true
   alphanumeric: true

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -1,492 +1,441 @@
 {
-  "region": "us-1",
   "account_id": "test_account",
-  "project_id": "test_project",
   "branch_id": "main",
+  "file_structure_info": {},
   "last_updated": "2024-01-01T00:00:00",
+  "migration_flags": [
+    "migrated_legacy_topic_files"
+  ],
+  "project_id": "test_project",
+  "region": "us-1",
   "resources": {
+    "additional_languages": {
+      "fr-FR": {
+        "name": "fr-FR",
+        "resource_id": "fr-FR"
+      }
+    },
+    "api_integration": {
+      "int-customer_api": {
+        "description": "test",
+        "environments": {
+          "live": {
+            "auth_type": "apiKey",
+            "base_url": "https://customer.com"
+          },
+          "pre_release": {
+            "auth_type": "basic",
+            "base_url": "https://dev-customer.com"
+          },
+          "sandbox": {
+            "auth_type": "basic",
+            "base_url": "https://dev-customer.com"
+          }
+        },
+        "name": "customer_api",
+        "operations": [
+          {
+            "method": "GET",
+            "name": "get_confirmation_status",
+            "resource": "/bookings/{booking_id}/confirmation-status",
+            "resource_id": ""
+          }
+        ],
+        "resource_id": "int-customer_api"
+      }
+    },
+    "asr_settings": {
+      "asr_settings": {
+        "barge_in": false,
+        "interaction_style": "balanced",
+        "name": "asr_settings",
+        "resource_id": "asr_settings"
+      }
+    },
+    "chat_greeting": {
+      "chat_greeting": {
+        "language_code": "en-GB",
+        "name": "chat_greeting",
+        "resource_id": "chat_greeting",
+        "welcome_message": "Hello! Welcome to our web chat. Your account shows {{attr:member_status}}. How can I assist you today?"
+      }
+    },
+    "chat_safety_filters": {
+      "chat_safety_filters": {
+        "categories": {
+          "hate": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "self_harm": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "sexual": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "violence": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          }
+        },
+        "enabled": true,
+        "filter_type": "azure",
+        "name": "chat_safety_filters",
+        "resource_id": "chat_safety_filters"
+      }
+    },
+    "chat_style_prompt": {
+      "chat_style_prompt": {
+        "name": "chat_style_prompt",
+        "prompt": "You are a helpful and professional web chat assistant.",
+        "resource_id": "chat_style_prompt"
+      }
+    },
+    "child_topics": {
+      "TOPIC-Spanish Only Topic": {
+        "actions": "Handle this request in Spanish using {{fn:FUNCTION-test_function}} and {{attr:customer_name}}.",
+        "content": "This topic only applies when the Spanish variant is active.",
+        "enabled": true,
+        "example_queries": [
+          "How can I help you?",
+          "What services do you offer?"
+        ],
+        "name": "Spanish Only Topic",
+        "resource_id": "TOPIC-Spanish Only Topic",
+        "variant_id": "VARIANT-spanish",
+        "variant_name": "spanish"
+      }
+    },
+    "custom_guardrails": {
+      "CUSTOM_GUARDRAILS-no_medical_advice": {
+        "action": "warn",
+        "enabled": true,
+        "name": "No medical advice",
+        "prompt": "Never give medical advice. Offer to transfer the caller to a human instead.",
+        "resource_id": "CUSTOM_GUARDRAILS-no_medical_advice"
+      }
+    },
+    "default_language": {
+      "en-GB": {
+        "name": "en-GB",
+        "resource_id": "en-GB"
+      }
+    },
+    "documents": {
+      "CONTEXT.MD": {
+        "contents": "This is platform context file.\n",
+        "name": "CONTEXT",
+        "path": "CONTEXT.MD",
+        "resource_id": "CONTEXT.MD"
+      },
+      "test_document.md": {
+        "contents": "This is a test document.\nIt has multiple lines.\n",
+        "name": "test_document",
+        "path": "test_document.md",
+        "resource_id": "test_document.md"
+      }
+    },
     "entities": {
-      "ENTITY-customer_name": {
-        "resource_id": "ENTITY-customer_name",
-        "name": "customer_name",
-        "description": "Customer name entity for collecting names",
-        "entity_type": "name_config",
-        "config": {}
-      },
-      "ENTITY-phone_number": {
-        "resource_id": "ENTITY-phone_number",
-        "name": "phone_number",
-        "description": "Phone number entity with country codes",
-        "entity_type": "phone_number",
-        "config": {
-          "enabled": true,
-          "country_codes": [
-            "US",
-            "UK"
-          ]
-        }
-      },
-      "ENTITY-date": {
-        "resource_id": "ENTITY-date",
-        "name": "date",
-        "description": "Date entity for appointment scheduling",
-        "entity_type": "date",
-        "config": {
-          "relative_date": true
-        }
-      },
-      "ENTITY-party_size": {
-        "resource_id": "ENTITY-party_size",
-        "name": "party_size",
-        "description": "Number of people in party",
-        "entity_type": "numeric",
-        "config": {
-          "has_decimal": false,
-          "has_range": true,
-          "min": 1,
-          "max": 20
-        }
-      },
       "ENTITY-confirmation_status": {
-        "resource_id": "ENTITY-confirmation_status",
-        "name": "confirmation_status",
-        "description": "Confirmation status options",
-        "entity_type": "enum",
         "config": {
           "options": [
             "confirmed",
             "pending",
             "cancelled"
           ]
-        }
+        },
+        "description": "Confirmation status options",
+        "entity_type": "enum",
+        "name": "confirmation_status",
+        "resource_id": "ENTITY-confirmation_status"
+      },
+      "ENTITY-customer_name": {
+        "config": {},
+        "description": "Customer name entity for collecting names",
+        "entity_type": "name_config",
+        "name": "customer_name",
+        "resource_id": "ENTITY-customer_name"
+      },
+      "ENTITY-date": {
+        "config": {
+          "relative_date": true
+        },
+        "description": "Date entity for appointment scheduling",
+        "entity_type": "date",
+        "name": "date",
+        "resource_id": "ENTITY-date"
       },
       "ENTITY-email": {
-        "resource_id": "ENTITY-email",
-        "name": "email",
-        "description": "Email address validation",
-        "entity_type": "alphanumeric",
         "config": {
           "enabled": true,
-          "validation_type": "email",
-          "regular_expression": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
-        }
+          "regular_expression": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
+          "validation_type": "email"
+        },
+        "description": "Email address validation",
+        "entity_type": "alphanumeric",
+        "name": "email",
+        "resource_id": "ENTITY-email"
+      },
+      "ENTITY-party_size": {
+        "config": {
+          "has_decimal": false,
+          "has_range": true,
+          "max": 20,
+          "min": 1
+        },
+        "description": "Number of people in party",
+        "entity_type": "numeric",
+        "name": "party_size",
+        "resource_id": "ENTITY-party_size"
+      },
+      "ENTITY-phone_number": {
+        "config": {
+          "country_codes": [
+            "US",
+            "UK"
+          ],
+          "enabled": true
+        },
+        "description": "Phone number entity with country codes",
+        "entity_type": "phone_number",
+        "name": "phone_number",
+        "resource_id": "ENTITY-phone_number"
       }
     },
-    "variants": {
-      "VARIANT-default": {
-        "resource_id": "VARIANT-default",
-        "name": "default",
-        "is_default": true
-      },
-      "VARIANT-spanish": {
-        "resource_id": "VARIANT-spanish",
-        "name": "spanish",
-        "is_default": false
-      }
-    },
-    "variant_attributes": {
-      "customer-name": {
-        "resource_id": "customer-name",
-        "name": "customer-name",
-        "mappings": {
-          "VARIANT-default": "value-1",
-          "VARIANT-spanish": "valor-1"
-        }
-      },
-      "email-address": {
-        "resource_id": "email-address",
-        "name": "email-address",
-        "mappings": {
-          "VARIANT-default": "value-2",
-          "VARIANT-spanish": "valor-2"
-        }
-      },
-      "member-status": {
-        "resource_id": "member-status",
-        "name": "member-status",
-        "mappings": {
-          "VARIANT-default": "value-3",
-          "VARIANT-spanish": "valor-3"
-        }
-      },
-      "booking-status": {
-        "resource_id": "booking-status",
-        "name": "booking-status",
-        "mappings": {
-          "VARIANT-default": "value-4",
-          "VARIANT-spanish": "valor-4"
-        }
-      }
-    },
-    "variables": {
-      "VAR-customer_name": {
-        "resource_id": "VAR-customer_name",
-        "name": "customer_name"
-      },
-      "VAR-payment_success": {
-        "resource_id": "VAR-payment_success",
-        "name": "payment_success"
-      },
-      "VAR-data_processed": {
-        "resource_id": "VAR-data_processed",
-        "name": "data_processed"
-      }
-    },
-    "functions": {
-      "FUNCTION-validate_email": {
-        "resource_id": "FUNCTION-validate_email",
-        "name": "validate_email",
-        "description": "Validate email format.",
-        "code": "def validate_email(conv: Conversation, email: str):\n    \"\"\"Validate email format.\"\"\"\n    return \"@\" in email and \".\" in email.split(\"@\")[1]\n",
-        "parameters": [
-          {
-            "name": "email",
-            "type": "string",
-            "description": "The email address to validate",
-            "id": "PARAMETER-email-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global"
-      },
-      "FUNCTION-format_date": {
-        "resource_id": "FUNCTION-format_date",
-        "name": "format_date",
-        "description": "Format date for display.",
-        "code": "def format_date(conv: Conversation, date: str):\n    \"\"\"Format date for display.\"\"\"\n    return date.upper()\n",
-        "parameters": [
-          {
-            "name": "date",
-            "type": "string",
-            "description": "The date string to format",
-            "id": "PARAMETER-date-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global"
-      },
-      "FUNCTION-shared_helper": {
-        "resource_id": "FUNCTION-shared_helper",
-        "name": "shared_helper",
-        "description": "A shared helper function that can be used by multiple flows.",
-        "code": "def shared_helper(conv: Conversation, value: str):\n    \"\"\"A shared helper function that can be used by multiple flows.\"\"\"\n    return f\"Processed: {value}\"\n",
-        "parameters": [
-          {
-            "name": "value",
-            "type": "string",
-            "description": "The value to process",
-            "id": "PARAMETER-value-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global"
-      },
-      "FUNCTION-test_function": {
-        "resource_id": "FUNCTION-test_function",
-        "name": "test_function",
-        "description": "A test function for global use.",
-        "code": "def test_function(conv: Conversation):\n    \"\"\"A test function for global use.\"\"\"\n    return \"Hello from global function\"\n",
-        "parameters": [],
-        "latency_control": {},
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global"
-      },
-      "FUNCTION-test_function_with_parameters": {
-        "resource_id": "FUNCTION-test_function_with_parameters",
-        "name": "test_function_with_parameters",
-        "description": "Test function with parameters.",
-        "code": "def test_function_with_parameters(conv: Conversation, param1: str, param2: int):\n    \"\"\"Test function with parameters.\"\"\"\n    return f\"Result: {param1} - {param2}\"\n",
-        "parameters": [
-          {
-            "name": "param1",
-            "type": "string",
-            "description": "First parameter as string",
-            "id": "PARAMETER-param1-1"
+    "experimental_config": {
+      "default": {
+        "config": {
+          "asr": {
+            "language": "en-GB",
+            "model": "poly-latency",
+            "provider": "riva"
           },
-          {
-            "name": "param2",
-            "type": "integer",
-            "description": "Second parameter as integer",
-            "id": "PARAMETER-param2-1"
+          "eot": {
+            "provider": "smart_turn",
+            "threshold": 0.5
+          },
+          "smart_vad": {
+            "is_enabled": true
+          },
+          "vad": {
+            "vad_end": 600
           }
-        ],
-        "latency_control": {},
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global"
-      },
-      "FUNCTION-start_function": {
-        "resource_id": "FUNCTION-start_function",
-        "name": "start_function",
-        "description": "",
-        "code": "def start_function(conv: Conversation):\n    \"\"\"Start function for the agent.\"\"\"\n    conv.state.customer_name = \"John Doe\"\n    pass\n",
-        "parameters": [],
-        "latency_control": {
-          "enabled": false,
-          "initial_delay": 0,
-          "interval": 0,
-          "delay_responses": []
         },
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "start",
-        "variable_references": {
-          "VAR-customer_name": true
-        }
-      },
-      "FUNCTION-end_function": {
-        "resource_id": "FUNCTION-end_function",
-        "name": "end_function",
-        "description": "",
-        "code": "def end_function(conv: Conversation):\n    \"\"\"End function for the agent.\"\"\"\n    pass\n",
-        "parameters": [],
-        "latency_control": {
-          "enabled": false,
-          "initial_delay": 0,
-          "interval": 0,
-          "delay_responses": []
-        },
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "end",
-        "variable_references": {}
-      },
-      "FUNCTION-process_data": {
-        "resource_id": "FUNCTION-process_data",
-        "name": "process_data",
-        "description": "Process data in flow context.",
-        "code": "def process_data(conv: Conversation, flow: Flow, data: str):\n    \"\"\"Process data in flow context.\"\"\"\n    conv.state.data_processed = True\n    return f\"Processed in flow: {data}\"\n",
-        "parameters": [
-          {
-            "name": "data",
-            "type": "string",
-            "description": "The data string to process",
-            "id": "PARAMETER-data-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition"
-      },
-      "FUNCTION-shared_helper_flow1": {
-        "resource_id": "FUNCTION-shared_helper_flow1",
-        "name": "shared_helper",
-        "description": "A shared helper function with same name as global function.",
-        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"A shared helper function with same name as global function.\"\"\"\n    return f\"Flow-specific helper: {value}\"\n",
-        "parameters": [
-          {
-            "name": "value",
-            "type": "string",
-            "description": "The value to process",
-            "id": "PARAMETER-value-2"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition"
-      },
-      "FUNCTION-validate_input_flow1": {
-        "resource_id": "FUNCTION-validate_input_flow1",
-        "name": "validate_input",
-        "description": "Validate input in flow.",
-        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Validate input in flow.\"\"\"\n    return len(input_value) > 0\n",
-        "parameters": [
-          {
-            "name": "input_value",
-            "type": "string",
-            "description": "The input value to validate",
-            "id": "PARAMETER-input_value-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition"
-      },
-      "FUNCTION-shared_helper_flow2": {
-        "resource_id": "FUNCTION-shared_helper_flow2",
-        "name": "shared_helper",
-        "description": "Another shared helper with same name as global and other flow.",
-        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"Another shared helper with same name as global and other flow.\"\"\"\n    return f\"Punctuation flow helper: {value}\"\n",
-        "parameters": [
-          {
-            "name": "value",
-            "type": "string",
-            "description": "The value to process",
-            "id": "PARAMETER-value-3"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition"
-      },
-      "FUNCTION-calculate_total": {
-        "resource_id": "FUNCTION-calculate_total",
-        "name": "calculate_total",
-        "description": "Calculate total amount.",
-        "code": "def calculate_total(conv: Conversation, flow: Flow, amount: float):\n    \"\"\"Calculate total amount.\"\"\"\n    return amount * 1.1\n",
-        "parameters": [
-          {
-            "name": "amount",
-            "type": "number",
-            "description": "The base amount to calculate from",
-            "id": "PARAMETER-amount-1"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition"
-      },
-      "FUNCTION-validate_input_flow2": {
-        "resource_id": "FUNCTION-validate_input_flow2",
-        "name": "validate_input",
-        "description": "Another validate_input with same name as other flow.",
-        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Another validate_input with same name as other flow.\"\"\"\n    return input_value.isdigit()\n",
-        "parameters": [
-          {
-            "name": "input_value",
-            "type": "string",
-            "description": "The input value to validate",
-            "id": "PARAMETER-input_value-2"
-          }
-        ],
-        "latency_control": {},
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition"
-      }
-    },
-    "topics": {
-      "TOPIC-Topic 1": {
-        "resource_id": "TOPIC-Topic 1",
-        "name": "Topic 1",
-        "actions": "Use {{fn:FUNCTION-test_function}} to handle this request and {{fn:FUNCTION-format_date}} for dates. Access customer info via {{attr:customer-name}} and handoff with {{ho:handoff-1}} if needed. Send notifications using {{twilio_sms:SMS_TEMPLATE-123}}.",
-        "content": "This topic covers general inquiries and uses global functions.",
-        "example_queries": [
-          "How can I help?",
-          "What services do you offer?",
-          "General information request"
-        ],
-        "enabled": true
-      },
-      "TOPIC-Topic 2": {
-        "resource_id": "TOPIC-Topic 2",
-        "name": "Topic 2",
-        "actions": "Validate using {{fn:FUNCTION-validate_email}} and process with {{fn:FUNCTION-shared_helper}}. Check {{attr:email-address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "content": "This topic handles email validation and processing.",
-        "example_queries": [
-          "I need to verify my email",
-          "Check my email address",
-          "Email validation request"
-        ],
-        "enabled": true
-      }
-    },
-    "child_topics": {
-      "TOPIC-Spanish Only Topic": {
-        "resource_id": "TOPIC-Spanish Only Topic",
-        "name": "Spanish Only Topic",
-        "variant_id": "VARIANT-spanish",
-        "variant_name": "spanish",
-        "actions": "Handle this request in Spanish using {{fn:FUNCTION-test_function}} and {{attr:customer-name}}.",
-        "content": "This topic only applies when the Spanish variant is active.",
-        "example_queries": [
-          "How can I help you?",
-          "What services do you offer?"
-        ],
-        "enabled": true
-      }
-    },
-    "voice_greeting": {
-      "voice_greeting": {
-        "resource_id": "voice_greeting",
-        "name": "voice_greeting",
-        "welcome_message": "Hello! Welcome to our service. Your account shows {{attr:member-status}}. How can I assist you today?",
-        "language_code": "en-GB"
-      }
-    },
-    "voice_style_prompt": {
-      "voice_style_prompt": {
-        "resource_id": "voice_style_prompt",
-        "name": "voice_style_prompt",
-        "prompt": "You are a helpful and professional customer service assistant."
-      }
-    },
-    "chat_greeting": {
-      "chat_greeting": {
-        "resource_id": "chat_greeting",
-        "name": "chat_greeting",
-        "welcome_message": "Hello! Welcome to our web chat. Your account shows {{attr:member-status}}. How can I assist you today?",
-        "language_code": "en-GB"
-      }
-    },
-    "chat_style_prompt": {
-      "chat_style_prompt": {
-        "resource_id": "chat_style_prompt",
-        "name": "chat_style_prompt",
-        "prompt": "You are a helpful and professional web chat assistant."
-      }
-    },
-    "persona": {
-      "PERSONA-persona": {
-        "resource_id": "PERSONA-persona",
-        "name": "persona",
-        "content": "You are a calm and polite concierge.\nGreet the caller by name using {{vrbl:VAR-customer_name}}.\n"
-      }
-    },
-    "rules": {
-      "RULES-rules": {
-        "resource_id": "RULES-rules",
-        "name": "rules",
-        "behaviour": "Be helpful and professional at all times.\nUse {{fn:FUNCTION-test_function}} when appropriate.\nAlways validate inputs using {{fn:FUNCTION-validate_email}} when dealing with email addresses.\nAccess customer information from {{attr:customer-name}} and {{attr:email-address}}.\nFor complex issues, use {{ho:handoff-1}} to transfer to a specialist.\nSend important notifications via {{twilio_sms:SMS_TEMPLATE-123}} or {{twilio_sms:SMS_TEMPLATE-456}} as appropriate.\nFollow the guidelines provided.\nUse variable {{vrbl:VAR-customer_name}}\n"
-      }
-    },
-    "voice_disclaimer": {
-      "voice_disclaimer": {
-        "resource_id": "voice_disclaimer",
-        "name": "voice_disclaimer",
-        "message": "This conversation may be recorded for quality assurance.",
-        "enabled": true,
-        "language_code": "en-GB"
+        "name": "experimental_config",
+        "resource_id": "default"
       }
     },
     "flow_config": {
       "FLOW_CONFIG-test_flow": {
-        "resource_id": "FLOW_CONFIG-test_flow",
-        "name": "test_flow",
         "description": "Test flow with advanced step as start",
+        "name": "test_flow",
+        "resource_id": "FLOW_CONFIG-test_flow",
         "start_step": "start_step"
       },
       "FLOW_CONFIG-test_flow_with_punctuation": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "name": "test_flow_with_punctuation!",
         "description": "Test flow with punctuation in name and default step as start",
+        "name": "test_flow_with_punctuation!",
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "start_step": "welcome_step"
       }
     },
     "flow_steps": {
-      "FLOW_CONFIG-test_flow_start_step": {
-        "resource_id": "FLOW_CONFIG-test_flow_start_step",
-        "step_id": "start_step",
-        "name": "start_step",
+      "FLOW_CONFIG-test_flow_collect_name": {
+        "conditions": [
+          {
+            "child_step": "confirm_details",
+            "condition_type": "step_condition",
+            "description": "User provided name",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow",
+            "ingress": "top",
+            "name": "has_name",
+            "position": {},
+            "required_entities": [
+              "ENTITY-customer_name"
+            ],
+            "resource_id": "CONDITION-has_name-1",
+            "step_id": "collect_name"
+          },
+          {
+            "child_step": "",
+            "condition_type": "exit_flow_condition",
+            "description": "Exit flow",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow",
+            "ingress": "top",
+            "name": "exit_flow",
+            "position": {},
+            "required_entities": [],
+            "resource_id": "CONDITION-exit_flow-1",
+            "step_id": "collect_name"
+          }
+        ],
+        "extracted_entities": [
+          "ENTITY-customer_name"
+        ],
         "flow_id": "FLOW_CONFIG-test_flow",
         "flow_name": "test_flow",
-        "step_type": "advanced_step",
-        "prompt": "Welcome! I'll help you today. Let me use {{fn:FUNCTION-test_function}} to get started. If needed, we can handoff using {{ho:handoff-1}} or send SMS via {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "name": "collect_name",
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        },
+        "prompt": "What is your name? {{entity:ENTITY-customer_name}}",
+        "resource_id": "FLOW_CONFIG-test_flow_collect_name",
+        "settings": {},
+        "step_id": "collect_name",
+        "step_type": "default_step"
+      },
+      "FLOW_CONFIG-test_flow_collect_phone": {
+        "conditions": [
+          {
+            "child_step": "final_step",
+            "condition_type": "step_condition",
+            "description": "User provided phone",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow",
+            "ingress": "top",
+            "name": "has_phone",
+            "position": {},
+            "required_entities": [
+              "ENTITY-phone_number"
+            ],
+            "resource_id": "CONDITION-has_phone-1",
+            "step_id": "collect_phone"
+          },
+          {
+            "child_step": "final_step",
+            "condition_type": "step_condition",
+            "description": "User declined to provide phone",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow",
+            "ingress": "top",
+            "name": "no_phone",
+            "position": {},
+            "required_entities": [],
+            "resource_id": "CONDITION-no_phone-1",
+            "step_id": "collect_phone"
+          }
+        ],
+        "extracted_entities": [
+          "ENTITY-phone_number"
+        ],
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "name": "collect_phone",
+        "position": {
+          "x": 1200.0,
+          "y": 500.0
+        },
+        "prompt": "What is your phone number?",
+        "resource_id": "FLOW_CONFIG-test_flow_collect_phone",
+        "settings": {},
+        "step_id": "collect_phone",
+        "step_type": "default_step"
+      },
+      "FLOW_CONFIG-test_flow_confirm_details": {
+        "conditions": [],
+        "extracted_entities": [],
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "name": "confirm_details",
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        },
+        "prompt": "Let me confirm your details using {{fn:FUNCTION-format_date}} and {{ft:FUNCTION-process_data}}. Your name is {{attr:customer_name}}. Is this correct?",
+        "resource_id": "FLOW_CONFIG-test_flow_confirm_details",
         "settings": {
           "asr_biasing": {
+            "address": false,
+            "alphanumeric": false,
+            "custom_keywords": [],
+            "is_enabled": true,
+            "name_spelling": false,
+            "numeric": true,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false
+          },
+          "dtmf": {
+            "collect_while_agent_speaking": false,
+            "end_key": "#",
+            "inter_digit_timeout": 0,
+            "is_enabled": true,
+            "is_pii": false,
+            "max_digits": 1
+          },
+          "flow_id": "FLOW_CONFIG-test_flow",
+          "step_id": "confirm_details"
+        },
+        "step_id": "confirm_details",
+        "step_type": "advanced_step"
+      },
+      "FLOW_CONFIG-test_flow_final_step": {
+        "conditions": [],
+        "extracted_entities": [],
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "name": "final_step",
+        "position": {
+          "x": 1200.0,
+          "y": 1000.0
+        },
+        "prompt": "Thank you! Using {{fn:FUNCTION-shared_helper}} and {{ft:FUNCTION-shared_helper_flow1}} to complete. If you need human assistance, use {{ho:handoff-2}}. I'll send a confirmation via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "resource_id": "FLOW_CONFIG-test_flow_final_step",
+        "settings": {
+          "asr_biasing": {
+            "address": false,
+            "alphanumeric": false,
+            "custom_keywords": [],
+            "is_enabled": false,
+            "name_spelling": false,
+            "numeric": false,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false
+          },
+          "dtmf": {
+            "collect_while_agent_speaking": false,
+            "end_key": "#",
+            "inter_digit_timeout": 0,
+            "is_enabled": false,
+            "is_pii": false,
+            "max_digits": 0
+          },
+          "flow_id": "FLOW_CONFIG-test_flow",
+          "step_id": "final_step"
+        },
+        "step_id": "final_step",
+        "step_type": "advanced_step"
+      },
+      "FLOW_CONFIG-test_flow_start_step": {
+        "conditions": [],
+        "extracted_entities": [],
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "name": "start_step",
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        },
+        "prompt": "Welcome! I'll help you today. Let me use {{fn:FUNCTION-test_function}} to get started. If needed, we can handoff using {{ho:handoff-1}} or send SMS via {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "resource_id": "FLOW_CONFIG-test_flow_start_step",
+        "settings": {
+          "asr_biasing": {
+            "address": false,
             "alphanumeric": true,
+            "custom_keywords": [],
+            "is_enabled": true,
             "name_spelling": true,
             "numeric": true,
             "party_size": false,
@@ -494,175 +443,40 @@
             "relative_date": false,
             "single_number": false,
             "time": false,
-            "yes_no": false,
-            "address": false,
-            "custom_keywords": [],
-            "is_enabled": true
+            "yes_no": false
           },
           "dtmf": {
+            "collect_while_agent_speaking": false,
+            "end_key": "#",
+            "inter_digit_timeout": 0,
             "is_enabled": false,
-            "inter_digit_timeout": 0,
-            "max_digits": 0,
-            "end_key": "#",
-            "collect_while_agent_speaking": false,
-            "is_pii": false
+            "is_pii": false,
+            "max_digits": 0
           },
-          "step_id": "start_step",
-          "flow_id": "FLOW_CONFIG-test_flow"
+          "flow_id": "FLOW_CONFIG-test_flow",
+          "step_id": "start_step"
         },
+        "step_id": "start_step",
+        "step_type": "advanced_step"
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_email": {
         "conditions": [],
         "extracted_entities": [],
-        "position": {
-          "x": 0.0,
-          "y": 0.0
-        }
-      },
-      "FLOW_CONFIG-test_flow_collect_name": {
-        "resource_id": "FLOW_CONFIG-test_flow_collect_name",
-        "name": "collect_name",
-        "step_id": "collect_name",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "step_type": "default_step",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "name": "collect_email",
         "position": {
           "x": 600.0,
           "y": 500.0
         },
-        "settings": {},
-        "conditions": [
-          {
-            "resource_id": "CONDITION-has_name-1",
-            "name": "has_name",
-            "description": "User provided name",
-            "required_entities": [
-              "ENTITY-customer_name"
-            ],
-            "condition_type": "step_condition",
-            "child_step": "confirm_details",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_name",
-            "flow_id": "FLOW_CONFIG-test_flow"
-          },
-          {
-            "resource_id": "CONDITION-exit_flow-1",
-            "name": "exit_flow",
-            "description": "Exit flow",
-            "required_entities": [],
-            "condition_type": "exit_flow_condition",
-            "child_step": "",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_name",
-            "flow_id": "FLOW_CONFIG-test_flow"
-          }
-        ],
-        "extracted_entities": [
-          "ENTITY-customer_name"
-        ],
-        "prompt": "What is your name? {{entity:ENTITY-customer_name}}"
-      },
-      "FLOW_CONFIG-test_flow_confirm_details": {
-        "resource_id": "FLOW_CONFIG-test_flow_confirm_details",
-        "step_id": "confirm_details",
-        "name": "confirm_details",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "step_type": "advanced_step",
-        "prompt": "Let me confirm your details using {{fn:FUNCTION-format_date}} and {{ft:FUNCTION-process_data}}. Your name is {{attr:customer-name}}. Is this correct?",
+        "prompt": "Please provide your email. I'll validate it using {{fn:FUNCTION-validate_email}} and process with {{ft:FUNCTION-calculate_total}}. Your current status is {{attr:booking_status}}. I can send updates via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_email",
         "settings": {
           "asr_biasing": {
-            "alphanumeric": false,
-            "name_spelling": false,
-            "numeric": true,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false,
             "address": false,
+            "alphanumeric": true,
             "custom_keywords": [],
-            "is_enabled": true
-          },
-          "dtmf": {
             "is_enabled": true,
-            "inter_digit_timeout": 0,
-            "max_digits": 1,
-            "end_key": "#",
-            "collect_while_agent_speaking": false,
-            "is_pii": false
-          },
-          "step_id": "confirm_details",
-          "flow_id": "FLOW_CONFIG-test_flow"
-        },
-        "conditions": [],
-        "extracted_entities": [],
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        }
-      },
-      "FLOW_CONFIG-test_flow_collect_phone": {
-        "resource_id": "FLOW_CONFIG-test_flow_collect_phone",
-        "name": "collect_phone",
-        "step_id": "collect_phone",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "step_type": "default_step",
-        "position": {
-          "x": 1200.0,
-          "y": 500.0
-        },
-        "settings": {},
-        "conditions": [
-          {
-            "resource_id": "CONDITION-has_phone-1",
-            "name": "has_phone",
-            "description": "User provided phone",
-            "required_entities": [
-              "ENTITY-phone_number"
-            ],
-            "condition_type": "step_condition",
-            "child_step": "final_step",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_phone",
-            "flow_id": "FLOW_CONFIG-test_flow"
-          },
-          {
-            "resource_id": "CONDITION-no_phone-1",
-            "name": "no_phone",
-            "description": "User declined to provide phone",
-            "required_entities": [],
-            "condition_type": "step_condition",
-            "child_step": "final_step",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_phone",
-            "flow_id": "FLOW_CONFIG-test_flow"
-          }
-        ],
-        "extracted_entities": [
-          "ENTITY-phone_number"
-        ],
-        "prompt": "What is your phone number?"
-      },
-      "FLOW_CONFIG-test_flow_final_step": {
-        "resource_id": "FLOW_CONFIG-test_flow_final_step",
-        "step_id": "final_step",
-        "name": "final_step",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "step_type": "advanced_step",
-        "prompt": "Thank you! Using {{fn:FUNCTION-shared_helper}} and {{ft:FUNCTION-shared_helper_flow1}} to complete. If you need human assistance, use {{ho:handoff-2}}. I'll send a confirmation via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "settings": {
-          "asr_biasing": {
-            "alphanumeric": false,
             "name_spelling": false,
             "numeric": false,
             "party_size": false,
@@ -670,289 +484,453 @@
             "relative_date": false,
             "single_number": false,
             "time": false,
-            "yes_no": false,
-            "address": false,
-            "custom_keywords": [],
-            "is_enabled": false
+            "yes_no": false
           },
           "dtmf": {
-            "is_enabled": false,
-            "inter_digit_timeout": 0,
-            "max_digits": 0,
-            "end_key": "#",
             "collect_while_agent_speaking": false,
-            "is_pii": false
+            "end_key": "#",
+            "inter_digit_timeout": 0,
+            "is_enabled": false,
+            "is_pii": false,
+            "max_digits": 0
           },
-          "step_id": "final_step",
-          "flow_id": "FLOW_CONFIG-test_flow"
+          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+          "step_id": "collect_email"
         },
-        "conditions": [],
-        "extracted_entities": [],
-        "position": {
-          "x": 1200.0,
-          "y": 1000.0
-        }
+        "step_id": "collect_email",
+        "step_type": "advanced_step"
       },
-      "FLOW_CONFIG-test_flow_with_punctuation_welcome_step": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_welcome_step",
-        "name": "welcome_step",
-        "step_id": "welcome_step",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "step_type": "default_step",
-        "position": {
-          "x": 0.0,
-          "y": 0.0
-        },
-        "settings": {},
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size": {
         "conditions": [
           {
-            "resource_id": "CONDITION-book_appointment-1",
-            "name": "book_appointment",
+            "child_step": "collect_email",
+            "condition_type": "step_condition",
+            "description": "User provided party size",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+            "ingress": "top",
+            "name": "has_party_size",
+            "position": {},
+            "required_entities": [
+              "ENTITY-party_size"
+            ],
+            "resource_id": "CONDITION-has_party_size-1",
+            "step_id": "collect_party_size"
+          },
+          {
+            "child_step": "",
+            "condition_type": "exit_flow_condition",
+            "description": "Exit flow",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+            "ingress": "top",
+            "name": "exit_flow",
+            "position": {},
+            "required_entities": [],
+            "resource_id": "CONDITION-exit_flow-2",
+            "step_id": "collect_party_size"
+          }
+        ],
+        "extracted_entities": [
+          "ENTITY-party_size"
+        ],
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "name": "collect_party_size",
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        },
+        "prompt": "How many people will be in your party?",
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size",
+        "settings": {},
+        "step_id": "collect_party_size",
+        "step_type": "default_step"
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_status_result": {
+        "conditions": [],
+        "extracted_entities": [],
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "name": "status_result",
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        },
+        "prompt": "Checking your status using {{fn:FUNCTION-test_function}} and {{ft:FUNCTION-shared_helper_flow2}}. For urgent matters, use {{ho:handoff-3}}. Status updates can be sent via {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_status_result",
+        "settings": {
+          "asr_biasing": {
+            "address": false,
+            "alphanumeric": false,
+            "custom_keywords": [],
+            "is_enabled": false,
+            "name_spelling": false,
+            "numeric": false,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false
+          },
+          "dtmf": {
+            "collect_while_agent_speaking": false,
+            "end_key": "#",
+            "inter_digit_timeout": 5,
+            "is_enabled": true,
+            "is_pii": false,
+            "max_digits": 2
+          },
+          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+          "step_id": "status_result"
+        },
+        "step_id": "status_result",
+        "step_type": "advanced_step"
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_welcome_step": {
+        "conditions": [
+          {
+            "child_step": "collect_party_size",
+            "condition_type": "no_code_step_condition",
             "description": "User wants to book appointment",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+            "ingress": "top",
+            "name": "book_appointment",
+            "position": {},
             "required_entities": [
               "ENTITY-date"
             ],
-            "condition_type": "no_code_step_condition",
-            "child_step": "collect_party_size",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "welcome_step",
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+            "resource_id": "CONDITION-book_appointment-1",
+            "step_id": "welcome_step"
           },
           {
-            "resource_id": "CONDITION-check_status-1",
-            "name": "check_status",
+            "child_step": "status_result",
+            "condition_type": "step_condition",
             "description": "User wants to check status",
+            "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+            "ingress": "top",
+            "name": "check_status",
+            "position": {},
             "required_entities": [
               "ENTITY-confirmation_status"
             ],
-            "condition_type": "step_condition",
-            "child_step": "status_result",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "welcome_step",
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+            "resource_id": "CONDITION-check_status-1",
+            "step_id": "welcome_step"
           },
           {
-            "resource_id": "CONDITION-exit-1",
-            "name": "exit",
-            "description": "User wants to exit",
-            "required_entities": [],
-            "condition_type": "exit_flow_condition",
             "child_step": "",
-            "position": {},
+            "condition_type": "exit_flow_condition",
+            "description": "User wants to exit",
             "exit_flow_position": {},
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
             "ingress": "top",
-            "step_id": "welcome_step",
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+            "name": "exit",
+            "position": {},
+            "required_entities": [],
+            "resource_id": "CONDITION-exit-1",
+            "step_id": "welcome_step"
           }
         ],
         "extracted_entities": [
           "ENTITY-date",
           "ENTITY-confirmation_status"
         ],
-        "prompt": "Welcome! How can I help you today?"
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size",
-        "name": "collect_party_size",
-        "step_id": "collect_party_size",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "flow_name": "test_flow_with_punctuation!",
-        "step_type": "default_step",
+        "name": "welcome_step",
         "position": {
-          "x": 600.0,
-          "y": 500.0
+          "x": 0.0,
+          "y": 0.0
         },
+        "prompt": "Welcome! How can I help you today?",
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_welcome_step",
         "settings": {},
-        "conditions": [
-          {
-            "resource_id": "CONDITION-has_party_size-1",
-            "name": "has_party_size",
-            "description": "User provided party size",
-            "required_entities": [
-              "ENTITY-party_size"
-            ],
-            "condition_type": "step_condition",
-            "child_step": "collect_email",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_party_size",
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
-          },
-          {
-            "resource_id": "CONDITION-exit_flow-2",
-            "name": "exit_flow",
-            "description": "Exit flow",
-            "required_entities": [],
-            "condition_type": "exit_flow_condition",
-            "child_step": "",
-            "position": {},
-            "exit_flow_position": {},
-            "ingress": "top",
-            "step_id": "collect_party_size",
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
-          }
-        ],
-        "extracted_entities": [
-          "ENTITY-party_size"
-        ],
-        "prompt": "How many people will be in your party?"
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_collect_email": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_email",
-        "step_id": "collect_email",
-        "name": "collect_email",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "step_type": "advanced_step",
-        "prompt": "Please provide your email. I'll validate it using {{fn:FUNCTION-validate_email}} and process with {{ft:FUNCTION-calculate_total}}. Your current status is {{attr:booking-status}}. I can send updates via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "settings": {
-          "asr_biasing": {
-            "alphanumeric": true,
-            "name_spelling": false,
-            "numeric": false,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false,
-            "address": false,
-            "custom_keywords": [],
-            "is_enabled": true
-          },
-          "dtmf": {
-            "is_enabled": false,
-            "inter_digit_timeout": 0,
-            "max_digits": 0,
-            "end_key": "#",
-            "collect_while_agent_speaking": false,
-            "is_pii": false
-          },
-          "step_id": "collect_email",
-          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
-        },
-        "conditions": [],
-        "extracted_entities": [],
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        }
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_status_result": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_status_result",
-        "step_id": "status_result",
-        "name": "status_result",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "step_type": "advanced_step",
-        "prompt": "Checking your status using {{fn:FUNCTION-test_function}} and {{ft:FUNCTION-shared_helper_flow2}}. For urgent matters, use {{ho:handoff-3}}. Status updates can be sent via {{twilio_sms:SMS_TEMPLATE-123}}.",
-        "settings": {
-          "asr_biasing": {
-            "alphanumeric": false,
-            "name_spelling": false,
-            "numeric": false,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false,
-            "address": false,
-            "custom_keywords": [],
-            "is_enabled": false
-          },
-          "dtmf": {
-            "is_enabled": true,
-            "inter_digit_timeout": 5,
-            "max_digits": 2,
-            "end_key": "#",
-            "collect_while_agent_speaking": false,
-            "is_pii": false
-          },
-          "step_id": "status_result",
-          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
-        },
-        "conditions": [],
-        "extracted_entities": [],
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        }
-      }
-    },
-    "experimental_config": {
-      "default": {
-        "resource_id": "default",
-        "name": "experimental_config",
-        "config": {
-          "asr": {
-            "provider": "riva",
-            "model": "poly-latency",
-            "language": "en-GB"
-          },
-          "vad": {
-            "vad_end": 600
-          },
-          "smart_vad": {
-            "is_enabled": true
-          },
-          "eot": {
-            "provider": "smart_turn",
-            "threshold": 0.5
-          }
-        }
+        "step_id": "welcome_step",
+        "step_type": "default_step"
       }
     },
     "function_steps": {
       "FLOW_CONFIG-test_flow_process_payment": {
-        "resource_id": "FLOW_CONFIG-test_flow_process_payment",
-        "step_id": "process_payment",
+        "code": "def process_payment(conv: Conversation, flow: Flow):\n    \"\"\"Process payment for the customer.\"\"\"\n    # Process payment logic here\n    conv.state.customer_name = \"John Doe\"\n    conv.state.payment_success = True\n    return \"Payment processed\"\n",
+        "description": "",
         "flow_id": "FLOW_CONFIG-test_flow",
         "flow_name": "test_flow",
-        "name": "process_payment",
-        "step_type": "function_step",
-        "description": "",
-        "code": "def process_payment(conv: Conversation, flow: Flow):\n    \"\"\"Process payment for the customer.\"\"\"\n    # Process payment logic here\n    conv.state.customer_name = \"John Doe\"\n    conv.state.payment_success = True\n    return \"Payment processed\"\n",
-        "parameters": [],
-        "latency_control": {},
-        "function_type": "function_step",
         "function_id": "FUNCTION-process_payment",
+        "function_type": "function_step",
+        "latency_control": {},
+        "name": "process_payment",
+        "parameters": [],
         "position": {
           "x": 0.0,
           "y": 0.0
-        }
+        },
+        "resource_id": "FLOW_CONFIG-test_flow_process_payment",
+        "step_id": "process_payment",
+        "step_type": "function_step"
       },
       "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount": {
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount",
-        "step_id": "calculate_discount",
+        "code": "def calculate_discount(conv: Conversation, flow: Flow):\n    \"\"\"Calculate discount for the order.\"\"\"\n    # Calculate discount logic here\n    return \"Discount calculated\"\n",
+        "description": "",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "flow_name": "test_flow_with_punctuation!",
-        "name": "calculate_discount",
-        "step_type": "function_step",
-        "description": "",
-        "code": "def calculate_discount(conv: Conversation, flow: Flow):\n    \"\"\"Calculate discount for the order.\"\"\"\n    # Calculate discount logic here\n    return \"Discount calculated\"\n",
-        "parameters": [],
-        "latency_control": {},
-        "function_type": "function_step",
         "function_id": "FUNCTION-process_payment",
+        "function_type": "function_step",
+        "latency_control": {},
+        "name": "calculate_discount",
+        "parameters": [],
         "position": {
           "x": 0.0,
           "y": 0.0
+        },
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount",
+        "step_id": "calculate_discount",
+        "step_type": "function_step"
+      }
+    },
+    "functions": {
+      "FUNCTION-calculate_total": {
+        "code": "def calculate_total(conv: Conversation, flow: Flow, amount: float):\n    \"\"\"Calculate total amount.\"\"\"\n    return amount * 1.1\n",
+        "description": "Calculate total amount.",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "calculate_total",
+        "parameters": [
+          {
+            "description": "The base amount to calculate from",
+            "id": "PARAMETER-amount-1",
+            "name": "amount",
+            "type": "number"
+          }
+        ],
+        "resource_id": "FUNCTION-calculate_total"
+      },
+      "FUNCTION-end_function": {
+        "code": "def end_function(conv: Conversation):\n    \"\"\"End function for the agent.\"\"\"\n    pass\n",
+        "description": "",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "end",
+        "latency_control": {
+          "delay_responses": [],
+          "enabled": false,
+          "initial_delay": 0,
+          "interval": 0
+        },
+        "name": "end_function",
+        "parameters": [],
+        "resource_id": "FUNCTION-end_function",
+        "variable_references": {}
+      },
+      "FUNCTION-format_date": {
+        "code": "def format_date(conv: Conversation, date: str):\n    \"\"\"Format date for display.\"\"\"\n    return date.upper()\n",
+        "description": "Format date for display.",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global",
+        "latency_control": {},
+        "name": "format_date",
+        "parameters": [
+          {
+            "description": "The date string to format",
+            "id": "PARAMETER-date-1",
+            "name": "date",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-format_date"
+      },
+      "FUNCTION-process_data": {
+        "code": "def process_data(conv: Conversation, flow: Flow, data: str):\n    \"\"\"Process data in flow context.\"\"\"\n    conv.state.data_processed = True\n    return f\"Processed in flow: {data}\"\n",
+        "description": "Process data in flow context.",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "process_data",
+        "parameters": [
+          {
+            "description": "The data string to process",
+            "id": "PARAMETER-data-1",
+            "name": "data",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-process_data"
+      },
+      "FUNCTION-shared_helper": {
+        "code": "def shared_helper(conv: Conversation, value: str):\n    \"\"\"A shared helper function that can be used by multiple flows.\"\"\"\n    return f\"Processed: {value}\"\n",
+        "description": "A shared helper function that can be used by multiple flows.",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global",
+        "latency_control": {},
+        "name": "shared_helper",
+        "parameters": [
+          {
+            "description": "The value to process",
+            "id": "PARAMETER-value-1",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-shared_helper"
+      },
+      "FUNCTION-shared_helper_flow1": {
+        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"A shared helper function with same name as global function.\"\"\"\n    return f\"Flow-specific helper: {value}\"\n",
+        "description": "A shared helper function with same name as global function.",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "shared_helper",
+        "parameters": [
+          {
+            "description": "The value to process",
+            "id": "PARAMETER-value-2",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-shared_helper_flow1"
+      },
+      "FUNCTION-shared_helper_flow2": {
+        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"Another shared helper with same name as global and other flow.\"\"\"\n    return f\"Punctuation flow helper: {value}\"\n",
+        "description": "Another shared helper with same name as global and other flow.",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "shared_helper",
+        "parameters": [
+          {
+            "description": "The value to process",
+            "id": "PARAMETER-value-3",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-shared_helper_flow2"
+      },
+      "FUNCTION-start_function": {
+        "code": "def start_function(conv: Conversation):\n    \"\"\"Start function for the agent.\"\"\"\n    conv.state.customer_name = \"John Doe\"\n    pass\n",
+        "description": "",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "start",
+        "latency_control": {
+          "delay_responses": [],
+          "enabled": false,
+          "initial_delay": 0,
+          "interval": 0
+        },
+        "name": "start_function",
+        "parameters": [],
+        "resource_id": "FUNCTION-start_function",
+        "variable_references": {
+          "VAR-customer_name": true
         }
+      },
+      "FUNCTION-test_function": {
+        "code": "def test_function(conv: Conversation):\n    \"\"\"A test function for global use.\"\"\"\n    return \"Hello from global function\"\n",
+        "description": "A test function for global use.",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global",
+        "latency_control": {},
+        "name": "test_function",
+        "parameters": [],
+        "resource_id": "FUNCTION-test_function"
+      },
+      "FUNCTION-test_function_with_parameters": {
+        "code": "def test_function_with_parameters(conv: Conversation, param1: str, param2: int):\n    \"\"\"Test function with parameters.\"\"\"\n    return f\"Result: {param1} - {param2}\"\n",
+        "description": "Test function with parameters.",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global",
+        "latency_control": {},
+        "name": "test_function_with_parameters",
+        "parameters": [
+          {
+            "description": "First parameter as string",
+            "id": "PARAMETER-param1-1",
+            "name": "param1",
+            "type": "string"
+          },
+          {
+            "description": "Second parameter as integer",
+            "id": "PARAMETER-param2-1",
+            "name": "param2",
+            "type": "integer"
+          }
+        ],
+        "resource_id": "FUNCTION-test_function_with_parameters"
+      },
+      "FUNCTION-validate_email": {
+        "code": "def validate_email(conv: Conversation, email: str):\n    \"\"\"Validate email format.\"\"\"\n    return \"@\" in email and \".\" in email.split(\"@\")[1]\n",
+        "description": "Validate email format.",
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global",
+        "latency_control": {},
+        "name": "validate_email",
+        "parameters": [
+          {
+            "description": "The email address to validate",
+            "id": "PARAMETER-email-1",
+            "name": "email",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-validate_email"
+      },
+      "FUNCTION-validate_input_flow1": {
+        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Validate input in flow.\"\"\"\n    return len(input_value) > 0\n",
+        "description": "Validate input in flow.",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "validate_input",
+        "parameters": [
+          {
+            "description": "The input value to validate",
+            "id": "PARAMETER-input_value-1",
+            "name": "input_value",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-validate_input_flow1"
+      },
+      "FUNCTION-validate_input_flow2": {
+        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Another validate_input with same name as other flow.\"\"\"\n    return input_value.isdigit()\n",
+        "description": "Another validate_input with same name as other flow.",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition",
+        "latency_control": {},
+        "name": "validate_input",
+        "parameters": [
+          {
+            "description": "The input value to validate",
+            "id": "PARAMETER-input_value-2",
+            "name": "input_value",
+            "type": "string"
+          }
+        ],
+        "resource_id": "FUNCTION-validate_input_flow2"
       }
     },
     "handoffs": {
       "handoff-1": {
-        "resource_id": "handoff-1",
-        "name": "default",
         "description": "default handoff",
         "is_default": true,
+        "name": "default",
+        "resource_id": "handoff-1",
         "sip_config": {
           "method": "refer",
           "phone_number": "+1234567890"
@@ -969,10 +947,10 @@
         ]
       },
       "handoff-2": {
-        "resource_id": "handoff-2",
-        "name": "front desk",
         "description": "Speak to front desk",
         "is_default": false,
+        "name": "front desk",
+        "resource_id": "handoff-2",
         "sip_config": {
           "method": "refer",
           "phone_number": "front desk"
@@ -980,10 +958,10 @@
         "sip_headers": []
       },
       "handoff-3": {
-        "resource_id": "handoff-3",
-        "name": "urgent support",
         "description": "Transfer for urgent matters",
         "is_default": false,
+        "name": "urgent support",
+        "resource_id": "handoff-3",
         "sip_config": {
           "method": "refer",
           "phone_number": "+1987654321"
@@ -991,91 +969,260 @@
         "sip_headers": []
       }
     },
+    "keyphrase_boosting": {
+      "KEYPHRASE_BOOSTING-checkin": {
+        "keyphrase": "check-in",
+        "level": "default",
+        "name": "check-in",
+        "resource_id": "KEYPHRASE_BOOSTING-checkin"
+      },
+      "KEYPHRASE_BOOSTING-polyai": {
+        "keyphrase": "PolyAI",
+        "level": "maximum",
+        "name": "PolyAI",
+        "resource_id": "KEYPHRASE_BOOSTING-polyai"
+      },
+      "KEYPHRASE_BOOSTING-reservation": {
+        "keyphrase": "reservation",
+        "level": "boosted",
+        "name": "reservation",
+        "resource_id": "KEYPHRASE_BOOSTING-reservation"
+      }
+    },
+    "persona": {
+      "PERSONA-persona": {
+        "content": "You are a calm and polite concierge.\nGreet the caller by name using {{vrbl:VAR-customer_name}}.\n",
+        "name": "persona",
+        "resource_id": "PERSONA-persona"
+      }
+    },
     "phrase_filtering": {
+      "STOP_KEYWORD-block_competitor_names": {
+        "description": "Prevents mentioning competitor names",
+        "name": "Block Competitor Names",
+        "regular_expressions": [
+          "\\bcompetitor\\b"
+        ],
+        "resource_id": "STOP_KEYWORD-block_competitor_names",
+        "say_phrase": true
+      },
       "STOP_KEYWORD-block_profanity": {
-        "resource_id": "STOP_KEYWORD-block_profanity",
-        "name": "Block Profanity",
         "description": "Blocks profane words from being spoken",
+        "function": "FUNCTION-validate_email",
+        "name": "Block Profanity",
         "regular_expressions": [
           "\\bbadword\\b",
           "\\boffensive\\b"
         ],
-        "say_phrase": false,
-        "function": "FUNCTION-validate_email"
+        "resource_id": "STOP_KEYWORD-block_profanity",
+        "say_phrase": false
+      }
+    },
+    "platform_guardrails": {
+      "ai_identity": {
+        "enabled": true,
+        "name": "ai_identity",
+        "resource_id": "ai_identity"
       },
-      "STOP_KEYWORD-block_competitor_names": {
-        "resource_id": "STOP_KEYWORD-block_competitor_names",
-        "name": "Block Competitor Names",
-        "description": "Prevents mentioning competitor names",
-        "regular_expressions": [
-          "\\bcompetitor\\b"
-        ],
-        "say_phrase": true
+      "emergency_escalation": {
+        "enabled": true,
+        "name": "emergency_escalation",
+        "resource_id": "emergency_escalation"
+      },
+      "hallucination_control": {
+        "enabled": false,
+        "name": "hallucination_control",
+        "resource_id": "hallucination_control"
+      },
+      "jailbreak_defence": {
+        "enabled": true,
+        "name": "jailbreak_defence",
+        "resource_id": "jailbreak_defence"
+      },
+      "tool_call_integrity": {
+        "enabled": false,
+        "name": "tool_call_integrity",
+        "resource_id": "tool_call_integrity"
       }
     },
     "pronunciations": {
       "PRONUNCIATION-dr_abbreviation": {
-        "resource_id": "PRONUNCIATION-dr_abbreviation",
+        "case_sensitive": true,
+        "position": 0,
         "regex": "\\bDr\\.",
         "replacement": "Doctor",
-        "case_sensitive": true,
-        "position": 0
+        "resource_id": "PRONUNCIATION-dr_abbreviation"
       },
       "PRONUNCIATION-mr_abbreviation": {
-        "resource_id": "PRONUNCIATION-mr_abbreviation",
+        "case_sensitive": true,
+        "position": 1,
         "regex": "\\bMr\\.",
         "replacement": "Mister",
-        "case_sensitive": true,
-        "position": 1
+        "resource_id": "PRONUNCIATION-mr_abbreviation"
+      }
+    },
+    "rules": {
+      "RULES-rules": {
+        "behaviour": "Be helpful and professional at all times.\nUse {{fn:FUNCTION-test_function}} when appropriate.\nAlways validate inputs using {{fn:FUNCTION-validate_email}} when dealing with email addresses.\nAccess customer information from {{attr:customer_name}} and {{attr:email_address}}.\nFor complex issues, use {{ho:handoff-1}} to transfer to a specialist.\nSend important notifications via {{twilio_sms:SMS_TEMPLATE-123}} or {{twilio_sms:SMS_TEMPLATE-456}} as appropriate.\nFollow the guidelines provided.\nUse variable {{vrbl:VAR-customer_name}}\n",
+        "name": "rules",
+        "resource_id": "RULES-rules"
+      }
+    },
+    "safety_filters": {
+      "safety_filters": {
+        "categories": {
+          "hate": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "self_harm": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "sexual": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "violence": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          }
+        },
+        "enabled": true,
+        "filter_type": "azure",
+        "name": "safety_filters",
+        "resource_id": "safety_filters"
       }
     },
     "sms_templates": {
       "SMS_TEMPLATE-123": {
-        "resource_id": "SMS_TEMPLATE-123",
-        "name": "test_template_1",
-        "text": "This is a test template",
         "env_phone_numbers": {
-          "sandbox": "",
+          "live": "+447700102347",
           "pre_release": "",
-          "live": "+447700102347"
-        }
+          "sandbox": ""
+        },
+        "name": "test_template_1",
+        "resource_id": "SMS_TEMPLATE-123",
+        "text": "This is a test template"
       },
       "SMS_TEMPLATE-456": {
-        "resource_id": "SMS_TEMPLATE-456",
-        "name": "test_template_2",
-        "text": "This is a second test template",
         "env_phone_numbers": {
-          "sandbox": "",
+          "live": "+447700102347",
           "pre_release": "",
-          "live": "+447700102347"
-        }
+          "sandbox": ""
+        },
+        "name": "test_template_2",
+        "resource_id": "SMS_TEMPLATE-456",
+        "text": "This is a second test template"
       }
     },
-    "keyphrase_boosting": {
-      "KEYPHRASE_BOOSTING-polyai": {
-        "resource_id": "KEYPHRASE_BOOSTING-polyai",
-        "name": "PolyAI",
-        "keyphrase": "PolyAI",
-        "level": "maximum"
+    "test_cases": {
+      "TEST-greeting_flow": {
+        "api_mocks": {
+          "mocks": {
+            "customer_api": {
+              "get_confirmation_status": [
+                {
+                  "respond": {
+                    "body": {
+                      "confirmed": true
+                    },
+                    "status": 200
+                  }
+                }
+              ]
+            }
+          }
+        },
+        "assertions": {
+          "function_calls": [
+            {
+              "arguments": [
+                {
+                  "assertion_type": "equals",
+                  "expected_value": "hello",
+                  "parameter_name": "param1",
+                  "value_type": "string"
+                }
+              ],
+              "name": "test_function"
+            }
+          ],
+          "name": "assertions",
+          "prompts": [
+            "The agent offers to help with booking"
+          ],
+          "resource_id": "TEST-greeting_flow"
+        },
+        "channel": "chat.polyai",
+        "language": "en-GB",
+        "name": "Greeting flow test",
+        "resource_id": "TEST-greeting_flow",
+        "scenario": "Ask for help with booking.",
+        "tags": {
+          "name": "tags",
+          "resource_id": "TEST-greeting_flow",
+          "tags": [
+            "booking",
+            "smoke"
+          ]
+        },
+        "variant": null
       },
-      "KEYPHRASE_BOOSTING-reservation": {
-        "resource_id": "KEYPHRASE_BOOSTING-reservation",
-        "name": "reservation",
-        "keyphrase": "reservation",
-        "level": "boosted"
+      "TEST-webchat_smoke": {
+        "assertions": {
+          "function_calls": [],
+          "name": "assertions",
+          "prompts": [
+            "The agent greets the user"
+          ],
+          "resource_id": "TEST-webchat_smoke"
+        },
+        "channel": "webchat.polyai",
+        "language": "en-GB",
+        "name": "Webchat smoke test",
+        "resource_id": "TEST-webchat_smoke",
+        "scenario": "Say hello on webchat.",
+        "tags": {
+          "name": "tags",
+          "resource_id": "TEST-webchat_smoke",
+          "tags": [
+            "smoke"
+          ]
+        },
+        "variant": null
+      }
+    },
+    "topics": {
+      "TOPIC-Topic 1": {
+        "actions": "Use {{fn:FUNCTION-test_function}} to handle this request and {{fn:FUNCTION-format_date}} for dates. Access customer info via {{attr:customer_name}} and handoff with {{ho:handoff-1}} if needed. Send notifications using {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "content": "This topic covers general inquiries and uses global functions.",
+        "enabled": true,
+        "example_queries": [
+          "How can I help?",
+          "What services do you offer?",
+          "General information request"
+        ],
+        "name": "Topic 1",
+        "resource_id": "TOPIC-Topic 1"
       },
-      "KEYPHRASE_BOOSTING-checkin": {
-        "resource_id": "KEYPHRASE_BOOSTING-checkin",
-        "name": "check-in",
-        "keyphrase": "check-in",
-        "level": "default"
+      "TOPIC-Topic 2": {
+        "actions": "Validate using {{fn:FUNCTION-validate_email}} and process with {{fn:FUNCTION-shared_helper}}. Check {{attr:email_address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "content": "This topic handles email validation and processing.",
+        "enabled": true,
+        "example_queries": [
+          "I need to verify my email",
+          "Check my email address",
+          "Email validation request"
+        ],
+        "name": "Topic 2",
+        "resource_id": "TOPIC-Topic 2"
       }
     },
     "transcript_corrections": {
       "TRANSCRIPT_CORRECTIONS-email_domain": {
-        "resource_id": "TRANSCRIPT_CORRECTIONS-email_domain",
-        "name": "Email domain fix",
         "description": "Correct common email domain misrecognitions",
+        "name": "Email domain fix",
         "regular_expressions": [
           {
             "regular_expression": "at gmail dot com",
@@ -1087,296 +1234,205 @@
             "replacement": "@hotmail.com",
             "replacement_type": "full"
           }
-        ]
+        ],
+        "resource_id": "TRANSCRIPT_CORRECTIONS-email_domain"
       },
       "TRANSCRIPT_CORRECTIONS-number_norm": {
-        "resource_id": "TRANSCRIPT_CORRECTIONS-number_norm",
-        "name": "Number normalization",
         "description": "Normalize spoken numbers to digits",
+        "name": "Number normalization",
         "regular_expressions": [
           {
             "regular_expression": "\\bdouble (\\d)\\b",
             "replacement": "\\1\\1",
             "replacement_type": "partial"
           }
-        ]
-      }
-    },
-    "api_integration": {
-      "int-customer_api": {
-        "resource_id": "int-customer_api",
-        "name": "customer_api",
-        "description": "test",
-        "environments": {
-          "sandbox": {
-            "base_url": "https://dev-customer.com",
-            "auth_type": "basic"
-          },
-          "pre_release": {
-            "base_url": "https://dev-customer.com",
-            "auth_type": "basic"
-          },
-          "live": {
-            "base_url": "https://customer.com",
-            "auth_type": "apiKey"
-          }
-        },
-        "operations": [
-          {
-            "resource_id": "",
-            "name": "get_confirmation_status",
-            "method": "GET",
-            "resource": "/bookings/{booking_id}/confirmation-status"
-          }
-        ]
-      }
-    },
-    "asr_settings": {
-      "asr_settings": {
-        "resource_id": "asr_settings",
-        "name": "asr_settings",
-        "barge_in": false,
-        "interaction_style": "balanced"
-      }
-    },
-    "safety_filters": {
-      "safety_filters": {
-        "resource_id": "safety_filters",
-        "name": "safety_filters",
-        "enabled": true,
-        "filter_type": "azure",
-        "categories": {
-          "violence": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "hate": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "sexual": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "self_harm": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          }
-        }
-      }
-    },
-    "voice_safety_filters": {
-      "voice_safety_filters": {
-        "resource_id": "voice_safety_filters",
-        "name": "voice_safety_filters",
-        "enabled": true,
-        "filter_type": "azure",
-        "categories": {
-          "violence": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "hate": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "sexual": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "self_harm": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          }
-        }
-      }
-    },
-    "chat_safety_filters": {
-      "chat_safety_filters": {
-        "resource_id": "chat_safety_filters",
-        "name": "chat_safety_filters",
-        "enabled": true,
-        "filter_type": "azure",
-        "categories": {
-          "violence": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "hate": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "sexual": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "self_harm": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          }
-        }
-      }
-    },
-    "test_cases": {
-      "TEST-greeting_flow": {
-        "resource_id": "TEST-greeting_flow",
-        "name": "Greeting flow test",
-        "scenario": "Ask for help with booking.",
-        "channel": "chat.polyai",
-        "assertions": {
-          "resource_id": "TEST-greeting_flow",
-          "name": "assertions",
-          "prompts": [
-            "The agent offers to help with booking"
-          ],
-          "function_calls": [
-            {
-              "name": "test_function",
-              "arguments": [
-                {
-                  "parameter_name": "param1",
-                  "expected_value": "hello",
-                  "value_type": "string",
-                  "assertion_type": "equals"
-                }
-              ]
-            }
-          ]
-        },
-        "tags": {
-          "resource_id": "TEST-greeting_flow",
-          "name": "tags",
-          "tags": [
-            "booking",
-            "smoke"
-          ]
-        },
-        "variant": null,
-        "language": "en-GB",
-        "api_mocks": {
-          "mocks": {
-            "customer_api": {
-              "get_confirmation_status": [
-                {
-                  "respond": {
-                    "status": 200,
-                    "body": {
-                      "confirmed": true
-                    }
-                  }
-                }
-              ]
-            }
-          }
-        }
-      },
-      "TEST-webchat_smoke": {
-        "resource_id": "TEST-webchat_smoke",
-        "name": "Webchat smoke test",
-        "scenario": "Say hello on webchat.",
-        "channel": "webchat.polyai",
-        "assertions": {
-          "resource_id": "TEST-webchat_smoke",
-          "name": "assertions",
-          "prompts": [
-            "The agent greets the user"
-          ],
-          "function_calls": []
-        },
-        "tags": {
-          "resource_id": "TEST-webchat_smoke",
-          "name": "tags",
-          "tags": [
-            "smoke"
-          ]
-        },
-        "variant": null,
-        "language": "en-GB"
+        ],
+        "resource_id": "TRANSCRIPT_CORRECTIONS-number_norm"
       }
     },
     "translations": {
-      "TN-greeting": {
-        "resource_id": "TN-greeting",
-        "name": "greeting",
-        "translations": {
-          "en-GB": "Hello, how can I help you?",
-          "fr-FR": "Bonjour, comment puis-je vous aider?"
-        }
-      },
       "TN-farewell": {
-        "resource_id": "TN-farewell",
         "name": "farewell",
+        "resource_id": "TN-farewell",
         "translations": {
           "en-GB": "Goodbye",
           "fr-FR": "Au revoir"
         }
+      },
+      "TN-greeting": {
+        "name": "greeting",
+        "resource_id": "TN-greeting",
+        "translations": {
+          "en-GB": "Hello, how can I help you?",
+          "fr-FR": "Bonjour, comment puis-je vous aider?"
+        }
       }
     },
-    "default_language": {
-      "en-GB": {
-        "resource_id": "en-GB",
-        "name": "en-GB"
+    "variables": {
+      "VAR-customer_name": {
+        "name": "customer_name",
+        "resource_id": "VAR-customer_name"
+      },
+      "VAR-data_processed": {
+        "name": "data_processed",
+        "resource_id": "VAR-data_processed"
+      },
+      "VAR-payment_success": {
+        "name": "payment_success",
+        "resource_id": "VAR-payment_success"
       }
     },
-    "additional_languages": {
-      "fr-FR": {
-        "resource_id": "fr-FR",
-        "name": "fr-FR"
+    "variant_attributes": {
+      "booking_status": {
+        "mappings": {
+          "VARIANT-default": "value-4",
+          "VARIANT-spanish": "valor-4"
+        },
+        "name": "booking_status",
+        "resource_id": "booking_status"
+      },
+      "customer_name": {
+        "mappings": {
+          "VARIANT-default": "value-1",
+          "VARIANT-spanish": "valor-1"
+        },
+        "name": "customer_name",
+        "resource_id": "customer_name"
+      },
+      "email_address": {
+        "mappings": {
+          "VARIANT-default": "value-2",
+          "VARIANT-spanish": "valor-2"
+        },
+        "name": "email_address",
+        "resource_id": "email_address"
+      },
+      "max_retries": {
+        "config": {},
+        "kind": "number",
+        "mappings": {
+          "VARIANT-default": 3,
+          "VARIANT-spanish": 5
+        },
+        "name": "max_retries",
+        "resource_id": "max_retries"
+      },
+      "member_status": {
+        "mappings": {
+          "VARIANT-default": "value-3",
+          "VARIANT-spanish": "valor-3"
+        },
+        "name": "member_status",
+        "resource_id": "member_status"
+      },
+      "menu_config": {
+        "config": {},
+        "kind": "object",
+        "mappings": {
+          "VARIANT-default": {
+            "categories": [
+              "pizza",
+              "pasta"
+            ],
+            "currency": "USD"
+          },
+          "VARIANT-spanish": {
+            "categories": [
+              "paella"
+            ],
+            "currency": "EUR"
+          }
+        },
+        "name": "menu_config",
+        "resource_id": "menu_config"
+      },
+      "serves_alcohol": {
+        "config": {},
+        "kind": "boolean",
+        "mappings": {
+          "VARIANT-default": true,
+          "VARIANT-spanish": false
+        },
+        "name": "serves_alcohol",
+        "resource_id": "serves_alcohol"
+      },
+      "tier": {
+        "config": {
+          "values": [
+            "basic",
+            "premium"
+          ]
+        },
+        "kind": "enum",
+        "mappings": {
+          "VARIANT-default": "premium",
+          "VARIANT-spanish": "basic"
+        },
+        "name": "tier",
+        "resource_id": "tier"
       }
     },
-    "documents": {
-      "test_document.md": {
-        "resource_id": "test_document.md",
-        "name": "test_document",
-        "path": "test_document.md",
-        "contents": "This is a test document.\nIt has multiple lines.\n"
+    "variants": {
+      "VARIANT-default": {
+        "is_default": true,
+        "name": "default",
+        "resource_id": "VARIANT-default"
       },
-      "CONTEXT.MD": {
-        "resource_id": "CONTEXT.MD",
-        "name": "CONTEXT",
-        "path": "CONTEXT.MD",
-        "contents": "This is platform context file.\n"
+      "VARIANT-spanish": {
+        "is_default": false,
+        "name": "spanish",
+        "resource_id": "VARIANT-spanish"
       }
     },
-    "platform_guardrails": {
-      "jailbreak_defence": {
-        "resource_id": "jailbreak_defence",
-        "name": "jailbreak_defence",
-        "enabled": true
-      },
-      "hallucination_control": {
-        "resource_id": "hallucination_control",
-        "name": "hallucination_control",
-        "enabled": false
-      },
-      "ai_identity": {
-        "resource_id": "ai_identity",
-        "name": "ai_identity",
-        "enabled": true
-      },
-      "emergency_escalation": {
-        "resource_id": "emergency_escalation",
-        "name": "emergency_escalation",
-        "enabled": true
-      },
-      "tool_call_integrity": {
-        "resource_id": "tool_call_integrity",
-        "name": "tool_call_integrity",
-        "enabled": false
+    "voice_disclaimer": {
+      "voice_disclaimer": {
+        "enabled": true,
+        "language_code": "en-GB",
+        "message": "This conversation may be recorded for quality assurance.",
+        "name": "voice_disclaimer",
+        "resource_id": "voice_disclaimer"
       }
     },
-    "custom_guardrails": {
-      "CUSTOM_GUARDRAILS-no_medical_advice": {
-        "resource_id": "CUSTOM_GUARDRAILS-no_medical_advice",
-        "name": "No medical advice",
-        "prompt": "Never give medical advice. Offer to transfer the caller to a human instead.",
-        "action": "warn",
-        "enabled": true
+    "voice_greeting": {
+      "voice_greeting": {
+        "language_code": "en-GB",
+        "name": "voice_greeting",
+        "resource_id": "voice_greeting",
+        "welcome_message": "Hello! Welcome to our service. Your account shows {{attr:member_status}}. How can I assist you today?"
+      }
+    },
+    "voice_safety_filters": {
+      "voice_safety_filters": {
+        "categories": {
+          "hate": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "self_harm": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "sexual": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "violence": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          }
+        },
+        "enabled": true,
+        "filter_type": "azure",
+        "name": "voice_safety_filters",
+        "resource_id": "voice_safety_filters"
+      }
+    },
+    "voice_style_prompt": {
+      "voice_style_prompt": {
+        "name": "voice_style_prompt",
+        "prompt": "You are a helpful and professional customer service assistant.",
+        "resource_id": "voice_style_prompt"
       }
     }
-  },
-  "file_structure_info": {},
-  "migration_flags": [
-    "migrated_legacy_topic_files"
-  ]
+  }
 }

--- a/src/poly/tests/test_projects/test_project/test_project.json
+++ b/src/poly/tests/test_projects/test_project/test_project.json
@@ -1,441 +1,548 @@
 {
-  "account_id": "test_account",
-  "branch_id": "main",
-  "file_structure_info": {},
-  "last_updated": "2024-01-01T00:00:00",
-  "migration_flags": [
-    "migrated_legacy_topic_files"
-  ],
-  "project_id": "test_project",
   "region": "us-1",
+  "account_id": "test_account",
+  "project_id": "test_project",
+  "branch_id": "main",
+  "last_updated": "2024-01-01T00:00:00",
   "resources": {
-    "additional_languages": {
-      "fr-FR": {
-        "name": "fr-FR",
-        "resource_id": "fr-FR"
-      }
-    },
-    "api_integration": {
-      "int-customer_api": {
-        "description": "test",
-        "environments": {
-          "live": {
-            "auth_type": "apiKey",
-            "base_url": "https://customer.com"
-          },
-          "pre_release": {
-            "auth_type": "basic",
-            "base_url": "https://dev-customer.com"
-          },
-          "sandbox": {
-            "auth_type": "basic",
-            "base_url": "https://dev-customer.com"
-          }
-        },
-        "name": "customer_api",
-        "operations": [
-          {
-            "method": "GET",
-            "name": "get_confirmation_status",
-            "resource": "/bookings/{booking_id}/confirmation-status",
-            "resource_id": ""
-          }
-        ],
-        "resource_id": "int-customer_api"
-      }
-    },
-    "asr_settings": {
-      "asr_settings": {
-        "barge_in": false,
-        "interaction_style": "balanced",
-        "name": "asr_settings",
-        "resource_id": "asr_settings"
-      }
-    },
-    "chat_greeting": {
-      "chat_greeting": {
-        "language_code": "en-GB",
-        "name": "chat_greeting",
-        "resource_id": "chat_greeting",
-        "welcome_message": "Hello! Welcome to our web chat. Your account shows {{attr:member_status}}. How can I assist you today?"
-      }
-    },
-    "chat_safety_filters": {
-      "chat_safety_filters": {
-        "categories": {
-          "hate": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "self_harm": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "sexual": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "violence": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          }
-        },
-        "enabled": true,
-        "filter_type": "azure",
-        "name": "chat_safety_filters",
-        "resource_id": "chat_safety_filters"
-      }
-    },
-    "chat_style_prompt": {
-      "chat_style_prompt": {
-        "name": "chat_style_prompt",
-        "prompt": "You are a helpful and professional web chat assistant.",
-        "resource_id": "chat_style_prompt"
-      }
-    },
-    "child_topics": {
-      "TOPIC-Spanish Only Topic": {
-        "actions": "Handle this request in Spanish using {{fn:FUNCTION-test_function}} and {{attr:customer_name}}.",
-        "content": "This topic only applies when the Spanish variant is active.",
-        "enabled": true,
-        "example_queries": [
-          "How can I help you?",
-          "What services do you offer?"
-        ],
-        "name": "Spanish Only Topic",
-        "resource_id": "TOPIC-Spanish Only Topic",
-        "variant_id": "VARIANT-spanish",
-        "variant_name": "spanish"
-      }
-    },
-    "custom_guardrails": {
-      "CUSTOM_GUARDRAILS-no_medical_advice": {
-        "action": "warn",
-        "enabled": true,
-        "name": "No medical advice",
-        "prompt": "Never give medical advice. Offer to transfer the caller to a human instead.",
-        "resource_id": "CUSTOM_GUARDRAILS-no_medical_advice"
-      }
-    },
-    "default_language": {
-      "en-GB": {
-        "name": "en-GB",
-        "resource_id": "en-GB"
-      }
-    },
-    "documents": {
-      "CONTEXT.MD": {
-        "contents": "This is platform context file.\n",
-        "name": "CONTEXT",
-        "path": "CONTEXT.MD",
-        "resource_id": "CONTEXT.MD"
-      },
-      "test_document.md": {
-        "contents": "This is a test document.\nIt has multiple lines.\n",
-        "name": "test_document",
-        "path": "test_document.md",
-        "resource_id": "test_document.md"
-      }
-    },
     "entities": {
+      "ENTITY-customer_name": {
+        "resource_id": "ENTITY-customer_name",
+        "name": "customer_name",
+        "description": "Customer name entity for collecting names",
+        "entity_type": "name_config",
+        "config": {}
+      },
+      "ENTITY-phone_number": {
+        "resource_id": "ENTITY-phone_number",
+        "name": "phone_number",
+        "description": "Phone number entity with country codes",
+        "entity_type": "phone_number",
+        "config": {
+          "enabled": true,
+          "country_codes": [
+            "US",
+            "UK"
+          ]
+        }
+      },
+      "ENTITY-date": {
+        "resource_id": "ENTITY-date",
+        "name": "date",
+        "description": "Date entity for appointment scheduling",
+        "entity_type": "date",
+        "config": {
+          "relative_date": true
+        }
+      },
+      "ENTITY-party_size": {
+        "resource_id": "ENTITY-party_size",
+        "name": "party_size",
+        "description": "Number of people in party",
+        "entity_type": "numeric",
+        "config": {
+          "has_decimal": false,
+          "has_range": true,
+          "min": 1,
+          "max": 20
+        }
+      },
       "ENTITY-confirmation_status": {
+        "resource_id": "ENTITY-confirmation_status",
+        "name": "confirmation_status",
+        "description": "Confirmation status options",
+        "entity_type": "enum",
         "config": {
           "options": [
             "confirmed",
             "pending",
             "cancelled"
           ]
-        },
-        "description": "Confirmation status options",
-        "entity_type": "enum",
-        "name": "confirmation_status",
-        "resource_id": "ENTITY-confirmation_status"
-      },
-      "ENTITY-customer_name": {
-        "config": {},
-        "description": "Customer name entity for collecting names",
-        "entity_type": "name_config",
-        "name": "customer_name",
-        "resource_id": "ENTITY-customer_name"
-      },
-      "ENTITY-date": {
-        "config": {
-          "relative_date": true
-        },
-        "description": "Date entity for appointment scheduling",
-        "entity_type": "date",
-        "name": "date",
-        "resource_id": "ENTITY-date"
+        }
       },
       "ENTITY-email": {
-        "config": {
-          "enabled": true,
-          "regular_expression": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$",
-          "validation_type": "email"
-        },
+        "resource_id": "ENTITY-email",
+        "name": "email",
         "description": "Email address validation",
         "entity_type": "alphanumeric",
-        "name": "email",
-        "resource_id": "ENTITY-email"
-      },
-      "ENTITY-party_size": {
         "config": {
-          "has_decimal": false,
-          "has_range": true,
-          "max": 20,
-          "min": 1
-        },
-        "description": "Number of people in party",
-        "entity_type": "numeric",
-        "name": "party_size",
-        "resource_id": "ENTITY-party_size"
-      },
-      "ENTITY-phone_number": {
-        "config": {
-          "country_codes": [
-            "US",
-            "UK"
-          ],
-          "enabled": true
-        },
-        "description": "Phone number entity with country codes",
-        "entity_type": "phone_number",
-        "name": "phone_number",
-        "resource_id": "ENTITY-phone_number"
+          "enabled": true,
+          "validation_type": "email",
+          "regular_expression": "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$"
+        }
       }
     },
-    "experimental_config": {
-      "default": {
+    "variants": {
+      "VARIANT-default": {
+        "resource_id": "VARIANT-default",
+        "name": "default",
+        "is_default": true
+      },
+      "VARIANT-spanish": {
+        "resource_id": "VARIANT-spanish",
+        "name": "spanish",
+        "is_default": false
+      }
+    },
+    "variant_attributes": {
+      "customer_name": {
+        "resource_id": "customer_name",
+        "name": "customer_name",
+        "mappings": {
+          "VARIANT-default": "value-1",
+          "VARIANT-spanish": "valor-1"
+        }
+      },
+      "email_address": {
+        "resource_id": "email_address",
+        "name": "email_address",
+        "mappings": {
+          "VARIANT-default": "value-2",
+          "VARIANT-spanish": "valor-2"
+        }
+      },
+      "member_status": {
+        "resource_id": "member_status",
+        "name": "member_status",
+        "mappings": {
+          "VARIANT-default": "value-3",
+          "VARIANT-spanish": "valor-3"
+        }
+      },
+      "booking_status": {
+        "resource_id": "booking_status",
+        "name": "booking_status",
+        "mappings": {
+          "VARIANT-default": "value-4",
+          "VARIANT-spanish": "valor-4"
+        }
+      },
+      "max_retries": {
+        "resource_id": "max_retries",
+        "name": "max_retries",
+        "mappings": {
+          "VARIANT-default": 3,
+          "VARIANT-spanish": 5
+        },
+        "kind": "number",
+        "config": {}
+      },
+      "serves_alcohol": {
+        "resource_id": "serves_alcohol",
+        "name": "serves_alcohol",
+        "mappings": {
+          "VARIANT-default": true,
+          "VARIANT-spanish": false
+        },
+        "kind": "boolean",
+        "config": {}
+      },
+      "tier": {
+        "resource_id": "tier",
+        "name": "tier",
+        "mappings": {
+          "VARIANT-default": "premium",
+          "VARIANT-spanish": "basic"
+        },
+        "kind": "enum",
         "config": {
-          "asr": {
-            "language": "en-GB",
-            "model": "poly-latency",
-            "provider": "riva"
+          "values": [
+            "basic",
+            "premium"
+          ]
+        }
+      },
+      "menu_config": {
+        "resource_id": "menu_config",
+        "name": "menu_config",
+        "mappings": {
+          "VARIANT-default": {
+            "categories": [
+              "pizza",
+              "pasta"
+            ],
+            "currency": "USD"
           },
-          "eot": {
-            "provider": "smart_turn",
-            "threshold": 0.5
-          },
-          "smart_vad": {
-            "is_enabled": true
-          },
-          "vad": {
-            "vad_end": 600
+          "VARIANT-spanish": {
+            "categories": [
+              "paella"
+            ],
+            "currency": "EUR"
           }
         },
-        "name": "experimental_config",
-        "resource_id": "default"
+        "kind": "object",
+        "config": {}
+      }
+    },
+    "variables": {
+      "VAR-customer_name": {
+        "resource_id": "VAR-customer_name",
+        "name": "customer_name"
+      },
+      "VAR-payment_success": {
+        "resource_id": "VAR-payment_success",
+        "name": "payment_success"
+      },
+      "VAR-data_processed": {
+        "resource_id": "VAR-data_processed",
+        "name": "data_processed"
+      }
+    },
+    "functions": {
+      "FUNCTION-validate_email": {
+        "resource_id": "FUNCTION-validate_email",
+        "name": "validate_email",
+        "description": "Validate email format.",
+        "code": "def validate_email(conv: Conversation, email: str):\n    \"\"\"Validate email format.\"\"\"\n    return \"@\" in email and \".\" in email.split(\"@\")[1]\n",
+        "parameters": [
+          {
+            "name": "email",
+            "type": "string",
+            "description": "The email address to validate",
+            "id": "PARAMETER-email-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global"
+      },
+      "FUNCTION-format_date": {
+        "resource_id": "FUNCTION-format_date",
+        "name": "format_date",
+        "description": "Format date for display.",
+        "code": "def format_date(conv: Conversation, date: str):\n    \"\"\"Format date for display.\"\"\"\n    return date.upper()\n",
+        "parameters": [
+          {
+            "name": "date",
+            "type": "string",
+            "description": "The date string to format",
+            "id": "PARAMETER-date-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global"
+      },
+      "FUNCTION-shared_helper": {
+        "resource_id": "FUNCTION-shared_helper",
+        "name": "shared_helper",
+        "description": "A shared helper function that can be used by multiple flows.",
+        "code": "def shared_helper(conv: Conversation, value: str):\n    \"\"\"A shared helper function that can be used by multiple flows.\"\"\"\n    return f\"Processed: {value}\"\n",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "string",
+            "description": "The value to process",
+            "id": "PARAMETER-value-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global"
+      },
+      "FUNCTION-test_function": {
+        "resource_id": "FUNCTION-test_function",
+        "name": "test_function",
+        "description": "A test function for global use.",
+        "code": "def test_function(conv: Conversation):\n    \"\"\"A test function for global use.\"\"\"\n    return \"Hello from global function\"\n",
+        "parameters": [],
+        "latency_control": {},
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global"
+      },
+      "FUNCTION-test_function_with_parameters": {
+        "resource_id": "FUNCTION-test_function_with_parameters",
+        "name": "test_function_with_parameters",
+        "description": "Test function with parameters.",
+        "code": "def test_function_with_parameters(conv: Conversation, param1: str, param2: int):\n    \"\"\"Test function with parameters.\"\"\"\n    return f\"Result: {param1} - {param2}\"\n",
+        "parameters": [
+          {
+            "name": "param1",
+            "type": "string",
+            "description": "First parameter as string",
+            "id": "PARAMETER-param1-1"
+          },
+          {
+            "name": "param2",
+            "type": "integer",
+            "description": "Second parameter as integer",
+            "id": "PARAMETER-param2-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "global"
+      },
+      "FUNCTION-start_function": {
+        "resource_id": "FUNCTION-start_function",
+        "name": "start_function",
+        "description": "",
+        "code": "def start_function(conv: Conversation):\n    \"\"\"Start function for the agent.\"\"\"\n    conv.state.customer_name = \"John Doe\"\n    pass\n",
+        "parameters": [],
+        "latency_control": {
+          "enabled": false,
+          "initial_delay": 0,
+          "interval": 0,
+          "delay_responses": []
+        },
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "start",
+        "variable_references": {
+          "VAR-customer_name": true
+        }
+      },
+      "FUNCTION-end_function": {
+        "resource_id": "FUNCTION-end_function",
+        "name": "end_function",
+        "description": "",
+        "code": "def end_function(conv: Conversation):\n    \"\"\"End function for the agent.\"\"\"\n    pass\n",
+        "parameters": [],
+        "latency_control": {
+          "enabled": false,
+          "initial_delay": 0,
+          "interval": 0,
+          "delay_responses": []
+        },
+        "flow_id": null,
+        "flow_name": null,
+        "function_type": "end",
+        "variable_references": {}
+      },
+      "FUNCTION-process_data": {
+        "resource_id": "FUNCTION-process_data",
+        "name": "process_data",
+        "description": "Process data in flow context.",
+        "code": "def process_data(conv: Conversation, flow: Flow, data: str):\n    \"\"\"Process data in flow context.\"\"\"\n    conv.state.data_processed = True\n    return f\"Processed in flow: {data}\"\n",
+        "parameters": [
+          {
+            "name": "data",
+            "type": "string",
+            "description": "The data string to process",
+            "id": "PARAMETER-data-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition"
+      },
+      "FUNCTION-shared_helper_flow1": {
+        "resource_id": "FUNCTION-shared_helper_flow1",
+        "name": "shared_helper",
+        "description": "A shared helper function with same name as global function.",
+        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"A shared helper function with same name as global function.\"\"\"\n    return f\"Flow-specific helper: {value}\"\n",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "string",
+            "description": "The value to process",
+            "id": "PARAMETER-value-2"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition"
+      },
+      "FUNCTION-validate_input_flow1": {
+        "resource_id": "FUNCTION-validate_input_flow1",
+        "name": "validate_input",
+        "description": "Validate input in flow.",
+        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Validate input in flow.\"\"\"\n    return len(input_value) > 0\n",
+        "parameters": [
+          {
+            "name": "input_value",
+            "type": "string",
+            "description": "The input value to validate",
+            "id": "PARAMETER-input_value-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "function_type": "transition"
+      },
+      "FUNCTION-shared_helper_flow2": {
+        "resource_id": "FUNCTION-shared_helper_flow2",
+        "name": "shared_helper",
+        "description": "Another shared helper with same name as global and other flow.",
+        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"Another shared helper with same name as global and other flow.\"\"\"\n    return f\"Punctuation flow helper: {value}\"\n",
+        "parameters": [
+          {
+            "name": "value",
+            "type": "string",
+            "description": "The value to process",
+            "id": "PARAMETER-value-3"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition"
+      },
+      "FUNCTION-calculate_total": {
+        "resource_id": "FUNCTION-calculate_total",
+        "name": "calculate_total",
+        "description": "Calculate total amount.",
+        "code": "def calculate_total(conv: Conversation, flow: Flow, amount: float):\n    \"\"\"Calculate total amount.\"\"\"\n    return amount * 1.1\n",
+        "parameters": [
+          {
+            "name": "amount",
+            "type": "number",
+            "description": "The base amount to calculate from",
+            "id": "PARAMETER-amount-1"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition"
+      },
+      "FUNCTION-validate_input_flow2": {
+        "resource_id": "FUNCTION-validate_input_flow2",
+        "name": "validate_input",
+        "description": "Another validate_input with same name as other flow.",
+        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Another validate_input with same name as other flow.\"\"\"\n    return input_value.isdigit()\n",
+        "parameters": [
+          {
+            "name": "input_value",
+            "type": "string",
+            "description": "The input value to validate",
+            "id": "PARAMETER-input_value-2"
+          }
+        ],
+        "latency_control": {},
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "function_type": "transition"
+      }
+    },
+    "topics": {
+      "TOPIC-Topic 1": {
+        "resource_id": "TOPIC-Topic 1",
+        "name": "Topic 1",
+        "actions": "Use {{fn:FUNCTION-test_function}} to handle this request and {{fn:FUNCTION-format_date}} for dates. Access customer info via {{attr:customer_name}} and handoff with {{ho:handoff-1}} if needed. Send notifications using {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "content": "This topic covers general inquiries and uses global functions.",
+        "example_queries": [
+          "How can I help?",
+          "What services do you offer?",
+          "General information request"
+        ],
+        "enabled": true
+      },
+      "TOPIC-Topic 2": {
+        "resource_id": "TOPIC-Topic 2",
+        "name": "Topic 2",
+        "actions": "Validate using {{fn:FUNCTION-validate_email}} and process with {{fn:FUNCTION-shared_helper}}. Check {{attr:email_address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "content": "This topic handles email validation and processing.",
+        "example_queries": [
+          "I need to verify my email",
+          "Check my email address",
+          "Email validation request"
+        ],
+        "enabled": true
+      }
+    },
+    "child_topics": {
+      "TOPIC-Spanish Only Topic": {
+        "resource_id": "TOPIC-Spanish Only Topic",
+        "name": "Spanish Only Topic",
+        "variant_id": "VARIANT-spanish",
+        "variant_name": "spanish",
+        "actions": "Handle this request in Spanish using {{fn:FUNCTION-test_function}} and {{attr:customer_name}}.",
+        "content": "This topic only applies when the Spanish variant is active.",
+        "example_queries": [
+          "How can I help you?",
+          "What services do you offer?"
+        ],
+        "enabled": true
+      }
+    },
+    "voice_greeting": {
+      "voice_greeting": {
+        "resource_id": "voice_greeting",
+        "name": "voice_greeting",
+        "welcome_message": "Hello! Welcome to our service. Your account shows {{attr:member_status}}. How can I assist you today?",
+        "language_code": "en-GB"
+      }
+    },
+    "voice_style_prompt": {
+      "voice_style_prompt": {
+        "resource_id": "voice_style_prompt",
+        "name": "voice_style_prompt",
+        "prompt": "You are a helpful and professional customer service assistant."
+      }
+    },
+    "chat_greeting": {
+      "chat_greeting": {
+        "resource_id": "chat_greeting",
+        "name": "chat_greeting",
+        "welcome_message": "Hello! Welcome to our web chat. Your account shows {{attr:member_status}}. How can I assist you today?",
+        "language_code": "en-GB"
+      }
+    },
+    "chat_style_prompt": {
+      "chat_style_prompt": {
+        "resource_id": "chat_style_prompt",
+        "name": "chat_style_prompt",
+        "prompt": "You are a helpful and professional web chat assistant."
+      }
+    },
+    "persona": {
+      "PERSONA-persona": {
+        "resource_id": "PERSONA-persona",
+        "name": "persona",
+        "content": "You are a calm and polite concierge.\nGreet the caller by name using {{vrbl:VAR-customer_name}}.\n"
+      }
+    },
+    "rules": {
+      "RULES-rules": {
+        "resource_id": "RULES-rules",
+        "name": "rules",
+        "behaviour": "Be helpful and professional at all times.\nUse {{fn:FUNCTION-test_function}} when appropriate.\nAlways validate inputs using {{fn:FUNCTION-validate_email}} when dealing with email addresses.\nAccess customer information from {{attr:customer_name}} and {{attr:email_address}}.\nFor complex issues, use {{ho:handoff-1}} to transfer to a specialist.\nSend important notifications via {{twilio_sms:SMS_TEMPLATE-123}} or {{twilio_sms:SMS_TEMPLATE-456}} as appropriate.\nFollow the guidelines provided.\nUse variable {{vrbl:VAR-customer_name}}\n"
+      }
+    },
+    "voice_disclaimer": {
+      "voice_disclaimer": {
+        "resource_id": "voice_disclaimer",
+        "name": "voice_disclaimer",
+        "message": "This conversation may be recorded for quality assurance.",
+        "enabled": true,
+        "language_code": "en-GB"
       }
     },
     "flow_config": {
       "FLOW_CONFIG-test_flow": {
-        "description": "Test flow with advanced step as start",
-        "name": "test_flow",
         "resource_id": "FLOW_CONFIG-test_flow",
+        "name": "test_flow",
+        "description": "Test flow with advanced step as start",
         "start_step": "start_step"
       },
       "FLOW_CONFIG-test_flow_with_punctuation": {
-        "description": "Test flow with punctuation in name and default step as start",
-        "name": "test_flow_with_punctuation!",
         "resource_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "name": "test_flow_with_punctuation!",
+        "description": "Test flow with punctuation in name and default step as start",
         "start_step": "welcome_step"
       }
     },
     "flow_steps": {
-      "FLOW_CONFIG-test_flow_collect_name": {
-        "conditions": [
-          {
-            "child_step": "confirm_details",
-            "condition_type": "step_condition",
-            "description": "User provided name",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow",
-            "ingress": "top",
-            "name": "has_name",
-            "position": {},
-            "required_entities": [
-              "ENTITY-customer_name"
-            ],
-            "resource_id": "CONDITION-has_name-1",
-            "step_id": "collect_name"
-          },
-          {
-            "child_step": "",
-            "condition_type": "exit_flow_condition",
-            "description": "Exit flow",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow",
-            "ingress": "top",
-            "name": "exit_flow",
-            "position": {},
-            "required_entities": [],
-            "resource_id": "CONDITION-exit_flow-1",
-            "step_id": "collect_name"
-          }
-        ],
-        "extracted_entities": [
-          "ENTITY-customer_name"
-        ],
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "name": "collect_name",
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        },
-        "prompt": "What is your name? {{entity:ENTITY-customer_name}}",
-        "resource_id": "FLOW_CONFIG-test_flow_collect_name",
-        "settings": {},
-        "step_id": "collect_name",
-        "step_type": "default_step"
-      },
-      "FLOW_CONFIG-test_flow_collect_phone": {
-        "conditions": [
-          {
-            "child_step": "final_step",
-            "condition_type": "step_condition",
-            "description": "User provided phone",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow",
-            "ingress": "top",
-            "name": "has_phone",
-            "position": {},
-            "required_entities": [
-              "ENTITY-phone_number"
-            ],
-            "resource_id": "CONDITION-has_phone-1",
-            "step_id": "collect_phone"
-          },
-          {
-            "child_step": "final_step",
-            "condition_type": "step_condition",
-            "description": "User declined to provide phone",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow",
-            "ingress": "top",
-            "name": "no_phone",
-            "position": {},
-            "required_entities": [],
-            "resource_id": "CONDITION-no_phone-1",
-            "step_id": "collect_phone"
-          }
-        ],
-        "extracted_entities": [
-          "ENTITY-phone_number"
-        ],
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "name": "collect_phone",
-        "position": {
-          "x": 1200.0,
-          "y": 500.0
-        },
-        "prompt": "What is your phone number?",
-        "resource_id": "FLOW_CONFIG-test_flow_collect_phone",
-        "settings": {},
-        "step_id": "collect_phone",
-        "step_type": "default_step"
-      },
-      "FLOW_CONFIG-test_flow_confirm_details": {
-        "conditions": [],
-        "extracted_entities": [],
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "name": "confirm_details",
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        },
-        "prompt": "Let me confirm your details using {{fn:FUNCTION-format_date}} and {{ft:FUNCTION-process_data}}. Your name is {{attr:customer_name}}. Is this correct?",
-        "resource_id": "FLOW_CONFIG-test_flow_confirm_details",
-        "settings": {
-          "asr_biasing": {
-            "address": false,
-            "alphanumeric": false,
-            "custom_keywords": [],
-            "is_enabled": true,
-            "name_spelling": false,
-            "numeric": true,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false
-          },
-          "dtmf": {
-            "collect_while_agent_speaking": false,
-            "end_key": "#",
-            "inter_digit_timeout": 0,
-            "is_enabled": true,
-            "is_pii": false,
-            "max_digits": 1
-          },
-          "flow_id": "FLOW_CONFIG-test_flow",
-          "step_id": "confirm_details"
-        },
-        "step_id": "confirm_details",
-        "step_type": "advanced_step"
-      },
-      "FLOW_CONFIG-test_flow_final_step": {
-        "conditions": [],
-        "extracted_entities": [],
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "name": "final_step",
-        "position": {
-          "x": 1200.0,
-          "y": 1000.0
-        },
-        "prompt": "Thank you! Using {{fn:FUNCTION-shared_helper}} and {{ft:FUNCTION-shared_helper_flow1}} to complete. If you need human assistance, use {{ho:handoff-2}}. I'll send a confirmation via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "resource_id": "FLOW_CONFIG-test_flow_final_step",
-        "settings": {
-          "asr_biasing": {
-            "address": false,
-            "alphanumeric": false,
-            "custom_keywords": [],
-            "is_enabled": false,
-            "name_spelling": false,
-            "numeric": false,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false
-          },
-          "dtmf": {
-            "collect_while_agent_speaking": false,
-            "end_key": "#",
-            "inter_digit_timeout": 0,
-            "is_enabled": false,
-            "is_pii": false,
-            "max_digits": 0
-          },
-          "flow_id": "FLOW_CONFIG-test_flow",
-          "step_id": "final_step"
-        },
-        "step_id": "final_step",
-        "step_type": "advanced_step"
-      },
       "FLOW_CONFIG-test_flow_start_step": {
-        "conditions": [],
-        "extracted_entities": [],
+        "resource_id": "FLOW_CONFIG-test_flow_start_step",
+        "step_id": "start_step",
+        "name": "start_step",
         "flow_id": "FLOW_CONFIG-test_flow",
         "flow_name": "test_flow",
-        "name": "start_step",
-        "position": {
-          "x": 0.0,
-          "y": 0.0
-        },
+        "step_type": "advanced_step",
         "prompt": "Welcome! I'll help you today. Let me use {{fn:FUNCTION-test_function}} to get started. If needed, we can handoff using {{ho:handoff-1}} or send SMS via {{twilio_sms:SMS_TEMPLATE-123}}.",
-        "resource_id": "FLOW_CONFIG-test_flow_start_step",
         "settings": {
           "asr_biasing": {
-            "address": false,
             "alphanumeric": true,
-            "custom_keywords": [],
-            "is_enabled": true,
             "name_spelling": true,
             "numeric": true,
             "party_size": false,
@@ -443,128 +550,175 @@
             "relative_date": false,
             "single_number": false,
             "time": false,
-            "yes_no": false
+            "yes_no": false,
+            "address": false,
+            "custom_keywords": [],
+            "is_enabled": true
           },
           "dtmf": {
-            "collect_while_agent_speaking": false,
-            "end_key": "#",
-            "inter_digit_timeout": 0,
             "is_enabled": false,
-            "is_pii": false,
-            "max_digits": 0
+            "inter_digit_timeout": 0,
+            "max_digits": 0,
+            "end_key": "#",
+            "collect_while_agent_speaking": false,
+            "is_pii": false
           },
-          "flow_id": "FLOW_CONFIG-test_flow",
-          "step_id": "start_step"
+          "step_id": "start_step",
+          "flow_id": "FLOW_CONFIG-test_flow"
         },
-        "step_id": "start_step",
-        "step_type": "advanced_step"
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_collect_email": {
         "conditions": [],
         "extracted_entities": [],
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "name": "collect_email",
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        }
+      },
+      "FLOW_CONFIG-test_flow_collect_name": {
+        "resource_id": "FLOW_CONFIG-test_flow_collect_name",
+        "name": "collect_name",
+        "step_id": "collect_name",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "step_type": "default_step",
         "position": {
           "x": 600.0,
           "y": 500.0
         },
-        "prompt": "Please provide your email. I'll validate it using {{fn:FUNCTION-validate_email}} and process with {{ft:FUNCTION-calculate_total}}. Your current status is {{attr:booking_status}}. I can send updates via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_email",
-        "settings": {
-          "asr_biasing": {
-            "address": false,
-            "alphanumeric": true,
-            "custom_keywords": [],
-            "is_enabled": true,
-            "name_spelling": false,
-            "numeric": false,
-            "party_size": false,
-            "precise_date": false,
-            "relative_date": false,
-            "single_number": false,
-            "time": false,
-            "yes_no": false
-          },
-          "dtmf": {
-            "collect_while_agent_speaking": false,
-            "end_key": "#",
-            "inter_digit_timeout": 0,
-            "is_enabled": false,
-            "is_pii": false,
-            "max_digits": 0
-          },
-          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-          "step_id": "collect_email"
-        },
-        "step_id": "collect_email",
-        "step_type": "advanced_step"
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size": {
+        "settings": {},
         "conditions": [
           {
-            "child_step": "collect_email",
-            "condition_type": "step_condition",
-            "description": "User provided party size",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-            "ingress": "top",
-            "name": "has_party_size",
-            "position": {},
+            "resource_id": "CONDITION-has_name-1",
+            "name": "has_name",
+            "description": "User provided name",
             "required_entities": [
-              "ENTITY-party_size"
+              "ENTITY-customer_name"
             ],
-            "resource_id": "CONDITION-has_party_size-1",
-            "step_id": "collect_party_size"
+            "condition_type": "step_condition",
+            "child_step": "confirm_details",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_name",
+            "flow_id": "FLOW_CONFIG-test_flow"
           },
           {
-            "child_step": "",
-            "condition_type": "exit_flow_condition",
-            "description": "Exit flow",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-            "ingress": "top",
+            "resource_id": "CONDITION-exit_flow-1",
             "name": "exit_flow",
-            "position": {},
+            "description": "Exit flow",
             "required_entities": [],
-            "resource_id": "CONDITION-exit_flow-2",
-            "step_id": "collect_party_size"
+            "condition_type": "exit_flow_condition",
+            "child_step": "",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_name",
+            "flow_id": "FLOW_CONFIG-test_flow"
           }
         ],
         "extracted_entities": [
-          "ENTITY-party_size"
+          "ENTITY-customer_name"
         ],
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "name": "collect_party_size",
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        },
-        "prompt": "How many people will be in your party?",
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size",
-        "settings": {},
-        "step_id": "collect_party_size",
-        "step_type": "default_step"
+        "prompt": "What is your name? {{entity:ENTITY-customer_name}}"
       },
-      "FLOW_CONFIG-test_flow_with_punctuation_status_result": {
-        "conditions": [],
-        "extracted_entities": [],
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "name": "status_result",
-        "position": {
-          "x": 600.0,
-          "y": 500.0
-        },
-        "prompt": "Checking your status using {{fn:FUNCTION-test_function}} and {{ft:FUNCTION-shared_helper_flow2}}. For urgent matters, use {{ho:handoff-3}}. Status updates can be sent via {{twilio_sms:SMS_TEMPLATE-123}}.",
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_status_result",
+      "FLOW_CONFIG-test_flow_confirm_details": {
+        "resource_id": "FLOW_CONFIG-test_flow_confirm_details",
+        "step_id": "confirm_details",
+        "name": "confirm_details",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "step_type": "advanced_step",
+        "prompt": "Let me confirm your details using {{fn:FUNCTION-format_date}} and {{ft:FUNCTION-process_data}}. Your name is {{attr:customer_name}}. Is this correct?",
         "settings": {
           "asr_biasing": {
-            "address": false,
             "alphanumeric": false,
+            "name_spelling": false,
+            "numeric": true,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false,
+            "address": false,
             "custom_keywords": [],
-            "is_enabled": false,
+            "is_enabled": true
+          },
+          "dtmf": {
+            "is_enabled": true,
+            "inter_digit_timeout": 0,
+            "max_digits": 1,
+            "end_key": "#",
+            "collect_while_agent_speaking": false,
+            "is_pii": false
+          },
+          "step_id": "confirm_details",
+          "flow_id": "FLOW_CONFIG-test_flow"
+        },
+        "conditions": [],
+        "extracted_entities": [],
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        }
+      },
+      "FLOW_CONFIG-test_flow_collect_phone": {
+        "resource_id": "FLOW_CONFIG-test_flow_collect_phone",
+        "name": "collect_phone",
+        "step_id": "collect_phone",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "step_type": "default_step",
+        "position": {
+          "x": 1200.0,
+          "y": 500.0
+        },
+        "settings": {},
+        "conditions": [
+          {
+            "resource_id": "CONDITION-has_phone-1",
+            "name": "has_phone",
+            "description": "User provided phone",
+            "required_entities": [
+              "ENTITY-phone_number"
+            ],
+            "condition_type": "step_condition",
+            "child_step": "final_step",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_phone",
+            "flow_id": "FLOW_CONFIG-test_flow"
+          },
+          {
+            "resource_id": "CONDITION-no_phone-1",
+            "name": "no_phone",
+            "description": "User declined to provide phone",
+            "required_entities": [],
+            "condition_type": "step_condition",
+            "child_step": "final_step",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_phone",
+            "flow_id": "FLOW_CONFIG-test_flow"
+          }
+        ],
+        "extracted_entities": [
+          "ENTITY-phone_number"
+        ],
+        "prompt": "What is your phone number?"
+      },
+      "FLOW_CONFIG-test_flow_final_step": {
+        "resource_id": "FLOW_CONFIG-test_flow_final_step",
+        "step_id": "final_step",
+        "name": "final_step",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "step_type": "advanced_step",
+        "prompt": "Thank you! Using {{fn:FUNCTION-shared_helper}} and {{ft:FUNCTION-shared_helper_flow1}} to complete. If you need human assistance, use {{ho:handoff-2}}. I'll send a confirmation via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "settings": {
+          "asr_biasing": {
+            "alphanumeric": false,
             "name_spelling": false,
             "numeric": false,
             "party_size": false,
@@ -572,365 +726,289 @@
             "relative_date": false,
             "single_number": false,
             "time": false,
-            "yes_no": false
+            "yes_no": false,
+            "address": false,
+            "custom_keywords": [],
+            "is_enabled": false
           },
           "dtmf": {
-            "collect_while_agent_speaking": false,
+            "is_enabled": false,
+            "inter_digit_timeout": 0,
+            "max_digits": 0,
             "end_key": "#",
-            "inter_digit_timeout": 5,
-            "is_enabled": true,
-            "is_pii": false,
-            "max_digits": 2
+            "collect_while_agent_speaking": false,
+            "is_pii": false
           },
-          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-          "step_id": "status_result"
+          "step_id": "final_step",
+          "flow_id": "FLOW_CONFIG-test_flow"
         },
-        "step_id": "status_result",
-        "step_type": "advanced_step"
+        "conditions": [],
+        "extracted_entities": [],
+        "position": {
+          "x": 1200.0,
+          "y": 1000.0
+        }
       },
       "FLOW_CONFIG-test_flow_with_punctuation_welcome_step": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_welcome_step",
+        "name": "welcome_step",
+        "step_id": "welcome_step",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "step_type": "default_step",
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        },
+        "settings": {},
         "conditions": [
           {
-            "child_step": "collect_party_size",
-            "condition_type": "no_code_step_condition",
-            "description": "User wants to book appointment",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-            "ingress": "top",
+            "resource_id": "CONDITION-book_appointment-1",
             "name": "book_appointment",
-            "position": {},
+            "description": "User wants to book appointment",
             "required_entities": [
               "ENTITY-date"
             ],
-            "resource_id": "CONDITION-book_appointment-1",
-            "step_id": "welcome_step"
+            "condition_type": "no_code_step_condition",
+            "child_step": "collect_party_size",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "welcome_step",
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
           },
           {
-            "child_step": "status_result",
-            "condition_type": "step_condition",
-            "description": "User wants to check status",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-            "ingress": "top",
+            "resource_id": "CONDITION-check_status-1",
             "name": "check_status",
-            "position": {},
+            "description": "User wants to check status",
             "required_entities": [
               "ENTITY-confirmation_status"
             ],
-            "resource_id": "CONDITION-check_status-1",
-            "step_id": "welcome_step"
+            "condition_type": "step_condition",
+            "child_step": "status_result",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "welcome_step",
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
           },
           {
-            "child_step": "",
-            "condition_type": "exit_flow_condition",
-            "description": "User wants to exit",
-            "exit_flow_position": {},
-            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-            "ingress": "top",
-            "name": "exit",
-            "position": {},
-            "required_entities": [],
             "resource_id": "CONDITION-exit-1",
-            "step_id": "welcome_step"
+            "name": "exit",
+            "description": "User wants to exit",
+            "required_entities": [],
+            "condition_type": "exit_flow_condition",
+            "child_step": "",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "welcome_step",
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
           }
         ],
         "extracted_entities": [
           "ENTITY-date",
           "ENTITY-confirmation_status"
         ],
+        "prompt": "Welcome! How can I help you today?"
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_party_size",
+        "name": "collect_party_size",
+        "step_id": "collect_party_size",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "flow_name": "test_flow_with_punctuation!",
-        "name": "welcome_step",
+        "step_type": "default_step",
         "position": {
-          "x": 0.0,
-          "y": 0.0
+          "x": 600.0,
+          "y": 500.0
         },
-        "prompt": "Welcome! How can I help you today?",
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_welcome_step",
         "settings": {},
-        "step_id": "welcome_step",
-        "step_type": "default_step"
+        "conditions": [
+          {
+            "resource_id": "CONDITION-has_party_size-1",
+            "name": "has_party_size",
+            "description": "User provided party size",
+            "required_entities": [
+              "ENTITY-party_size"
+            ],
+            "condition_type": "step_condition",
+            "child_step": "collect_email",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_party_size",
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+          },
+          {
+            "resource_id": "CONDITION-exit_flow-2",
+            "name": "exit_flow",
+            "description": "Exit flow",
+            "required_entities": [],
+            "condition_type": "exit_flow_condition",
+            "child_step": "",
+            "position": {},
+            "exit_flow_position": {},
+            "ingress": "top",
+            "step_id": "collect_party_size",
+            "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+          }
+        ],
+        "extracted_entities": [
+          "ENTITY-party_size"
+        ],
+        "prompt": "How many people will be in your party?"
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_collect_email": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_collect_email",
+        "step_id": "collect_email",
+        "name": "collect_email",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "step_type": "advanced_step",
+        "prompt": "Please provide your email. I'll validate it using {{fn:FUNCTION-validate_email}} and process with {{ft:FUNCTION-calculate_total}}. Your current status is {{attr:booking_status}}. I can send updates via {{twilio_sms:SMS_TEMPLATE-456}}.",
+        "settings": {
+          "asr_biasing": {
+            "alphanumeric": true,
+            "name_spelling": false,
+            "numeric": false,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false,
+            "address": false,
+            "custom_keywords": [],
+            "is_enabled": true
+          },
+          "dtmf": {
+            "is_enabled": false,
+            "inter_digit_timeout": 0,
+            "max_digits": 0,
+            "end_key": "#",
+            "collect_while_agent_speaking": false,
+            "is_pii": false
+          },
+          "step_id": "collect_email",
+          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+        },
+        "conditions": [],
+        "extracted_entities": [],
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        }
+      },
+      "FLOW_CONFIG-test_flow_with_punctuation_status_result": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_status_result",
+        "step_id": "status_result",
+        "name": "status_result",
+        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
+        "flow_name": "test_flow_with_punctuation!",
+        "step_type": "advanced_step",
+        "prompt": "Checking your status using {{fn:FUNCTION-test_function}} and {{ft:FUNCTION-shared_helper_flow2}}. For urgent matters, use {{ho:handoff-3}}. Status updates can be sent via {{twilio_sms:SMS_TEMPLATE-123}}.",
+        "settings": {
+          "asr_biasing": {
+            "alphanumeric": false,
+            "name_spelling": false,
+            "numeric": false,
+            "party_size": false,
+            "precise_date": false,
+            "relative_date": false,
+            "single_number": false,
+            "time": false,
+            "yes_no": false,
+            "address": false,
+            "custom_keywords": [],
+            "is_enabled": false
+          },
+          "dtmf": {
+            "is_enabled": true,
+            "inter_digit_timeout": 5,
+            "max_digits": 2,
+            "end_key": "#",
+            "collect_while_agent_speaking": false,
+            "is_pii": false
+          },
+          "step_id": "status_result",
+          "flow_id": "FLOW_CONFIG-test_flow_with_punctuation"
+        },
+        "conditions": [],
+        "extracted_entities": [],
+        "position": {
+          "x": 600.0,
+          "y": 500.0
+        }
+      }
+    },
+    "experimental_config": {
+      "default": {
+        "resource_id": "default",
+        "name": "experimental_config",
+        "config": {
+          "asr": {
+            "provider": "riva",
+            "model": "poly-latency",
+            "language": "en-GB"
+          },
+          "vad": {
+            "vad_end": 600
+          },
+          "smart_vad": {
+            "is_enabled": true
+          },
+          "eot": {
+            "provider": "smart_turn",
+            "threshold": 0.5
+          }
+        }
       }
     },
     "function_steps": {
       "FLOW_CONFIG-test_flow_process_payment": {
-        "code": "def process_payment(conv: Conversation, flow: Flow):\n    \"\"\"Process payment for the customer.\"\"\"\n    # Process payment logic here\n    conv.state.customer_name = \"John Doe\"\n    conv.state.payment_success = True\n    return \"Payment processed\"\n",
-        "description": "",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_id": "FUNCTION-process_payment",
-        "function_type": "function_step",
-        "latency_control": {},
-        "name": "process_payment",
-        "parameters": [],
-        "position": {
-          "x": 0.0,
-          "y": 0.0
-        },
         "resource_id": "FLOW_CONFIG-test_flow_process_payment",
         "step_id": "process_payment",
-        "step_type": "function_step"
-      },
-      "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount": {
-        "code": "def calculate_discount(conv: Conversation, flow: Flow):\n    \"\"\"Calculate discount for the order.\"\"\"\n    # Calculate discount logic here\n    return \"Discount calculated\"\n",
+        "flow_id": "FLOW_CONFIG-test_flow",
+        "flow_name": "test_flow",
+        "name": "process_payment",
+        "step_type": "function_step",
         "description": "",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_id": "FUNCTION-process_payment",
-        "function_type": "function_step",
-        "latency_control": {},
-        "name": "calculate_discount",
+        "code": "def process_payment(conv: Conversation, flow: Flow):\n    \"\"\"Process payment for the customer.\"\"\"\n    # Process payment logic here\n    conv.state.customer_name = \"John Doe\"\n    conv.state.payment_success = True\n    return \"Payment processed\"\n",
         "parameters": [],
+        "latency_control": {},
+        "function_type": "function_step",
+        "function_id": "FUNCTION-process_payment",
         "position": {
           "x": 0.0,
           "y": 0.0
-        },
-        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount",
-        "step_id": "calculate_discount",
-        "step_type": "function_step"
-      }
-    },
-    "functions": {
-      "FUNCTION-calculate_total": {
-        "code": "def calculate_total(conv: Conversation, flow: Flow, amount: float):\n    \"\"\"Calculate total amount.\"\"\"\n    return amount * 1.1\n",
-        "description": "Calculate total amount.",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition",
-        "latency_control": {},
-        "name": "calculate_total",
-        "parameters": [
-          {
-            "description": "The base amount to calculate from",
-            "id": "PARAMETER-amount-1",
-            "name": "amount",
-            "type": "number"
-          }
-        ],
-        "resource_id": "FUNCTION-calculate_total"
-      },
-      "FUNCTION-end_function": {
-        "code": "def end_function(conv: Conversation):\n    \"\"\"End function for the agent.\"\"\"\n    pass\n",
-        "description": "",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "end",
-        "latency_control": {
-          "delay_responses": [],
-          "enabled": false,
-          "initial_delay": 0,
-          "interval": 0
-        },
-        "name": "end_function",
-        "parameters": [],
-        "resource_id": "FUNCTION-end_function",
-        "variable_references": {}
-      },
-      "FUNCTION-format_date": {
-        "code": "def format_date(conv: Conversation, date: str):\n    \"\"\"Format date for display.\"\"\"\n    return date.upper()\n",
-        "description": "Format date for display.",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global",
-        "latency_control": {},
-        "name": "format_date",
-        "parameters": [
-          {
-            "description": "The date string to format",
-            "id": "PARAMETER-date-1",
-            "name": "date",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-format_date"
-      },
-      "FUNCTION-process_data": {
-        "code": "def process_data(conv: Conversation, flow: Flow, data: str):\n    \"\"\"Process data in flow context.\"\"\"\n    conv.state.data_processed = True\n    return f\"Processed in flow: {data}\"\n",
-        "description": "Process data in flow context.",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition",
-        "latency_control": {},
-        "name": "process_data",
-        "parameters": [
-          {
-            "description": "The data string to process",
-            "id": "PARAMETER-data-1",
-            "name": "data",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-process_data"
-      },
-      "FUNCTION-shared_helper": {
-        "code": "def shared_helper(conv: Conversation, value: str):\n    \"\"\"A shared helper function that can be used by multiple flows.\"\"\"\n    return f\"Processed: {value}\"\n",
-        "description": "A shared helper function that can be used by multiple flows.",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global",
-        "latency_control": {},
-        "name": "shared_helper",
-        "parameters": [
-          {
-            "description": "The value to process",
-            "id": "PARAMETER-value-1",
-            "name": "value",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-shared_helper"
-      },
-      "FUNCTION-shared_helper_flow1": {
-        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"A shared helper function with same name as global function.\"\"\"\n    return f\"Flow-specific helper: {value}\"\n",
-        "description": "A shared helper function with same name as global function.",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition",
-        "latency_control": {},
-        "name": "shared_helper",
-        "parameters": [
-          {
-            "description": "The value to process",
-            "id": "PARAMETER-value-2",
-            "name": "value",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-shared_helper_flow1"
-      },
-      "FUNCTION-shared_helper_flow2": {
-        "code": "def shared_helper(conv: Conversation, flow: Flow, value: str):\n    \"\"\"Another shared helper with same name as global and other flow.\"\"\"\n    return f\"Punctuation flow helper: {value}\"\n",
-        "description": "Another shared helper with same name as global and other flow.",
-        "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
-        "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition",
-        "latency_control": {},
-        "name": "shared_helper",
-        "parameters": [
-          {
-            "description": "The value to process",
-            "id": "PARAMETER-value-3",
-            "name": "value",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-shared_helper_flow2"
-      },
-      "FUNCTION-start_function": {
-        "code": "def start_function(conv: Conversation):\n    \"\"\"Start function for the agent.\"\"\"\n    conv.state.customer_name = \"John Doe\"\n    pass\n",
-        "description": "",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "start",
-        "latency_control": {
-          "delay_responses": [],
-          "enabled": false,
-          "initial_delay": 0,
-          "interval": 0
-        },
-        "name": "start_function",
-        "parameters": [],
-        "resource_id": "FUNCTION-start_function",
-        "variable_references": {
-          "VAR-customer_name": true
         }
       },
-      "FUNCTION-test_function": {
-        "code": "def test_function(conv: Conversation):\n    \"\"\"A test function for global use.\"\"\"\n    return \"Hello from global function\"\n",
-        "description": "A test function for global use.",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global",
-        "latency_control": {},
-        "name": "test_function",
-        "parameters": [],
-        "resource_id": "FUNCTION-test_function"
-      },
-      "FUNCTION-test_function_with_parameters": {
-        "code": "def test_function_with_parameters(conv: Conversation, param1: str, param2: int):\n    \"\"\"Test function with parameters.\"\"\"\n    return f\"Result: {param1} - {param2}\"\n",
-        "description": "Test function with parameters.",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global",
-        "latency_control": {},
-        "name": "test_function_with_parameters",
-        "parameters": [
-          {
-            "description": "First parameter as string",
-            "id": "PARAMETER-param1-1",
-            "name": "param1",
-            "type": "string"
-          },
-          {
-            "description": "Second parameter as integer",
-            "id": "PARAMETER-param2-1",
-            "name": "param2",
-            "type": "integer"
-          }
-        ],
-        "resource_id": "FUNCTION-test_function_with_parameters"
-      },
-      "FUNCTION-validate_email": {
-        "code": "def validate_email(conv: Conversation, email: str):\n    \"\"\"Validate email format.\"\"\"\n    return \"@\" in email and \".\" in email.split(\"@\")[1]\n",
-        "description": "Validate email format.",
-        "flow_id": null,
-        "flow_name": null,
-        "function_type": "global",
-        "latency_control": {},
-        "name": "validate_email",
-        "parameters": [
-          {
-            "description": "The email address to validate",
-            "id": "PARAMETER-email-1",
-            "name": "email",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-validate_email"
-      },
-      "FUNCTION-validate_input_flow1": {
-        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Validate input in flow.\"\"\"\n    return len(input_value) > 0\n",
-        "description": "Validate input in flow.",
-        "flow_id": "FLOW_CONFIG-test_flow",
-        "flow_name": "test_flow",
-        "function_type": "transition",
-        "latency_control": {},
-        "name": "validate_input",
-        "parameters": [
-          {
-            "description": "The input value to validate",
-            "id": "PARAMETER-input_value-1",
-            "name": "input_value",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-validate_input_flow1"
-      },
-      "FUNCTION-validate_input_flow2": {
-        "code": "def validate_input(conv: Conversation, flow: Flow, input_value: str):\n    \"\"\"Another validate_input with same name as other flow.\"\"\"\n    return input_value.isdigit()\n",
-        "description": "Another validate_input with same name as other flow.",
+      "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount": {
+        "resource_id": "FLOW_CONFIG-test_flow_with_punctuation_calculate_discount",
+        "step_id": "calculate_discount",
         "flow_id": "FLOW_CONFIG-test_flow_with_punctuation",
         "flow_name": "test_flow_with_punctuation!",
-        "function_type": "transition",
+        "name": "calculate_discount",
+        "step_type": "function_step",
+        "description": "",
+        "code": "def calculate_discount(conv: Conversation, flow: Flow):\n    \"\"\"Calculate discount for the order.\"\"\"\n    # Calculate discount logic here\n    return \"Discount calculated\"\n",
+        "parameters": [],
         "latency_control": {},
-        "name": "validate_input",
-        "parameters": [
-          {
-            "description": "The input value to validate",
-            "id": "PARAMETER-input_value-2",
-            "name": "input_value",
-            "type": "string"
-          }
-        ],
-        "resource_id": "FUNCTION-validate_input_flow2"
+        "function_type": "function_step",
+        "function_id": "FUNCTION-process_payment",
+        "position": {
+          "x": 0.0,
+          "y": 0.0
+        }
       }
     },
     "handoffs": {
       "handoff-1": {
+        "resource_id": "handoff-1",
+        "name": "default",
         "description": "default handoff",
         "is_default": true,
-        "name": "default",
-        "resource_id": "handoff-1",
         "sip_config": {
           "method": "refer",
           "phone_number": "+1234567890"
@@ -947,10 +1025,10 @@
         ]
       },
       "handoff-2": {
+        "resource_id": "handoff-2",
+        "name": "front desk",
         "description": "Speak to front desk",
         "is_default": false,
-        "name": "front desk",
-        "resource_id": "handoff-2",
         "sip_config": {
           "method": "refer",
           "phone_number": "front desk"
@@ -958,10 +1036,10 @@
         "sip_headers": []
       },
       "handoff-3": {
+        "resource_id": "handoff-3",
+        "name": "urgent support",
         "description": "Transfer for urgent matters",
         "is_default": false,
-        "name": "urgent support",
-        "resource_id": "handoff-3",
         "sip_config": {
           "method": "refer",
           "phone_number": "+1987654321"
@@ -969,260 +1047,91 @@
         "sip_headers": []
       }
     },
-    "keyphrase_boosting": {
-      "KEYPHRASE_BOOSTING-checkin": {
-        "keyphrase": "check-in",
-        "level": "default",
-        "name": "check-in",
-        "resource_id": "KEYPHRASE_BOOSTING-checkin"
-      },
-      "KEYPHRASE_BOOSTING-polyai": {
-        "keyphrase": "PolyAI",
-        "level": "maximum",
-        "name": "PolyAI",
-        "resource_id": "KEYPHRASE_BOOSTING-polyai"
-      },
-      "KEYPHRASE_BOOSTING-reservation": {
-        "keyphrase": "reservation",
-        "level": "boosted",
-        "name": "reservation",
-        "resource_id": "KEYPHRASE_BOOSTING-reservation"
-      }
-    },
-    "persona": {
-      "PERSONA-persona": {
-        "content": "You are a calm and polite concierge.\nGreet the caller by name using {{vrbl:VAR-customer_name}}.\n",
-        "name": "persona",
-        "resource_id": "PERSONA-persona"
-      }
-    },
     "phrase_filtering": {
-      "STOP_KEYWORD-block_competitor_names": {
-        "description": "Prevents mentioning competitor names",
-        "name": "Block Competitor Names",
-        "regular_expressions": [
-          "\\bcompetitor\\b"
-        ],
-        "resource_id": "STOP_KEYWORD-block_competitor_names",
-        "say_phrase": true
-      },
       "STOP_KEYWORD-block_profanity": {
-        "description": "Blocks profane words from being spoken",
-        "function": "FUNCTION-validate_email",
+        "resource_id": "STOP_KEYWORD-block_profanity",
         "name": "Block Profanity",
+        "description": "Blocks profane words from being spoken",
         "regular_expressions": [
           "\\bbadword\\b",
           "\\boffensive\\b"
         ],
-        "resource_id": "STOP_KEYWORD-block_profanity",
-        "say_phrase": false
-      }
-    },
-    "platform_guardrails": {
-      "ai_identity": {
-        "enabled": true,
-        "name": "ai_identity",
-        "resource_id": "ai_identity"
+        "say_phrase": false,
+        "function": "FUNCTION-validate_email"
       },
-      "emergency_escalation": {
-        "enabled": true,
-        "name": "emergency_escalation",
-        "resource_id": "emergency_escalation"
-      },
-      "hallucination_control": {
-        "enabled": false,
-        "name": "hallucination_control",
-        "resource_id": "hallucination_control"
-      },
-      "jailbreak_defence": {
-        "enabled": true,
-        "name": "jailbreak_defence",
-        "resource_id": "jailbreak_defence"
-      },
-      "tool_call_integrity": {
-        "enabled": false,
-        "name": "tool_call_integrity",
-        "resource_id": "tool_call_integrity"
+      "STOP_KEYWORD-block_competitor_names": {
+        "resource_id": "STOP_KEYWORD-block_competitor_names",
+        "name": "Block Competitor Names",
+        "description": "Prevents mentioning competitor names",
+        "regular_expressions": [
+          "\\bcompetitor\\b"
+        ],
+        "say_phrase": true
       }
     },
     "pronunciations": {
       "PRONUNCIATION-dr_abbreviation": {
-        "case_sensitive": true,
-        "position": 0,
+        "resource_id": "PRONUNCIATION-dr_abbreviation",
         "regex": "\\bDr\\.",
         "replacement": "Doctor",
-        "resource_id": "PRONUNCIATION-dr_abbreviation"
+        "case_sensitive": true,
+        "position": 0
       },
       "PRONUNCIATION-mr_abbreviation": {
-        "case_sensitive": true,
-        "position": 1,
+        "resource_id": "PRONUNCIATION-mr_abbreviation",
         "regex": "\\bMr\\.",
         "replacement": "Mister",
-        "resource_id": "PRONUNCIATION-mr_abbreviation"
-      }
-    },
-    "rules": {
-      "RULES-rules": {
-        "behaviour": "Be helpful and professional at all times.\nUse {{fn:FUNCTION-test_function}} when appropriate.\nAlways validate inputs using {{fn:FUNCTION-validate_email}} when dealing with email addresses.\nAccess customer information from {{attr:customer_name}} and {{attr:email_address}}.\nFor complex issues, use {{ho:handoff-1}} to transfer to a specialist.\nSend important notifications via {{twilio_sms:SMS_TEMPLATE-123}} or {{twilio_sms:SMS_TEMPLATE-456}} as appropriate.\nFollow the guidelines provided.\nUse variable {{vrbl:VAR-customer_name}}\n",
-        "name": "rules",
-        "resource_id": "RULES-rules"
-      }
-    },
-    "safety_filters": {
-      "safety_filters": {
-        "categories": {
-          "hate": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "self_harm": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "sexual": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          },
-          "violence": {
-            "enabled": true,
-            "precision": "MEDIUM"
-          }
-        },
-        "enabled": true,
-        "filter_type": "azure",
-        "name": "safety_filters",
-        "resource_id": "safety_filters"
+        "case_sensitive": true,
+        "position": 1
       }
     },
     "sms_templates": {
       "SMS_TEMPLATE-123": {
-        "env_phone_numbers": {
-          "live": "+447700102347",
-          "pre_release": "",
-          "sandbox": ""
-        },
-        "name": "test_template_1",
         "resource_id": "SMS_TEMPLATE-123",
-        "text": "This is a test template"
+        "name": "test_template_1",
+        "text": "This is a test template",
+        "env_phone_numbers": {
+          "sandbox": "",
+          "pre_release": "",
+          "live": "+447700102347"
+        }
       },
       "SMS_TEMPLATE-456": {
-        "env_phone_numbers": {
-          "live": "+447700102347",
-          "pre_release": "",
-          "sandbox": ""
-        },
-        "name": "test_template_2",
         "resource_id": "SMS_TEMPLATE-456",
-        "text": "This is a second test template"
+        "name": "test_template_2",
+        "text": "This is a second test template",
+        "env_phone_numbers": {
+          "sandbox": "",
+          "pre_release": "",
+          "live": "+447700102347"
+        }
       }
     },
-    "test_cases": {
-      "TEST-greeting_flow": {
-        "api_mocks": {
-          "mocks": {
-            "customer_api": {
-              "get_confirmation_status": [
-                {
-                  "respond": {
-                    "body": {
-                      "confirmed": true
-                    },
-                    "status": 200
-                  }
-                }
-              ]
-            }
-          }
-        },
-        "assertions": {
-          "function_calls": [
-            {
-              "arguments": [
-                {
-                  "assertion_type": "equals",
-                  "expected_value": "hello",
-                  "parameter_name": "param1",
-                  "value_type": "string"
-                }
-              ],
-              "name": "test_function"
-            }
-          ],
-          "name": "assertions",
-          "prompts": [
-            "The agent offers to help with booking"
-          ],
-          "resource_id": "TEST-greeting_flow"
-        },
-        "channel": "chat.polyai",
-        "language": "en-GB",
-        "name": "Greeting flow test",
-        "resource_id": "TEST-greeting_flow",
-        "scenario": "Ask for help with booking.",
-        "tags": {
-          "name": "tags",
-          "resource_id": "TEST-greeting_flow",
-          "tags": [
-            "booking",
-            "smoke"
-          ]
-        },
-        "variant": null
+    "keyphrase_boosting": {
+      "KEYPHRASE_BOOSTING-polyai": {
+        "resource_id": "KEYPHRASE_BOOSTING-polyai",
+        "name": "PolyAI",
+        "keyphrase": "PolyAI",
+        "level": "maximum"
       },
-      "TEST-webchat_smoke": {
-        "assertions": {
-          "function_calls": [],
-          "name": "assertions",
-          "prompts": [
-            "The agent greets the user"
-          ],
-          "resource_id": "TEST-webchat_smoke"
-        },
-        "channel": "webchat.polyai",
-        "language": "en-GB",
-        "name": "Webchat smoke test",
-        "resource_id": "TEST-webchat_smoke",
-        "scenario": "Say hello on webchat.",
-        "tags": {
-          "name": "tags",
-          "resource_id": "TEST-webchat_smoke",
-          "tags": [
-            "smoke"
-          ]
-        },
-        "variant": null
-      }
-    },
-    "topics": {
-      "TOPIC-Topic 1": {
-        "actions": "Use {{fn:FUNCTION-test_function}} to handle this request and {{fn:FUNCTION-format_date}} for dates. Access customer info via {{attr:customer_name}} and handoff with {{ho:handoff-1}} if needed. Send notifications using {{twilio_sms:SMS_TEMPLATE-123}}.",
-        "content": "This topic covers general inquiries and uses global functions.",
-        "enabled": true,
-        "example_queries": [
-          "How can I help?",
-          "What services do you offer?",
-          "General information request"
-        ],
-        "name": "Topic 1",
-        "resource_id": "TOPIC-Topic 1"
+      "KEYPHRASE_BOOSTING-reservation": {
+        "resource_id": "KEYPHRASE_BOOSTING-reservation",
+        "name": "reservation",
+        "keyphrase": "reservation",
+        "level": "boosted"
       },
-      "TOPIC-Topic 2": {
-        "actions": "Validate using {{fn:FUNCTION-validate_email}} and process with {{fn:FUNCTION-shared_helper}}. Check {{attr:email_address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:SMS_TEMPLATE-456}}.",
-        "content": "This topic handles email validation and processing.",
-        "enabled": true,
-        "example_queries": [
-          "I need to verify my email",
-          "Check my email address",
-          "Email validation request"
-        ],
-        "name": "Topic 2",
-        "resource_id": "TOPIC-Topic 2"
+      "KEYPHRASE_BOOSTING-checkin": {
+        "resource_id": "KEYPHRASE_BOOSTING-checkin",
+        "name": "check-in",
+        "keyphrase": "check-in",
+        "level": "default"
       }
     },
     "transcript_corrections": {
       "TRANSCRIPT_CORRECTIONS-email_domain": {
-        "description": "Correct common email domain misrecognitions",
+        "resource_id": "TRANSCRIPT_CORRECTIONS-email_domain",
         "name": "Email domain fix",
+        "description": "Correct common email domain misrecognitions",
         "regular_expressions": [
           {
             "regular_expression": "at gmail dot com",
@@ -1234,181 +1143,70 @@
             "replacement": "@hotmail.com",
             "replacement_type": "full"
           }
-        ],
-        "resource_id": "TRANSCRIPT_CORRECTIONS-email_domain"
+        ]
       },
       "TRANSCRIPT_CORRECTIONS-number_norm": {
-        "description": "Normalize spoken numbers to digits",
+        "resource_id": "TRANSCRIPT_CORRECTIONS-number_norm",
         "name": "Number normalization",
+        "description": "Normalize spoken numbers to digits",
         "regular_expressions": [
           {
             "regular_expression": "\\bdouble (\\d)\\b",
             "replacement": "\\1\\1",
             "replacement_type": "partial"
           }
-        ],
-        "resource_id": "TRANSCRIPT_CORRECTIONS-number_norm"
+        ]
       }
     },
-    "translations": {
-      "TN-farewell": {
-        "name": "farewell",
-        "resource_id": "TN-farewell",
-        "translations": {
-          "en-GB": "Goodbye",
-          "fr-FR": "Au revoir"
-        }
-      },
-      "TN-greeting": {
-        "name": "greeting",
-        "resource_id": "TN-greeting",
-        "translations": {
-          "en-GB": "Hello, how can I help you?",
-          "fr-FR": "Bonjour, comment puis-je vous aider?"
-        }
-      }
-    },
-    "variables": {
-      "VAR-customer_name": {
-        "name": "customer_name",
-        "resource_id": "VAR-customer_name"
-      },
-      "VAR-data_processed": {
-        "name": "data_processed",
-        "resource_id": "VAR-data_processed"
-      },
-      "VAR-payment_success": {
-        "name": "payment_success",
-        "resource_id": "VAR-payment_success"
-      }
-    },
-    "variant_attributes": {
-      "booking_status": {
-        "mappings": {
-          "VARIANT-default": "value-4",
-          "VARIANT-spanish": "valor-4"
-        },
-        "name": "booking_status",
-        "resource_id": "booking_status"
-      },
-      "customer_name": {
-        "mappings": {
-          "VARIANT-default": "value-1",
-          "VARIANT-spanish": "valor-1"
-        },
-        "name": "customer_name",
-        "resource_id": "customer_name"
-      },
-      "email_address": {
-        "mappings": {
-          "VARIANT-default": "value-2",
-          "VARIANT-spanish": "valor-2"
-        },
-        "name": "email_address",
-        "resource_id": "email_address"
-      },
-      "max_retries": {
-        "config": {},
-        "kind": "number",
-        "mappings": {
-          "VARIANT-default": 3,
-          "VARIANT-spanish": 5
-        },
-        "name": "max_retries",
-        "resource_id": "max_retries"
-      },
-      "member_status": {
-        "mappings": {
-          "VARIANT-default": "value-3",
-          "VARIANT-spanish": "valor-3"
-        },
-        "name": "member_status",
-        "resource_id": "member_status"
-      },
-      "menu_config": {
-        "config": {},
-        "kind": "object",
-        "mappings": {
-          "VARIANT-default": {
-            "categories": [
-              "pizza",
-              "pasta"
-            ],
-            "currency": "USD"
+    "api_integration": {
+      "int-customer_api": {
+        "resource_id": "int-customer_api",
+        "name": "customer_api",
+        "description": "test",
+        "environments": {
+          "sandbox": {
+            "base_url": "https://dev-customer.com",
+            "auth_type": "basic"
           },
-          "VARIANT-spanish": {
-            "categories": [
-              "paella"
-            ],
-            "currency": "EUR"
+          "pre_release": {
+            "base_url": "https://dev-customer.com",
+            "auth_type": "basic"
+          },
+          "live": {
+            "base_url": "https://customer.com",
+            "auth_type": "apiKey"
           }
         },
-        "name": "menu_config",
-        "resource_id": "menu_config"
-      },
-      "serves_alcohol": {
-        "config": {},
-        "kind": "boolean",
-        "mappings": {
-          "VARIANT-default": true,
-          "VARIANT-spanish": false
-        },
-        "name": "serves_alcohol",
-        "resource_id": "serves_alcohol"
-      },
-      "tier": {
-        "config": {
-          "values": [
-            "basic",
-            "premium"
-          ]
-        },
-        "kind": "enum",
-        "mappings": {
-          "VARIANT-default": "premium",
-          "VARIANT-spanish": "basic"
-        },
-        "name": "tier",
-        "resource_id": "tier"
+        "operations": [
+          {
+            "resource_id": "",
+            "name": "get_confirmation_status",
+            "method": "GET",
+            "resource": "/bookings/{booking_id}/confirmation-status"
+          }
+        ]
       }
     },
-    "variants": {
-      "VARIANT-default": {
-        "is_default": true,
-        "name": "default",
-        "resource_id": "VARIANT-default"
-      },
-      "VARIANT-spanish": {
-        "is_default": false,
-        "name": "spanish",
-        "resource_id": "VARIANT-spanish"
+    "asr_settings": {
+      "asr_settings": {
+        "resource_id": "asr_settings",
+        "name": "asr_settings",
+        "barge_in": false,
+        "interaction_style": "balanced"
       }
     },
-    "voice_disclaimer": {
-      "voice_disclaimer": {
+    "safety_filters": {
+      "safety_filters": {
+        "resource_id": "safety_filters",
+        "name": "safety_filters",
         "enabled": true,
-        "language_code": "en-GB",
-        "message": "This conversation may be recorded for quality assurance.",
-        "name": "voice_disclaimer",
-        "resource_id": "voice_disclaimer"
-      }
-    },
-    "voice_greeting": {
-      "voice_greeting": {
-        "language_code": "en-GB",
-        "name": "voice_greeting",
-        "resource_id": "voice_greeting",
-        "welcome_message": "Hello! Welcome to our service. Your account shows {{attr:member_status}}. How can I assist you today?"
-      }
-    },
-    "voice_safety_filters": {
-      "voice_safety_filters": {
+        "filter_type": "azure",
         "categories": {
-          "hate": {
+          "violence": {
             "enabled": true,
             "precision": "MEDIUM"
           },
-          "self_harm": {
+          "hate": {
             "enabled": true,
             "precision": "MEDIUM"
           },
@@ -1416,23 +1214,225 @@
             "enabled": true,
             "precision": "MEDIUM"
           },
-          "violence": {
+          "self_harm": {
             "enabled": true,
             "precision": "MEDIUM"
           }
-        },
-        "enabled": true,
-        "filter_type": "azure",
-        "name": "voice_safety_filters",
-        "resource_id": "voice_safety_filters"
+        }
       }
     },
-    "voice_style_prompt": {
-      "voice_style_prompt": {
-        "name": "voice_style_prompt",
-        "prompt": "You are a helpful and professional customer service assistant.",
-        "resource_id": "voice_style_prompt"
+    "voice_safety_filters": {
+      "voice_safety_filters": {
+        "resource_id": "voice_safety_filters",
+        "name": "voice_safety_filters",
+        "enabled": true,
+        "filter_type": "azure",
+        "categories": {
+          "violence": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "hate": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "sexual": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "self_harm": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          }
+        }
+      }
+    },
+    "chat_safety_filters": {
+      "chat_safety_filters": {
+        "resource_id": "chat_safety_filters",
+        "name": "chat_safety_filters",
+        "enabled": true,
+        "filter_type": "azure",
+        "categories": {
+          "violence": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "hate": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "sexual": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          },
+          "self_harm": {
+            "enabled": true,
+            "precision": "MEDIUM"
+          }
+        }
+      }
+    },
+    "test_cases": {
+      "TEST-greeting_flow": {
+        "resource_id": "TEST-greeting_flow",
+        "name": "Greeting flow test",
+        "scenario": "Ask for help with booking.",
+        "channel": "chat.polyai",
+        "assertions": {
+          "resource_id": "TEST-greeting_flow",
+          "name": "assertions",
+          "prompts": [
+            "The agent offers to help with booking"
+          ],
+          "function_calls": [
+            {
+              "name": "test_function",
+              "arguments": [
+                {
+                  "parameter_name": "param1",
+                  "expected_value": "hello",
+                  "value_type": "string",
+                  "assertion_type": "equals"
+                }
+              ]
+            }
+          ]
+        },
+        "tags": {
+          "resource_id": "TEST-greeting_flow",
+          "name": "tags",
+          "tags": [
+            "booking",
+            "smoke"
+          ]
+        },
+        "variant": null,
+        "language": "en-GB",
+        "api_mocks": {
+          "mocks": {
+            "customer_api": {
+              "get_confirmation_status": [
+                {
+                  "respond": {
+                    "status": 200,
+                    "body": {
+                      "confirmed": true
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "TEST-webchat_smoke": {
+        "resource_id": "TEST-webchat_smoke",
+        "name": "Webchat smoke test",
+        "scenario": "Say hello on webchat.",
+        "channel": "webchat.polyai",
+        "assertions": {
+          "resource_id": "TEST-webchat_smoke",
+          "name": "assertions",
+          "prompts": [
+            "The agent greets the user"
+          ],
+          "function_calls": []
+        },
+        "tags": {
+          "resource_id": "TEST-webchat_smoke",
+          "name": "tags",
+          "tags": [
+            "smoke"
+          ]
+        },
+        "variant": null,
+        "language": "en-GB"
+      }
+    },
+    "translations": {
+      "TN-greeting": {
+        "resource_id": "TN-greeting",
+        "name": "greeting",
+        "translations": {
+          "en-GB": "Hello, how can I help you?",
+          "fr-FR": "Bonjour, comment puis-je vous aider?"
+        }
+      },
+      "TN-farewell": {
+        "resource_id": "TN-farewell",
+        "name": "farewell",
+        "translations": {
+          "en-GB": "Goodbye",
+          "fr-FR": "Au revoir"
+        }
+      }
+    },
+    "default_language": {
+      "en-GB": {
+        "resource_id": "en-GB",
+        "name": "en-GB"
+      }
+    },
+    "additional_languages": {
+      "fr-FR": {
+        "resource_id": "fr-FR",
+        "name": "fr-FR"
+      }
+    },
+    "documents": {
+      "test_document.md": {
+        "resource_id": "test_document.md",
+        "name": "test_document",
+        "path": "test_document.md",
+        "contents": "This is a test document.\nIt has multiple lines.\n"
+      },
+      "CONTEXT.MD": {
+        "resource_id": "CONTEXT.MD",
+        "name": "CONTEXT",
+        "path": "CONTEXT.MD",
+        "contents": "This is platform context file.\n"
+      }
+    },
+    "platform_guardrails": {
+      "jailbreak_defence": {
+        "resource_id": "jailbreak_defence",
+        "name": "jailbreak_defence",
+        "enabled": true
+      },
+      "hallucination_control": {
+        "resource_id": "hallucination_control",
+        "name": "hallucination_control",
+        "enabled": false
+      },
+      "ai_identity": {
+        "resource_id": "ai_identity",
+        "name": "ai_identity",
+        "enabled": true
+      },
+      "emergency_escalation": {
+        "resource_id": "emergency_escalation",
+        "name": "emergency_escalation",
+        "enabled": true
+      },
+      "tool_call_integrity": {
+        "resource_id": "tool_call_integrity",
+        "name": "tool_call_integrity",
+        "enabled": false
+      }
+    },
+    "custom_guardrails": {
+      "CUSTOM_GUARDRAILS-no_medical_advice": {
+        "resource_id": "CUSTOM_GUARDRAILS-no_medical_advice",
+        "name": "No medical advice",
+        "prompt": "Never give medical advice. Offer to transfer the caller to a human instead.",
+        "action": "warn",
+        "enabled": true
       }
     }
-  }
+  },
+  "file_structure_info": {},
+  "migration_flags": [
+    "migrated_legacy_topic_files"
+  ]
 }

--- a/src/poly/tests/test_projects/test_project/topics/topic_1.yaml
+++ b/src/poly/tests/test_projects/test_project/topics/topic_1.yaml
@@ -1,7 +1,7 @@
 name: Topic 1
 enabled: true
 actions: Use {{fn:test_function}} to handle this request and {{fn:format_date}}
-  for dates. Access customer info via {{attr:customer-name}} and handoff with {{ho:handoff-1}} if
+  for dates. Access customer info via {{attr:customer_name}} and handoff with {{ho:handoff-1}} if
   needed. Send notifications using {{twilio_sms:test_template_1}}.
 content: This topic covers general inquiries and uses global functions.
 example_queries:

--- a/src/poly/tests/test_projects/test_project/topics/topic_2.yaml
+++ b/src/poly/tests/test_projects/test_project/topics/topic_2.yaml
@@ -1,6 +1,6 @@
 name: Topic 2
 enabled: true
-actions: Validate using {{fn:validate_email}} and process with {{fn:shared_helper}}. Check {{attr:email-address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:test_template_2}}.
+actions: Validate using {{fn:validate_email}} and process with {{fn:shared_helper}}. Check {{attr:email_address}} attribute and use {{ho:handoff-2}} for escalation. Send email verification via {{twilio_sms:test_template_2}}.
 content: This topic handles email validation and processing.
 example_queries:
   - I need to verify my email

--- a/src/poly/tests/test_projects/test_project/voice/configuration.yaml
+++ b/src/poly/tests/test_projects/test_project/voice/configuration.yaml
@@ -1,5 +1,5 @@
 greeting:
-  welcome_message: Hello! Welcome to our service. Your account shows {{attr:member-status}}. How can
+  welcome_message: Hello! Welcome to our service. Your account shows {{attr:member_status}}. How can
     I assist you today?
   language_code: en-GB
 style_prompt:

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -675,10 +675,10 @@ class ResourceMappingTests(unittest.TestCase):
             resource_prefix="ft",
         ),
         ResourceMapping(
-            resource_id="attr-customer-name",
-            resource_name="customer-name",
+            resource_id="attr-customer_name",
+            resource_name="customer_name",
             resource_type=VariantAttribute,
-            file_path="config/variant_attributes.yaml/variant_attributes/customer-name",
+            file_path="config/variant_attributes.yaml/variant_attributes/customer_name",
             flow_name=None,
             resource_prefix="attr",
         ),
@@ -834,14 +834,14 @@ class ResourceMappingTests(unittest.TestCase):
     def test_replace_resource_ids_with_names_attributes_handoff_sms_entities(self):
         """Test IDs->names swap for attr, ho, twilio_sms, entity references."""
         prompt = (
-            "Use {{attr:attr-customer-name}}, {{ho:handoff-1}}, "
+            "Use {{attr:attr-customer_name}}, {{ho:handoff-1}}, "
             "{{twilio_sms:SMS_TEMPLATE-123}} and {{entity:ENTITY-customer_name}}."
         )
         updated = resource_utils.replace_resource_ids_with_names(
             prompt, self.TEST_RESOURCE_MAPPINGS
         )
         expected = (
-            "Use {{attr:customer-name}}, {{ho:default}}, "
+            "Use {{attr:customer_name}}, {{ho:default}}, "
             "{{twilio_sms:test_template}} and {{entity:customer_name}}."
         )
         self.assertEqual(updated, expected)
@@ -849,14 +849,14 @@ class ResourceMappingTests(unittest.TestCase):
     def test_replace_resource_names_with_ids_attributes_handoff_sms_entities(self):
         """Test names->IDs swap for attr, ho, twilio_sms, entity references."""
         prompt = (
-            "Use {{attr:customer-name}}, {{ho:default}}, "
+            "Use {{attr:customer_name}}, {{ho:default}}, "
             "{{twilio_sms:test_template}} and {{entity:customer_name}}."
         )
         updated = resource_utils.replace_resource_names_with_ids(
             prompt, self.TEST_RESOURCE_MAPPINGS
         )
         expected = (
-            "Use {{attr:attr-customer-name}}, {{ho:handoff-1}}, "
+            "Use {{attr:attr-customer_name}}, {{ho:handoff-1}}, "
             "{{twilio_sms:SMS_TEMPLATE-123}} and {{entity:ENTITY-customer_name}}."
         )
         self.assertEqual(updated, expected)
@@ -908,7 +908,7 @@ class ReplaceResourceNamesWithIdsInDataTests(unittest.TestCase):
                     },
                 },
             ],
-            "closing": "Finally {{attr:customer-name}}.",
+            "closing": "Finally {{attr:customer_name}}.",
         }
 
     def test_equivalence_with_string_path_over_serialized_yaml(self):
@@ -950,7 +950,7 @@ class ReplaceResourceNamesWithIdsInDataTests(unittest.TestCase):
             result["steps"][2]["nested"]["deep"],
             "Send {{twilio_sms:SMS_TEMPLATE-123}} now.",
         )
-        self.assertEqual(result["closing"], "Finally {{attr:attr-customer-name}}.")
+        self.assertEqual(result["closing"], "Finally {{attr:attr-customer_name}}.")
 
     def test_reference_shaped_keys_are_not_rewritten(self):
         """Only scalar string values are rewritten; dict keys are left untouched."""

--- a/src/poly/utils/prepush.py
+++ b/src/poly/utils/prepush.py
@@ -13,6 +13,7 @@ import copy
 from typing import Callable, TypeAlias
 
 from poly.resources import (
+    AttributeKind,
     ChatGreeting,
     ChatSafetyFilters,
     ChatStylePrompt,
@@ -327,17 +328,18 @@ def default_new_variant_attributes(
     current_resources: ResourceMap,
 ) -> None:
     """Give new variants all known (non-deleted) attributes as default values."""
-    # Add known attributes to any new variant to give it a default value
+    # Add known attributes to any new variant to give it a default value. A typed
+    # attribute cannot hold "", so its seed is a native null; the real value follows
+    # in the attribute update pushed straight after.
     deleted_attribute_ids = set(deleted_resources.get(VariantAttribute, {}).keys())
     for variant in new_resources.get(Variant, {}).values():
         if not isinstance(variant, Variant):
             raise TypeError(f"Variant is not a Variant: {variant}")
-        attribute_ids = [
-            aid
-            for aid in current_resources.get(VariantAttribute, {}).keys()
-            if aid not in deleted_attribute_ids
-        ]
-        variant.attribute_ids = attribute_ids
+        variant.attribute_values = {
+            attribute_id: "" if attribute.kind == AttributeKind.STRING else None
+            for attribute_id, attribute in current_resources.get(VariantAttribute, {}).items()
+            if attribute_id not in deleted_attribute_ids
+        }
 
 
 def fix_conditions_for_deleted_steps(

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.51.0"
+version = "0.53.1"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },


### PR DESCRIPTION
## Summary

Variant attributes can now declare a type. ADK reads an attribute's `kind` (and an
enum's `config`) from the platform, validates every value against it locally, and
dual-writes native typed values on push — matching the `AttributeType` support the
platform added in the Variant Attribute Types project.

## Motivation

The platform now stores variant attribute values twice: the legacy stringified
`values` map and a native `typedValues` map that wins on read. ADK knew about
neither, so it flattened every typed attribute to a string on pull, and its pushes
were rejected outright by the backend's type validation once a project had a typed
attribute.

Linear project: https://linear.app/poly-ai/project/variant-attribute-types-a7bc31d07a9c/overview

## Changes

- Variant attributes gain an optional `kind` (`string`, `number`, `boolean`, `enum`,
  `object`) and, for enums, a `config` listing the allowed values.
- Push dual-writes both maps and sends the declared type on create and update.
- Pull prefers `typedValues`, falls back to the whole `values` map when it is
  malformed, and parses a legacy string against the declared kind — so an attribute
  typed in Agent Studio but never re-saved still reads natively.
- Values are validated against their kind before push, naming the variant a
  mismatch came from instead of surfacing it on a live call.
- `values` stays a map of strings on disk, with `kind` saying how to read them. An
  ADK released before typed attributes calls `.strip()` on every value and would
  fail on a native int, bool or nested map in a file a newer ADK had written. Native
  YAML is still accepted on input, and both spellings hash identically so neither
  shows as a diff against the other.
- New variants seed typed attributes with a native null rather than `""`, which the
  platform rejects for any non-string kind.
- Docs updated, including two behaviours that aren't discoverable from the file: a
  blank typed attribute is omitted from the deployed agent (a blank string
  substitutes empty), and Agent Studio's Date & time / Opening hours / Voice types
  are stored as `string` or `enum` here.

A project that never adopts a type sees no change to its file at all.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

1585 tests pass. New coverage pins the wire round trip per kind, the projection read
including the malformed-`typedValues` fallback, YAML round trips for every kind, and
the backward-compatible encoding — including a test that runs the pre-types reader's
exact comprehension over what this writes, plus a guard asserting that same reader
really does fail on a native value.

Not yet exercised against a live project. Worth a real `poly push` of a typed
attribute before merging, since this changes the push payload.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)