### PR TITLE
fix: push deleted asr_biasing/dtmf_config sections as disabled

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -1076,8 +1076,6 @@ class DTMFConfig:
 
     def __init__(
         self,
-        step_id: str,
-        flow_id: str,
         is_enabled: bool = False,
         inter_digit_timeout: int = 0,
         max_digits: int = 0,
@@ -1086,9 +1084,6 @@ class DTMFConfig:
         is_pii: bool = False,
     ):
         self.name = "dtmf"
-        self.step_id = step_id
-        self.flow_id = flow_id
-        self.resource_id = f"{flow_id}.{step_id}"
         self.is_enabled = is_enabled
         self.inter_digit_timeout = inter_digit_timeout
         self.max_digits = max_digits
@@ -1295,8 +1290,9 @@ class FlowSettings(SubResource):
     step_id: str
     flow_id: str
 
-    asr_biasing: Optional[ASRBiasing]
-    dtmf: Optional[DTMFConfig]
+    # Never None: absent means disabled, because the backend can't clear these.
+    asr_biasing: ASRBiasing
+    dtmf: DTMFConfig
     asr: Optional[ASRConfig]
     vad: Optional[VADConfig]
     barge_in: Optional[BargeInConfig]
@@ -1321,7 +1317,7 @@ class FlowSettings(SubResource):
         if isinstance(asr_biasing, dict):
             asr_biasing = ASRBiasing(**asr_biasing)
         if isinstance(dtmf, dict):
-            dtmf = DTMFConfig(step_id, flow_id, **dtmf)
+            dtmf = DTMFConfig(**dtmf)
         if isinstance(asr, dict):
             asr = ASRConfig(**asr)
         if isinstance(vad, dict):
@@ -1335,8 +1331,11 @@ class FlowSettings(SubResource):
             )
             llm = LLMConfig(**llm)
 
-        self.asr_biasing = asr_biasing
-        self.dtmf = dtmf
+        # asr_biasing and dtmf can't be cleared on the backend, so an absent section
+        # means disabled — normalise here so every construction path (YAML, projection,
+        # bare defaults) compares equal.
+        self.asr_biasing = asr_biasing if asr_biasing is not None else ASRBiasing()
+        self.dtmf = dtmf if dtmf is not None else DTMFConfig()
         self.asr = asr
         self.vad = vad
         self.barge_in = barge_in
@@ -1345,9 +1344,9 @@ class FlowSettings(SubResource):
     def to_yaml_dict(self) -> dict:
         """Return a dictionary suitable for YAML serialization."""
         output = {}
-        if self.asr_biasing and self.asr_biasing.is_enabled:
+        if self.asr_biasing.is_enabled:
             output["asr_biasing"] = self.asr_biasing.to_yaml_dict()
-        if self.dtmf and self.dtmf.is_enabled:
+        if self.dtmf.is_enabled:
             output["dtmf_config"] = self.dtmf.to_yaml_dict()
         if self.asr:
             output["asr"] = self.asr.to_yaml_dict()
@@ -1410,8 +1409,8 @@ class FlowSettings(SubResource):
         return cls(
             step_id=step_id,
             flow_id=flow_id,
-            asr_biasing=ASRBiasing(**asr_biasing_data) if asr_biasing_data else None,
-            dtmf=DTMFConfig(step_id, flow_id, **dtmf_data) if dtmf_data else None,
+            asr_biasing=ASRBiasing(**asr_biasing_data) if asr_biasing_data else ASRBiasing(),
+            dtmf=DTMFConfig(**dtmf_data) if dtmf_data else DTMFConfig(),
             asr=ASRConfig(**asr_data) if asr_data else None,
             vad=VADConfig(**vad_data) if vad_data else None,
             barge_in=BargeInConfig(**barge_in_data) if barge_in_data else None,
@@ -1420,10 +1419,8 @@ class FlowSettings(SubResource):
 
     def validate(self, **kwargs):
         """Validate the flow settings resource."""
-        if self.asr_biasing:
-            self.asr_biasing.validate()
-        if self.dtmf:
-            self.dtmf.validate()
+        self.asr_biasing.validate()
+        self.dtmf.validate()
         if self.asr:
             self.asr.validate()
         if self.vad:
@@ -1439,8 +1436,10 @@ class FlowSettings(SubResource):
             flow_id=self.flow_id,
             step_id=self.step_id,
             settings=FlowStepSettings(
-                asr_biasing=self.asr_biasing.to_proto() if self.asr_biasing else None,
-                dtmf=self.dtmf.to_proto() if self.dtmf else None,
+                # Always sent: these can't be cleared, so a disabled state must go
+                # out explicitly or the backend reads the omission as "not updated".
+                asr_biasing=self.asr_biasing.to_proto(),
+                dtmf=self.dtmf.to_proto(),
                 asr=self.asr.to_proto() if self.asr else None,
                 vad=self.vad.to_proto() if self.vad else None,
                 barge_in=self.barge_in.to_proto() if self.barge_in else None,

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -233,7 +233,7 @@ class SerializationRoundTripTest(unittest.TestCase):
                 step_id="step-1",
                 flow_id="flow-123",
                 asr_biasing=ASRBiasing(is_enabled=True),
-                dtmf=DTMFConfig(step_id="step-1", flow_id="flow-123"),
+                dtmf=DTMFConfig(),
             ),
         )
         serialized = resource_utils.resource_to_dict(step)

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -3155,8 +3155,6 @@ TEST_FLOW_STEP = FlowStep(
         ),
         # Enabled so it survives to_yaml_dict, which omits disabled sections.
         dtmf=DTMFConfig(
-            flow_id="flow-123",
-            step_id="step-1",
             is_enabled=True,
             max_digits=4,
         ),
@@ -3380,8 +3378,10 @@ class FlowStepTests(unittest.TestCase):
             flow_name="Test Flow",
             resource_mappings=[],
         )
-        self.assertIsNone(step.settings.asr_biasing)
-        self.assertIsNone(step.settings.dtmf)
+        # Absent sections read as disabled — they can't be cleared on the backend,
+        # so absence and disabled are the same state.
+        self.assertFalse(step.settings.asr_biasing.is_enabled)
+        self.assertFalse(step.settings.dtmf.is_enabled)
 
     def test_prompt_whitespace_is_stripped(self):
         """Prompts with leading/trailing whitespace are stripped on read."""
@@ -3848,8 +3848,6 @@ conditions:
             end_key="#",
             collect_while_agent_speaking=False,
             is_pii=False,
-            step_id="step-1",
-            flow_id="flow-123",
         )
 
         def advanced_step_with(**settings_kwargs) -> FlowStep:
@@ -3872,6 +3870,9 @@ conditions:
             ("ASR biasing changed", advanced_step_with(asr_biasing=new_asr)),
             ("DTMF changed", advanced_step_with(dtmf=new_dtmf)),
             ("both changed", advanced_step_with(asr_biasing=new_asr, dtmf=new_dtmf)),
+            # Deleting the blocks reads as disabled, which still differs from the
+            # enabled originals and must go out as a settings update.
+            ("both deleted", advanced_step_with()),
         ]:
             with self.subTest(description):
                 new, updated, deleted = step.get_new_updated_deleted_subresources(
@@ -11576,8 +11577,8 @@ class FlowSettingsFromProjectionTest(unittest.TestCase):
             }
         )
 
-        self.assertIsNone(settings.asr_biasing)
-        self.assertIsNone(settings.dtmf)
+        self.assertFalse(settings.asr_biasing.is_enabled)
+        self.assertFalse(settings.dtmf.is_enabled)
         self.assertEqual(settings.llm.provider_model_id, "m")
 
     def test_legacy_top_level_config_is_read_when_there_is_no_settings_block(self):
@@ -11616,7 +11617,7 @@ class FlowSettingsSerializationTest(unittest.TestCase):
     def test_round_trips_every_section(self):
         settings = self._settings(
             asr_biasing=ASRBiasing(is_enabled=True, custom_keywords=["acme"], numeric=True),
-            dtmf=DTMFConfig(self.STEP_ID, self.FLOW_ID, is_enabled=True, max_digits=4),
+            dtmf=DTMFConfig(is_enabled=True, max_digits=4),
             asr=ASRConfig(provider="prov", model="mod"),
             vad=VADConfig(
                 provider="prov",
@@ -11644,7 +11645,7 @@ class FlowSettingsSerializationTest(unittest.TestCase):
     def test_dtmf_uses_legacy_yaml_key(self):
         """The YAML key stays dtmf_config so existing step files keep working."""
         settings = self._settings(
-            dtmf=DTMFConfig(self.STEP_ID, self.FLOW_ID, is_enabled=True, max_digits=2)
+            dtmf=DTMFConfig(is_enabled=True, max_digits=2)
         )
 
         yaml_dict = settings.to_yaml_dict()
@@ -11661,7 +11662,7 @@ class FlowSettingsSerializationTest(unittest.TestCase):
         """Disabled is represented as absent for the sections that deep-merge."""
         settings = self._settings(
             asr_biasing=ASRBiasing(is_enabled=False, custom_keywords=["acme"]),
-            dtmf=DTMFConfig(self.STEP_ID, self.FLOW_ID, is_enabled=False),
+            dtmf=DTMFConfig(is_enabled=False),
         )
 
         self.assertEqual(settings.to_yaml_dict(), {})
@@ -11686,8 +11687,58 @@ class FlowSettingsSerializationTest(unittest.TestCase):
         self.assertTrue(proto.settings.HasField("barge_in"))
         self.assertTrue(proto.settings.HasField("llm"))
         self.assertEqual(proto.settings.llm.provider_model_id, "mod-1")
-        for absent in ("asr_biasing", "dtmf", "asr", "vad"):
+        # asr and vad are clearable, so absence means "no override" and they must
+        # stay unset. asr_biasing and dtmf can't be cleared on the backend — absence
+        # means disabled, and the disable only lands if the section is sent.
+        for absent in ("asr", "vad"):
             self.assertFalse(proto.settings.HasField(absent), absent)
+        for disabled in ("asr_biasing", "dtmf"):
+            self.assertTrue(proto.settings.HasField(disabled), disabled)
+            self.assertFalse(proto.settings.asr_biasing.is_enabled)
+            self.assertFalse(proto.settings.dtmf.is_enabled)
+
+    def test_absent_asr_biasing_and_dtmf_read_as_disabled(self):
+        """Absence and disabled are the same state for the unclearable sections,
+        regardless of how the settings were constructed."""
+        from_yaml = FlowSettings.from_yaml_dict({}, step_id=self.STEP_ID, flow_id=self.FLOW_ID)
+        from_projection = FlowSettings.from_projection(
+            {"settings": {}}, step_id=self.STEP_ID, flow_id=self.FLOW_ID
+        )
+        bare = self._settings()
+
+        for name, settings in [
+            ("from_yaml_dict", from_yaml),
+            ("from_projection", from_projection),
+            ("defaults", bare),
+        ]:
+            with self.subTest(name):
+                self.assertFalse(settings.asr_biasing.is_enabled)
+                self.assertFalse(settings.dtmf.is_enabled)
+        # All construction paths must compare equal, or unchanged steps would queue
+        # spurious settings updates on push.
+        self.assertEqual(from_yaml, from_projection)
+        self.assertEqual(from_yaml, bare)
+
+    def test_deleting_asr_biasing_pushes_it_as_disabled(self):
+        """asr_biasing/dtmf can't go through clear_step_settings, so deleting the
+        YAML block must push the section explicitly disabled — omitting it would be
+        read by the backend as "not updated" and the deletion would silently no-op."""
+        original = self._settings(
+            asr_biasing=ASRBiasing(is_enabled=True, name_spelling=True, yes_no=True),
+            dtmf=DTMFConfig(is_enabled=True, max_digits=4),
+        )
+        # Deleting both blocks from the step YAML reads back as disabled sections.
+        updated = FlowSettings.from_yaml_dict(
+            {}, step_id=self.STEP_ID, flow_id=self.FLOW_ID
+        )
+
+        self.assertNotEqual(updated, original)
+
+        proto = updated.build_update_proto()
+        self.assertTrue(proto.settings.HasField("asr_biasing"))
+        self.assertFalse(proto.settings.asr_biasing.is_enabled)
+        self.assertTrue(proto.settings.HasField("dtmf"))
+        self.assertFalse(proto.settings.dtmf.is_enabled)
 
     def test_command_type_is_the_combined_settings_command(self):
         settings = self._settings(barge_in=BargeInConfig(is_enabled=True))
@@ -11781,7 +11832,7 @@ class FlowSettingsValidationTest(unittest.TestCase):
                 settings = FlowSettings(
                     step_id="step-1",
                     flow_id="flow-123",
-                    dtmf=DTMFConfig("step-1", "flow-123", **kwargs),
+                    dtmf=DTMFConfig(**kwargs),
                 )
                 with self.assertRaises(ValueError) as ctx:
                     settings.validate()
@@ -11814,7 +11865,7 @@ class FlowSettingsValidationTest(unittest.TestCase):
 
     def test_flow_step_validate_checks_its_settings(self):
         """Settings are a sub-resource, so nothing else validates them."""
-        step = self._step(dtmf=DTMFConfig("step-1", "flow-123", max_digits=-1))
+        step = self._step(dtmf=DTMFConfig(max_digits=-1))
 
         with self.assertRaises(ValueError) as ctx:
             step.validate(resource_mappings=self._mappings())
@@ -11823,7 +11874,7 @@ class FlowSettingsValidationTest(unittest.TestCase):
 
     def test_valid_settings_pass_flow_step_validation(self):
         step = self._step(
-            dtmf=DTMFConfig("step-1", "flow-123", max_digits=4, inter_digit_timeout=0),
+            dtmf=DTMFConfig(max_digits=4, inter_digit_timeout=0),
             vad=VADConfig(vad_start=0.0, vad_end=2.5),
         )
 

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -1126,7 +1126,7 @@ class ClearUnusedSettingsFromFlowStepTest(unittest.TestCase):
     def _all_sections(self) -> dict:
         return {
             "asr_biasing": ASRBiasing(is_enabled=True),
-            "dtmf": DTMFConfig(self.STEP_ID, self.FLOW_ID, is_enabled=True),
+            "dtmf": DTMFConfig(is_enabled=True),
             "asr": ASRConfig(provider="p", model="m"),
             "vad": VADConfig(
                 provider="p",


### PR DESCRIPTION
## Summary

Deleting an `asr_biasing` or `dtmf_config` block from a step's YAML was silently dropped on push, so the deletion never reached Agent Studio and `poly diff` kept showing it as pending forever. Absent sections now read as disabled and are pushed explicitly with `is_enabled: false`.

## Motivation

The backend's `clear_step_settings` command rejects the `asrBiasing`/`dtmf` sections (they deep-merge into legacy top-level mirrors), so these two sections can't go through the clear path like `asr`/`vad`/`barge_in`/`llm` do. Meanwhile the update proto omitted the section entirely when the block was deleted, which the backend reads as "not updated". Since disabling is the only way to express removal for these sections — and `to_yaml_dict` already omits disabled sections — absence and disabled are treated as the same state, and the round trip (push → fetch → diff) converges cleanly.

## Changes

- `FlowSettings` normalises absent `asr_biasing`/`dtmf` to disabled instances in `__init__`, so every construction path (YAML read, projection read, bare defaults) compares equal and a deleted block is detected as a settings update
- `build_update_proto` always sends the `asr_biasing` and `dtmf` sections (enabled or disabled) instead of omitting them when unset; the clearable sections (`asr`, `vad`, `barge_in`, `llm`) are still omitted when absent
- `DTMFConfig` drops its unused `step_id`/`flow_id`/`resource_id`
- Added regression tests: deleted blocks push as disabled, all construction paths agree on the disabled state, and sub-resource diffing flags deleted sections as an update

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)