### PR TITLE
docs: note keyphrase uniqueness rule

### DIFF
--- a/docs/docs/reference/resources/speech_recognition.md
+++ b/docs/docs/reference/resources/speech_recognition.md
@@ -178,10 +178,19 @@ corrections:
         replacement_type: partial
 ~~~
 
+## Validation
+
+- `interaction_style` must be one of `precise`, `balanced`, `swift`, `sonic`, or `turbo`.
+- Each keyphrase must be non-empty, with a `level` of `default`, `boosted`, or `maximum`.
+- Keyphrases must be unique once trimmed and lowercased — Agent Studio treats `Infusion Sets` and `infusion sets` as the same phrase, and rejects a project that keeps both.
+- Each transcript correction needs a unique `name` and at least one regex rule, and every rule needs a `regular_expression`.
+- `replacement_type` must be one of `full`, `partial`, or `substring`.
+
 ## Best practices
 
 - use `keyphrase_boosting` for terms the recognizer is likely to miss
 - keep boosted keyphrases focused and specific
+- keep each keyphrase unique after trimming and lowercasing
 - use transcript corrections for common, repeated recognition errors
 - avoid overly broad regex rules that may alter normal input unexpectedly
 - choose the ASR interaction style deliberately based on latency and accuracy needs


### PR DESCRIPTION
## Summary

Document the keyphrase uniqueness rule on the speech recognition reference page, so the validation added in `21692da` is discoverable before a push fails.

## Motivation

Agent Studio normalizes keyphrases (trim + lowercase) and rejects a push containing two entries that normalize to the same phrase. Nothing in the docs said so, so the constraint was only discoverable by hitting the error.

## Changes

- Add a `Validation` section to the speech recognition page, covering the keyphrase uniqueness rule along with the existing rules for ASR settings, keyphrase boosting, and transcript corrections
- Add a matching bullet to the speech recognition best practices list

## Test strategy

- [ ] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [x] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

N/A
