### PR TITLE
fix: compare versions, not timestamps, when checking convergence

### DIFF
--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3934,7 +3934,11 @@ class AgentStudioProject:
 
     @cached_property
     def using_simplified_deployments(self) -> bool:
-        """Check if the project is using simplified deployments."""
+        """Check if the project is using simplified deployments.
+
+        Two conditions, both required: the project has been rolled out to, and it
+        has *converged* — main and live already hold the same version.
+        """
         flag_enabled = self.api_handler.feature_flag_enabled(
             key="deployment-simplification",
             region=self.region,
@@ -3944,26 +3948,62 @@ class AgentStudioProject:
         if not flag_enabled:
             return False
 
-        # A project is converged if the main == live
-        # Once a project is converged, all deployments will go to live
-        # To check, look at most recent deployment in sandbox and live. If it is the same as live, then the project is converged
-        live_deployments = self.api_handler.get_deployments(
-            self.region, self.account_id, self.project_id, client_env="live"
+        return self._has_converged()
+
+    def _has_converged(self) -> bool:
+        """Whether main and live hold the same version.
+
+        Main's latest deployment is the newest of its live deployments and its
+        *untagged* sandbox deployments — the two environments main owns. A
+        sandbox deployment carrying a tag was made by a branch holding that tag,
+        not by main, so counting it would make a branch's work look like main
+        had moved.
+
+        Convergence compares the two versions, not their timestamps. Under
+        simplified deployments a publish to live is followed by a sandbox
+        deployment mirroring it, so sandbox is routinely the newer row while
+        holding identical content — a timestamp comparison reports a difference
+        that does not exist.
+        """
+        live_deployments = self._live_deployments("live")
+        sandbox_deployments = self._live_deployments("sandbox")
+
+        live_head = self._newest(live_deployments)
+        main_head = self._newest(
+            live_deployments + [d for d in sandbox_deployments if not self._tag_of(d)]
         )
-        sandbox_deployments = self.api_handler.get_deployments(
-            self.region, self.account_id, self.project_id, client_env="sandbox"
-        )
 
-        live_head = next((d for d in live_deployments if not d.get("deleted", False)), None)
-        sandbox_head = next((d for d in sandbox_deployments if not d.get("deleted", False)), None)
-
-        def _parse_created_at(deployment: dict) -> datetime:
-            return datetime.strptime(deployment["created_at"], "%a, %d %b %Y %H:%M:%S %Z")
-
-        if live_head is None and sandbox_head is None:
-            # No deployments in either environment, consider converged
+        if live_head is None and main_head is None:
+            # Nothing deployed anywhere, so there is no version for the two to
+            # disagree on.
             return True
 
-        return live_head is not None and (
-            sandbox_head is None or _parse_created_at(live_head) >= _parse_created_at(sandbox_head)
+        if live_head is None or main_head is None:
+            return False
+
+        return live_head.get("version_hash") == main_head.get("version_hash")
+
+    def _live_deployments(self, client_env: str) -> list[dict[str, Any]]:
+        """Deployments for an environment, excluding deleted ones."""
+        deployments = self.api_handler.get_deployments(
+            self.region, self.account_id, self.project_id, client_env=client_env
         )
+        return [d for d in (deployments or []) if not d.get("deleted", False)]
+
+    @staticmethod
+    def _tag_of(deployment: dict[str, Any]) -> Optional[str]:
+        """The tag a deployment was made under, if any."""
+        return (deployment.get("deployment_metadata") or {}).get("tag")
+
+    @staticmethod
+    def _newest(deployments: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        """The most recently created deployment, or None when there are none.
+
+        Sorted rather than assuming the API returns newest first, so the answer
+        does not depend on response ordering.
+        """
+
+        def created_at(deployment: dict[str, Any]) -> datetime:
+            return datetime.strptime(deployment["created_at"], "%a, %d %b %Y %H:%M:%S %Z")
+
+        return max(deployments, key=created_at, default=None)

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3952,8 +3952,14 @@ class AgentStudioProject:
     def _has_converged(self) -> bool:
         """Whether main and live hold the same version.
 
-        Versions, not timestamps: a publish to live is mirrored into sandbox
-        seconds later, so sandbox is often newer while holding identical content.
+        main is a branch with no environment of its own. Its deploys land in
+        sandbox before migration and in live after, so its version is the newest
+        across both — and converged means live is the one holding it.
+
+        Versions, not timestamps: deployments to live are mirrored into sandbox
+        so the two always match, which leaves sandbox newer while holding
+        identical content. Both eras have a newer sandbox row; only the version
+        tells them apart.
         """
         live_deployments = self._active_deployments("live")
         sandbox_deployments = self._active_deployments("sandbox")

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3959,11 +3959,7 @@ class AgentStudioProject:
         sandbox_deployments = self._live_deployments("sandbox")
 
         live_head = self._newest(live_deployments)
-        # Main owns live plus its untagged sandbox deployments; a tagged one was
-        # deployed by the branch holding that tag.
-        main_head = self._newest(
-            live_deployments + [d for d in sandbox_deployments if not self._tag_of(d)]
-        )
+        main_head = self._newest(live_deployments + sandbox_deployments)
 
         # Nothing deployed at all: no live content to regress.
         if live_head is None and main_head is None:
@@ -3988,11 +3984,6 @@ class AgentStudioProject:
             self.region, self.account_id, self.project_id, client_env=client_env
         )
         return [d for d in (deployments or []) if not d.get("deleted", False)]
-
-    @staticmethod
-    def _tag_of(deployment: dict[str, Any]) -> Optional[str]:
-        """The tag a deployment was made under, if any."""
-        return (deployment.get("deployment_metadata") or {}).get("tag")
 
     @staticmethod
     def _newest(deployments: list[dict[str, Any]]) -> Optional[dict[str, Any]]:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3965,13 +3965,22 @@ class AgentStudioProject:
             live_deployments + [d for d in sandbox_deployments if not self._tag_of(d)]
         )
 
+        # Nothing deployed at all: no live content to regress.
         if live_head is None and main_head is None:
             return True
 
         if live_head is None or main_head is None:
             return False
 
-        return live_head.get("version_hash") == main_head.get("version_hash")
+        # Past that, a usable hash on both sides is what makes equality provable.
+        # Draft deploys record an empty hash, and treating two unknowns as equal
+        # would report converged when it cannot be known.
+        live_hash = live_head.get("version_hash")
+        main_hash = main_head.get("version_hash")
+        if not live_hash or not main_hash:
+            return False
+
+        return live_hash == main_hash
 
     def _live_deployments(self, client_env: str) -> list[dict[str, Any]]:
         """Deployments for an environment, excluding deleted ones."""

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3955,8 +3955,8 @@ class AgentStudioProject:
         Versions, not timestamps: a publish to live is mirrored into sandbox
         seconds later, so sandbox is often newer while holding identical content.
         """
-        live_deployments = self._live_deployments("live")
-        sandbox_deployments = self._live_deployments("sandbox")
+        live_deployments = self._active_deployments("live")
+        sandbox_deployments = self._active_deployments("sandbox")
 
         live_head = self._newest(live_deployments)
         main_head = self._newest(live_deployments + sandbox_deployments)
@@ -3978,7 +3978,7 @@ class AgentStudioProject:
 
         return live_hash == main_hash
 
-    def _live_deployments(self, client_env: str) -> list[dict[str, Any]]:
+    def _active_deployments(self, client_env: str) -> list[dict[str, Any]]:
         """Deployments for an environment, excluding deleted ones."""
         deployments = self.api_handler.get_deployments(
             self.region, self.account_id, self.project_id, client_env=client_env

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3958,6 +3958,13 @@ class AgentStudioProject:
         live_deployments = self._active_deployments("live")
         sandbox_deployments = self._active_deployments("sandbox")
 
+        # Tagging a branch deploys it to sandbox, which is only possible under
+        # simplified deployments — so a tagged sandbox deployment settles the
+        # question on its own. It also holds a branch's version rather than
+        # main's, which the comparison below would read as diverged.
+        if any(self._tag_of(deployment) for deployment in sandbox_deployments):
+            return True
+
         live_head = self._newest(live_deployments)
         main_head = self._newest(live_deployments + sandbox_deployments)
 
@@ -3984,6 +3991,15 @@ class AgentStudioProject:
             self.region, self.account_id, self.project_id, client_env=client_env
         )
         return [d for d in (deployments or []) if not d.get("deleted", False)]
+
+    @staticmethod
+    def _tag_of(deployment: dict[str, Any]) -> Optional[str]:
+        """The tag a deployment was made under, if any.
+
+        Only the tag that deploys to sandbox appears here; the other deploys to
+        pre-release, which convergence does not read.
+        """
+        return (deployment.get("deployment_metadata") or {}).get("tag")
 
     @staticmethod
     def _newest(deployments: list[dict[str, Any]]) -> Optional[dict[str, Any]]:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3936,8 +3936,7 @@ class AgentStudioProject:
     def using_simplified_deployments(self) -> bool:
         """Check if the project is using simplified deployments.
 
-        Two conditions, both required: the project has been rolled out to, and it
-        has *converged* — main and live already hold the same version.
+        Requires both the rollout flag and convergence.
         """
         flag_enabled = self.api_handler.feature_flag_enabled(
             key="deployment-simplification",
@@ -3953,29 +3952,20 @@ class AgentStudioProject:
     def _has_converged(self) -> bool:
         """Whether main and live hold the same version.
 
-        Main's latest deployment is the newest of its live deployments and its
-        *untagged* sandbox deployments — the two environments main owns. A
-        sandbox deployment carrying a tag was made by a branch holding that tag,
-        not by main, so counting it would make a branch's work look like main
-        had moved.
-
-        Convergence compares the two versions, not their timestamps. Under
-        simplified deployments a publish to live is followed by a sandbox
-        deployment mirroring it, so sandbox is routinely the newer row while
-        holding identical content — a timestamp comparison reports a difference
-        that does not exist.
+        Versions, not timestamps: a publish to live is mirrored into sandbox
+        seconds later, so sandbox is often newer while holding identical content.
         """
         live_deployments = self._live_deployments("live")
         sandbox_deployments = self._live_deployments("sandbox")
 
         live_head = self._newest(live_deployments)
+        # Main owns live plus its untagged sandbox deployments; a tagged one was
+        # deployed by the branch holding that tag.
         main_head = self._newest(
             live_deployments + [d for d in sandbox_deployments if not self._tag_of(d)]
         )
 
         if live_head is None and main_head is None:
-            # Nothing deployed anywhere, so there is no version for the two to
-            # disagree on.
             return True
 
         if live_head is None or main_head is None:
@@ -3997,11 +3987,7 @@ class AgentStudioProject:
 
     @staticmethod
     def _newest(deployments: list[dict[str, Any]]) -> Optional[dict[str, Any]]:
-        """The most recently created deployment, or None when there are none.
-
-        Sorted rather than assuming the API returns newest first, so the answer
-        does not depend on response ordering.
-        """
+        """The most recently created deployment, by date rather than list order."""
 
         def created_at(deployment: dict[str, Any]) -> datetime:
             return datetime.strptime(deployment["created_at"], "%a, %d %b %Y %H:%M:%S %Z")

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3952,14 +3952,8 @@ class AgentStudioProject:
     def _has_converged(self) -> bool:
         """Whether main and live hold the same version.
 
-        main is a branch with no environment of its own. Its deploys land in
-        sandbox before migration and in live after, so its version is the newest
-        across both — and converged means live is the one holding it.
-
-        Versions, not timestamps: deployments to live are mirrored into sandbox
-        so the two always match, which leaves sandbox newer while holding
-        identical content. Both eras have a newer sandbox row; only the version
-        tells them apart.
+        main's version is the newest deployment across live and sandbox: it has
+        no environment of its own.
         """
         live_deployments = self._active_deployments("live")
         sandbox_deployments = self._active_deployments("sandbox")

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -5114,6 +5114,23 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
             expected=True,
         )
 
+    def test_an_untagged_sandbox_deployment_still_counts_behind_a_tagged_one(self):
+        """Filtering tagged deployments must not hide main's own sandbox deploys.
+
+        The newest sandbox deployment belongs to a branch, but main deployed the
+        one behind it and live has not caught up.
+        """
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[
+                self._deployment(
+                    "Wed, 03 Jan 2026 12:00:00 GMT", version_hash="branch", tag="internal"
+                ),
+                self._deployment("Tue, 02 Jan 2026 12:00:00 GMT", version_hash="def"),
+            ],
+            expected=False,
+        )
+
     def test_converges_when_no_deployments_exist_in_either_environment(self):
         """With no deployments anywhere there is no version to disagree on."""
         self._assert_converged(live=[], sandbox=[], expected=True)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -5135,6 +5135,35 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
         """With no deployments anywhere there is no version to disagree on."""
         self._assert_converged(live=[], sandbox=[], expected=True)
 
+    def test_is_not_converged_when_a_version_hash_is_missing(self):
+        """Two unknown versions are not a match.
+
+        Draft deploys record an empty hash. Reporting converged here would claim
+        live holds main's version without being able to know it.
+        """
+        for live_hash, main_hash in (("", "abc"), ("abc", ""), ("", ""), (None, None)):
+            with self.subTest(live=live_hash, main=main_hash):
+                self._assert_converged(
+                    live=[
+                        self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash=live_hash)
+                    ],
+                    sandbox=[
+                        self._deployment("Tue, 02 Jan 2026 12:00:00 GMT", version_hash=main_hash)
+                    ],
+                    expected=False,
+                )
+
+    def test_is_not_converged_when_version_hash_is_absent_entirely(self):
+        """A row with no version_hash key at all is treated the same as an empty one."""
+        self._set_deployments(
+            self.mock_api,
+            live=[{"created_at": "Mon, 01 Jan 2026 12:00:00 GMT", "deleted": False}],
+            sandbox=[{"created_at": "Tue, 02 Jan 2026 12:00:00 GMT", "deleted": False}],
+        )
+        self.project.__dict__.pop("using_simplified_deployments", None)
+
+        self.assertFalse(self.project.using_simplified_deployments)
+
     def test_is_not_converged_without_a_live_deployment(self):
         """Nothing has reached live, so live cannot hold main's version."""
         self._assert_converged(

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -5058,7 +5058,7 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
             "deleted": deleted,
         }
         if tag is not None:
-            deployment["deployment_metadata"] = {"deployment_message": "x", "tag": tag}
+            deployment["deployment_metadata"] = {"tag": tag}
         return deployment
 
     def _set_deployments(self, api: MagicMock, live: list, sandbox: list) -> None:

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -12,7 +12,6 @@ import shutil
 import tempfile
 import unittest
 from copy import deepcopy
-from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import poly.resources.resource_utils as resource_utils
@@ -5044,22 +5043,13 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
         self.assertFalse(project.using_simplified_deployments)
         project.api_handler.get_deployments.assert_not_called()
 
-    def _deployment(
-        self,
-        created_at: str,
-        version_hash: str = "v1",
-        deleted: bool = False,
-        tag: Optional[str] = None,
-    ) -> dict:
+    def _deployment(self, created_at: str, version_hash: str = "v1", deleted: bool = False) -> dict:
         """Build a minimal deployment dict for convergence checks."""
-        deployment = {
+        return {
             "created_at": created_at,
             "version_hash": version_hash,
             "deleted": deleted,
         }
-        if tag is not None:
-            deployment["deployment_metadata"] = {"tag": tag}
-        return deployment
 
     def _set_deployments(self, api: MagicMock, live: list, sandbox: list) -> None:
         """Stub get_deployments to return a different list per client_env."""
@@ -5100,35 +5090,6 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
             live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
             sandbox=[self._deployment("Mon, 01 Jan 2026 10:00:00 GMT", version_hash="old")],
             expected=True,
-        )
-
-    def test_a_tagged_sandbox_deployment_belongs_to_a_branch_not_main(self):
-        """A branch holding a tag deploys to sandbox without moving main."""
-        self._assert_converged(
-            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
-            sandbox=[
-                self._deployment(
-                    "Mon, 01 Jan 2026 13:00:00 GMT", version_hash="branch", tag="internal"
-                )
-            ],
-            expected=True,
-        )
-
-    def test_an_untagged_sandbox_deployment_still_counts_behind_a_tagged_one(self):
-        """Filtering tagged deployments must not hide main's own sandbox deploys.
-
-        The newest sandbox deployment belongs to a branch, but main deployed the
-        one behind it and live has not caught up.
-        """
-        self._assert_converged(
-            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
-            sandbox=[
-                self._deployment(
-                    "Wed, 03 Jan 2026 12:00:00 GMT", version_hash="branch", tag="internal"
-                ),
-                self._deployment("Tue, 02 Jan 2026 12:00:00 GMT", version_hash="def"),
-            ],
-            expected=False,
         )
 
     def test_converges_when_no_deployments_exist_in_either_environment(self):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -12,6 +12,7 @@ import shutil
 import tempfile
 import unittest
 from copy import deepcopy
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import poly.resources.resource_utils as resource_utils
@@ -2060,7 +2061,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             {},
         )
 
-        self.assertEqual(push_changes.main.updated[Variant], {"VARIANTS-production": renamed_variant})
+        self.assertEqual(
+            push_changes.main.updated[Variant], {"VARIANTS-production": renamed_variant}
+        )
 
 
 class PushProjectTest(unittest.TestCase):
@@ -5041,9 +5044,22 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
         self.assertFalse(project.using_simplified_deployments)
         project.api_handler.get_deployments.assert_not_called()
 
-    def _deployment(self, created_at: str, deleted: bool = False) -> dict:
+    def _deployment(
+        self,
+        created_at: str,
+        version_hash: str = "v1",
+        deleted: bool = False,
+        tag: Optional[str] = None,
+    ) -> dict:
         """Build a minimal deployment dict for convergence checks."""
-        return {"created_at": created_at, "deleted": deleted}
+        deployment = {
+            "created_at": created_at,
+            "version_hash": version_hash,
+            "deleted": deleted,
+        }
+        if tag is not None:
+            deployment["deployment_metadata"] = {"tag": tag}
+        return deployment
 
     def _set_deployments(self, api: MagicMock, live: list, sandbox: list) -> None:
         """Stub get_deployments to return a different list per client_env."""
@@ -5051,44 +5067,88 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
             lambda *args, **kwargs: live if kwargs["client_env"] == "live" else sandbox
         )
 
-    def test_converges_when_no_deployments_exist_in_either_environment(self):
-        """With no deployments anywhere, there's nothing for live to lag behind."""
-        self._set_deployments(self.mock_api, live=[], sandbox=[])
+    def _assert_converged(self, live: list, sandbox: list, expected: bool) -> None:
+        self._set_deployments(self.mock_api, live=live, sandbox=sandbox)
+        self.project.__dict__.pop("using_simplified_deployments", None)
 
-        self.assertTrue(self.project.using_simplified_deployments)
+        self.assertEqual(self.project.using_simplified_deployments, expected)
 
-    def test_convergence_depends_on_relative_head_timestamps(self):
-        """Live is converged once its head is at least as new as sandbox's."""
-        earlier, later = "Mon, 01 Jan 2026 10:00:00 GMT", "Mon, 01 Jan 2026 12:00:00 GMT"
-        cases = {
-            "live newer": ((later, earlier), True),
-            "equal": ((later, later), True),
-            "live older": ((earlier, later), False),
-            "only live has deployments": ((earlier, None), True),
-            "only sandbox has deployments": ((None, earlier), False),
-        }
-        for name, ((live_time, sandbox_time), expected) in cases.items():
-            with self.subTest(name):
-                live = [self._deployment(live_time)] if live_time else []
-                sandbox = [self._deployment(sandbox_time)] if sandbox_time else []
-                self._set_deployments(self.mock_api, live=live, sandbox=sandbox)
-                self.project.__dict__.pop("using_simplified_deployments", None)
+    def test_a_sandbox_mirror_of_live_is_converged(self):
+        """A publish to live is mirrored into sandbox moments later.
 
-                self.assertEqual(self.project.using_simplified_deployments, expected)
-
-    def test_skips_deleted_deployments_to_find_the_head(self):
-        """A deleted deployment at the top of the list is not treated as the head."""
-        self._set_deployments(
-            self.mock_api,
-            live=[
-                self._deployment("Mon, 01 Jan 2026 14:00:00 GMT", deleted=True),
-                self._deployment("Mon, 01 Jan 2026 10:00:00 GMT"),
-            ],
-            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT")],
+        The mirror is newer but holds the same version, so the project is
+        converged. Comparing timestamps instead of versions would report this
+        routine case as diverged and drop the project out of the model.
+        """
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:09 GMT", version_hash="abc")],
+            expected=True,
         )
 
-        # The live head (10:00, ignoring the deleted 14:00 entry) is older than sandbox's (12:00).
-        self.assertFalse(self.project.using_simplified_deployments)
+    def test_a_sandbox_deployment_of_its_own_is_not_converged(self):
+        """A sandbox deployment holding a different version means main has moved."""
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 13:00:00 GMT", version_hash="def")],
+            expected=False,
+        )
+
+    def test_an_older_sandbox_deployment_does_not_affect_convergence(self):
+        """Only the newest deployment main owns is compared against live."""
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 10:00:00 GMT", version_hash="old")],
+            expected=True,
+        )
+
+    def test_a_tagged_sandbox_deployment_belongs_to_a_branch_not_main(self):
+        """A branch holding a tag deploys to sandbox without moving main."""
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[
+                self._deployment(
+                    "Mon, 01 Jan 2026 13:00:00 GMT", version_hash="branch", tag="internal"
+                )
+            ],
+            expected=True,
+        )
+
+    def test_converges_when_no_deployments_exist_in_either_environment(self):
+        """With no deployments anywhere there is no version to disagree on."""
+        self._assert_converged(live=[], sandbox=[], expected=True)
+
+    def test_is_not_converged_without_a_live_deployment(self):
+        """Nothing has reached live, so live cannot hold main's version."""
+        self._assert_converged(
+            live=[],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT")],
+            expected=False,
+        )
+
+    def test_skips_deleted_deployments_to_find_the_head(self):
+        """A deleted deployment is not treated as the head of its environment."""
+        self._assert_converged(
+            live=[
+                self._deployment(
+                    "Mon, 01 Jan 2026 14:00:00 GMT", version_hash="deleted", deleted=True
+                ),
+                self._deployment("Mon, 01 Jan 2026 10:00:00 GMT", version_hash="abc"),
+            ],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            expected=True,
+        )
+
+    def test_head_does_not_depend_on_response_ordering(self):
+        """The newest deployment is found by date, not by list position."""
+        self._assert_converged(
+            live=[
+                self._deployment("Mon, 01 Jan 2026 10:00:00 GMT", version_hash="old"),
+                self._deployment("Mon, 01 Jan 2026 14:00:00 GMT", version_hash="abc"),
+            ],
+            sandbox=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="mid")],
+            expected=True,
+        )
 
 
 class DeploymentModePropertyTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -12,6 +12,7 @@ import shutil
 import tempfile
 import unittest
 from copy import deepcopy
+from typing import Optional
 from unittest.mock import MagicMock, patch
 
 import poly.resources.resource_utils as resource_utils
@@ -5043,13 +5044,22 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
         self.assertFalse(project.using_simplified_deployments)
         project.api_handler.get_deployments.assert_not_called()
 
-    def _deployment(self, created_at: str, version_hash: str = "v1", deleted: bool = False) -> dict:
+    def _deployment(
+        self,
+        created_at: str,
+        version_hash: str = "v1",
+        deleted: bool = False,
+        tag: Optional[str] = None,
+    ) -> dict:
         """Build a minimal deployment dict for convergence checks."""
-        return {
+        deployment = {
             "created_at": created_at,
             "version_hash": version_hash,
             "deleted": deleted,
         }
+        if tag is not None:
+            deployment["deployment_metadata"] = {"deployment_message": "x", "tag": tag}
+        return deployment
 
     def _set_deployments(self, api: MagicMock, live: list, sandbox: list) -> None:
         """Stub get_deployments to return a different list per client_env."""
@@ -5095,6 +5105,53 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
     def test_converges_when_no_deployments_exist_in_either_environment(self):
         """With no deployments anywhere there is no version to disagree on."""
         self._assert_converged(live=[], sandbox=[], expected=True)
+
+    def test_a_tagged_sandbox_deployment_proves_simplified_deployments(self):
+        """Tagging a branch deploys it to sandbox, which only simplified allows.
+
+        Its version is the branch's, not main's, so the comparison below would
+        otherwise read it as diverged.
+        """
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[
+                self._deployment(
+                    "Tue, 02 Jan 2026 12:00:00 GMT", version_hash="branch", tag="internal"
+                )
+            ],
+            expected=True,
+        )
+
+    def test_a_tagged_deployment_does_not_override_the_flag(self):
+        """The rollout flag is still the first condition."""
+        project = self._build_project(flag_value=False)
+        self._set_deployments(
+            project.api_handler,
+            live=[],
+            sandbox=[self._deployment("Tue, 02 Jan 2026 12:00:00 GMT", tag="internal")],
+        )
+
+        self.assertFalse(project.using_simplified_deployments)
+
+    def test_a_deleted_tagged_deployment_does_not_prove_anything(self):
+        """Removing the tag soft-deletes its deployment.
+
+        The untagged sandbox deployment alongside it holds main's version, and
+        live has not caught up — so the tag must not short-circuit to converged.
+        """
+        self._assert_converged(
+            live=[self._deployment("Mon, 01 Jan 2026 12:00:00 GMT", version_hash="abc")],
+            sandbox=[
+                self._deployment(
+                    "Wed, 03 Jan 2026 12:00:00 GMT",
+                    version_hash="branch",
+                    tag="internal",
+                    deleted=True,
+                ),
+                self._deployment("Tue, 02 Jan 2026 12:00:00 GMT", version_hash="def"),
+            ],
+            expected=False,
+        )
 
     def test_is_not_converged_when_a_version_hash_is_missing(self):
         """Two unknown versions are not a match.


### PR DESCRIPTION
## Summary

`using_simplified_deployments` decides convergence by comparing deployment timestamps, which reports every converged project as unconverged. It now compares version hashes, and treats a tagged sandbox deployment as proof on its own.

## Motivation

The comment states the rule: *"A project is converged if the main == live"*. The code compares timestamps — newest live vs newest sandbox.

`main` has no environment of its own. Its deploys land in sandbox before migration and in live after, so its version is the newest across both.

Two kinds of sandbox deployment sit newer than live:

- the mirror written after each live publish, holding live's version
- a tagged branch deployment, holding that branch's version

A project has therefore migrated if any sandbox deployment carries the tag, or if live and main hold the same version hash.

## Changes

- Compare the newest live deployment's `version_hash` against main's newest deployment's, instead of timestamps.
- Return converged when a sandbox deployment carries a tag. The rollout flag is still checked first, and a soft-deleted tagged deployment doesn't count.
- Require a non-empty hash on both sides. Comparing directly made two absent hashes equal, and draft deploys record an empty hash.
- Find each head by `created_at` rather than assuming the API returns newest first.
- Convergence extracted into `_has_converged`.

## Test strategy

- [x] Added/updated unit tests
- [x] Tested against a live Agent Studio project

Convergence cases: a sandbox mirror of live, a sandbox deployment holding its own version, an older sandbox deployment, a tagged deployment, a tagged deployment with the flag off, a soft-deleted tagged deployment, no deployments at all, no live deployment, a missing or empty hash, a deleted head, and unordered API responses.

Verified against two real projects: a converged one now reports `True` where it reported `False`; an unconverged one still reports `False`.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)

1555 passed; two pre-existing `posthog_test.py` failures also fail on unmodified `main`.

Note this changes behaviour: affected projects will start targeting `live`. Intended, but real.
