### PR TITLE
fix: read feature flags from the region's PostHog project

### DIFF
--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1539,6 +1539,7 @@ class AgentStudioInterface:
         identity: Optional[str] = None,
         region: Optional[str] = None,
         project_id: Optional[str] = None,
+        account_id: Optional[str] = None,
         default: bool = False,
     ) -> bool:
         """Check if a feature flag is enabled for a given identity.
@@ -1548,6 +1549,7 @@ class AgentStudioInterface:
             identity (Optional[str]): The unique identifier for the user or entity.
             region (Optional[str]): The region name for grouping.
             project_id (Optional[str]): The project ID for grouping.
+            account_id (Optional[str]): The account ID, for account-scoped conditions.
             default (bool): The default value to return if the flag cannot be evaluated.
 
         Returns:
@@ -1558,4 +1560,5 @@ class AgentStudioInterface:
             key=key,
             default=default,
             project_id=project_id,
+            account_id=account_id,
         )

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -8,10 +8,8 @@ from typing import TYPE_CHECKING
 
 POSTHOG_HOST = "https://eu.i.posthog.com"
 
-# One PostHog project per environment, matching what the platform services are
-# deployed with. Reading a flag from the wrong project returns that project's
-# rollout rather than the region's — and the non-prod project has rollouts at
-# 100%, so every flag reads as enabled.
+# Public client-side project keys, safe to commit. One PostHog project per
+# environment.
 POSTHOG_KEY_PROD = "phc_oBh3uJGQWyQkWdoxrTAEqghjkHSgjd5FGEn5vM6CyXBp"
 POSTHOG_KEY_NON_PROD = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
 NON_PROD_REGIONS = frozenset({"dev", "staging"})
@@ -30,9 +28,7 @@ region_to_posthog_cluster = {
     "dev": "apollo",
 }
 
-# Cluster environment, matching what the platform services send as a group
-# property. Anything unlisted is production, so a new region is never reported
-# as a non-production one.
+# Anything unlisted is production.
 region_to_cluster_env = {
     "dev": "dev",
     "staging": "staging",

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -7,7 +7,15 @@ import logging
 from typing import TYPE_CHECKING
 
 POSTHOG_HOST = "https://eu.i.posthog.com"
-POSTHOG_KEY = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
+
+# One PostHog project per environment, matching what the platform services are
+# deployed with. Reading a flag from the wrong project returns that project's
+# rollout rather than the region's — and the non-prod project has rollouts at
+# 100%, so every flag reads as enabled.
+POSTHOG_KEY_PROD = "phc_oBh3uJGQWyQkWdoxrTAEqghjkHSgjd5FGEn5vM6CyXBp"
+POSTHOG_KEY_NON_PROD = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
+NON_PROD_REGIONS = frozenset({"dev", "staging"})
+
 FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
 logger = logging.getLogger(__name__)
 
@@ -15,31 +23,48 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from posthog import Posthog
 
-_client: Posthog | None = None
+# Keyed by project api key: a session can touch more than one region.
+_clients: dict[str, Posthog] = {}
 
 region_to_posthog_cluster = {
     "dev": "apollo",
 }
 
+# Cluster environment, matching what the platform services send as a group
+# property. Anything unlisted is production, so a new region is never reported
+# as a non-production one.
+region_to_cluster_env = {
+    "dev": "dev",
+    "staging": "staging",
+}
 
-def get_posthog_client() -> Posthog:
-    """Get a Posthog client instance.
+
+def posthog_key_for_region(region: str) -> str:
+    """The PostHog project a region's flags live in."""
+    return POSTHOG_KEY_NON_PROD if (region or "").lower() in NON_PROD_REGIONS else POSTHOG_KEY_PROD
+
+
+def get_posthog_client(region: str) -> Posthog:
+    """Get a Posthog client for the region's PostHog project.
+
+    Args:
+        region (str): The region whose flags are being read.
 
     Returns:
-        A Posthog client instance.
+        A Posthog client instance, cached per PostHog project.
     """
     from posthog import Posthog
 
-    global _client
-
-    if _client is not None:
-        return _client
-    _client = Posthog(
-        project_api_key=POSTHOG_KEY,
-        host=POSTHOG_HOST,
-        feature_flags_request_timeout_seconds=FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS,
-    )
-    return _client
+    project_api_key = posthog_key_for_region(region)
+    client = _clients.get(project_api_key)
+    if client is None:
+        client = Posthog(
+            project_api_key=project_api_key,
+            host=POSTHOG_HOST,
+            feature_flags_request_timeout_seconds=FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS,
+        )
+        _clients[project_api_key] = client
+    return client
 
 
 def get_user_identity() -> str:
@@ -63,33 +88,51 @@ class PosthogHandler:
         *,
         default: bool,
         project_id: str | None = None,
+        account_id: str | None = None,
     ) -> bool:
         """Evaluate a boolean feature flag against PostHog.
 
         Args:
-            region: The region the user is in, used to determine the PostHog cluster.
+            region: The region the user is in, used to determine the PostHog
+                project and cluster.
             key: The PostHog feature flag key.
             default: Returned whenever the flag cannot be evaluated. Pick the
                 safe state for the gated code path.
-            project_id: The project ID (`project` group key). Workspace
-                targeting goes through the `project` group — the workspace id
-                lives on it as a group property in PostHog.
+            project_id: The project ID. Namespaced by cluster to form the
+                `project` group key, because project ids are minted per-cluster
+                and several clusters share one PostHog project.
+            account_id: The account ID, sent as a group property so
+                account-scoped conditions can match. Omitted when unknown
+                rather than sent empty, which would fail an exact condition.
 
         Returns:
             The flag value, or `default` if it cannot be evaluated.
         """
         try:
-            client = get_posthog_client()
+            client = get_posthog_client(region)
             if not client:
                 return default
 
-            groups = {"cluster": region_to_posthog_cluster.get(region, region)}
+            cluster = region_to_posthog_cluster.get(region, region)
+            env = region_to_cluster_env.get(region, "prod")
+
+            groups = {"cluster": cluster}
+            group_properties = {"cluster": {"cluster": cluster, "env": env}}
             if project_id:
-                groups["project"] = project_id
+                groups["project"] = f"{cluster}/{project_id}"
+                group_properties["project"] = {
+                    "project_id": project_id,
+                    "cluster": cluster,
+                    "env": env,
+                }
+                if account_id:
+                    group_properties["project"]["account_id"] = account_id
+
             result = client.feature_enabled(
                 key,
                 distinct_id=get_user_identity(),
                 groups=groups,
+                group_properties=group_properties,
                 send_feature_flag_events=False,
             )
         except Exception as exc:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -3942,6 +3942,7 @@ class AgentStudioProject:
             key="deployment-simplification",
             region=self.region,
             project_id=self.project_id,
+            account_id=self.account_id,
             default=False,
         )
         if not flag_enabled:

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -77,7 +77,13 @@ class IsFeatureEnabledTest(unittest.TestCase):
         self.assertTrue(result)
 
     def test_passes_key_identity_and_project_group(self):
-        """The flag key, distinct_id and project group are forwarded to PostHog."""
+        """The flag key, distinct_id and project group are forwarded to PostHog.
+
+        The project group key is namespaced by cluster: project ids are minted
+        per-cluster, and several clusters share one PostHog project, so a bare
+        id matches no group. Conditions match on the properties, so those are
+        sent too.
+        """
         self.client.feature_enabled.return_value = True
 
         PosthogHandler.is_feature_enabled(
@@ -85,14 +91,49 @@ class IsFeatureEnabledTest(unittest.TestCase):
             key="deployment-simplification",
             default=False,
             project_id="proj-1",
+            account_id="acct-1",
         )
 
         self.client.feature_enabled.assert_called_once_with(
             "deployment-simplification",
             distinct_id="test-user",
-            groups={"cluster": "studio", "project": "proj-1"},
+            groups={"cluster": "studio", "project": "studio/proj-1"},
+            group_properties={
+                "cluster": {"cluster": "studio", "env": "prod"},
+                "project": {
+                    "project_id": "proj-1",
+                    "cluster": "studio",
+                    "env": "prod",
+                    "account_id": "acct-1",
+                },
+            },
             send_feature_flag_events=False,
         )
+
+    def test_omits_account_id_when_unknown(self):
+        """An absent account leaves the stored property alone; an empty one fails
+        an exact condition."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(
+            region="studio", key="some-flag", default=False, project_id="proj-1"
+        )
+
+        project_properties = self.client.feature_enabled.call_args.kwargs[
+            "group_properties"
+        ]["project"]
+        self.assertNotIn("account_id", project_properties)
+
+    def test_non_production_regions_send_their_own_env(self):
+        """The env property separates the two deployments sharing a cluster key."""
+        self.client.feature_enabled.return_value = True
+
+        PosthogHandler.is_feature_enabled(
+            region="staging", key="some-flag", default=False, project_id="proj-1"
+        )
+
+        properties = self.client.feature_enabled.call_args.kwargs["group_properties"]
+        self.assertEqual(properties["cluster"]["env"], "staging")
 
     def test_omits_project_group_when_no_project_id(self):
         """Without a project id only the cluster group is sent."""
@@ -118,29 +159,86 @@ class IsFeatureEnabledTest(unittest.TestCase):
                 )
 
 
+class PosthogKeyForRegionTest(unittest.TestCase):
+    """Tests for which PostHog project a region's flags are read from."""
+
+    def test_production_regions_use_the_production_project(self):
+        for region in ("us-1", "uk-1", "euw-1"):
+            with self.subTest(region=region):
+                self.assertEqual(
+                    posthog_module.posthog_key_for_region(region),
+                    posthog_module.POSTHOG_KEY_PROD,
+                )
+
+    def test_non_production_regions_use_the_non_production_project(self):
+        for region in ("dev", "staging"):
+            with self.subTest(region=region):
+                self.assertEqual(
+                    posthog_module.posthog_key_for_region(region),
+                    posthog_module.POSTHOG_KEY_NON_PROD,
+                )
+
+    def test_region_is_matched_case_insensitively(self):
+        self.assertEqual(
+            posthog_module.posthog_key_for_region("DEV"),
+            posthog_module.POSTHOG_KEY_NON_PROD,
+        )
+
+    def test_an_unknown_region_uses_the_production_project(self):
+        """Non-prod is the exception; anything else reads production.
+
+        The non-production project has rollouts at 100%, so defaulting there
+        would report every flag as enabled.
+        """
+        for region in ("", "studio", "something-new"):
+            with self.subTest(region=region):
+                self.assertEqual(
+                    posthog_module.posthog_key_for_region(region),
+                    posthog_module.POSTHOG_KEY_PROD,
+                )
+
+
 class GetPosthogClientTest(unittest.TestCase):
-    """Tests for the module-level PostHog client singleton."""
+    """Tests for the per-project PostHog client cache."""
 
     def setUp(self):
-        self.original_client = posthog_module._client
-        posthog_module._client = None
+        self.original_clients = dict(posthog_module._clients)
+        posthog_module._clients.clear()
 
     def tearDown(self):
-        posthog_module._client = self.original_client
+        posthog_module._clients.clear()
+        posthog_module._clients.update(self.original_clients)
 
-    def test_client_is_constructed_once_and_reused(self):
-        """The client is built on first use and cached for subsequent calls."""
+    def test_client_is_constructed_once_per_project_and_reused(self):
+        """One client per PostHog project, built on first use."""
         with patch("posthog.Posthog") as mock_posthog_cls:
-            first = get_posthog_client()
-            second = get_posthog_client()
+            first = get_posthog_client("us-1")
+            second = get_posthog_client("uk-1")
 
         self.assertIs(first, second)
         mock_posthog_cls.assert_called_once()
 
+    def test_regions_in_different_projects_get_different_clients(self):
+        """A session touching both environments must not share one client."""
+        with patch("posthog.Posthog", side_effect=lambda **kwargs: MagicMock()):
+            production = get_posthog_client("us-1")
+            non_production = get_posthog_client("dev")
+
+        self.assertIsNot(production, non_production)
+
+    def test_client_is_built_with_the_region_project_key(self):
+        with patch("posthog.Posthog") as mock_posthog_cls:
+            get_posthog_client("us-1")
+
+        self.assertEqual(
+            mock_posthog_cls.call_args.kwargs["project_api_key"],
+            posthog_module.POSTHOG_KEY_PROD,
+        )
+
     def test_client_is_configured_with_a_request_timeout(self):
         """A feature-flag read is bounded so the CLI cannot hang on PostHog."""
         with patch("posthog.Posthog") as mock_posthog_cls:
-            get_posthog_client()
+            get_posthog_client("us-1")
 
         timeout = mock_posthog_cls.call_args.kwargs["feature_flags_request_timeout_seconds"]
         self.assertEqual(timeout, posthog_module.FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS)

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -5012,6 +5012,7 @@ class UsingSimplifiedDeploymentsTest(unittest.TestCase):
             key="deployment-simplification",
             region=self.project.region,
             project_id=self.project.project_id,
+            account_id=self.project.account_id,
             default=False,
         )
 


### PR DESCRIPTION
## Summary

Every feature-flag read went to the non-production PostHog project, whose rollouts sit at 100%, so every flag reported as enabled. The client is now built per region's project, and the project group key and properties match what the platform services send.

## Motivation

`deployment-simplification` returned `true` for every input — including project ids that don't exist:

```
                            before   after
a migrated project          True     True
a non-migrated project      True     False
a project id that does      True     False
not exist
```

Two separate causes, both needed fixing:

- **Wrong PostHog project.** One key was hardcoded, the non-production one. There are two: `dev`/`staging`/`apollo` share one, the production clusters share the other.
- **Wrong group key.** Project ids are minted per-cluster and several clusters share one PostHog project, so the `project` group key is namespaced as `<cluster>/<project_id>`. A bare id matches no group. Release conditions match on group *properties*, which weren't sent at all.

## Changes

- Select the PostHog project by region; cache one client per project key, since a session can touch more than one region. An unlisted region is treated as production, so a new region is never reported as non-production.
- Namespace the `project` group key by cluster.
- Send `group_properties` for both groups, including `account_id` so account-scoped conditions can match. `account_id` is omitted when unknown rather than sent empty, which would fail an exact condition.
- Send the cluster `env` property, which is what separates two deployments sharing a cluster key.

## Test strategy

- [x] Added/updated unit tests
- [x] Tested against a live Agent Studio project

Payload assertions for the group key, properties, an omitted account, and a non-production env. Region-to-project mapping covered for production, non-production, mixed casing and unknown regions.

Verified against real projects: `deployment-simplification` now answers `true` for a migrated project and `false` for one that isn't, and `false` for an invented project id.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)

1565 passed, none failing. `get_posthog_client()` now takes a region — it has one caller in the package.

Note this changes behaviour wherever a flag gates something: flags that read as enabled everywhere will start resolving per project. That is the point, but it is a real change.
