### PR TITLE
feat: proactively match parent branch ids on push

### DIFF
--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -190,7 +190,7 @@ class AgentStudioCLI:
                     command.run(args)
                     return
         except Exception as e:
-            if hasattr(args, "json") and args.json:
+            if getattr(args, "json", False) or getattr(args, "output_json_commands", False):
                 json_print({"success": False, "error": str(e), "traceback": traceback.format_exc()})
                 sys.exit(1)
             else:

--- a/src/poly/cli_commands/shared.py
+++ b/src/poly/cli_commands/shared.py
@@ -173,10 +173,16 @@ def parse_from_projection_json(
     from_projection: Optional[str],
     *,
     json_errors: bool,
+    flag_name: str = "--from-projection",
 ) -> Optional[dict[str, Any]]:
-    """Parse ``--from-projection`` CLI value into a projection dict, or exit on failure.
+    """Parse a projection-carrying CLI value into a projection dict, or exit on failure.
 
     If the value is ``-`` (after stripping), JSON is read from stdin until EOF.
+
+    Args:
+        from_projection (Optional[str]): The raw CLI value; None/empty returns None.
+        json_errors (bool): Emit failures as JSON instead of console errors.
+        flag_name (str): The flag the value came from, used in error messages.
     """
     from poly.output.console import error
 
@@ -190,14 +196,14 @@ def parse_from_projection_json(
         if isinstance(parsed, dict) and "projection" in parsed:
             parsed = parsed["projection"]
     except json.JSONDecodeError as e:
-        msg = f"Invalid JSON in --from-projection: {e}"
+        msg = f"Invalid JSON in {flag_name}: {e}"
         if json_errors:
             json_print({"success": False, "error": msg})
         else:
             error(msg)
         sys.exit(1)
     if not isinstance(parsed, dict):
-        msg = "--from-projection must be a JSON object (dictionary)."
+        msg = f"{flag_name} must be a JSON object (dictionary)."
         if json_errors:
             json_print({"success": False, "error": msg})
         else:

--- a/src/poly/cli_commands/sync.py
+++ b/src/poly/cli_commands/sync.py
@@ -327,6 +327,13 @@ class PushCommand(BaseCommand):
             default=None,
         )
         push_parser.add_argument(
+            "--parent-projection",
+            type=str,
+            metavar="JSON|-",
+            help=SUPPRESS,
+            default=None,
+        )
+        push_parser.add_argument(
             "--output-json-commands",
             action="store_true",
             help=SUPPRESS,
@@ -361,6 +368,7 @@ class PushCommand(BaseCommand):
             args.dry_run,
             args.format,
             args.from_projection,
+            parent_projection=args.parent_projection,
             output_json=args.json,
             output_commands=args.output_json_commands,
             include_rtc=args.include_rtc,
@@ -376,6 +384,7 @@ class PushCommand(BaseCommand):
         dry_run: bool = False,
         format: bool = False,
         from_projection: str = None,
+        parent_projection: str = None,
         output_json: bool = False,
         output_commands: bool = False,
         include_rtc: bool = False,
@@ -390,9 +399,23 @@ class PushCommand(BaseCommand):
                 f"Pushing local changes for [bold]{project.account_id}/{project.project_id}[/bold]..."
             )
 
+        json_errors = output_json or output_commands
+        if (from_projection or "").strip() == "-" and (parent_projection or "").strip() == "-":
+            msg = "Only one of --from-projection and --parent-projection may read from stdin."
+            if json_errors:
+                json_print({"success": False, "error": msg})
+            else:
+                error(msg)
+            sys.exit(1)
+
         projection_json = parse_from_projection_json(
             from_projection,
-            json_errors=output_json or output_commands,
+            json_errors=json_errors,
+        )
+        parent_projection_json = parse_from_projection_json(
+            parent_projection,
+            json_errors=json_errors,
+            flag_name="--parent-projection",
         )
 
         original_branch_id = project.branch_id
@@ -402,6 +425,7 @@ class PushCommand(BaseCommand):
             dry_run=dry_run,
             format=format,
             projection_json=projection_json,
+            parent_projection_json=parent_projection_json,
         )
         new_branch_name = None
         if original_branch_id != project.branch_id:

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -24,6 +24,7 @@ import poly.utils as utils
 from poly.handlers.interface import (
     AgentStudioInterface,
 )
+from poly.handlers.sdk import SourcererAPIError
 from poly.migration_utils import (
     MigrationFlag,
     get_all_migration_flags,
@@ -1278,7 +1279,10 @@ class AgentStudioProject:
         if parent_projection_json is not None:
             parent_resources, _ = load_resources_from_projection(parent_projection_json)
         elif not dry_run or os.environ.get("POLY_ADK_SYNC_PARENT_IDS_TEST"):
-            parent_resources = self._fetch_parent_resources()
+            try:
+                parent_resources = self._fetch_parent_resources()
+            except Exception as e:
+                raise SourcererAPIError("Failed to fetch parent resources") from e
         parent_branch_paths_to_resource = self._resources_by_absolute_path(parent_resources)
 
         # Push Algorithm

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -1224,6 +1224,7 @@ class AgentStudioProject:
         dry_run=False,
         format=False,
         projection_json: Optional[dict[str, Any]] = None,
+        parent_projection_json: Optional[dict[str, Any]] = None,
     ) -> tuple[bool, str, list[Message]]:
         """Push the project configuration to the Agent Studio Interactor.
 
@@ -1234,6 +1235,10 @@ class AgentStudioProject:
             format (bool): If True, format the resource before saving.
             projection_json (dict[str, Any]): A dictionary containing the projection
                 If provided, the projection will be used instead of fetching it from the API.
+            parent_projection_json (Optional[dict[str, Any]]): The parent branch's
+                projection. When provided, parent ids are adopted from it entirely
+                offline (also on dry runs); an empty dict means "no parent". When
+                None, the parent branch is fetched from the platform instead.
 
         Returns:
             Tuple[bool, str, list[Message]]:
@@ -1265,11 +1270,16 @@ class AgentStudioProject:
 
         # New local resources that path-match a parent branch resource adopt the
         # parent's ids at mint time, so pushing does not mint ids that diverge from
-        # resources the parent already has. Dry runs skip the parent fetch unless the
-        # test env var forces it (to inspect the adopted ids without pushing).
-        parent_branch_paths_to_resource: dict[str, Resource] = {}
-        if not dry_run or os.environ.get("POLY_ADK_SYNC_PARENT_IDS_TEST"):
-            parent_branch_paths_to_resource = self._fetch_parent_resources_by_path()
+        # resources the parent already has. A supplied parent projection is used
+        # entirely offline (also on dry runs); otherwise dry runs skip the parent
+        # fetch unless the test env var forces it (to inspect the adopted ids
+        # without pushing).
+        parent_resources: ResourceMap = {}
+        if parent_projection_json is not None:
+            parent_resources, _ = load_resources_from_projection(parent_projection_json)
+        elif not dry_run or os.environ.get("POLY_ADK_SYNC_PARENT_IDS_TEST"):
+            parent_resources = self._fetch_parent_resources()
+        parent_branch_paths_to_resource = self._resources_by_absolute_path(parent_resources)
 
         # Push Algorithm
         # 1. Get new/kept/deleted resources
@@ -3105,13 +3115,13 @@ class AgentStudioProject:
             self.switch_branch("main", force=True)
         return True
 
-    def _fetch_parent_resources_by_path(self) -> dict[str, Resource]:
-        """Fetch the parent branch's resources, keyed by absolute file path.
+    def _fetch_parent_resources(self) -> ResourceMap:
+        """Fetch the parent branch's resources from the platform.
 
         Returns:
-            dict[str, Resource]: The parent branch's resources by path. Empty when on
-                main, when the local branch no longer exists remotely, or when the
-                branch has no parent.
+            ResourceMap: The parent branch's resources. Empty when on main, when the
+                local branch no longer exists remotely, or when the branch has no
+                parent.
         """
         current_branch, branches = self.get_branches()
         if current_branch is None or current_branch == "main":
@@ -3125,7 +3135,17 @@ class AgentStudioProject:
             self.region, self.account_id, self.project_id, parent_branch_id
         )
         resources, _, _ = branch_api_handler.pull_resources()
+        return resources
 
+    def _resources_by_absolute_path(self, resources: ResourceMap) -> dict[str, Resource]:
+        """Key a ResourceMap's resources by absolute file path.
+
+        Args:
+            resources (ResourceMap): Resources grouped by type and id.
+
+        Returns:
+            dict[str, Resource]: The same resources keyed by absolute file path.
+        """
         return {
             os.path.join(self.root_path, resource.file_path): resource
             for resources_dict in resources.values()
@@ -3190,22 +3210,6 @@ class AgentStudioProject:
         Returns:
             bool: True if the sync was successful, False otherwise
         """
-        if parent_name is None:
-            branches = self.api_handler.get_branches()
-            branch_meta = {meta["branchId"]: meta for meta in branches.values()}
-            current_branch_meta = branch_meta.get(self.branch_id)
-            if not current_branch_meta:
-                raise ValueError(f"Branch {self.branch_id} does not exist.")
-            parent_branch_id = current_branch_meta.get("parentBranchId")
-            parent_branch_meta = branch_meta.get(parent_branch_id) or {}
-            parent_name = parent_branch_meta.get("name")
-            if not parent_name:
-                logger.warning(
-                    f"Could not resolve parent branch for '{self.branch_id}' "
-                    f"(parentBranchId={parent_branch_id!r}); defaulting to 'main'."
-                )
-                parent_name = "main"
-
         if self.branch_id == "main":
             raise ValueError("Cannot sync ids while on main branch.")
 
@@ -3215,7 +3219,15 @@ class AgentStudioProject:
         # Parent slim mappings describe what the parent withheld; local files resolve
         # their references against this branch's own slim mappings, so they are not
         # needed here.
-        parent_resources, _ = self.get_remote_resources_by_name(parent_name)
+        if parent_name is None:
+            parent_resources = self._fetch_parent_resources()
+            if not parent_resources:
+                logger.warning(
+                    f"Could not resolve parent branch for '{self.branch_id}'; defaulting to 'main'."
+                )
+                parent_resources, _ = self.get_remote_resources_by_name("main")
+        else:
+            parent_resources, _ = self.get_remote_resources_by_name(parent_name)
         parent_resource_lookup: dict[str, Resource] = {
             resource.file_path: resource
             for resources_dict in parent_resources.values()

--- a/src/poly/project.py
+++ b/src/poly/project.py
@@ -4,6 +4,7 @@ Copyright PolyAI Limited
 """
 
 import base64
+import copy
 import json
 import logging
 import os
@@ -1262,10 +1263,21 @@ class AgentStudioProject:
                         [],
                     )
 
+        # New local resources that path-match a parent branch resource adopt the
+        # parent's ids at mint time, so pushing does not mint ids that diverge from
+        # resources the parent already has. Dry runs skip the parent fetch unless the
+        # test env var forces it (to inspect the adopted ids without pushing).
+        parent_branch_paths_to_resource: dict[str, Resource] = {}
+        if not dry_run or os.environ.get("POLY_ADK_SYNC_PARENT_IDS_TEST"):
+            parent_branch_paths_to_resource = self._fetch_parent_resources_by_path()
+
         # Push Algorithm
         # 1. Get new/kept/deleted resources
         new_resource_mappings, kept_resource_mappings, deleted_resource_mappings = (
-            self.find_new_kept_deleted(self.discover_local_resources())
+            self.find_new_kept_deleted(
+                self.discover_local_resources(),
+                parent_lookup=parent_branch_paths_to_resource,
+            )
         )
         local_resource_mappings = new_resource_mappings + kept_resource_mappings
         # Slim resources have no file to read - they exist only so that references
@@ -1285,10 +1297,31 @@ class AgentStudioProject:
         # 2. Read all new/kept resources from disk
         new_state: ResourceMap = {}
 
+        new_file_paths = {rm.file_path for rm in new_resource_mappings}
         for resource_mapping in local_resource_mappings:
+            # The parent resource supplies known_* subresource ids (function parameters,
+            # step conditions): new resources take the parent's wholesale, kept resources
+            # only inherit subresources they do not already have by name.
+            parent_resource = parent_branch_paths_to_resource.get(resource_mapping.file_path)
+            if resource_mapping.file_path in new_file_paths:
+                original_resource = parent_resource
+            elif parent_resource is not None:
+                branch_resource = self.resources.get(resource_mapping.resource_type, {}).get(
+                    resource_mapping.resource_id
+                )
+                original_resource = (
+                    self._augment_original_with_parent_subresources(
+                        branch_resource, parent_resource
+                    )
+                    if branch_resource
+                    else None
+                )
+            else:
+                original_resource = None
             local_resource = self.read_local_resource(
                 resource=resource_mapping,
                 resource_mappings=resource_mappings,
+                original_resource=original_resource,
             )
             new_state.setdefault(resource_mapping.resource_type, {})[
                 resource_mapping.resource_id
@@ -2211,6 +2244,7 @@ class AgentStudioProject:
         self,
         discovered_resources: dict[type[Resource], list[str]],
         conflict_files: Optional[list[str]] = None,
+        parent_lookup: Optional[dict[str, Resource]] = None,
     ) -> tuple[
         list[ResourceMapping],
         list[ResourceMapping],
@@ -2221,6 +2255,12 @@ class AgentStudioProject:
         Args:
             discovered_resources (dict[type[Resource], list[str]]): The discovered
                 resources to compare against.
+            conflict_files (Optional[list[str]]): If provided, files whose discovery hits a
+                merge conflict are appended here and that resource type is skipped instead of
+                raising. If None, a MergeConflictError propagates.
+            parent_lookup (Optional[dict[str, Resource]]): Parent branch resources keyed by
+                absolute file path. When provided, a new resource whose file path-matches a
+                parent resource adopts the parent's id at mint time instead of a fresh one.
 
         Returns:
             tuple[
@@ -2232,6 +2272,7 @@ class AgentStudioProject:
                 - Kept resources
                 - Deleted resources
         """
+        parent_lookup = parent_lookup or {}
         deleted_resource_mappings: list[ResourceMapping] = []
         new_resource_mappings: list[ResourceMapping] = []
         kept_resource_mappings: list[ResourceMapping] = []
@@ -2258,12 +2299,15 @@ class AgentStudioProject:
         for flow_id, flow_cfg in self.resources.get(FlowConfig, {}).items():
             flow_paths_to_ids[resource_utils.clean_name(flow_cfg.name)] = flow_id
 
-        # Add to mapping for new flows
+        # Add to mapping for new flows: adopt the parent branch's flow id when the flow
+        # config path-matches a parent resource, otherwise mint a fresh id. Resolving
+        # flows first keeps every composite step id consistent with its flow_id below.
         for flow_path in discovered_resources.get(FlowConfig, []):
             flow_name = resource_utils.get_flow_name_from_path(flow_path)
             if resource_utils.clean_name(flow_name) not in flow_paths_to_ids:
-                flow_paths_to_ids[resource_utils.clean_name(flow_name)] = self.generate_uuid(
-                    FlowConfig
+                parent_flow = parent_lookup.get(flow_path)
+                flow_paths_to_ids[resource_utils.clean_name(flow_name)] = (
+                    parent_flow.resource_id if parent_flow else self.generate_uuid(FlowConfig)
                 )
 
         if not self.file_structure_info:
@@ -2345,17 +2389,31 @@ class AgentStudioProject:
                     )
 
                 else:
-                    # Compute new resource ID
-                    resource_id = self.generate_uuid(resource_type)
-
-                    if resource_type == Document:
-                        resource_id = os.path.basename(file_path).upper()
+                    # Compute new resource ID, adopting the parent branch's id on a
+                    # file path match so the ids never diverge from the parent's.
+                    parent_resource = parent_lookup.get(file_path)
 
                     if resource_type in (FlowStep, FunctionStep):
-                        resource_id = f"{flow_id}_{resource_id}"
-
-                    if resource_type == FlowConfig:
+                        if parent_resource:
+                            # Re-composite the parent's bare step id under the local flow
+                            # id: in a kept flow whose id diverges from the parent's, the
+                            # prefix must still agree with the flow_id that step_id
+                            # derivation strips.
+                            parent_flow_id = getattr(parent_resource, "flow_id", None) or ""
+                            bare_step_id = parent_resource.resource_id.removeprefix(
+                                f"{parent_flow_id}_"
+                            )
+                            resource_id = f"{flow_id}_{bare_step_id}"
+                        else:
+                            resource_id = f"{flow_id}_{self.generate_uuid(resource_type)}"
+                    elif resource_type == FlowConfig:
                         resource_id = flow_id
+                    elif resource_type == Document:
+                        resource_id = os.path.basename(file_path).upper()
+                    elif parent_resource:
+                        resource_id = parent_resource.resource_id
+                    else:
+                        resource_id = self.generate_uuid(resource_type)
 
                     new_resource_mappings.append(
                         ResourceMapping(
@@ -3047,26 +3105,122 @@ class AgentStudioProject:
             self.switch_branch("main", force=True)
         return True
 
+    def _fetch_parent_resources_by_path(self) -> dict[str, Resource]:
+        """Fetch the parent branch's resources, keyed by absolute file path.
+
+        Returns:
+            dict[str, Resource]: The parent branch's resources by path. Empty when on
+                main, when the local branch no longer exists remotely, or when the
+                branch has no parent.
+        """
+        current_branch, branches = self.get_branches()
+        if current_branch is None or current_branch == "main":
+            return {}
+
+        parent_branch_id = branches.get(current_branch, {}).get("parentBranchId")
+        if not parent_branch_id:
+            return {}
+
+        branch_api_handler = AgentStudioInterface(
+            self.region, self.account_id, self.project_id, parent_branch_id
+        )
+        resources, _, _ = branch_api_handler.pull_resources()
+
+        return {
+            os.path.join(self.root_path, resource.file_path): resource
+            for resources_dict in resources.values()
+            for resource in resources_dict.values()
+        }
+
+    def _augment_original_with_parent_subresources(
+        self, branch_resource: Resource, parent_resource: Resource
+    ) -> Resource:
+        """Merge parent-only subresources into a copy of a kept resource.
+
+        Subresources (function parameters, flow step conditions) are matched by name
+        when local files are read, so a subresource added both on the parent branch and
+        locally would otherwise mint a fresh id here and diverge from the parent's. The
+        branch resource wins for every name it already knows; only names the branch does
+        not have inherit the parent's subresource (and therefore its id).
+
+        Args:
+            branch_resource (Resource): This branch's version of the resource.
+            parent_resource (Resource): The parent branch's path-matched version.
+
+        Returns:
+            Resource: A copy of ``branch_resource`` with parent-only subresources
+                appended, or ``branch_resource`` itself when there is nothing to merge.
+        """
+        # Exact-type gates mirror read_local_resource's known_* extraction; note a
+        # FunctionStep is a Function subclass but takes no known_parameters there.
+        if type(branch_resource) is Function and type(parent_resource) is Function:
+            branch_names = {param.name for param in branch_resource.parameters}
+            extra = [
+                param for param in parent_resource.parameters if param.name not in branch_names
+            ]
+            if extra:
+                augmented = copy.copy(branch_resource)
+                augmented.parameters = [*branch_resource.parameters, *extra]
+                return augmented
+        elif type(branch_resource) is FlowStep and type(parent_resource) is FlowStep:
+            branch_names = {cond.name for cond in branch_resource.conditions}
+            extra = [cond for cond in parent_resource.conditions if cond.name not in branch_names]
+            if extra:
+                augmented = copy.copy(branch_resource)
+                augmented.conditions = [*branch_resource.conditions, *extra]
+                return augmented
+        return branch_resource
+
     def sync_ids_with_sandbox(self) -> bool:
-        """Sync ids of resources in sandbox into current branch
+        """Sync ids of resources in sandbox into current branch.
 
         Returns:
             bool: True if the sync was successful, False otherwise
         """
+        return self.sync_ids_with_parent(parent_name="main")
+
+    def sync_ids_with_parent(self, parent_name: Optional[str] = None) -> bool:
+        """Sync ids of resources of the parent branch into the current branch.
+
+        Args:
+            parent_name (Optional[str]): Name of the branch to sync ids from. Defaults
+                to the current branch's parent, falling back to "main" when the parent
+                cannot be resolved.
+
+        Returns:
+            bool: True if the sync was successful, False otherwise
+        """
+        if parent_name is None:
+            branches = self.api_handler.get_branches()
+            branch_meta = {meta["branchId"]: meta for meta in branches.values()}
+            current_branch_meta = branch_meta.get(self.branch_id)
+            if not current_branch_meta:
+                raise ValueError(f"Branch {self.branch_id} does not exist.")
+            parent_branch_id = current_branch_meta.get("parentBranchId")
+            parent_branch_meta = branch_meta.get(parent_branch_id) or {}
+            parent_name = parent_branch_meta.get("name")
+            if not parent_name:
+                logger.warning(
+                    f"Could not resolve parent branch for '{self.branch_id}' "
+                    f"(parentBranchId={parent_branch_id!r}); defaulting to 'main'."
+                )
+                parent_name = "main"
+
         if self.branch_id == "main":
             raise ValueError("Cannot sync ids while on main branch.")
 
         if self.get_diffs():
             raise ValueError("Cannot sync ids due to uncommitted changes.")
 
-        # Sandbox slim mappings describe what main withheld; local files resolve their
-        # references against this branch's own slim mappings, so they are not needed here.
-        sandbox_resources, _ = self.get_remote_resources_by_name("main")
-        # Build lookup by file path -> Resource
-        sandbox_resource_lookup: dict[str, Resource] = {}
-        for resources_dict in sandbox_resources.values():
-            for resource in resources_dict.values():
-                sandbox_resource_lookup[resource.file_path] = resource
+        # Parent slim mappings describe what the parent withheld; local files resolve
+        # their references against this branch's own slim mappings, so they are not
+        # needed here.
+        parent_resources, _ = self.get_remote_resources_by_name(parent_name)
+        parent_resource_lookup: dict[str, Resource] = {
+            resource.file_path: resource
+            for resources_dict in parent_resources.values()
+            for resource in resources_dict.values()
+        }
 
         # 1a. Resolve synced FlowConfig ids first, so flow-scoped resources below can
         # translate their (stale, local) flow_id to the id the flow was synced to.
@@ -3075,29 +3229,29 @@ class AgentStudioProject:
             for resource in resources_dict.values():
                 if not isinstance(resource, FlowConfig):
                     continue
-                sandbox_version = sandbox_resource_lookup.get(resource.file_path)
+                parent_version = parent_resource_lookup.get(resource.file_path)
                 flow_id_translation[resource.resource_id] = (
-                    sandbox_version.resource_id if sandbox_version else resource.resource_id
+                    parent_version.resource_id if parent_version else resource.resource_id
                 )
 
-        # 1b. Build sync resource_mappings: use sandbox id when there is a sandbox match by file_path
+        # 1b. Build sync resource_mappings: use parent id when there is a parent match by file_path
         sync_mappings: list[ResourceMapping] = []
         for resource_type, resources_dict in self.resources.items():
             for resource_id, resource in resources_dict.items():
-                sandbox_version = sandbox_resource_lookup.get(resource.file_path)
+                parent_version = parent_resource_lookup.get(resource.file_path)
                 local_flow_id = getattr(resource, "flow_id", None)
 
                 if isinstance(resource, FlowConfig):
                     mapping_resource_id = (
-                        sandbox_version.resource_id if sandbox_version else resource.resource_id
+                        parent_version.resource_id if parent_version else resource.resource_id
                     )
                     mapping_flow_id = mapping_resource_id
                 else:
                     mapping_flow_id = flow_id_translation.get(local_flow_id, local_flow_id)
-                    if sandbox_version:
-                        mapping_resource_id = sandbox_version.resource_id
+                    if parent_version:
+                        mapping_resource_id = parent_version.resource_id
                     else:
-                        # No sandbox counterpart, so this resource was added on the branch and
+                        # No parent counterpart, so this resource was added on the branch and
                         # its composite `{flow_id}_{step_id}` id still carries the pre-sync flow
                         # id. Re-point it at the synced flow id, otherwise the prefix and flow_id
                         # disagree and references (start_step, child_step) cannot be resolved
@@ -3148,11 +3302,11 @@ class AgentStudioProject:
             relative_file_path = os.path.relpath(mapping.file_path, self.root_path)
             original = branch_by_path.get(relative_file_path)
             branch_resource = original[2] if original else None
-            sandbox_resource = sandbox_resource_lookup.get(relative_file_path, branch_resource)
+            parent_resource = parent_resource_lookup.get(relative_file_path, branch_resource)
             local_resource = self.read_local_resource(
                 resource=mapping,
                 resource_mappings=[*slim_mappings, *sync_mappings],
-                original_resource=sandbox_resource,
+                original_resource=parent_resource,
             )
 
             new_state.setdefault(mapping.resource_type, {})[mapping.resource_id] = local_resource

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -512,7 +512,12 @@ class FlowStep(BaseFlowStep, YamlResource):
                     resource_id=(
                         known_condition.resource_id
                         if known_condition
-                        else f"CONDITION-{uuid.uuid4().hex[:8]}"
+                        else utils.generate_subresource_id(
+                            "CONDITION",
+                            flow_name or "",
+                            yaml_dict.get("name") or "",
+                            condition_name or "",
+                        )
                     ),
                     position=known_condition.position if known_condition else None,
                     ingress=known_condition.ingress if known_condition else None,

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -8,7 +8,6 @@ import logging
 import os
 import re
 import typing as ty
-import uuid
 from dataclasses import dataclass, field
 from enum import Enum
 from functools import cached_property, lru_cache
@@ -184,7 +183,8 @@ class LatencyControl(SubResource):
         delay_responses = DelayResponsesUpdate(
             delay_responses=[
                 DelayResponseUpdate(
-                    id=dr.id or f"DELAY-{uuid.uuid4().hex[:8]}",
+                    id=dr.id
+                    or utils.generate_subresource_id("DELAY", dr.message, str(dr.duration)),
                     message=dr.message,
                     duration=dr.duration,
                     references=utils.get_references_from_prompt(
@@ -887,7 +887,7 @@ class Function(Resource):
 
                     _id = next(
                         (param.id for param in known_parameters if param.name == name),
-                        f"PARAMETER-{uuid.uuid4().hex[:8]}",
+                        utils.generate_subresource_id("PARAMETER", function_name, name),
                     )
 
                     if _type in PY_TO_SCHEMA:
@@ -955,7 +955,8 @@ class Function(Resource):
                             used_delay_response_ids.add(existing_id)
                         delay_responses.append(
                             FunctionDelayResponse(
-                                id=existing_id or f"DELAY-{uuid.uuid4().hex[:8]}",
+                                id=existing_id
+                                or utils.generate_subresource_id("DELAY", msg, str(dur)),
                                 message=msg,
                                 duration=dur,
                             )
@@ -1108,7 +1109,7 @@ class Function(Resource):
     def _build_create_latency_control_proto(self) -> FunctionCreateLatencyControl:
         delay_responses = [
             FunctionDelayResponseProto(
-                id=dr.id or f"DELAY-{uuid.uuid4().hex[:8]}",
+                id=dr.id or utils.generate_subresource_id("DELAY", dr.message, str(dr.duration)),
                 message=dr.message,
                 duration=dr.duration,
             )

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -936,7 +936,7 @@ class Function(Resource):
             elif kw.arg == "randomize" and isinstance(kw.value, ast.Constant):
                 randomize = bool(kw.value.value)
             elif kw.arg == "delay_responses" and isinstance(kw.value, ast.List):
-                for elt in kw.value.elts:
+                for i, elt in enumerate(kw.value.elts):
                     if isinstance(elt, ast.Tuple) and len(elt.elts) == 2:
                         msg = elt.elts[0].value if isinstance(elt.elts[0], ast.Constant) else ""
                         dur = elt.elts[1].value if isinstance(elt.elts[1], ast.Constant) else 0
@@ -956,7 +956,7 @@ class Function(Resource):
                         delay_responses.append(
                             FunctionDelayResponse(
                                 id=existing_id
-                                or utils.generate_subresource_id("DELAY", msg, str(dur)),
+                                or utils.generate_subresource_id("DELAY", msg, str(dur), str(i)),
                                 message=msg,
                                 duration=dur,
                             )
@@ -1109,7 +1109,7 @@ class Function(Resource):
     def _build_create_latency_control_proto(self) -> FunctionCreateLatencyControl:
         delay_responses = [
             FunctionDelayResponseProto(
-                id=dr.id or utils.generate_subresource_id("DELAY", dr.message, str(dr.duration)),
+                id=dr.id,
                 message=dr.message,
                 duration=dr.duration,
             )

--- a/src/poly/resources/function.py
+++ b/src/poly/resources/function.py
@@ -183,8 +183,7 @@ class LatencyControl(SubResource):
         delay_responses = DelayResponsesUpdate(
             delay_responses=[
                 DelayResponseUpdate(
-                    id=dr.id
-                    or utils.generate_subresource_id("DELAY", dr.message, str(dr.duration)),
+                    id=dr.id,
                     message=dr.message,
                     duration=dr.duration,
                     references=utils.get_references_from_prompt(
@@ -956,7 +955,9 @@ class Function(Resource):
                         delay_responses.append(
                             FunctionDelayResponse(
                                 id=existing_id
-                                or utils.generate_subresource_id("DELAY", msg, str(dur), str(i)),
+                                or utils.generate_subresource_id(
+                                    "DELAY", str(msg), str(dur), str(i)
+                                ),
                                 message=msg,
                                 duration=dur,
                             )

--- a/src/poly/resources/resource_utils.py
+++ b/src/poly/resources/resource_utils.py
@@ -602,6 +602,27 @@ NON_LETTER_REGEX = re.compile(r"[^\w\s]", re.UNICODE)
 MULTI_UNDERSCORE_REGEX = re.compile(r"_+")
 
 
+def generate_subresource_id(prefix: str, *scope: str) -> str:
+    """Derive a stable subresource id from its scoped name.
+
+    Subresources (function parameters, step conditions, delay responses) are matched by
+    name within their parent, so deriving the id from the scoped name means any two
+    reads - and any two branches - mint the same id for the same subresource. Parent
+    NAMES form the scope, never parent ids: ids are what diverge across branches.
+
+    Args:
+        prefix (str): The id prefix, e.g. "CONDITION".
+        *scope (str): The scoped name parts, outermost first (e.g. flow name, step
+            name, condition name).
+
+    Returns:
+        str: ``{prefix}-{8 hex chars}`` derived from the scope, matching the shape of
+            randomly minted ids.
+    """
+    digest = hashlib.sha1("/".join(scope).encode("utf-8")).hexdigest()
+    return f"{prefix}-{digest[:8]}"
+
+
 @functools.cache
 def clean_name(name: str, lowercase: bool = True) -> str:
     """Convert a resource name to a folder-friendly format."""

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -36,10 +36,11 @@ from poly.cli_commands.functions import (
 from poly.cli_commands.project import InitCommand, ProjectCommand
 from poly.cli_commands.shared import (
     compute_diff,
+    parse_from_projection_json,
     require_deployment_simplification,
     resolve_project_scope,
 )
-from poly.cli_commands.sync import FormatCommand, RevertCommand
+from poly.cli_commands.sync import FormatCommand, PushCommand, RevertCommand
 from poly.cli_commands.utils import CompletionCommand
 from poly.project import DeploymentMode
 from poly.tests.project_test import TEST_DIR
@@ -2021,6 +2022,129 @@ class RevertTest(unittest.TestCase):
         RevertCommand.revert(TEST_DIR, files=[])
 
         self.proj.revert_changes.assert_called_once_with(file_paths=[])
+
+
+class ParseFromProjectionJsonTest(unittest.TestCase):
+    """Tests for parse_from_projection_json, shared by every projection-carrying flag."""
+
+    def test_bare_projection_object_is_returned_unchanged(self):
+        """A plain projection object is already what callers want."""
+        self.assertEqual(
+            parse_from_projection_json('{"knowledgeBase": {}}', json_errors=False),
+            {"knowledgeBase": {}},
+        )
+
+    def test_envelope_is_unwrapped_to_the_projection_it_carries(self):
+        """API responses wrap the projection in a `projection` key; both forms are accepted."""
+        self.assertEqual(
+            parse_from_projection_json('{"projection": {"a": 1}}', json_errors=False), {"a": 1}
+        )
+
+    def test_no_value_means_no_projection(self):
+        """An unset flag leaves the caller to fetch the projection itself."""
+        self.assertIsNone(parse_from_projection_json(None, json_errors=False))
+
+    @patch("poly.output.console.error")
+    def test_invalid_json_error_names_the_flag_it_came_from(self, mock_error):
+        """push takes two projection flags, so the error has to say which one was bad."""
+        with self.assertRaises(SystemExit) as ctx:
+            parse_from_projection_json(
+                "not json", json_errors=False, flag_name="--parent-projection"
+            )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("--parent-projection", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_non_object_json_error_names_the_flag_it_came_from(self, mock_error):
+        """Valid JSON that is not an object is rejected against the same flag."""
+        with self.assertRaises(SystemExit) as ctx:
+            parse_from_projection_json("[1, 2]", json_errors=False, flag_name="--parent-projection")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn("--parent-projection", mock_error.call_args[0][0])
+
+    @patch("poly.output.console.error")
+    def test_flag_name_defaults_to_from_projection(self, mock_error):
+        """Callers that pass no flag name still get an error naming a real flag."""
+        with self.assertRaises(SystemExit):
+            parse_from_projection_json("not json", json_errors=False)
+
+        self.assertIn("--from-projection", mock_error.call_args[0][0])
+
+    @patch("poly.cli_commands.shared.json_print")
+    def test_failure_is_reported_as_json_when_json_errors_is_set(self, mock_json_print):
+        """Machine callers get the same message as a JSON failure, not console output."""
+        with self.assertRaises(SystemExit):
+            parse_from_projection_json("not json", json_errors=True, flag_name="--parent-projection")
+
+        output = mock_json_print.call_args[0][0]
+        self.assertFalse(output["success"])
+        self.assertIn("--parent-projection", output["error"])
+
+
+class UnreadableStdin:
+    """A stdin that fails the test if anything reads it."""
+
+    def read(self, *args, **kwargs) -> str:
+        """Reading is the mistake this stands guard against."""
+        raise AssertionError("stdin was read")
+
+
+class PushStdinProjectionGuardTest(unittest.TestCase):
+    """Tests for `poly push` refusing to read two projections from one stdin.
+
+    --from-projection and --parent-projection both accept `-`. Reading both would have
+    the first consume the whole stream and the second see EOF, so the combination is
+    refused up front instead of failing as unparseable JSON.
+    """
+
+    def setUp(self):
+        self.mock_load = patch("poly.cli_commands.sync.load_project").start()
+        self.project = MagicMock()
+        self.project.account_id = "test_account"
+        self.project.project_id = "test_project"
+        self.mock_load.return_value = self.project
+        self.addCleanup(patch.stopall)
+
+    @patch("poly.output.console.error")
+    def test_both_projection_flags_reading_stdin_is_refused(self, mock_error):
+        """The refusal comes before stdin is touched and before anything is pushed."""
+        with patch("sys.stdin", UnreadableStdin()):
+            with self.assertRaises(SystemExit) as ctx:
+                PushCommand.push(TEST_DIR, from_projection="-", parent_projection="-")
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertIn(
+            "Only one of --from-projection and --parent-projection may read from stdin.",
+            mock_error.call_args[0][0],
+        )
+        self.project.push_project.assert_not_called()
+
+    @patch("poly.cli_commands.sync.json_print")
+    def test_the_refusal_is_reported_as_json_in_json_mode(self, mock_json_print):
+        """Machine callers get the refusal as a JSON failure."""
+        with patch("sys.stdin", UnreadableStdin()):
+            with self.assertRaises(SystemExit) as ctx:
+                PushCommand.push(
+                    TEST_DIR, from_projection="-", parent_projection="-", output_json=True
+                )
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertFalse(mock_json_print.call_args[0][0]["success"])
+        self.project.push_project.assert_not_called()
+
+    def test_a_single_flag_may_still_read_stdin(self):
+        """One flag reading stdin is fine: the projection is parsed and handed to push."""
+        self.project.push_project.return_value = (True, "Dry run completed.", [])
+
+        with patch("sys.stdin", StringIO('{"knowledgeBase": {}}')):
+            PushCommand.push(TEST_DIR, dry_run=True, parent_projection="-")
+
+        self.assertEqual(
+            self.project.push_project.call_args.kwargs["parent_projection_json"],
+            {"knowledgeBase": {}},
+        )
 
 
 class PrintDeploymentsTest(unittest.TestCase):

--- a/src/poly/tests/cli_test.py
+++ b/src/poly/tests/cli_test.py
@@ -2076,7 +2076,9 @@ class ParseFromProjectionJsonTest(unittest.TestCase):
     def test_failure_is_reported_as_json_when_json_errors_is_set(self, mock_json_print):
         """Machine callers get the same message as a JSON failure, not console output."""
         with self.assertRaises(SystemExit):
-            parse_from_projection_json("not json", json_errors=True, flag_name="--parent-projection")
+            parse_from_projection_json(
+                "not json", json_errors=True, flag_name="--parent-projection"
+            )
 
         output = mock_json_print.call_args[0][0]
         self.assertFalse(output["success"])

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -58,7 +58,7 @@ from poly.resources.flows import (
     FlowSettings,
     StepType,
 )
-from poly.resources.function import FunctionType
+from poly.resources.function import FunctionParameters, FunctionType
 from poly.resources.resource import MultiResourceYamlResource
 from poly.tests.testing_utils import mock_read_from_file
 
@@ -5892,6 +5892,511 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
             with self.assertRaises(ValueError) as ctx:
                 self.project.sync_ids_with_sandbox()
         self.assertIn("uncommitted changes", str(ctx.exception))
+
+
+class FindNewKeptDeletedParentLookupTest(unittest.TestCase):
+    """Tests for find_new_kept_deleted minting new resource ids from the parent branch.
+
+    A resource added locally is minted a fresh id, while the same file on the parent
+    branch already carries a platform assigned id. Pushing the fresh id would leave one
+    file with two ids, which a later merge cannot reconcile, so a new resource whose file
+    path-matches a parent resource adopts the parent's id at mint time.
+    """
+
+    PARENT_FLOW_ID = "FLOW-parent-assigned-id"
+    # The flow id the fixture project already stores, kept when the flow is not new.
+    BRANCH_FLOW_ID = "FLOW_CONFIG-test_flow"
+
+    FLOW_PATH = "flows/test_flow/flow_config.yaml"
+    STEP_PATH = "flows/test_flow/steps/start_step.yaml"
+    FUNCTION_STEP_PATH = "flows/test_flow/function_steps/process_payment.py"
+    FLOW_FUNCTION_PATH = "flows/test_flow/functions/process_data.py"
+    TOPIC_PATH = "topics/topic_1.yaml"
+
+    def setUp(self):
+        # The untouched fixture project stands in for the parent branch: the same files,
+        # with ids that tests overwrite with the ones the parent's platform assigned.
+        parent_project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.parent_fixtures: dict[str, Resource] = {
+            resource.file_path: resource
+            for resources_by_id in parent_project.resources.values()
+            for resource in resources_by_id.values()
+        }
+
+    def _project_where_files_are_new(self, **stored_ids_to_drop: str) -> AgentStudioProject:
+        """A project that has forgotten the given resources, so their files look new.
+
+        Args:
+            **stored_ids_to_drop: section of test_project.json -> resource id to drop from
+                it, e.g. ``topics="TOPIC-Topic 1"``.
+        """
+        project_data = deepcopy(PROJECT_DATA)
+        for section, resource_id in stored_ids_to_drop.items():
+            project_data["resources"][section].pop(resource_id)
+        return AgentStudioProject.from_dict(project_data, TEST_DIR)
+
+    def _parent(self, relative_path: str, resource_id: str, flow_id: str = None) -> Resource:
+        """The parent branch's copy of a fixture file, under the parent's assigned ids."""
+        resource = deepcopy(self.parent_fixtures[relative_path])
+        resource.resource_id = resource_id
+        if flow_id is not None:
+            resource.flow_id = flow_id
+        return resource
+
+    def _parent_lookup(self, *resources: Resource) -> dict[str, Resource]:
+        """Parent resources keyed by absolute file path, exactly as push keys them."""
+        return {os.path.join(TEST_DIR, resource.file_path): resource for resource in resources}
+
+    def _mapping_for(
+        self, mappings: list[ResourceMapping], relative_path: str
+    ) -> ResourceMapping:
+        """The single mapping covering a fixture file."""
+        file_path = os.path.join(TEST_DIR, relative_path)
+        matches = [mapping for mapping in mappings if mapping.file_path == file_path]
+        self.assertEqual(len(matches), 1, f"expected exactly one mapping for {relative_path}")
+        return matches[0]
+
+    def test_new_flow_adopts_the_parent_flow_id(self):
+        """A new flow config that path-matches the parent takes the parent's id."""
+        project = self._project_where_files_are_new(flow_config="FLOW_CONFIG-test_flow")
+        parent_lookup = self._parent_lookup(self._parent(self.FLOW_PATH, self.PARENT_FLOW_ID))
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        flow_mapping = self._mapping_for(new_mappings, self.FLOW_PATH)
+        self.assertEqual(flow_mapping.resource_id, self.PARENT_FLOW_ID)
+        # A flow's flow_id is its own id, so the whole flow moves together.
+        self.assertEqual(flow_mapping.flow_id, self.PARENT_FLOW_ID)
+
+    def test_new_flow_without_a_parent_match_is_minted_a_fresh_id(self):
+        """A flow with no counterpart on the parent still gets a randomly minted id."""
+        project = self._project_where_files_are_new(flow_config="FLOW_CONFIG-test_flow")
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup={}
+        )
+
+        flow_mapping = self._mapping_for(new_mappings, self.FLOW_PATH)
+        self.assertRegex(flow_mapping.resource_id, r"^FLOW_CONFIG-[a-f0-9]{8}$")
+        self.assertEqual(flow_mapping.flow_id, flow_mapping.resource_id)
+
+    def test_new_step_in_a_new_flow_adopts_the_parent_composite_id(self):
+        """A new step matching a parent step takes that step's id, prefix and all.
+
+        The parent named the step `greeting` while the local file would mint its own id,
+        so the whole composite `{parent_flow_id}_{parent_step_id}` must be adopted.
+        """
+        project = self._project_where_files_are_new(
+            flow_config="FLOW_CONFIG-test_flow",
+            flow_steps="FLOW_CONFIG-test_flow_start_step",
+        )
+        parent_lookup = self._parent_lookup(
+            self._parent(self.FLOW_PATH, self.PARENT_FLOW_ID),
+            self._parent(
+                self.STEP_PATH, f"{self.PARENT_FLOW_ID}_greeting", flow_id=self.PARENT_FLOW_ID
+            ),
+        )
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        step_mapping = self._mapping_for(new_mappings, self.STEP_PATH)
+        self.assertEqual(step_mapping.resource_id, f"{self.PARENT_FLOW_ID}_greeting")
+        self.assertEqual(step_mapping.flow_id, self.PARENT_FLOW_ID)
+
+    def test_new_step_without_a_parent_match_is_minted_under_its_flow_id(self):
+        """A step the parent does not have is minted a fresh id under the flow it belongs to.
+
+        Step ids embed the flow id as a prefix, and start_step / child_step references are
+        resolved by stripping that prefix, so the prefix must agree with the flow_id even
+        when only the flow was adopted from the parent.
+        """
+        project = self._project_where_files_are_new(
+            flow_config="FLOW_CONFIG-test_flow",
+            flow_steps="FLOW_CONFIG-test_flow_start_step",
+        )
+        parent_lookup = self._parent_lookup(self._parent(self.FLOW_PATH, self.PARENT_FLOW_ID))
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        step_mapping = self._mapping_for(new_mappings, self.STEP_PATH)
+        self.assertRegex(
+            step_mapping.resource_id, rf"^{self.PARENT_FLOW_ID}_FLOW_STEPS-[a-f0-9]{{8}}$"
+        )
+        self.assertEqual(step_mapping.flow_id, self.PARENT_FLOW_ID)
+
+    def test_new_step_in_a_kept_flow_adopts_only_the_parent_bare_step_id(self):
+        """A new step in an existing flow keeps this branch's flow id in its prefix.
+
+        The flow is not new, so it keeps this branch's id. Adopting the parent's composite
+        id verbatim would file the step under the parent's flow id instead.
+        """
+        project = self._project_where_files_are_new(
+            flow_steps="FLOW_CONFIG-test_flow_start_step"
+        )
+        parent_lookup = self._parent_lookup(
+            self._parent(
+                self.STEP_PATH, f"{self.PARENT_FLOW_ID}_greeting", flow_id=self.PARENT_FLOW_ID
+            )
+        )
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        step_mapping = self._mapping_for(new_mappings, self.STEP_PATH)
+        self.assertEqual(step_mapping.resource_id, f"{self.BRANCH_FLOW_ID}_greeting")
+        self.assertEqual(step_mapping.flow_id, self.BRANCH_FLOW_ID)
+
+    def test_new_function_step_adopts_the_parent_composite_id(self):
+        """Function steps carry composite ids too, so they adopt them the same way."""
+        project = self._project_where_files_are_new(
+            flow_config="FLOW_CONFIG-test_flow",
+            function_steps="FLOW_CONFIG-test_flow_process_payment",
+        )
+        parent_lookup = self._parent_lookup(
+            self._parent(self.FLOW_PATH, self.PARENT_FLOW_ID),
+            self._parent(
+                self.FUNCTION_STEP_PATH,
+                f"{self.PARENT_FLOW_ID}_take_payment",
+                flow_id=self.PARENT_FLOW_ID,
+            ),
+        )
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        function_step_mapping = self._mapping_for(new_mappings, self.FUNCTION_STEP_PATH)
+        self.assertEqual(function_step_mapping.resource_id, f"{self.PARENT_FLOW_ID}_take_payment")
+        self.assertEqual(function_step_mapping.flow_id, self.PARENT_FLOW_ID)
+
+    def test_new_flow_scoped_function_adopts_the_parent_id_without_a_flow_prefix(self):
+        """A function inside a flow has a flow_id but a standalone id.
+
+        Only step ids embed the flow id, so prefixing a function's id with the flow id
+        would corrupt it: the parent's id is adopted exactly as it stands.
+        """
+        project = self._project_where_files_are_new(functions="FUNCTION-process_data")
+        parent_lookup = self._parent_lookup(
+            self._parent(
+                self.FLOW_FUNCTION_PATH,
+                "FUNCTION-parent-process-data",
+                flow_id=self.PARENT_FLOW_ID,
+            )
+        )
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        function_mapping = self._mapping_for(new_mappings, self.FLOW_FUNCTION_PATH)
+        self.assertEqual(function_mapping.resource_id, "FUNCTION-parent-process-data")
+        self.assertEqual(function_mapping.flow_id, self.BRANCH_FLOW_ID)
+
+    def test_new_topic_adopts_the_parent_id(self):
+        """A new topic whose file exists on the parent takes the parent's id."""
+        project = self._project_where_files_are_new(topics="TOPIC-Topic 1")
+        parent_lookup = self._parent_lookup(
+            self._parent(self.TOPIC_PATH, "TOPIC-parent-assigned-id")
+        )
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        topic_mapping = self._mapping_for(new_mappings, self.TOPIC_PATH)
+        self.assertEqual(topic_mapping.resource_id, "TOPIC-parent-assigned-id")
+
+    def test_new_topic_without_a_parent_match_is_minted_a_fresh_id(self):
+        """A topic the parent does not have is minted a random id as before."""
+        project = self._project_where_files_are_new(topics="TOPIC-Topic 1")
+
+        new_mappings, _, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup={}
+        )
+
+        topic_mapping = self._mapping_for(new_mappings, self.TOPIC_PATH)
+        self.assertRegex(topic_mapping.resource_id, r"^TOPICS-[a-f0-9]{8}$")
+
+    def test_parent_ids_are_ignored_when_no_parent_lookup_is_passed(self):
+        """Without a parent lookup, minting stays random even for a path the parent has.
+
+        Adopting parent ids is opt-in: every caller that does not ask for it must see the
+        behaviour it saw before the feature existed.
+        """
+        project = self._project_where_files_are_new(topics="TOPIC-Topic 1")
+        # Built but deliberately not passed.
+        self._parent_lookup(self._parent(self.TOPIC_PATH, "TOPIC-parent-assigned-id"))
+
+        new_mappings, _, _ = project.find_new_kept_deleted(project.discover_local_resources())
+
+        topic_mapping = self._mapping_for(new_mappings, self.TOPIC_PATH)
+        self.assertRegex(topic_mapping.resource_id, r"^TOPICS-[a-f0-9]{8}$")
+
+    def test_kept_resources_keep_their_branch_ids_when_the_parent_matches(self):
+        """A file the branch already knows keeps its own id, however the parent named it.
+
+        Only newly minted ids may follow the parent: rewriting a kept resource's id would
+        orphan every reference the branch has already pushed under the old id.
+        """
+        project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        parent_lookup = self._parent_lookup(
+            self._parent(self.TOPIC_PATH, "TOPIC-parent-assigned-id"),
+            self._parent(
+                self.STEP_PATH, f"{self.PARENT_FLOW_ID}_greeting", flow_id=self.PARENT_FLOW_ID
+            ),
+        )
+
+        new_mappings, kept_mappings, _ = project.find_new_kept_deleted(
+            project.discover_local_resources(), parent_lookup=parent_lookup
+        )
+
+        self.assertEqual(new_mappings, [])
+        self.assertEqual(
+            self._mapping_for(kept_mappings, self.TOPIC_PATH).resource_id, "TOPIC-Topic 1"
+        )
+        self.assertEqual(
+            self._mapping_for(kept_mappings, self.STEP_PATH).resource_id,
+            f"{self.BRANCH_FLOW_ID}_start_step",
+        )
+
+
+class AugmentOriginalWithParentSubresourcesTest(unittest.TestCase):
+    """Tests for _augment_original_with_parent_subresources merging parent subresources.
+
+    Subresources (function parameters, flow step conditions) are matched by name when a
+    local file is read, so a parameter added on both the parent branch and this branch
+    would mint a fresh id here and diverge from the id the parent already gave it. For a
+    kept resource that path-matches the parent, the parent's subresources are folded into
+    a copy of the branch resource so those names can find an existing id.
+    """
+
+    FLOW_ID = "FLOW-test_flow"
+    STEP_ID = "start_step"
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+
+    def _parameter(self, name: str, parameter_id: str) -> FunctionParameters:
+        """A function parameter carrying the id its branch assigned it."""
+        return FunctionParameters(
+            name=name, type="string", description=f"the {name}", id=parameter_id
+        )
+
+    def _function(self, *parameters: FunctionParameters) -> Function:
+        """A function whose only interesting content is its parameter list."""
+        return Function(
+            resource_id="FUNCTION-book_table",
+            name="book_table",
+            description="Book a table",
+            code="def book_table():\n    pass\n",
+            parameters=list(parameters),
+        )
+
+    def _condition(self, name: str, condition_id: str) -> Condition:
+        """A step condition carrying the id its branch assigned it."""
+        return Condition(
+            resource_id=condition_id,
+            name=name,
+            condition_type="step_condition",
+            step_id=self.STEP_ID,
+            flow_id=self.FLOW_ID,
+        )
+
+    def _flow_step(self, *conditions: Condition) -> FlowStep:
+        """A flow step whose only interesting content is its condition list."""
+        return FlowStep(
+            resource_id=f"{self.FLOW_ID}_{self.STEP_ID}",
+            name="Start step",
+            step_id=self.STEP_ID,
+            flow_id=self.FLOW_ID,
+            flow_name="test_flow",
+            step_type=StepType.DEFAULT_STEP,
+            prompt="Greet the caller",
+            conditions=list(conditions),
+        )
+
+    def test_function_inherits_a_parameter_only_the_parent_has(self):
+        """A parameter name the branch does not know is appended with the parent's id."""
+        branch_function = self._function(self._parameter("party_size", "PARAM-branch-party-size"))
+        parent_function = self._function(
+            self._parameter("party_size", "PARAM-parent-party-size"),
+            self._parameter("seating_area", "PARAM-parent-seating-area"),
+        )
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_function, parent_function
+        )
+
+        self.assertEqual(
+            [(param.name, param.id) for param in augmented.parameters],
+            [
+                ("party_size", "PARAM-branch-party-size"),
+                ("seating_area", "PARAM-parent-seating-area"),
+            ],
+        )
+
+    def test_augmenting_a_function_leaves_the_branch_resource_untouched(self):
+        """The branch function keeps its own parameters after augmentation.
+
+        The branch resource is the one held in self.resources and diffed against later,
+        so mutating it in place would make the parent's parameters look like local edits.
+        """
+        branch_function = self._function(self._parameter("party_size", "PARAM-branch-party-size"))
+        parent_function = self._function(
+            self._parameter("seating_area", "PARAM-parent-seating-area")
+        )
+
+        self.project._augment_original_with_parent_subresources(branch_function, parent_function)
+
+        self.assertEqual(
+            [(param.name, param.id) for param in branch_function.parameters],
+            [("party_size", "PARAM-branch-party-size")],
+        )
+
+    def test_function_parameter_present_on_both_keeps_the_branch_version(self):
+        """A shared parameter name is not duplicated with the parent's copy."""
+        branch_function = self._function(self._parameter("party_size", "PARAM-branch-party-size"))
+        parent_function = self._function(self._parameter("party_size", "PARAM-parent-party-size"))
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_function, parent_function
+        )
+
+        self.assertEqual(
+            [(param.name, param.id) for param in augmented.parameters],
+            [("party_size", "PARAM-branch-party-size")],
+        )
+
+    def test_function_with_nothing_to_inherit_is_returned_as_is(self):
+        """With no parent-only parameters the branch function itself comes back."""
+        branch_function = self._function(self._parameter("party_size", "PARAM-branch-party-size"))
+        parent_function = self._function(self._parameter("party_size", "PARAM-parent-party-size"))
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_function, parent_function
+        )
+
+        self.assertIs(augmented, branch_function)
+
+    def test_flow_step_inherits_a_condition_only_the_parent_has(self):
+        """A condition name the branch does not know is appended with the parent's id."""
+        branch_step = self._flow_step(self._condition("wants_table", "COND-branch-wants-table"))
+        parent_step = self._flow_step(
+            self._condition("wants_table", "COND-parent-wants-table"),
+            self._condition("wants_takeaway", "COND-parent-wants-takeaway"),
+        )
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_step, parent_step
+        )
+
+        self.assertEqual(
+            [(cond.name, cond.resource_id) for cond in augmented.conditions],
+            [
+                ("wants_table", "COND-branch-wants-table"),
+                ("wants_takeaway", "COND-parent-wants-takeaway"),
+            ],
+        )
+
+    def test_augmenting_a_flow_step_leaves_the_branch_resource_untouched(self):
+        """The branch step keeps its own conditions after augmentation."""
+        branch_step = self._flow_step(self._condition("wants_table", "COND-branch-wants-table"))
+        parent_step = self._flow_step(
+            self._condition("wants_takeaway", "COND-parent-wants-takeaway")
+        )
+
+        self.project._augment_original_with_parent_subresources(branch_step, parent_step)
+
+        self.assertEqual(
+            [(cond.name, cond.resource_id) for cond in branch_step.conditions],
+            [("wants_table", "COND-branch-wants-table")],
+        )
+
+    def test_flow_step_condition_present_on_both_keeps_the_branch_version(self):
+        """A shared condition name is not duplicated with the parent's copy."""
+        branch_step = self._flow_step(self._condition("wants_table", "COND-branch-wants-table"))
+        parent_step = self._flow_step(self._condition("wants_table", "COND-parent-wants-table"))
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_step, parent_step
+        )
+
+        self.assertEqual(
+            [(cond.name, cond.resource_id) for cond in augmented.conditions],
+            [("wants_table", "COND-branch-wants-table")],
+        )
+
+    def test_flow_step_with_nothing_to_inherit_is_returned_as_is(self):
+        """With no parent-only conditions the branch step itself comes back."""
+        branch_step = self._flow_step(self._condition("wants_table", "COND-branch-wants-table"))
+        parent_step = self._flow_step(self._condition("wants_table", "COND-parent-wants-table"))
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_step, parent_step
+        )
+
+        self.assertIs(augmented, branch_step)
+
+    def test_function_step_is_returned_unchanged_despite_parent_only_parameters(self):
+        """A function step is not augmented even though it is a Function subclass.
+
+        Reading a function step off disk takes no known_parameters, so handing it merged
+        parameters here would offer ids that the read can never claim.
+        """
+
+        def function_step(*parameters: FunctionParameters) -> FunctionStep:
+            return FunctionStep(
+                resource_id=f"{self.FLOW_ID}_take_payment",
+                name="take_payment",
+                step_id="take_payment",
+                flow_id=self.FLOW_ID,
+                flow_name="test_flow",
+                code="def take_payment():\n    pass\n",
+                parameters=list(parameters),
+            )
+
+        branch_step = function_step(self._parameter("amount", "PARAM-branch-amount"))
+        parent_step = function_step(
+            self._parameter("amount", "PARAM-parent-amount"),
+            self._parameter("currency", "PARAM-parent-currency"),
+        )
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_step, parent_step
+        )
+
+        self.assertIs(augmented, branch_step)
+        self.assertEqual([param.name for param in augmented.parameters], ["amount"])
+
+    def test_resource_without_named_subresources_is_returned_unchanged(self):
+        """A type with no name-matched subresources, such as a topic, is passed through."""
+        branch_topic = Topic(
+            resource_id="TOPIC-branch-id",
+            name="Opening hours",
+            actions="Answer the question",
+            content="We open at 9am",
+            example_queries=["when do you open?"],
+        )
+        parent_topic = Topic(
+            resource_id="TOPIC-parent-id",
+            name="Opening hours",
+            actions="Answer the question",
+            content="We open at 8am",
+            example_queries=["when do you open?", "are you open now?"],
+        )
+
+        augmented = self.project._augment_original_with_parent_subresources(
+            branch_topic, parent_topic
+        )
+
+        self.assertIs(augmented, branch_topic)
 
 
 class TestProjectFixtureIntegrityTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import poly.resources.resource_utils as resource_utils
 from poly.handlers.interface import AgentStudioInterface
 from poly.handlers.protobuf.commands_pb2 import Command
+from poly.handlers.sdk import SourcererAPIError
 from poly.project import AgentStudioProject, DeploymentMode
 from poly.resources import (
     AsrSettings,
@@ -6342,6 +6343,41 @@ class PushProjectParentProjectionTest(unittest.TestCase):
 
         self.assertTrue(success, message)
         mock_fetch.assert_called_once_with()
+
+    def test_a_failed_parent_fetch_is_reported_as_an_api_error(self):
+        """Whatever the platform call raised, push must say what actually went wrong.
+
+        The raw error (a transport or auth failure) surfaced to the user as an unhandled
+        crash with no hint that fetching the parent branch was the step that failed.
+        """
+        project = self._project_where_topic_1_is_new()
+        fetch_failure = RuntimeError("boom")
+
+        with patch.object(
+            AgentStudioProject, "_fetch_parent_resources", side_effect=fetch_failure
+        ):
+            with patch.dict(os.environ, {"POLY_ADK_SYNC_PARENT_IDS_TEST": "1"}):
+                with self.assertRaises(SourcererAPIError) as raised:
+                    project.push_project(dry_run=True, skip_validation=True)
+
+        self.assertIn("Failed to fetch parent resources", str(raised.exception))
+        self.assertIs(raised.exception.__cause__, fetch_failure)
+
+    def test_a_supplied_parent_projection_never_reaches_the_failing_fetch(self):
+        """The projection is the answer, so a broken platform call cannot fail the push."""
+        project = self._project_where_topic_1_is_new()
+
+        with patch.object(
+            AgentStudioProject, "_fetch_parent_resources", side_effect=RuntimeError("boom")
+        ):
+            success, message, _ = project.push_project(
+                dry_run=True,
+                skip_validation=True,
+                parent_projection_json=self.PARENT_PROJECTION,
+            )
+
+        self.assertTrue(success, message)
+        self.assertEqual(self._staged_topic_ids(project), {"Topic 1": self.PARENT_TOPIC_ID})
 
 
 class FindNewKeptDeletedParentLookupTest(unittest.TestCase):

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -2060,7 +2060,9 @@ class CleanResourcesBeforePushTest(unittest.TestCase):
             {},
         )
 
-        self.assertEqual(push_changes.main.updated[Variant], {"VARIANTS-production": renamed_variant})
+        self.assertEqual(
+            push_changes.main.updated[Variant], {"VARIANTS-production": renamed_variant}
+        )
 
 
 class PushProjectTest(unittest.TestCase):
@@ -5907,11 +5909,13 @@ class FindNewKeptDeletedParentLookupTest(unittest.TestCase):
     # The flow id the fixture project already stores, kept when the flow is not new.
     BRANCH_FLOW_ID = "FLOW_CONFIG-test_flow"
 
-    FLOW_PATH = "flows/test_flow/flow_config.yaml"
-    STEP_PATH = "flows/test_flow/steps/start_step.yaml"
-    FUNCTION_STEP_PATH = "flows/test_flow/function_steps/process_payment.py"
-    FLOW_FUNCTION_PATH = "flows/test_flow/functions/process_data.py"
-    TOPIC_PATH = "topics/topic_1.yaml"
+    # Built with os.path.join because they are matched against Resource.file_path,
+    # which carries native separators (backslashes on Windows).
+    FLOW_PATH = os.path.join("flows", "test_flow", "flow_config.yaml")
+    STEP_PATH = os.path.join("flows", "test_flow", "steps", "start_step.yaml")
+    FUNCTION_STEP_PATH = os.path.join("flows", "test_flow", "function_steps", "process_payment.py")
+    FLOW_FUNCTION_PATH = os.path.join("flows", "test_flow", "functions", "process_data.py")
+    TOPIC_PATH = os.path.join("topics", "topic_1.yaml")
 
     def setUp(self):
         # The untouched fixture project stands in for the parent branch: the same files,
@@ -5947,9 +5951,7 @@ class FindNewKeptDeletedParentLookupTest(unittest.TestCase):
         """Parent resources keyed by absolute file path, exactly as push keys them."""
         return {os.path.join(TEST_DIR, resource.file_path): resource for resource in resources}
 
-    def _mapping_for(
-        self, mappings: list[ResourceMapping], relative_path: str
-    ) -> ResourceMapping:
+    def _mapping_for(self, mappings: list[ResourceMapping], relative_path: str) -> ResourceMapping:
         """The single mapping covering a fixture file."""
         file_path = os.path.join(TEST_DIR, relative_path)
         matches = [mapping for mapping in mappings if mapping.file_path == file_path]
@@ -6036,9 +6038,7 @@ class FindNewKeptDeletedParentLookupTest(unittest.TestCase):
         The flow is not new, so it keeps this branch's id. Adopting the parent's composite
         id verbatim would file the step under the parent's flow id instead.
         """
-        project = self._project_where_files_are_new(
-            flow_steps="FLOW_CONFIG-test_flow_start_step"
-        )
+        project = self._project_where_files_are_new(flow_steps="FLOW_CONFIG-test_flow_start_step")
         parent_lookup = self._parent_lookup(
             self._parent(
                 self.STEP_PATH, f"{self.PARENT_FLOW_ID}_greeting", flow_id=self.PARENT_FLOW_ID

--- a/src/poly/tests/project_test.py
+++ b/src/poly/tests/project_test.py
@@ -5896,6 +5896,331 @@ class SyncIdsWithSandboxTest(unittest.TestCase):
         self.assertIn("uncommitted changes", str(ctx.exception))
 
 
+class FetchParentResourcesTest(unittest.TestCase):
+    """Tests for _fetch_parent_resources pulling the branch this one was cut from.
+
+    Both push and sync-ids lean on this to learn the ids the parent already assigned, so
+    a branch with no resolvable parent must answer "no parent" rather than fall through
+    to whichever branch happens to be current.
+    """
+
+    PARENT_BRANCH_ID = "main-branch-id"
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.mock_api = MagicMock()
+        self.mock_api.get_branches.return_value = {
+            "main": {"branchId": self.PARENT_BRANCH_ID},
+            "feature-a": {"branchId": "branch-1", "parentBranchId": self.PARENT_BRANCH_ID},
+            "orphan": {"branchId": "branch-2"},
+        }
+        self.project._api_handler = self.mock_api
+        self._on_branch("branch-1")
+        patch.object(AgentStudioProject, "save_config").start()
+        self.addCleanup(patch.stopall)
+
+    def _on_branch(self, branch_id: str) -> None:
+        """Put the project on a branch, as the api handler also reports the current one."""
+        self.project.branch_id = branch_id
+        self.mock_api.branch_id = branch_id
+
+    @patch("poly.project.AgentStudioInterface")
+    def test_resources_are_pulled_from_the_parent_branch(self, mock_interface):
+        """The pull goes to the parent's branch id, not the branch we are standing on."""
+        parent_resources = {Topic: {"TOPIC-parent": "the parent's topic"}}
+        mock_interface.return_value.pull_resources.return_value = (parent_resources, [], [])
+
+        self.assertEqual(self.project._fetch_parent_resources(), parent_resources)
+        self.assertIn(self.PARENT_BRANCH_ID, mock_interface.call_args[0])
+
+    @patch("poly.project.AgentStudioInterface")
+    def test_main_branch_has_no_parent(self, mock_interface):
+        """Main is the root, so there is nothing to pull."""
+        self._on_branch(self.PARENT_BRANCH_ID)
+
+        self.assertEqual(self.project._fetch_parent_resources(), {})
+        mock_interface.assert_not_called()
+
+    @patch("poly.project.AgentStudioInterface")
+    def test_branch_without_a_recorded_parent_has_no_parent(self, mock_interface):
+        """A branch the platform records no parent for is treated as having none."""
+        self._on_branch("branch-2")
+
+        self.assertEqual(self.project._fetch_parent_resources(), {})
+        mock_interface.assert_not_called()
+
+    @patch("poly.project.AgentStudioInterface")
+    def test_branch_that_no_longer_exists_remotely_has_no_parent(self, mock_interface):
+        """A locally known branch that is gone from the remote resolves to no parent."""
+        self._on_branch("deleted-branch-id")
+
+        self.assertEqual(self.project._fetch_parent_resources(), {})
+        mock_interface.assert_not_called()
+
+
+class SyncIdsWithParentTest(unittest.TestCase):
+    """Tests for sync_ids_with_parent resolving the branch's own parent branch.
+
+    Syncing ids without naming a branch means "sync with whatever branch this one was
+    cut from", which is fetched from the platform. Falling back to main is only for
+    when that parent cannot be resolved: a branch cut from another branch would
+    otherwise silently adopt main's ids.
+    """
+
+    LOCAL_FLOW_ID = "FLOW_CONFIG-test_flow"
+    PARENT_FLOW_ID = "FLOW-parent-assigned-id"
+
+    def setUp(self):
+        self.project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        self.project.branch_id = "branch-1"
+        self.mock_api = MagicMock()
+        self.mock_api.branch_id = "branch-1"
+        self.mock_api.send_queued_commands.return_value = True
+        self.project._api_handler = self.mock_api
+        patch.object(AgentStudioProject, "save_config").start()
+        self.mock_get_remote = patch.object(
+            AgentStudioProject, "get_remote_resources_by_name"
+        ).start()
+        self.mock_get_remote.return_value = (self._resources_with_reassigned_flow_id(), [])
+        self.addCleanup(patch.stopall)
+
+    def _resources_with_reassigned_flow_id(self):
+        """The fixture's resources, with test_flow carrying the parent's flow id.
+
+        Mirrors a flow created on the parent after this branch was cut: the same files,
+        under the id the parent's platform assigned, so steps carry a
+        `{parent_flow_id}_{step_id}` composite id.
+        """
+        parent = deepcopy(self.project.resources)
+        for resource_type, resources_by_id in parent.items():
+            rekeyed = {}
+            for resource in resources_by_id.values():
+                if isinstance(resource, FlowConfig) and resource.resource_id == self.LOCAL_FLOW_ID:
+                    resource.resource_id = self.PARENT_FLOW_ID
+                elif getattr(resource, "flow_id", None) == self.LOCAL_FLOW_ID:
+                    resource.flow_id = self.PARENT_FLOW_ID
+                    resource.resource_id = resource.resource_id.replace(
+                        self.LOCAL_FLOW_ID, self.PARENT_FLOW_ID, 1
+                    )
+                rekeyed[resource.resource_id] = resource
+            parent[resource_type] = rekeyed
+        return parent
+
+    def test_unnamed_parent_syncs_against_the_fetched_parent_branch(self):
+        """With no branch named, ids come from the branch's own parent, not from main."""
+        parent_resources = self._resources_with_reassigned_flow_id()
+
+        with patch.object(
+            AgentStudioProject, "_fetch_parent_resources", return_value=parent_resources
+        ):
+            self.assertTrue(self.project.sync_ids_with_parent())
+
+        self.assertIn(self.PARENT_FLOW_ID, self.project.resources[FlowConfig])
+        self.mock_get_remote.assert_not_called()
+
+    def test_unresolvable_parent_falls_back_to_main_with_a_warning(self):
+        """A branch whose parent cannot be fetched syncs with main, and says so.
+
+        An empty parent fetch means the parent is unknown, not that it is empty, so
+        silently syncing against nothing would leave the branch's ids untouched.
+        """
+        with patch.object(AgentStudioProject, "_fetch_parent_resources", return_value={}):
+            with self.assertLogs("poly.project", level="WARNING") as logs:
+                self.assertTrue(self.project.sync_ids_with_parent())
+
+        self.mock_get_remote.assert_called_once_with("main")
+        self.assertIn("defaulting to 'main'", "\n".join(logs.output))
+        self.assertIn(self.PARENT_FLOW_ID, self.project.resources[FlowConfig])
+
+    def test_named_parent_is_looked_up_by_name_without_fetching_the_parent(self):
+        """An explicitly named branch is taken at its word, with no parent lookup."""
+        with patch.object(AgentStudioProject, "_fetch_parent_resources") as mock_fetch:
+            self.assertTrue(self.project.sync_ids_with_parent(parent_name="release"))
+
+        self.mock_get_remote.assert_called_once_with("release")
+        mock_fetch.assert_not_called()
+
+    def test_syncing_on_main_raises_before_any_parent_is_fetched(self):
+        """Main has no parent, so the refusal must come before any network call."""
+        self.project.branch_id = "main"
+
+        with patch.object(AgentStudioProject, "_fetch_parent_resources") as mock_fetch:
+            with self.assertRaises(ValueError) as ctx:
+                self.project.sync_ids_with_parent()
+
+        self.assertIn("Cannot sync ids while on main branch", str(ctx.exception))
+        mock_fetch.assert_not_called()
+        self.mock_get_remote.assert_not_called()
+
+
+class ResourcesByAbsolutePathTest(unittest.TestCase):
+    """Tests for _resources_by_absolute_path flattening a ResourceMap onto file paths."""
+
+    def test_resources_of_every_type_are_keyed_by_their_absolute_path(self):
+        """Types are flattened away: the key is the project root joined with file_path."""
+        project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+        topic = Topic(
+            resource_id="TOPIC-1", name="Topic 1", actions="", content="hello", example_queries=[]
+        )
+        function = Function(
+            resource_id="FUNCTION-1",
+            name="lookup_order",
+            description="Looks an order up.",
+            code="def lookup_order(conv):\n    return None\n",
+            parameters=[],
+        )
+
+        by_path = project._resources_by_absolute_path(
+            {Topic: {topic.resource_id: topic}, Function: {function.resource_id: function}}
+        )
+
+        self.assertEqual(
+            by_path,
+            {
+                os.path.join(TEST_DIR, "topics", "topic_1.yaml"): topic,
+                os.path.join(TEST_DIR, "functions", "lookup_order.py"): function,
+            },
+        )
+
+    def test_no_resources_gives_an_empty_lookup(self):
+        """A branch with no parent produces an empty lookup rather than failing."""
+        project = AgentStudioProject.from_dict(deepcopy(PROJECT_DATA), TEST_DIR)
+
+        self.assertEqual(project._resources_by_absolute_path({}), {})
+
+
+class OfflineOnlyApiHandler:
+    """An api_handler that answers offline command staging and refuses everything else.
+
+    Staging commands is local bookkeeping, so those calls are served. Every other call -
+    listing branches, pulling a parent branch, sending commands - would reach the
+    platform, so it raises: that is what makes "the parent projection was used entirely
+    offline" something a test can assert rather than assume.
+    """
+
+    def __init__(self):
+        self.branch_id = "branch-1"
+        self.staged_new_resources: dict[type, dict[str, Resource]] = {}
+
+    def get_queued_commands(self) -> list:
+        """The queue each push starts with: empty."""
+        return []
+
+    def queue_resources(self, *, new_resources, updated_resources, deleted_resources) -> list:
+        """Record the resources push wants to create; building commands needs no network."""
+        for resource_type, resources_by_id in new_resources.items():
+            self.staged_new_resources.setdefault(resource_type, {}).update(resources_by_id)
+        return []
+
+    def clear_command_queue(self) -> None:
+        """Dry runs throw the staged queue away."""
+
+    def __getattr__(self, name: str):
+        """Anything not served offline is a platform call, and must not happen."""
+        raise AssertionError(f"push reached the platform via api_handler.{name}")
+
+
+class PushProjectParentProjectionTest(unittest.TestCase):
+    """Tests for push_project adopting parent ids from a supplied parent projection.
+
+    A caller that already holds the parent branch's projection (the Studio backend does)
+    can hand it to push instead of having push fetch it. The ids are then adopted with no
+    platform call at all, which is what lets a dry run report the ids a real push would
+    mint.
+    """
+
+    PARENT_TOPIC_ID = "TOPIC-parent-assigned-id"
+    # The smallest projection Topic.from_projection accepts: one topic whose name maps
+    # to the fixture's topics/topic_1.yaml.
+    PARENT_PROJECTION = {
+        "knowledgeBase": {
+            "topics": {
+                "ids": [PARENT_TOPIC_ID],
+                "entities": {
+                    PARENT_TOPIC_ID: {
+                        "id": PARENT_TOPIC_ID,
+                        "name": "Topic 1",
+                        "actions": "",
+                        "content": "The parent branch's copy of this topic.",
+                    }
+                },
+            },
+            "uninstantiatedTopics": {"ids": [], "entities": {}},
+        }
+    }
+
+    def setUp(self):
+        patch.object(AgentStudioProject, "save_config").start()
+        self.addCleanup(patch.stopall)
+
+    def _project_where_topic_1_is_new(self) -> AgentStudioProject:
+        """A project that has forgotten Topic 1, so its file looks newly added."""
+        project_data = deepcopy(PROJECT_DATA)
+        project_data["resources"]["topics"].pop("TOPIC-Topic 1")
+        project = AgentStudioProject.from_dict(project_data, TEST_DIR)
+        project._api_handler = OfflineOnlyApiHandler()
+        return project
+
+    def _staged_topic_ids(self, project: AgentStudioProject) -> dict[str, str]:
+        """The name -> id of every topic the push staged as new."""
+        return {
+            topic.name: topic.resource_id
+            for topic in project._api_handler.staged_new_resources.get(Topic, {}).values()
+        }
+
+    def test_new_resource_adopts_the_id_from_the_supplied_parent_projection(self):
+        """A new file matching the projection is pushed under the parent's id, offline."""
+        project = self._project_where_topic_1_is_new()
+
+        success, message, _ = project.push_project(
+            dry_run=True,
+            skip_validation=True,
+            parent_projection_json=self.PARENT_PROJECTION,
+        )
+
+        self.assertTrue(success, message)
+        self.assertEqual(self._staged_topic_ids(project), {"Topic 1": self.PARENT_TOPIC_ID})
+
+    def test_empty_parent_projection_means_no_parent_and_mints_a_fresh_id(self):
+        """An empty projection is "this branch has no parent", not "go and look".
+
+        The branch really may have no parent, so an empty dict must be honoured as an
+        answer: ids are minted as they always were, still without a platform call.
+        """
+        project = self._project_where_topic_1_is_new()
+
+        success, message, _ = project.push_project(
+            dry_run=True, skip_validation=True, parent_projection_json={}
+        )
+
+        self.assertTrue(success, message)
+        self.assertRegex(self._staged_topic_ids(project)["Topic 1"], r"^TOPICS-[a-f0-9]{8}$")
+
+    def test_dry_run_without_a_parent_projection_does_not_fetch_the_parent(self):
+        """No projection and no push means no reason to go to the platform for one."""
+        project = self._project_where_topic_1_is_new()
+
+        with patch.object(AgentStudioProject, "_fetch_parent_resources") as mock_fetch:
+            success, message, _ = project.push_project(dry_run=True, skip_validation=True)
+
+        self.assertTrue(success, message)
+        mock_fetch.assert_not_called()
+        self.assertRegex(self._staged_topic_ids(project)["Topic 1"], r"^TOPICS-[a-f0-9]{8}$")
+
+    def test_dry_run_fetches_the_parent_when_the_test_env_var_is_set(self):
+        """The env var is the escape hatch for inspecting the ids a real push would use."""
+        project = self._project_where_topic_1_is_new()
+
+        with patch.object(
+            AgentStudioProject, "_fetch_parent_resources", return_value={}
+        ) as mock_fetch:
+            with patch.dict(os.environ, {"POLY_ADK_SYNC_PARENT_IDS_TEST": "1"}):
+                success, message, _ = project.push_project(dry_run=True, skip_validation=True)
+
+        self.assertTrue(success, message)
+        mock_fetch.assert_called_once_with()
+
+
 class FindNewKeptDeletedParentLookupTest(unittest.TestCase):
     """Tests for find_new_kept_deleted minting new resource ids from the parent branch.
 

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -606,6 +606,56 @@ def my_func(conv: Conversation):
         _, _, _, lc = Function._extract_decorators(code_with_decorator, "my_func", [], known_lc)
         self.assertEqual(lc.delay_responses[0].id, "DELAY-existing")
 
+    def test_two_identical_delay_responses_get_distinct_ids(self):
+        """Same message and same duration twice is two delays, so it must be two ids.
+
+        Delay ids are derived from the delay's contents, so deriving from message and
+        duration alone collapsed duplicates onto one id and lost one of the two.
+        """
+        code_with_decorator = """@func_latency_control(delay_responses=[('One moment.', 2), ('One moment.', 2)])
+def my_func(conv: Conversation):
+    pass
+"""
+        _, _, _, lc = Function._extract_decorators(code_with_decorator, "my_func", [])
+
+        first, second = lc.delay_responses
+        self.assertNotEqual(first.id, second.id)
+
+    def test_extract_gives_delay_responses_the_same_ids_on_every_read(self):
+        """Unchanged decorator code reads back the same delay ids every time."""
+        code_with_decorator = """@func_latency_control(delay_responses=[('One moment.', 2), ('One moment.', 2)])
+def my_func(conv: Conversation):
+    pass
+"""
+        _, _, _, first_read = Function._extract_decorators(code_with_decorator, "my_func", [])
+        _, _, _, second_read = Function._extract_decorators(code_with_decorator, "my_func", [])
+
+        first_ids = [dr.id for dr in first_read.delay_responses]
+        second_ids = [dr.id for dr in second_read.delay_responses]
+        self.assertEqual(first_ids, second_ids)
+        for delay_id in first_ids:
+            self.assertRegex(delay_id, r"^DELAY-[a-f0-9]{8}$")
+
+    def test_one_known_id_is_claimed_by_the_first_of_two_identical_delays(self):
+        """A known id is used once, and the duplicate falls back to a derived id."""
+        code_with_decorator = """@func_latency_control(delay_responses=[('One moment.', 2), ('One moment.', 2)])
+def my_func(conv: Conversation):
+    pass
+"""
+        known_lc = FunctionLatencyControl(
+            enabled=True,
+            delay_responses=[
+                FunctionDelayResponse(id="DELAY-existing", message="One moment.", duration=2),
+            ],
+        )
+
+        _, _, _, lc = Function._extract_decorators(code_with_decorator, "my_func", [], known_lc)
+
+        first, second = lc.delay_responses
+        self.assertEqual(first.id, "DELAY-existing")
+        self.assertRegex(second.id, r"^DELAY-[a-f0-9]{8}$")
+        self.assertNotEqual(first.id, second.id)
+
     def test_latency_control_roundtrip(self):
         """to_pretty -> from_pretty -> _extract_decorators round-trip."""
         lc = FunctionLatencyControl(

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -12111,5 +12111,154 @@ class AsrSettingsFromProjection(unittest.TestCase):
         self.assertEqual(AsrSettings.from_projection({}), {})
 
 
+class DeterministicConditionIdTests(unittest.TestCase):
+    """Tests for condition ids being derived from the condition's scoped name.
+
+    A condition in a step file carries no id of its own, so reading a step used to mint a
+    random one. Two reads of an unchanged file then disagreed about the id, which showed
+    up as a spurious change to push and as one condition owning two ids across branches.
+    """
+
+    def _read_condition(
+        self,
+        flow_name: str = "Booking Flow",
+        step_name: str = "Greeting",
+        condition_name: str = "Go to menu",
+        known_conditions: list[Condition] = None,
+    ) -> Condition:
+        """Read a step file holding a single condition, and return that condition."""
+        step_file_name = resource_utils.clean_name(step_name)
+        flow_folder = resource_utils.clean_name(flow_name)
+        file_path = f"flows/{flow_folder}/steps/{step_file_name}.yaml"
+        step_yaml = (
+            "step_type: default_step\n"
+            f"name: {step_name}\n"
+            "conditions:\n"
+            f"  - name: {condition_name}\n"
+            "    condition_type: exit_flow_condition\n"
+            "    description: Leave the flow\n"
+            "    required_entities: []\n"
+            "prompt: Say hello\n"
+        )
+        flow_mapping = ResourceMapping(
+            resource_id="FLOW-1",
+            resource_name=flow_name,
+            resource_type=FlowConfig,
+            file_path=f"flows/{flow_folder}/flow_config.yaml",
+            flow_name=flow_name,
+            resource_prefix=None,
+        )
+
+        with mock_read_from_file({file_path: step_yaml}):
+            step = FlowStep.read_local_resource(
+                file_path=file_path,
+                resource_id="FLOW-1_step-1",
+                resource_name=step_file_name,
+                resource_mappings=[flow_mapping],
+                known_conditions=known_conditions,
+            )
+
+        self.assertEqual(len(step.conditions), 1)
+        return step.conditions[0]
+
+    def test_reading_the_same_step_twice_gives_the_condition_the_same_id(self):
+        """An unchanged step file reads back the same condition id every time."""
+        first_read = self._read_condition()
+        second_read = self._read_condition()
+
+        self.assertEqual(first_read.resource_id, second_read.resource_id)
+        self.assertRegex(first_read.resource_id, r"^CONDITION-[a-f0-9]{8}$")
+
+    def test_same_condition_name_in_another_flow_gets_a_different_id(self):
+        """Two flows may each have a "Go to menu" condition, and they are not the same one."""
+        booking_flow_condition = self._read_condition(flow_name="Booking Flow")
+        support_flow_condition = self._read_condition(flow_name="Support Flow")
+
+        self.assertNotEqual(
+            booking_flow_condition.resource_id, support_flow_condition.resource_id
+        )
+
+    def test_same_condition_name_in_another_step_gets_a_different_id(self):
+        """Steps within one flow may repeat a condition name, so the step is part of the scope."""
+        greeting_condition = self._read_condition(step_name="Greeting")
+        farewell_condition = self._read_condition(step_name="Farewell")
+
+        self.assertNotEqual(greeting_condition.resource_id, farewell_condition.resource_id)
+
+    def test_known_condition_with_a_matching_name_keeps_its_existing_id(self):
+        """An id the platform already assigned wins over the derived one."""
+        known_condition = Condition(
+            resource_id="cond-assigned-by-the-platform",
+            name="Go to menu",
+            description="Leave the flow",
+            condition_type=ConditionType.EXIT_FLOW,
+            child_step="",
+            step_id="step-1",
+            flow_id="FLOW-1",
+            required_entities=[],
+        )
+
+        condition = self._read_condition(known_conditions=[known_condition])
+
+        self.assertEqual(condition.resource_id, "cond-assigned-by-the-platform")
+
+
+class DeterministicParameterIdTests(unittest.TestCase):
+    """Tests for function parameter ids being derived from the parameter's scoped name.
+
+    A @func_parameter decorator carries no id, so reading a function used to mint a random
+    one and two reads of unchanged code disagreed about the parameter's id.
+    """
+
+    def _code(self, function_name: str = "look_up_booking") -> str:
+        """Function source declaring one decorated parameter."""
+        return (
+            "from _gen import *  # <AUTO GENERATED>\n"
+            "\n"
+            "@func_description('Look up a booking')\n"
+            "@func_parameter('booking_ref', 'the booking reference')\n"
+            f"def {function_name}(conv: Conversation, booking_ref: str):\n"
+            "    return booking_ref\n"
+        )
+
+    def test_reading_the_same_code_twice_gives_the_parameter_the_same_id(self):
+        """Unchanged function code reads back the same parameter id every time."""
+        _, first_read, _, _ = Function._extract_decorators(
+            self._code(), "look_up_booking", known_parameters=[]
+        )
+        _, second_read, _, _ = Function._extract_decorators(
+            self._code(), "look_up_booking", known_parameters=[]
+        )
+
+        self.assertEqual(first_read[0].id, second_read[0].id)
+        self.assertRegex(first_read[0].id, r"^PARAMETER-[a-f0-9]{8}$")
+
+    def test_same_parameter_name_in_another_function_gets_a_different_id(self):
+        """Functions may share a parameter name, so the function is part of the scope."""
+        _, look_up_params, _, _ = Function._extract_decorators(
+            self._code("look_up_booking"), "look_up_booking", known_parameters=[]
+        )
+        _, cancel_params, _, _ = Function._extract_decorators(
+            self._code("cancel_booking"), "cancel_booking", known_parameters=[]
+        )
+
+        self.assertNotEqual(look_up_params[0].id, cancel_params[0].id)
+
+    def test_known_parameter_with_a_matching_name_keeps_its_existing_id(self):
+        """An id the platform already assigned wins over the derived one."""
+        known_parameter = FunctionParameters(
+            id="param-assigned-by-the-platform",
+            name="booking_ref",
+            description="the booking reference",
+            type="string",
+        )
+
+        _, parameters, _, _ = Function._extract_decorators(
+            self._code(), "look_up_booking", known_parameters=[known_parameter]
+        )
+
+        self.assertEqual(parameters[0].id, "param-assigned-by-the-platform")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/src/poly/tests/utils_test.py
+++ b/src/poly/tests/utils_test.py
@@ -440,6 +440,57 @@ class StringUtilsTests(unittest.TestCase):
         self.assertEqual(resource_utils.to_camel_case(mixed_case), "thisIsAnotherTestName")
 
 
+class GenerateSubresourceIdTests(unittest.TestCase):
+    """Tests for generate_subresource_id deriving ids from a subresource's scoped name.
+
+    Subresources (conditions, parameters, delay responses) are matched by name inside
+    their parent, so deriving the id from that scoped name is what makes two reads - and
+    two branches - agree on an id instead of each minting a random one.
+    """
+
+    def test_same_scope_always_yields_the_same_id(self):
+        """The same scope derives the same id, however many times it is asked for."""
+        first = resource_utils.generate_subresource_id(
+            "CONDITION", "Booking Flow", "Greeting", "Go to menu"
+        )
+        second = resource_utils.generate_subresource_id(
+            "CONDITION", "Booking Flow", "Greeting", "Go to menu"
+        )
+
+        self.assertEqual(first, second)
+
+    def test_id_has_the_shape_of_a_randomly_minted_id(self):
+        """Derived ids must be drop-in replacements for the random ids they replaced."""
+        derived = resource_utils.generate_subresource_id("PARAMETER", "look_up_booking", "ref")
+
+        self.assertRegex(derived, r"^PARAMETER-[a-f0-9]{8}$")
+
+    def test_different_scopes_yield_different_ids(self):
+        """The same condition name under a different step is a different subresource."""
+        under_greeting = resource_utils.generate_subresource_id(
+            "CONDITION", "Booking Flow", "Greeting", "Go to menu"
+        )
+        under_farewell = resource_utils.generate_subresource_id(
+            "CONDITION", "Booking Flow", "Farewell", "Go to menu"
+        )
+
+        self.assertNotEqual(under_greeting, under_farewell)
+
+    def test_scope_order_is_significant(self):
+        """Scope parts are ordered outermost first, so swapping them is a different scope."""
+        flow_then_step = resource_utils.generate_subresource_id("CONDITION", "booking", "greeting")
+        step_then_flow = resource_utils.generate_subresource_id("CONDITION", "greeting", "booking")
+
+        self.assertNotEqual(flow_then_step, step_then_flow)
+
+    def test_different_prefixes_yield_different_ids(self):
+        """Two kinds of subresource sharing a scope must not share an id."""
+        condition = resource_utils.generate_subresource_id("CONDITION", "greet", "confirm")
+        parameter = resource_utils.generate_subresource_id("PARAMETER", "greet", "confirm")
+
+        self.assertNotEqual(condition, parameter)
+
+
 class ResourceReferenceTests(unittest.TestCase):
     """Tests for resource reference extraction and manipulation."""
 


### PR DESCRIPTION
## Summary

`poly push` now proactively adopts the parent branch's resource ids for new local resources that match by file path, and mints subresource ids (conditions, function parameters, delay responses) deterministically from their scoped names. This keeps ids aligned across branches so merges reconcile resources instead of duplicating them.

## Motivation

When a resource is added on the parent branch and its files reach a child branch (e.g. via a git-side merge of the project repo), pushing previously minted fresh random ids for them. The same logical resource then had a different id on each branch, and merges treated the two copies as unrelated — producing duplicates or name collisions. Adopting existing ids at mint time and deriving subresource ids from stable names removes the main sources of this divergence.

## Changes

- `poly push` fetches the parent branch's resources by file path and passes them into `find_new_kept_deleted`; a new resource whose file path-matches a parent resource adopts the parent's id at mint time. Flows resolve first so composite step ids stay consistent, and steps adopt the parent's bare step id under the local flow prefix.
- Parent-id adoption always runs on real pushes; dry runs skip the parent fetch unless `POLY_ADK_SYNC_PARENT_IDS_TEST=1` forces it for testing.
- Kept resources inherit parent-only subresources by name, so a condition or parameter added on both the parent and the branch ends up with one shared id.
- Condition, function parameter, and delay-response ids are derived from their scoped names (`generate_subresource_id`) instead of minted randomly — repeated reads are idempotent and independently created same-named subresources agree across branches.
- `sync_ids_with_sandbox` is generalized to `sync_ids_with_parent`, defaulting to the branch's actual parent and falling back to main.
- The parent branch's projection can be supplied directly — `push_project(parent_projection_json=...)` for library consumers (e.g. a service embedding the ADK), mirrored by a hidden `--parent-projection JSON|-` CLI flag. A supplied projection builds the parent-id lookup fully offline (no branch or projection fetch) and enables adoption on dry runs; an empty dict means "no parent"; omitting it keeps the fetch behavior.
- Parent fetching and path-keying are split (`_fetch_parent_resources` returning the raw resources + a shared `_resources_by_absolute_path`), and `sync_ids_with_parent` reuses the same fetch for its default-parent resolution.
- Retargeted the id-sync tests at the mint site and added coverage for deterministic ids, subresource inheritance, the offline parent-projection path (enforced by a test API handler that fails on any network call), and the new CLI parsing.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

Manual test pass:

- [x] 1. New resource from the parent adopts the parent's id on push
- [x] 2. New flow with steps — flow id adopted, step ids bare in commands, conditions carry parent ids, references resolve
- [x] 3. New step in a kept flow adopts the parent's bare step id under the branch flow prefix
- [x] 4. Condition added on both sides keeps the parent's condition id (kept step)
- [x] 5. Parameter added on both sides keeps the parent's parameter id
- [x] 6. Repeated dry runs mint identical condition ids (read idempotence)
- [x] 7. Sibling branches mint identical ids for the same-named condition
- [x] 8. Delay-response ids stable across pushes
- [x] 9. Push from main unchanged
- [x] 10. Dry run without the test env var does not fetch the parent
- [x] 11. Local-only resource still mints a random id
- [x] 12. Parent fetch failure mode on a real push
- [x] 13. `sync_ids_with_parent` against a non-main parent
- [x] 14. Pull + status clean after a push with adopted ids
- [x] 15. Merge with an untouched adopted-id resource auto-resolves (audit-only diff)
- [x] 16. Merge with a branch-edited adopted-id resource surfaces a real conflict
- [x] 17. Merge without the audit-field auto-resolve deployed (control)
- [x] 18. `poly push --dry-run --parent-projection -` (projection piped in) shows adopted ids fully offline

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented) — note: real pushes now always attempt parent-id adoption for new resources; dry-run output is unchanged unless the test env var is set
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
