### PR TITLE
feat: add `poly apikey` for one-shot GitHub sign-in and API key setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once installed, use the `poly` command to manage your projects:
 
 ```bash
 poly setup      # Set up everything: account, API key, AI skills, and a project
-poly apikey     # One-shot setup for AI coding assistants
+poly apikey --region studio     # Get an API key for the PolyAI APIs / Dialog RSN
 poly init       # Initialize a project
 poly project    # Manage poly projects
 poly pull       # Pull latest configuration

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Once installed, use the `poly` command to manage your projects:
 
 ```bash
 poly setup      # Set up everything: account, API key, AI skills, and a project
-poly onboard    # One-shot setup for AI coding assistants
+poly apikey     # One-shot setup for AI coding assistants
 poly init       # Initialize a project
 poly project    # Manage poly projects
 poly pull       # Pull latest configuration

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Once installed, use the `poly` command to manage your projects:
 
 ```bash
 poly setup      # Set up everything: account, API key, AI skills, and a project
+poly onboard    # One-shot setup for AI coding assistants
 poly init       # Initialize a project
 poly project    # Manage poly projects
 poly pull       # Pull latest configuration

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -79,12 +79,12 @@ poly login --region us-1
 
 To sign in to more than one region from the same machine, re-run `poly login` for each — the credential file stores them side by side.
 
-### Setup from an AI coding assistant — `poly onboard`
+### Setup from an AI coding assistant — `poly apikey`
 
-If an AI coding agent is setting this up on your behalf, it can run [`poly onboard`](../reference/cli/onboard.md) — a non-interactive, one-shot command that signs in via GitHub, provisions an account-scoped API key, and exports `POLY_API_KEY` into your shell profile without any prompts.
+If an AI coding agent is setting this up on your behalf, it can run [`poly apikey`](../reference/cli/apikey.md) — a non-interactive, one-shot command that signs in via GitHub, provisions an account-scoped API key, and exports `POLY_API_KEY` into your shell profile without any prompts.
 
 ```bash
-poly onboard
+poly apikey
 ```
 
 ### Manual API key export { #manual-api-key-export }

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -79,6 +79,14 @@ poly login --region us-1
 
 To sign in to more than one region from the same machine, re-run `poly login` for each — the credential file stores them side by side.
 
+### Setup from an AI coding assistant — `poly onboard`
+
+If an AI coding agent is setting this up on your behalf, it can run [`poly onboard`](../reference/cli/onboard.md) — a non-interactive, one-shot command that signs in via GitHub, provisions an account-scoped API key, and exports `POLY_API_KEY` into your shell profile without any prompts.
+
+```bash
+poly onboard
+```
+
 ### Manual API key export { #manual-api-key-export }
 
 If you would rather store your credentials in an environment variable - in a CI for example - create the key yourself in the Agent Studio UI:

--- a/docs/docs/get-started/get-started.md
+++ b/docs/docs/get-started/get-started.md
@@ -79,12 +79,12 @@ poly login --region us-1
 
 To sign in to more than one region from the same machine, re-run `poly login` for each — the credential file stores them side by side.
 
-### Setup from an AI coding assistant — `poly apikey`
+### Need an API key for the PolyAI APIs or Dialog RSN? — `poly apikey`
 
-If an AI coding agent is setting this up on your behalf, it can run [`poly apikey`](../reference/cli/apikey.md) — a non-interactive, one-shot command that signs in via GitHub, provisions an account-scoped API key, and exports `POLY_API_KEY` into your shell profile without any prompts.
+`poly apikey --region studio` signs you in, creates an account-scoped API key, and exports `POLY_API_KEY` into your shell profile for use in your own code. It's non-interactive, so an AI coding assistant can run it for you. For setting up the ADK itself, `poly setup`/`poly login` above is the path — the ADK doesn't need `POLY_API_KEY`.
 
 ```bash
-poly apikey
+poly apikey --region studio
 ```
 
 ### Manual API key export { #manual-api-key-export }

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -45,7 +45,7 @@ poly push --help
 |---|---|
 | [`poly setup`](./cli/setup.md) | Set up everything in one command: auth, completion, AI skills, and a project |
 | [`poly login`](./cli/login.md) | Sign in to, or sign up for, an Agent Studio account |
-| [`poly apikey`](./cli/apikey.md) | One-shot GitHub sign-in, account API key, and `POLY_API_KEY` export |
+| [`poly apikey`](./cli/apikey.md) | One-shot sign-in, account API key, and `POLY_API_KEY` export |
 | [`poly init`](./cli/init.md) | Connect a local folder to an existing project |
 | [`poly project`](./cli/project.md) | Create and manage Agent Studio projects |
 | [`poly template`](./cli/template.md) | Browse and load example project templates |

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -45,7 +45,7 @@ poly push --help
 |---|---|
 | [`poly setup`](./cli/setup.md) | Set up everything in one command: auth, completion, AI skills, and a project |
 | [`poly login`](./cli/login.md) | Sign in to, or sign up for, an Agent Studio account |
-| [`poly apikey`](./cli/apikey.md) | One-shot sign-in, account API key, and `POLY_API_KEY` export |
+| [`poly apikey`](./cli/apikey.md) | Get an account-scoped API key for the PolyAI APIs / Dialog RSN and export `POLY_API_KEY` |
 | [`poly init`](./cli/init.md) | Connect a local folder to an existing project |
 | [`poly project`](./cli/project.md) | Create and manage Agent Studio projects |
 | [`poly template`](./cli/template.md) | Browse and load example project templates |
@@ -142,7 +142,7 @@ poly audio-cache bulk-delete --ids id1,id2 --json
 poly audio-cache synthesize <entry_id> --text "Hello" --json
 poly functions execute <function_name> --args '{"x": 1}' --json
 poly functions validate --json
-poly apikey --json
+poly apikey --region studio --json
 ~~~
 
 ### `--json` contract

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -22,7 +22,7 @@ Commands are listed under section headers so related ones stay together:
 
 | Section | Commands |
 |---|---|
-| Getting started | `init`, `setup`, `login`, `onboard`, `studio`, `project` |
+| Getting started | `init`, `setup`, `login`, `apikey`, `studio`, `project` |
 | Project sync | `pull`, `push`, `status`, `revert`, `format`, `validate`, `diff`, `review`, `branch`, `test`, `rtc`, `chat` |
 | Builder API | `deployments`, `conversations`, `audio-cache`, `functions` |
 | Other | `template`, `docs`, `completion` |
@@ -45,7 +45,7 @@ poly push --help
 |---|---|
 | [`poly setup`](./cli/setup.md) | Set up everything in one command: auth, completion, AI skills, and a project |
 | [`poly login`](./cli/login.md) | Sign in to, or sign up for, an Agent Studio account |
-| [`poly onboard`](./cli/onboard.md) | One-shot GitHub sign-in, account API key, and `POLY_API_KEY` export |
+| [`poly apikey`](./cli/apikey.md) | One-shot GitHub sign-in, account API key, and `POLY_API_KEY` export |
 | [`poly init`](./cli/init.md) | Connect a local folder to an existing project |
 | [`poly project`](./cli/project.md) | Create and manage Agent Studio projects |
 | [`poly template`](./cli/template.md) | Browse and load example project templates |
@@ -142,7 +142,7 @@ poly audio-cache bulk-delete --ids id1,id2 --json
 poly audio-cache synthesize <entry_id> --text "Hello" --json
 poly functions execute <function_name> --args '{"x": 1}' --json
 poly functions validate --json
-poly onboard --json
+poly apikey --json
 ~~~
 
 ### `--json` contract

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -22,7 +22,7 @@ Commands are listed under section headers so related ones stay together:
 
 | Section | Commands |
 |---|---|
-| Getting started | `init`, `setup`, `login`, `studio`, `project` |
+| Getting started | `init`, `setup`, `login`, `onboard`, `studio`, `project` |
 | Project sync | `pull`, `push`, `status`, `revert`, `format`, `validate`, `diff`, `review`, `branch`, `test`, `rtc`, `chat` |
 | Builder API | `deployments`, `conversations`, `audio-cache`, `functions` |
 | Other | `template`, `docs`, `completion` |
@@ -45,6 +45,7 @@ poly push --help
 |---|---|
 | [`poly setup`](./cli/setup.md) | Set up everything in one command: auth, completion, AI skills, and a project |
 | [`poly login`](./cli/login.md) | Sign in to, or sign up for, an Agent Studio account |
+| [`poly onboard`](./cli/onboard.md) | One-shot GitHub sign-in, account API key, and `POLY_API_KEY` export |
 | [`poly init`](./cli/init.md) | Connect a local folder to an existing project |
 | [`poly project`](./cli/project.md) | Create and manage Agent Studio projects |
 | [`poly template`](./cli/template.md) | Browse and load example project templates |
@@ -141,6 +142,7 @@ poly audio-cache bulk-delete --ids id1,id2 --json
 poly audio-cache synthesize <entry_id> --text "Hello" --json
 poly functions execute <function_name> --args '{"x": 1}' --json
 poly functions validate --json
+poly onboard --json
 ~~~
 
 ### `--json` contract

--- a/docs/docs/reference/cli/apikey.md
+++ b/docs/docs/reference/cli/apikey.md
@@ -60,9 +60,5 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 
 With `--json`, the sign-in URL and code are printed to stderr instead of being suppressed, since the JSON contract only constrains stdout and an agent that can't open a browser still needs them to complete sign-in. `key_active` is `false` if the key never finished activating within the poll window — the human-readable warning that would normally say so is suppressed in `--json` mode, so this is how an agent detects it.
 
-## Telemetry
-
-`poly apikey` sends anonymous usage events (`apikey_started`, `apikey_authenticated`, `apikey_account_resolved`, `apikey_key_reused`/`apikey_key_created`, `apikey_env_written`, `apikey_completed`, `apikey_failed`) to help improve the flow; the API key and sign-in token are never included. Set `DO_NOT_TRACK=1` or `POLY_NO_TELEMETRY=1` to opt out.
-
 !!! info "Designed for AI coding assistants"
     `poly apikey` never prompts, so it can be run unattended by an agent. It is not a replacement for [`poly login`](./login.md) — that remains the interactive path for a human at the keyboard.

--- a/docs/docs/reference/cli/apikey.md
+++ b/docs/docs/reference/cli/apikey.md
@@ -19,8 +19,8 @@ poly apikey --region us-1
 `poly apikey`:
 
 1. Signs in via the Auth0 device authorization flow. For the default `studio` region, this is a dedicated client whose login page shows only "Continue with GitHub". For any other `--region`, it's the same standard sign-in page (email/SSO) that [`poly login`](./login.md) uses.
-2. Calls the authorise endpoint, which creates your account in that region if it doesn't already exist.
-3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this.
+2. Calls the authorise endpoint. On `studio`, this creates your workspace if you don't already have one. On an enterprise region (`us-1`, `uk-1`, `euw-1`), your account must already be provisioned by PolyAI — the command stops with a clear message if it isn't.
+3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this. On an enterprise region, more than one account without `--account-id` is an error rather than a guess: the command lists the accounts found and asks you to pick one.
 4. Reuses an active, unexpired API key with the default name if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
 5. Saves the key to `~/.poly/credentials.json` under `--region` — but only if no entry for that region already exists there. An existing ADK credential is never overwritten, and credentials for different regions coexist independently.
 6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically. The ADK itself reads `~/.poly/credentials.json` and doesn't need this variable; it's exported for the PolyAI SDKs and other tools that read `POLY_API_KEY` directly.
@@ -53,11 +53,12 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
   "api_key_masked": "sk-n****7890",
   "credentials_file": "/home/user/.poly/credentials.json (studio)",
   "profile_path": "/home/user/.zshrc",
-  "profile_shell": "zsh"
+  "profile_shell": "zsh",
+  "key_active": true
 }
 ~~~
 
-With `--json`, the sign-in URL and code are printed to stderr instead of being suppressed, since the JSON contract only constrains stdout and an agent that can't open a browser still needs them to complete sign-in.
+With `--json`, the sign-in URL and code are printed to stderr instead of being suppressed, since the JSON contract only constrains stdout and an agent that can't open a browser still needs them to complete sign-in. `key_active` is `false` if the key never finished activating within the poll window — the human-readable warning that would normally say so is suppressed in `--json` mode, so this is how an agent detects it.
 
 ## Telemetry
 

--- a/docs/docs/reference/cli/apikey.md
+++ b/docs/docs/reference/cli/apikey.md
@@ -5,22 +5,22 @@ description: Reference for the `poly apikey` command.
 
 # `poly apikey`
 
-One-shot setup for an AI coding assistant: sign-in, an account-scoped API key, and `POLY_API_KEY` exported into your shell profile. Never prompts — use [`poly login`](./login.md) for the interactive, human-driven flow.
+`poly apikey` is the narrower cousin of [`poly login`](./login.md): it gets you an account-scoped API key for the PolyAI APIs and Dialog RSN, not an ADK setup. It signs you in, creates (or reuses) that key, and exports it as `POLY_API_KEY` into your shell profile. Never prompts, so an AI coding assistant can run it for you. To set up the ADK itself, use [`poly setup`](./setup.md) or [`poly login`](./login.md) instead — the ADK reads its credentials from `~/.poly/credentials.json` and does not need `POLY_API_KEY`.
 
 Examples:
 
 ~~~bash
-poly apikey
-poly apikey --account-id acc-123
-poly apikey --key-name my-key --force
+poly apikey --region studio
+poly apikey --region studio --account-id acc-123
+poly apikey --region studio --key-name my-key --force
 poly apikey --region us-1
 ~~~
 
 `poly apikey`:
 
-1. Signs in via the Auth0 device authorization flow. For the default `studio` region, this is a dedicated client whose login page shows only "Continue with GitHub". For any other `--region`, it's the same standard sign-in page (email/SSO) that [`poly login`](./login.md) uses.
+1. Signs in via the Auth0 device authorization flow. For `--region studio`, this is a dedicated client whose login page shows only "Continue with GitHub". For any other `--region`, it's the same standard sign-in page (email/SSO) that [`poly login`](./login.md) uses.
 2. Calls the authorise endpoint. On `studio`, this creates your workspace if you don't already have one. On an enterprise region (`us-1`, `uk-1`, `euw-1`), your account must already be provisioned by PolyAI — the command stops with a clear message if it isn't.
-3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this. On an enterprise region, more than one account without `--account-id` is an error rather than a guess: the command lists the accounts found and asks you to pick one.
+3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this. More than one account without `--account-id` is an error rather than a guess: the command lists the accounts found and asks you to pick one.
 4. Reuses an active, unexpired API key with the default name if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
 5. Saves the key to `~/.poly/credentials.json` under `--region` — but only if no entry for that region already exists there. An existing ADK credential is never overwritten, and credentials for different regions coexist independently.
 6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically. The ADK itself reads `~/.poly/credentials.json` and doesn't need this variable; it's exported for the PolyAI SDKs and other tools that read `POLY_API_KEY` directly.
@@ -29,7 +29,7 @@ poly apikey --region us-1
 Exit codes: `0` on success, `1` on a sign-in, account, or API failure, `2` when `POLY_API_KEY` is already set in your profile to a different value and `--force` was not passed.
 
 !!! info "Which region should I pick?"
-    `--region` defaults to `studio` (PLG) — the cluster individual developers sign up on via GitHub. Pick a production region (`us-1`, `uk-1`, `euw-1`) only if you already have an enterprise account provisioned there; those regions require signing in through the standard email/SSO login page rather than GitHub, since the GitHub-only client only exists for `studio`.
+    `--region` is required. `studio` is the self-serve cluster individual developers sign up on via GitHub. Pick a production region (`us-1`, `uk-1`, `euw-1`) only if you already have an enterprise account provisioned there; those regions require signing in through the standard email/SSO login page rather than GitHub, since the GitHub-only client only exists for `studio`.
 
 ### Windows
 
@@ -37,9 +37,9 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 
 | Flag | Description |
 |---|---|
-| `--region REGION` | Region/cluster to create the key for. Defaults to `studio`. Choices match the standard region list. |
+| `--region REGION` | Region/cluster to create the key for. Required. Choices match the standard region list. |
 | `--key-name NAME` | Name for the account-scoped API key. Defaults to `cli-generated-key` for `studio`, or `cli-generated-key-<region>` for any other region. |
-| `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. |
+| `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. Required when your account has more than one - the command refuses to guess which one you mean. |
 | `--force`, `-f` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
 
 `--json` output shape:
@@ -61,4 +61,4 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 With `--json`, the sign-in URL and code are printed to stderr instead of being suppressed, since the JSON contract only constrains stdout and an agent that can't open a browser still needs them to complete sign-in. `key_active` is `false` if the key never finished activating within the poll window — the human-readable warning that would normally say so is suppressed in `--json` mode, so this is how an agent detects it.
 
 !!! info "Designed for AI coding assistants"
-    `poly apikey` never prompts, so it can be run unattended by an agent. It is not a replacement for [`poly login`](./login.md) — that remains the interactive path for a human at the keyboard.
+    `poly apikey` never prompts, so it can be run unattended by an agent. It gets you an API key for the PolyAI APIs and Dialog RSN, not an ADK setup — for that, use [`poly setup`](./setup.md) or [`poly login`](./login.md), which remain the interactive path for a human at the keyboard.

--- a/docs/docs/reference/cli/apikey.md
+++ b/docs/docs/reference/cli/apikey.md
@@ -5,7 +5,7 @@ description: Reference for the `poly apikey` command.
 
 # `poly apikey`
 
-One-shot setup for an AI coding assistant: GitHub sign-in, an account-scoped API key, and `POLY_API_KEY` exported into your shell profile. Never prompts — use [`poly login`](./login.md) for the interactive, human-driven flow.
+One-shot setup for an AI coding assistant: sign-in, an account-scoped API key, and `POLY_API_KEY` exported into your shell profile. Never prompts — use [`poly login`](./login.md) for the interactive, human-driven flow.
 
 Examples:
 
@@ -13,19 +13,23 @@ Examples:
 poly apikey
 poly apikey --account-id acc-123
 poly apikey --key-name my-key --force
+poly apikey --region us-1
 ~~~
 
 `poly apikey`:
 
-1. Signs in via the Auth0 device authorization flow, against a dedicated client whose login page shows only "Continue with GitHub".
-2. Calls the authorise endpoint, which creates your account if it doesn't already exist.
+1. Signs in via the Auth0 device authorization flow. For the default `studio` region, this is a dedicated client whose login page shows only "Continue with GitHub". For any other `--region`, it's the same standard sign-in page (email/SSO) that [`poly login`](./login.md) uses.
+2. Calls the authorise endpoint, which creates your account in that region if it doesn't already exist.
 3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this.
-4. Reuses an active, unexpired API key named `cli-generated-key` if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
-5. Saves the key to `~/.poly/credentials.json` under the `studio` region — but only if no `studio` entry already exists there. An existing ADK credential is never overwritten.
+4. Reuses an active, unexpired API key with the default name if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
+5. Saves the key to `~/.poly/credentials.json` under `--region` — but only if no entry for that region already exists there. An existing ADK credential is never overwritten, and credentials for different regions coexist independently.
 6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically. The ADK itself reads `~/.poly/credentials.json` and doesn't need this variable; it's exported for the PolyAI SDKs and other tools that read `POLY_API_KEY` directly.
 7. Prints a summary with the key masked. The key and your sign-in token are never printed or logged.
 
 Exit codes: `0` on success, `1` on a sign-in, account, or API failure, `2` when `POLY_API_KEY` is already set in your profile to a different value and `--force` was not passed.
+
+!!! info "Which region should I pick?"
+    `--region` defaults to `studio` (PLG) — the cluster individual developers sign up on via GitHub. Pick a production region (`us-1`, `uk-1`, `euw-1`) only if you already have an enterprise account provisioned there; those regions require signing in through the standard email/SSO login page rather than GitHub, since the GitHub-only client only exists for `studio`.
 
 ### Windows
 
@@ -33,7 +37,8 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 
 | Flag | Description |
 |---|---|
-| `--key-name NAME` | Name for the account-scoped API key. Defaults to `cli-generated-key`. |
+| `--region REGION` | Region/cluster to create the key for. Defaults to `studio`. Choices match the standard region list. |
+| `--key-name NAME` | Name for the account-scoped API key. Defaults to `cli-generated-key` for `studio`, or `cli-generated-key-<region>` for any other region. |
 | `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. |
 | `--force`, `-f` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
 

--- a/docs/docs/reference/cli/apikey.md
+++ b/docs/docs/reference/cli/apikey.md
@@ -1,26 +1,26 @@
 ---
-title: poly onboard
-description: Reference for the `poly onboard` command.
+title: poly apikey
+description: Reference for the `poly apikey` command.
 ---
 
-# `poly onboard`
+# `poly apikey`
 
 One-shot setup for an AI coding assistant: GitHub sign-in, an account-scoped API key, and `POLY_API_KEY` exported into your shell profile. Never prompts — use [`poly login`](./login.md) for the interactive, human-driven flow.
 
 Examples:
 
 ~~~bash
-poly onboard
-poly onboard --account-id acc-123
-poly onboard --key-name my-key --force
+poly apikey
+poly apikey --account-id acc-123
+poly apikey --key-name my-key --force
 ~~~
 
-`poly onboard`:
+`poly apikey`:
 
-1. Signs in via the Auth0 device authorization flow, against a dedicated onboarding client whose login page shows only "Continue with GitHub".
+1. Signs in via the Auth0 device authorization flow, against a dedicated client whose login page shows only "Continue with GitHub".
 2. Calls the authorise endpoint, which creates your account if it doesn't already exist.
 3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this.
-4. Reuses an active, unexpired API key named `onboard-key` if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
+4. Reuses an active, unexpired API key named `cli-generated-key` if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
 5. Saves the key to `~/.poly/credentials.json` under the `studio` region — but only if no `studio` entry already exists there. An existing ADK credential is never overwritten.
 6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically. The ADK itself reads `~/.poly/credentials.json` and doesn't need this variable; it's exported for the PolyAI SDKs and other tools that read `POLY_API_KEY` directly.
 7. Prints a summary with the key masked. The key and your sign-in token are never printed or logged.
@@ -33,7 +33,7 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 
 | Flag | Description |
 |---|---|
-| `--key-name NAME` | Name for the account-scoped API key. Defaults to `onboard-key`. |
+| `--key-name NAME` | Name for the account-scoped API key. Defaults to `cli-generated-key`. |
 | `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. |
 | `--force`, `-f` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
 
@@ -43,7 +43,7 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 {
   "success": true,
   "account_id": "acc-123",
-  "key_name": "onboard-key",
+  "key_name": "cli-generated-key",
   "key_reused": false,
   "api_key_masked": "sk-n****7890",
   "credentials_file": "/home/user/.poly/credentials.json (studio)",
@@ -56,7 +56,7 @@ With `--json`, the sign-in URL and code are printed to stderr instead of being s
 
 ## Telemetry
 
-`poly onboard` sends anonymous usage events (`onboard_started`, `onboard_authenticated`, `onboard_account_resolved`, `onboard_key_reused`/`onboard_key_created`, `onboard_env_written`, `onboard_completed`, `onboard_failed`) to help improve the flow; the API key and sign-in token are never included. Set `DO_NOT_TRACK=1` or `POLY_NO_TELEMETRY=1` to opt out.
+`poly apikey` sends anonymous usage events (`apikey_started`, `apikey_authenticated`, `apikey_account_resolved`, `apikey_key_reused`/`apikey_key_created`, `apikey_env_written`, `apikey_completed`, `apikey_failed`) to help improve the flow; the API key and sign-in token are never included. Set `DO_NOT_TRACK=1` or `POLY_NO_TELEMETRY=1` to opt out.
 
 !!! info "Designed for AI coding assistants"
-    `poly onboard` never prompts, so it can be run unattended by an agent. It is not a replacement for [`poly login`](./login.md) — that remains the interactive path for a human at the keyboard.
+    `poly apikey` never prompts, so it can be run unattended by an agent. It is not a replacement for [`poly login`](./login.md) — that remains the interactive path for a human at the keyboard.

--- a/docs/docs/reference/cli/onboard.md
+++ b/docs/docs/reference/cli/onboard.md
@@ -10,7 +10,6 @@ One-shot setup for an AI coding assistant: GitHub sign-in, an account-scoped API
 Examples:
 
 ~~~bash
-uv tool install --python 3.14 polyai-adk
 poly onboard
 poly onboard --account-id acc-123
 poly onboard --key-name my-key --force
@@ -23,7 +22,7 @@ poly onboard --key-name my-key --force
 3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this.
 4. Reuses an active, unexpired API key named `onboard-key` if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
 5. Saves the key to `~/.poly/credentials.json` under the `studio` region — but only if no `studio` entry already exists there. An existing ADK credential is never overwritten.
-6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically.
+6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically. The ADK itself reads `~/.poly/credentials.json` and doesn't need this variable; it's exported for the PolyAI SDKs and other tools that read `POLY_API_KEY` directly.
 7. Prints a summary with the key masked. The key and your sign-in token are never printed or logged.
 
 Exit codes: `0` on success, `1` on a sign-in, account, or API failure, `2` when `POLY_API_KEY` is already set in your profile to a different value and `--force` was not passed.
@@ -36,7 +35,7 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 |---|---|
 | `--key-name NAME` | Name for the account-scoped API key. Defaults to `onboard-key`. |
 | `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. |
-| `--force` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
+| `--force`, `-f` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
 
 `--json` output shape:
 

--- a/docs/docs/reference/cli/onboard.md
+++ b/docs/docs/reference/cli/onboard.md
@@ -53,6 +53,8 @@ Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If 
 }
 ~~~
 
+With `--json`, the sign-in URL and code are printed to stderr instead of being suppressed, since the JSON contract only constrains stdout and an agent that can't open a browser still needs them to complete sign-in.
+
 ## Telemetry
 
 `poly onboard` sends anonymous usage events (`onboard_started`, `onboard_authenticated`, `onboard_account_resolved`, `onboard_key_reused`/`onboard_key_created`, `onboard_env_written`, `onboard_completed`, `onboard_failed`) to help improve the flow; the API key and sign-in token are never included. Set `DO_NOT_TRACK=1` or `POLY_NO_TELEMETRY=1` to opt out.

--- a/docs/docs/reference/cli/onboard.md
+++ b/docs/docs/reference/cli/onboard.md
@@ -1,0 +1,61 @@
+---
+title: poly onboard
+description: Reference for the `poly onboard` command.
+---
+
+# `poly onboard`
+
+One-shot setup for an AI coding assistant: GitHub sign-in, an account-scoped API key, and `POLY_API_KEY` exported into your shell profile. Never prompts — use [`poly login`](./login.md) for the interactive, human-driven flow.
+
+Examples:
+
+~~~bash
+uv tool install --python 3.14 polyai-adk
+poly onboard
+poly onboard --account-id acc-123
+poly onboard --key-name my-key --force
+~~~
+
+`poly onboard`:
+
+1. Signs in via the Auth0 device authorization flow, against a dedicated onboarding client whose login page shows only "Continue with GitHub".
+2. Calls the authorise endpoint, which creates your account if it doesn't already exist.
+3. Resolves your account id — by default, polls for up to 20 seconds for the newly created account to appear; pass `--account-id` to skip this.
+4. Reuses an active, unexpired API key named `onboard-key` if one already exists for the account, otherwise creates one. Unlike [`poly login`](./login.md)'s Personal Access Token, this key is **account-scoped**.
+5. Saves the key to `~/.poly/credentials.json` under the `studio` region — but only if no `studio` entry already exists there. An existing ADK credential is never overwritten.
+6. Writes `export POLY_API_KEY="..."` (or, on Windows, sets the variable in your user environment) into your detected shell profile, so new shells and processes pick it up automatically.
+7. Prints a summary with the key masked. The key and your sign-in token are never printed or logged.
+
+Exit codes: `0` on success, `1` on a sign-in, account, or API failure, `2` when `POLY_API_KEY` is already set in your profile to a different value and `--force` was not passed.
+
+### Windows
+
+Install [uv](https://docs.astral.sh/uv/) with `winget install astral-sh.uv`. If `poly` is not found after installing, run `uv tool update-shell` and open a new terminal. `POLY_API_KEY` is written to your user environment (`HKCU\Environment`) rather than a shell profile file — it is visible in new terminals and under System Properties → Environment Variables → User variables.
+
+| Flag | Description |
+|---|---|
+| `--key-name NAME` | Name for the account-scoped API key. Defaults to `onboard-key`. |
+| `--account-id ID` | Account ID to scope the key to. Skips polling for a newly created account. |
+| `--force` | Overwrite an existing `POLY_API_KEY` in your profile if it holds a different value. |
+
+`--json` output shape:
+
+~~~json
+{
+  "success": true,
+  "account_id": "acc-123",
+  "key_name": "onboard-key",
+  "key_reused": false,
+  "api_key_masked": "sk-n****7890",
+  "credentials_file": "/home/user/.poly/credentials.json (studio)",
+  "profile_path": "/home/user/.zshrc",
+  "profile_shell": "zsh"
+}
+~~~
+
+## Telemetry
+
+`poly onboard` sends anonymous usage events (`onboard_started`, `onboard_authenticated`, `onboard_account_resolved`, `onboard_key_reused`/`onboard_key_created`, `onboard_env_written`, `onboard_completed`, `onboard_failed`) to help improve the flow; the API key and sign-in token are never included. Set `DO_NOT_TRACK=1` or `POLY_NO_TELEMETRY=1` to opt out.
+
+!!! info "Designed for AI coding assistants"
+    `poly onboard` never prompts, so it can be run unattended by an agent. It is not a replacement for [`poly login`](./login.md) — that remains the interactive path for a human at the keyboard.

--- a/docs/docs/tooling/tooling.md
+++ b/docs/docs/tooling/tooling.md
@@ -72,7 +72,7 @@ Reference `rules.md` in your session prompt. This gives the coding tool accurate
 
     The IDE extension and Claude Code cover different modes of work. You can edit in VS Code or Cursor day-to-day and still reach for Claude Code when you want an agent to generate or refactor a large slice of the project on your behalf.
 
-If you are setting up the ADK from Claude Code or another coding assistant, [`poly onboard`](../reference/cli/onboard.md) performs the GitHub sign-in and API key setup in one non-interactive command.
+If you are setting up the ADK from Claude Code or another coding assistant, [`poly apikey`](../reference/cli/apikey.md) performs the GitHub sign-in and API key setup in one non-interactive command.
 
 ## Other local tools
 

--- a/docs/docs/tooling/tooling.md
+++ b/docs/docs/tooling/tooling.md
@@ -72,6 +72,8 @@ Reference `rules.md` in your session prompt. This gives the coding tool accurate
 
     The IDE extension and Claude Code cover different modes of work. You can edit in VS Code or Cursor day-to-day and still reach for Claude Code when you want an agent to generate or refactor a large slice of the project on your behalf.
 
+If you are setting up the ADK from Claude Code or another coding assistant, [`poly onboard`](../reference/cli/onboard.md) performs the GitHub sign-in and API key setup in one non-interactive command.
+
 ## Other local tools
 
 The ADK also fits well with standard local development tooling such as:

--- a/docs/docs/tooling/tooling.md
+++ b/docs/docs/tooling/tooling.md
@@ -72,8 +72,6 @@ Reference `rules.md` in your session prompt. This gives the coding tool accurate
 
     The IDE extension and Claude Code cover different modes of work. You can edit in VS Code or Cursor day-to-day and still reach for Claude Code when you want an agent to generate or refactor a large slice of the project on your behalf.
 
-If you are setting up the ADK from Claude Code or another coding assistant, [`poly apikey`](../reference/cli/apikey.md) performs the GitHub sign-in and API key setup in one non-interactive command.
-
 ## Other local tools
 
 The ADK also fits well with standard local development tooling such as:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -117,7 +117,7 @@ nav:
           - Overview: reference/cli.md
           - login: reference/cli/login.md
           - setup: reference/cli/setup.md
-          - onboard: reference/cli/onboard.md
+          - apikey: reference/cli/apikey.md
           - init: reference/cli/init.md
           - project: reference/cli/project.md
           - template: reference/cli/template.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -117,6 +117,7 @@ nav:
           - Overview: reference/cli.md
           - login: reference/cli/login.md
           - setup: reference/cli/setup.md
+          - onboard: reference/cli/onboard.md
           - init: reference/cli/init.md
           - project: reference/cli/project.md
           - template: reference/cli/template.md

--- a/src/poly/auth/__init__.py
+++ b/src/poly/auth/__init__.py
@@ -1,0 +1,4 @@
+"""Shared authentication helpers used across CLI command families.
+
+Copyright PolyAI Limited
+"""

--- a/src/poly/auth/device_flow.py
+++ b/src/poly/auth/device_flow.py
@@ -1,0 +1,103 @@
+"""Shared RFC 8628 device authorization flow, used by every command that signs a
+user in via Auth0 (``poly login``, ``poly start``, ``poly onboard``).
+
+Copyright PolyAI Limited
+"""
+
+import logging
+import time
+import webbrowser
+from collections.abc import Callable
+from typing import Optional
+
+import requests
+
+from poly.handlers.auth0_handler import Auth0Handler, AuthDetails
+
+logger = logging.getLogger(__name__)
+
+# Ceiling for the poll interval when Auth0 repeatedly asks us to slow down, so
+# a misbehaving server can't turn this into a near-infinite, ever-slower loop.
+MAX_POLL_INTERVAL_SECONDS = 30
+
+
+class DeviceFlowError(Exception):
+    """Raised when the device authorization flow cannot complete.
+
+    Callers decide how to surface this (e.g. print and exit for a CLI
+    command); the flow itself never calls ``sys.exit``.
+    """
+
+
+def signin_with_device_flow(
+    auth_details: AuthDetails,
+    *,
+    open_browser: bool = True,
+    on_verification_url: Optional[Callable[[str, str], None]] = None,
+) -> str:
+    """Run the device authorization flow against ``auth_details`` and return a JWT.
+
+    Args:
+        auth_details: The Auth0 application (base URL + client id) to authenticate against.
+        open_browser: Whether to open the verification URL in the user's default browser.
+        on_verification_url: Called with ``(verification_uri, user_code)`` once the device
+            code has been issued, so a caller can print its own framing. When omitted, the
+            same message ``poly login``/``poly start`` have always shown is printed.
+
+    Returns:
+        The JWT access token.
+
+    Raises:
+        DeviceFlowError: The flow could not start, timed out, or was rejected.
+    """
+    from poly.output.console import console, info
+
+    try:
+        device_response = Auth0Handler.request_device_code_for(auth_details)
+    except Exception as e:
+        raise DeviceFlowError(f"Failed to start authorization: {e}") from e
+
+    user_code = device_response["user_code"]
+    verification_uri = device_response["verification_uri_complete"]
+    device_code = device_response["device_code"]
+    interval = device_response.get("interval", 5)
+
+    if on_verification_url is not None:
+        on_verification_url(verification_uri, user_code)
+    else:
+        info(
+            "To sign in or create an account, open the following link in your browser\n"
+            "and enter the code when prompted.\n\n"
+            f"  URL:  {verification_uri}\n"
+            f"  Code: [bold]{user_code}[/bold]"
+        )
+
+    if open_browser:
+        webbrowser.open(verification_uri)
+
+    access_token = None
+    with console.status("[info]Waiting for authorization...[/info]"):
+        while not access_token:
+            time.sleep(interval)
+            try:
+                token_response = Auth0Handler.poll_device_token_for(auth_details, device_code)
+                access_token = token_response.get("access_token")
+            except requests.HTTPError as e:
+                try:
+                    body = e.response.json()
+                except (ValueError, AttributeError):
+                    raise DeviceFlowError(f"Authorization failed: {e}") from e
+                err_code = body.get("error")
+                if err_code == "authorization_pending":
+                    continue
+                elif err_code == "slow_down":
+                    interval = min(interval + 5, MAX_POLL_INTERVAL_SECONDS)
+                    continue
+                elif err_code == "expired_token":
+                    raise DeviceFlowError("Authorization timed out. Please try again.") from e
+                else:
+                    raise DeviceFlowError(
+                        f"Authorization failed: {body.get('error_description', e)}"
+                    ) from e
+
+    return access_token

--- a/src/poly/auth/device_flow.py
+++ b/src/poly/auth/device_flow.py
@@ -1,5 +1,5 @@
 """Shared RFC 8628 device authorization flow, used by every command that signs a
-user in via Auth0 (``poly login``, ``poly apikey``).
+user in via Auth0 (``poly login``, ``poly setup``, ``poly apikey``).
 
 Copyright PolyAI Limited
 """

--- a/src/poly/auth/device_flow.py
+++ b/src/poly/auth/device_flow.py
@@ -1,5 +1,5 @@
 """Shared RFC 8628 device authorization flow, used by every command that signs a
-user in via Auth0 (``poly login``, ``poly start``, ``poly onboard``).
+user in via Auth0 (``poly login``, ``poly onboard``).
 
 Copyright PolyAI Limited
 """
@@ -42,7 +42,7 @@ def signin_with_device_flow(
         open_browser: Whether to open the verification URL in the user's default browser.
         on_verification_url: Called with ``(verification_uri, user_code)`` once the device
             code has been issued, so a caller can print its own framing. When omitted, the
-            same message ``poly login``/``poly start`` have always shown is printed.
+            same message ``poly login`` has always shown is printed.
 
     Returns:
         The JWT access token.

--- a/src/poly/auth/device_flow.py
+++ b/src/poly/auth/device_flow.py
@@ -1,5 +1,5 @@
 """Shared RFC 8628 device authorization flow, used by every command that signs a
-user in via Auth0 (``poly login``, ``poly onboard``).
+user in via Auth0 (``poly login``, ``poly apikey``).
 
 Copyright PolyAI Limited
 """

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -11,6 +11,7 @@ from argparse import ArgumentParser
 
 import argcomplete
 
+from poly.cli_commands.apikey import ApiKeyCommand
 from poly.cli_commands.audio_cache import AudioCacheCommand
 from poly.cli_commands.auth import LoginCommand
 from poly.cli_commands.base import (
@@ -26,7 +27,6 @@ from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.functions import FunctionsCommand
-from poly.cli_commands.onboard import OnboardCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand, StudioCommand
 from poly.cli_commands.review import ReviewCommand
 from poly.cli_commands.rtc import RTCCommand
@@ -55,7 +55,7 @@ COMMANDS = [
     InitCommand,
     SetupCommand,
     LoginCommand,
-    OnboardCommand,
+    ApiKeyCommand,
     StudioCommand,
     ProjectCommand,
     TemplateCommand,

--- a/src/poly/cli.py
+++ b/src/poly/cli.py
@@ -26,6 +26,7 @@ from poly.cli_commands.chat import ChatCommand
 from poly.cli_commands.conversations import ConversationsCommand
 from poly.cli_commands.deployments import DeploymentsCommand
 from poly.cli_commands.functions import FunctionsCommand
+from poly.cli_commands.onboard import OnboardCommand
 from poly.cli_commands.project import InitCommand, ProjectCommand, StudioCommand
 from poly.cli_commands.review import ReviewCommand
 from poly.cli_commands.rtc import RTCCommand
@@ -54,6 +55,7 @@ COMMANDS = [
     InitCommand,
     SetupCommand,
     LoginCommand,
+    OnboardCommand,
     StudioCommand,
     ProjectCommand,
     TemplateCommand,

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -12,8 +12,6 @@ Copyright PolyAI Limited
 """
 
 import contextlib
-import logging
-import platform
 import sys
 import time
 import traceback
@@ -31,9 +29,7 @@ from poly.utils.credentials import (
     load_api_key_from_credential_file,
     save_api_key_credential_file,
 )
-from poly.utils.env_profile import EnvVarConflict, ProfileTarget, detect_profile, write_env_var
-
-logger = logging.getLogger(__name__)
+from poly.utils.env_profile import EnvVarConflict, ProfileTarget, write_env_var
 
 DEFAULT_KEY_NAME = "cli-generated-key"
 ACCOUNT_POLL_ATTEMPTS = 20
@@ -47,62 +43,35 @@ def _default_key_name(region: str) -> str:
     return DEFAULT_KEY_NAME if region == "studio" else f"{DEFAULT_KEY_NAME}-{region}"
 
 
-class _Reporter:
-    """Quiet-when-json printing and telemetry, tied to the flow's distinct id.
+def _say(output_json: bool, fn: Callable[[str], None], message: str) -> None:
+    """Print via `fn` unless --json is active (stdout must then be a single JSON object)."""
+    if not output_json:
+        fn(message)
 
-    A small stateful object rather than closures, since the distinct id
-    changes partway through the flow (from an anonymous id to the resolved
-    account id) and every step after that needs to see the new value.
-    """
 
-    def __init__(self, region: str, output_json: bool, base_properties: dict[str, str]):
-        from poly.handlers.posthog import get_anonymous_id, telemetry_disabled
+def _fail(exc: Exception, step: str, exit_code: int, *, output_json: bool, verbose: bool) -> None:
+    """Print a clean error (or re-raise under --verbose) and exit."""
+    if verbose:
+        raise exc
+    message = str(exc)
+    if isinstance(exc, EnvVarConflict):
+        message = f"{exc} Re-run with --force to replace it."
+    if output_json:
+        from poly.output.json_output import json_print
 
-        self.region = region
-        self.output_json = output_json
-        self.base_properties = base_properties
-        # Skip creating ~/.poly/telemetry_id entirely when telemetry is off,
-        # rather than writing it and then never using it.
-        self.distinct_id = "disabled" if telemetry_disabled() else get_anonymous_id()
+        json_print(
+            {
+                "success": False,
+                "error": message,
+                "traceback": traceback.format_exc(),
+                "step": step,
+            }
+        )
+    else:
+        from poly.output.console import error
 
-    def say(self, fn: Callable[[str], None], message: str) -> None:
-        """Print via `fn`, unless --json is active - its output must be the only thing on stdout."""
-        if not self.output_json:
-            fn(message)
-
-    def emit(self, event: str, **extra: object) -> None:
-        """Capture a telemetry event tagged with the current distinct id."""
-        from poly.handlers.posthog import capture_event
-
-        capture_event(self.region, event, {**self.base_properties, **extra}, self.distinct_id)
-
-    def fail(self, exc: Exception, step: str, exit_code: int, *, verbose: bool) -> None:
-        """Report a failure - telemetry, then a clean message or a full traceback - and exit."""
-        from poly.handlers.posthog import flush
-
-        self.emit("apikey_failed", step=step, error_class=type(exc).__name__)
-        flush(self.region)
-        if verbose:
-            raise exc
-        message = str(exc)
-        if isinstance(exc, EnvVarConflict):
-            message = f"{exc} Re-run with --force to replace it."
-        if self.output_json:
-            from poly.output.json_output import json_print
-
-            json_print(
-                {
-                    "success": False,
-                    "error": message,
-                    "traceback": traceback.format_exc(),
-                    "step": step,
-                }
-            )
-        else:
-            from poly.output.console import error
-
-            error(message)
-        sys.exit(exit_code)
+        error(message)
+    sys.exit(exit_code)
 
 
 def _resolve_account_id(
@@ -345,27 +314,13 @@ class ApiKeyCommand(BaseCommand):
         """Sign in and provision an account API key for `region`, then export it."""
         import requests
 
-        from poly.cli_commands.shared import get_package_version
-        from poly.handlers.posthog import flush
         from poly.output.console import err_console, info, mask_api_key, plain, success
 
         key_name = key_name if key_name is not None else _default_key_name(region)
 
-        reporter = _Reporter(
-            region,
-            output_json,
-            {
-                "source": APIKEY_SOURCE,
-                "adk_version": get_package_version(),
-                "os": platform.system(),
-                "shell": detect_profile().shell,
-            },
-        )
-
         step = "start"
         try:
-            reporter.emit("apikey_started")
-            reporter.say(info, "Setting up your PolyAI account and API key...")
+            _say(output_json, info, "Setting up your PolyAI account and API key...")
 
             step = "signin"
             auth_details = (
@@ -384,25 +339,23 @@ class ApiKeyCommand(BaseCommand):
                     f"  URL:  {verification_uri}\n"
                     f"  Code: [bold]{user_code}[/bold]"
                 )
-                if reporter.output_json:
+                if output_json:
                     # --json only constrains stdout - an agent that can't open a
                     # browser itself still needs this to complete sign-in, so it
                     # goes to stderr rather than being dropped like every other
                     # human-readable message in this mode.
                     err_console.print(f"[info]{message}[/info]")
                 else:
-                    reporter.say(info, message)
-                reporter.emit("apikey_device_code_issued")
+                    _say(output_json, info, message)
 
             jwt_token = signin_with_device_flow(
                 auth_details, on_verification_url=on_verification_url
             )
-            reporter.emit("apikey_authenticated")
-            reporter.say(success, "Authenticated successfully!")
+            _say(output_json, success, "Authenticated successfully!")
 
             step = "authorise"
             api = AgentStudioInterface()
-            reporter.say(info, "Setting up your account...")
+            _say(output_json, info, "Setting up your account...")
             try:
                 api.authorise(region=region, jwt_token=jwt_token)
             except requests.HTTPError as e:
@@ -416,44 +369,40 @@ class ApiKeyCommand(BaseCommand):
 
             step = "account"
             resolved_account_id = _resolve_account_id(api, region, jwt_token, account_id)
-            reporter.emit("apikey_account_resolved", account_id=resolved_account_id)
-            _alias_to_account(region, reporter.distinct_id, resolved_account_id)
-            reporter.distinct_id = resolved_account_id
 
             step = "key"
             api_key, key_reused = _get_or_create_key(
                 api, region, jwt_token, resolved_account_id, key_name
             )
             if key_reused:
-                reporter.say(success, f"Reusing existing '{key_name}' key: {mask_api_key(api_key)}")
-                reporter.emit(
-                    "apikey_key_reused", account_id=resolved_account_id, key_name=key_name
+                _say(
+                    output_json,
+                    success,
+                    f"Reusing existing '{key_name}' key: {mask_api_key(api_key)}",
                 )
             else:
-                reporter.say(success, f"Created API key '{key_name}': {mask_api_key(api_key)}")
-                reporter.emit(
-                    "apikey_key_created", account_id=resolved_account_id, key_name=key_name
-                )
+                _say(output_json, success, f"Created API key '{key_name}': {mask_api_key(api_key)}")
 
             step = "credentials"
             saved, credentials_summary = _save_credentials(region, api_key)
             if saved:
-                reporter.say(info, f"Saved to {credentials_summary}.")
+                _say(output_json, info, f"Saved to {credentials_summary}.")
             else:
-                reporter.say(info, f"Existing ADK credential for {region} kept.")
+                _say(output_json, info, f"Existing ADK credential for {region} kept.")
 
             step = "activation"
             from poly.output.console import console, warning
 
             status_ctx = (
                 contextlib.nullcontext()
-                if reporter.output_json
+                if output_json
                 else console.status("[info]Verifying API key is active...[/info]")
             )
             with status_ctx:
                 key_active = _wait_for_key_active(api, region)
             if not key_active:
-                reporter.say(
+                _say(
+                    output_json,
                     warning,
                     "API key was saved but is not active yet."
                     " If your next command fails, wait a moment and retry.",
@@ -461,14 +410,8 @@ class ApiKeyCommand(BaseCommand):
 
             step = "env"
             target, masked_line = write_env_var("POLY_API_KEY", api_key, force=force)
-            reporter.say(info, f"Wrote to {target.path}:")
-            reporter.say(plain, f"  {masked_line}")
-            reporter.emit(
-                "apikey_env_written", account_id=resolved_account_id, profile_shell=target.shell
-            )
-
-            reporter.emit("apikey_completed", account_id=resolved_account_id, key_reused=key_reused)
-            flush(region)
+            _say(output_json, info, f"Wrote to {target.path}:")
+            _say(output_json, plain, f"  {masked_line}")
 
             if output_json:
                 _print_json(
@@ -492,21 +435,6 @@ class ApiKeyCommand(BaseCommand):
                 )
 
         except EnvVarConflict as e:
-            reporter.fail(e, step, exit_code=2, verbose=verbose)
+            _fail(e, step, exit_code=2, output_json=output_json, verbose=verbose)
         except (DeviceFlowError, requests.HTTPError, ValueError) as e:
-            reporter.fail(e, step, exit_code=1, verbose=verbose)
-
-
-def _alias_to_account(region: str, anonymous_id: str, account_id: str) -> None:
-    """Link the anonymous telemetry id to the resolved account, once.
-
-    Never raises: a failure here must not interrupt the flow.
-    """
-    from poly.handlers.posthog import get_posthog_client, telemetry_disabled
-
-    if telemetry_disabled():
-        return
-    try:
-        get_posthog_client(region).alias(previous_id=anonymous_id, distinct_id=account_id)
-    except Exception:
-        logger.warning("PostHog alias failed", exc_info=True)
+            _fail(e, step, exit_code=1, output_json=output_json, verbose=verbose)

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -1,10 +1,12 @@
-"""API key command: one-shot GitHub sign-in and account API key setup.
+"""API key command: one-shot sign-in and account API key setup.
 
-`poly apikey` signs a user in via the GitHub-only Auth0 device flow, creates
-their PolyAI account if needed, provisions (or reuses) an account-scoped API
-key, and writes ``POLY_API_KEY`` into their shell profile - or, on Windows,
-their user environment. It never prompts. See ``poly apikey --help`` or
-``docs/docs/reference/cli/apikey.md`` for the full step-by-step behaviour.
+`poly apikey` signs a user in - via the GitHub-only Auth0 device flow for the
+default `studio` region, or the standard sign-in page for any other region -
+creates their PolyAI account if needed, provisions (or reuses) an
+account-scoped API key, and writes ``POLY_API_KEY`` into their shell profile -
+or, on Windows, their user environment. It never prompts. See
+``poly apikey --help`` or ``docs/docs/reference/cli/apikey.md`` for the full
+step-by-step behaviour.
 
 Copyright PolyAI Limited
 """
@@ -21,8 +23,8 @@ from typing import Callable
 
 from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
 from poly.cli_commands.base import GETTING_STARTED_GROUP, BaseCommand, Parents
-from poly.handlers.auth0_handler import APIKEY_AUTH_DETAILS
-from poly.handlers.interface import AgentStudioInterface
+from poly.handlers.auth0_handler import APIKEY_AUTH_DETAILS, REGION_TO_AUTH_DETAILS
+from poly.handlers.interface import REGIONS, AgentStudioInterface
 from poly.utils.api_keys import select_reusable_api_key
 from poly.utils.credentials import (
     CREDENTIALS_FILE_PATH,
@@ -33,16 +35,16 @@ from poly.utils.env_profile import EnvVarConflict, ProfileTarget, detect_profile
 
 logger = logging.getLogger(__name__)
 
-# `poly apikey` always targets the PLG/studio cluster - it is the only
-# cluster the dedicated Auth0 client (GitHub-only login) is registered
-# against, so unlike `login` there is no --region choice here.
-APIKEY_REGION = "studio"
-
 DEFAULT_KEY_NAME = "cli-generated-key"
 ACCOUNT_POLL_ATTEMPTS = 20
 ACCOUNT_POLL_INTERVAL_SECONDS = 1
 ACCOUNT_POLL_TIMEOUT_SECONDS = ACCOUNT_POLL_ATTEMPTS * ACCOUNT_POLL_INTERVAL_SECONDS
 APIKEY_SOURCE = "apikey"
+
+
+def _default_key_name(region: str) -> str:
+    """The default API key name - disambiguated by region so keys never collide."""
+    return DEFAULT_KEY_NAME if region == "studio" else f"{DEFAULT_KEY_NAME}-{region}"
 
 
 def _adk_version() -> str:
@@ -61,9 +63,10 @@ class _Reporter:
     account id) and every step after that needs to see the new value.
     """
 
-    def __init__(self, output_json: bool, base_properties: dict[str, str]):
+    def __init__(self, region: str, output_json: bool, base_properties: dict[str, str]):
         from poly.handlers.posthog import get_anonymous_id, telemetry_disabled
 
+        self.region = region
         self.output_json = output_json
         self.base_properties = base_properties
         # Skip creating ~/.poly/telemetry_id entirely when telemetry is off,
@@ -79,14 +82,14 @@ class _Reporter:
         """Capture a telemetry event tagged with the current distinct id."""
         from poly.handlers.posthog import capture_event
 
-        capture_event(APIKEY_REGION, event, {**self.base_properties, **extra}, self.distinct_id)
+        capture_event(self.region, event, {**self.base_properties, **extra}, self.distinct_id)
 
     def fail(self, exc: Exception, step: str, exit_code: int, *, verbose: bool) -> None:
         """Report a failure - telemetry, then a clean message or a full traceback - and exit."""
         from poly.handlers.posthog import flush
 
         self.emit("apikey_failed", step=step, error_class=type(exc).__name__)
-        flush(APIKEY_REGION)
+        flush(self.region)
         if verbose:
             raise exc
         message = str(exc)
@@ -110,7 +113,9 @@ class _Reporter:
         sys.exit(exit_code)
 
 
-def _resolve_account_id(api: AgentStudioInterface, jwt_token: str, account_id: str | None) -> str:
+def _resolve_account_id(
+    api: AgentStudioInterface, region: str, jwt_token: str, account_id: str | None
+) -> str:
     """Return `account_id` unchanged, or poll for the first account to appear.
 
     Raises:
@@ -120,7 +125,7 @@ def _resolve_account_id(api: AgentStudioInterface, jwt_token: str, account_id: s
         return account_id
     for _ in range(ACCOUNT_POLL_ATTEMPTS):
         accounts = api.get_accounts_internal(
-            region=APIKEY_REGION, jwt_token=jwt_token, source=APIKEY_SOURCE
+            region=region, jwt_token=jwt_token, source=APIKEY_SOURCE
         )
         if accounts:
             return accounts[0]["id"]
@@ -131,7 +136,7 @@ def _resolve_account_id(api: AgentStudioInterface, jwt_token: str, account_id: s
 
 
 def _get_or_create_key(
-    api: AgentStudioInterface, jwt_token: str, account_id: str, key_name: str
+    api: AgentStudioInterface, region: str, jwt_token: str, account_id: str, key_name: str
 ) -> tuple[str, bool]:
     """Reuse an active, unexpired key named `key_name`, or create one.
 
@@ -142,14 +147,14 @@ def _get_or_create_key(
         ValueError: The create call succeeded but returned no key.
     """
     keys = api.list_account_api_keys_internal(
-        region=APIKEY_REGION, jwt_token=jwt_token, account_id=account_id, source=APIKEY_SOURCE
+        region=region, jwt_token=jwt_token, account_id=account_id, source=APIKEY_SOURCE
     )
     existing_key = select_reusable_api_key(keys, key_name, datetime.now(timezone.utc))
     if existing_key is not None:
         return existing_key, True
 
     response = api.create_account_api_key_internal(
-        region=APIKEY_REGION,
+        region=region,
         jwt_token=jwt_token,
         account_id=account_id,
         name=key_name,
@@ -161,17 +166,17 @@ def _get_or_create_key(
     return api_key, False
 
 
-def _save_credentials(api_key: str) -> tuple[bool, str]:
-    """Save `api_key` to the credential file, unless studio already has one.
+def _save_credentials(region: str, api_key: str) -> tuple[bool, str]:
+    """Save `api_key` to the credential file, unless `region` already has one.
 
     Returns:
         tuple[bool, str]: Whether a new credential was saved, and a summary
             of what happened, for the completion output.
     """
-    if load_api_key_from_credential_file(APIKEY_REGION) is not None:
+    if load_api_key_from_credential_file(region) is not None:
         return False, "existing credential kept"
-    save_api_key_credential_file(api_key, region=APIKEY_REGION)
-    return True, f"{CREDENTIALS_FILE_PATH} ({APIKEY_REGION})"
+    save_api_key_credential_file(api_key, region=region)
+    return True, f"{CREDENTIALS_FILE_PATH} ({region})"
 
 
 def _print_summary(
@@ -229,7 +234,7 @@ def _print_json(
 
 
 class ApiKeyCommand(BaseCommand):
-    """One-shot GitHub sign-in, account API key, and POLY_API_KEY setup."""
+    """One-shot sign-in, account API key, and POLY_API_KEY setup."""
 
     command = "apikey"
 
@@ -243,7 +248,7 @@ class ApiKeyCommand(BaseCommand):
             parents=[parents.verbose, parents.debug, parents.json],
             help="One-shot setup for AI coding assistants.",
             description=(
-                "One-shot setup: GitHub sign-in, account API key, POLY_API_KEY in your"
+                "One-shot setup: sign-in, account API key, POLY_API_KEY in your"
                 " environment.\n\n"
                 "Never prompts. Designed to be run by an AI coding assistant; fine to run"
                 " yourself.\n\n"
@@ -251,13 +256,28 @@ class ApiKeyCommand(BaseCommand):
                 "Examples:\n"
                 "  poly apikey\n"
                 "  poly apikey --account-id acc-123\n"
+                "  poly apikey --region us-1\n"
+            ),
+        )
+        apikey_parser.add_argument(
+            "--region",
+            type=str,
+            choices=REGIONS,
+            default="studio",
+            help=(
+                "Region/cluster to create the key for. Defaults to 'studio' (PLG), which"
+                " signs in via GitHub only. Any other region uses the standard sign-in page"
+                " (email/SSO), the same one `poly login` uses."
             ),
         )
         apikey_parser.add_argument(
             "--key-name",
             type=str,
-            default=DEFAULT_KEY_NAME,
-            help=f"Name for the account-scoped API key. Defaults to '{DEFAULT_KEY_NAME}'.",
+            default=None,
+            help=(
+                f"Name for the account-scoped API key. Defaults to '{DEFAULT_KEY_NAME}' for"
+                f" studio, or '{DEFAULT_KEY_NAME}-<region>' for any other region."
+            ),
         )
         apikey_parser.add_argument(
             "--account-id",
@@ -276,6 +296,7 @@ class ApiKeyCommand(BaseCommand):
     def run(cls, args: Namespace) -> None:
         """Dispatch to the apikey handler."""
         cls.apikey(
+            region=args.region,
             key_name=args.key_name,
             account_id=args.account_id,
             force=args.force,
@@ -286,19 +307,23 @@ class ApiKeyCommand(BaseCommand):
     @classmethod
     def apikey(
         cls,
-        key_name: str = DEFAULT_KEY_NAME,
+        region: str = "studio",
+        key_name: str | None = None,
         account_id: str | None = None,
         force: bool = False,
         output_json: bool = False,
         verbose: bool = False,
     ) -> None:
-        """Sign in via GitHub, provision an account API key, and export it."""
+        """Sign in and provision an account API key for `region`, then export it."""
         import requests
 
         from poly.handlers.posthog import flush
         from poly.output.console import err_console, info, mask_api_key, plain, success
 
+        key_name = key_name if key_name is not None else _default_key_name(region)
+
         reporter = _Reporter(
+            region,
             output_json,
             {
                 "source": APIKEY_SOURCE,
@@ -314,10 +339,14 @@ class ApiKeyCommand(BaseCommand):
             reporter.say(info, "Setting up your PolyAI account and API key...")
 
             step = "signin"
+            auth_details = (
+                APIKEY_AUTH_DETAILS if region == "studio" else REGION_TO_AUTH_DETAILS[region]
+            )
+            sign_in_via = "GitHub" if region == "studio" else "your browser"
 
             def on_verification_url(verification_uri: str, user_code: str) -> None:
                 message = (
-                    "To sign in with GitHub, open the following link in your browser\n"
+                    f"To sign in with {sign_in_via}, open the following link in your browser\n"
                     "and enter the code when prompted.\n\n"
                     f"  URL:  {verification_uri}\n"
                     f"  Code: [bold]{user_code}[/bold]"
@@ -333,7 +362,7 @@ class ApiKeyCommand(BaseCommand):
                 reporter.emit("apikey_device_code_issued")
 
             jwt_token = signin_with_device_flow(
-                APIKEY_AUTH_DETAILS, on_verification_url=on_verification_url
+                auth_details, on_verification_url=on_verification_url
             )
             reporter.emit("apikey_authenticated")
             reporter.say(success, "Authenticated successfully!")
@@ -341,16 +370,18 @@ class ApiKeyCommand(BaseCommand):
             step = "authorise"
             api = AgentStudioInterface()
             reporter.say(info, "Setting up your account...")
-            api.authorise(region=APIKEY_REGION, jwt_token=jwt_token)
+            api.authorise(region=region, jwt_token=jwt_token)
 
             step = "account"
-            resolved_account_id = _resolve_account_id(api, jwt_token, account_id)
+            resolved_account_id = _resolve_account_id(api, region, jwt_token, account_id)
             reporter.emit("apikey_account_resolved", account_id=resolved_account_id)
-            _alias_to_account(reporter.distinct_id, resolved_account_id)
+            _alias_to_account(region, reporter.distinct_id, resolved_account_id)
             reporter.distinct_id = resolved_account_id
 
             step = "key"
-            api_key, key_reused = _get_or_create_key(api, jwt_token, resolved_account_id, key_name)
+            api_key, key_reused = _get_or_create_key(
+                api, region, jwt_token, resolved_account_id, key_name
+            )
             if key_reused:
                 reporter.say(success, f"Reusing existing '{key_name}' key: {mask_api_key(api_key)}")
                 reporter.emit(
@@ -363,11 +394,11 @@ class ApiKeyCommand(BaseCommand):
                 )
 
             step = "credentials"
-            saved, credentials_summary = _save_credentials(api_key)
+            saved, credentials_summary = _save_credentials(region, api_key)
             if saved:
                 reporter.say(info, f"Saved to {credentials_summary}.")
             else:
-                reporter.say(info, f"Existing ADK credential for {APIKEY_REGION} kept.")
+                reporter.say(info, f"Existing ADK credential for {region} kept.")
 
             step = "env"
             target, masked_line = write_env_var("POLY_API_KEY", api_key, force=force)
@@ -378,7 +409,7 @@ class ApiKeyCommand(BaseCommand):
             )
 
             reporter.emit("apikey_completed", account_id=resolved_account_id, key_reused=key_reused)
-            flush(APIKEY_REGION)
+            flush(region)
 
             if output_json:
                 _print_json(
@@ -401,7 +432,7 @@ class ApiKeyCommand(BaseCommand):
             reporter.fail(e, step, exit_code=1, verbose=verbose)
 
 
-def _alias_to_account(anonymous_id: str, account_id: str) -> None:
+def _alias_to_account(region: str, anonymous_id: str, account_id: str) -> None:
     """Link the anonymous telemetry id to the resolved account, once.
 
     Never raises: a failure here must not interrupt the flow.
@@ -411,6 +442,6 @@ def _alias_to_account(anonymous_id: str, account_id: str) -> None:
     if telemetry_disabled():
         return
     try:
-        get_posthog_client(APIKEY_REGION).alias(previous_id=anonymous_id, distinct_id=account_id)
+        get_posthog_client(region).alias(previous_id=anonymous_id, distinct_id=account_id)
     except Exception:
         logger.warning("PostHog alias failed", exc_info=True)

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -1,10 +1,10 @@
-"""Onboard command: one-shot GitHub sign-in and account API key setup.
+"""API key command: one-shot GitHub sign-in and account API key setup.
 
-`poly onboard` signs a user in via the GitHub-only Auth0 device flow, creates
+`poly apikey` signs a user in via the GitHub-only Auth0 device flow, creates
 their PolyAI account if needed, provisions (or reuses) an account-scoped API
 key, and writes ``POLY_API_KEY`` into their shell profile - or, on Windows,
-their user environment. It never prompts. See ``poly onboard --help`` or
-``docs/docs/reference/cli/onboard.md`` for the full step-by-step behaviour.
+their user environment. It never prompts. See ``poly apikey --help`` or
+``docs/docs/reference/cli/apikey.md`` for the full step-by-step behaviour.
 
 Copyright PolyAI Limited
 """
@@ -21,7 +21,7 @@ from typing import Callable
 
 from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
 from poly.cli_commands.base import GETTING_STARTED_GROUP, BaseCommand, Parents
-from poly.handlers.auth0_handler import ONBOARD_AUTH_DETAILS
+from poly.handlers.auth0_handler import APIKEY_AUTH_DETAILS
 from poly.handlers.interface import AgentStudioInterface
 from poly.utils.api_keys import select_reusable_api_key
 from poly.utils.credentials import (
@@ -33,16 +33,16 @@ from poly.utils.env_profile import EnvVarConflict, ProfileTarget, detect_profile
 
 logger = logging.getLogger(__name__)
 
-# `poly onboard` always targets the PLG/studio cluster - it is the only
-# cluster the onboarding Auth0 client (GitHub-only login) is registered
+# `poly apikey` always targets the PLG/studio cluster - it is the only
+# cluster the dedicated Auth0 client (GitHub-only login) is registered
 # against, so unlike `login` there is no --region choice here.
-ONBOARD_REGION = "studio"
+APIKEY_REGION = "studio"
 
-DEFAULT_KEY_NAME = "onboard-key"
+DEFAULT_KEY_NAME = "cli-generated-key"
 ACCOUNT_POLL_ATTEMPTS = 20
 ACCOUNT_POLL_INTERVAL_SECONDS = 1
 ACCOUNT_POLL_TIMEOUT_SECONDS = ACCOUNT_POLL_ATTEMPTS * ACCOUNT_POLL_INTERVAL_SECONDS
-POSTHOG_SOURCE = "onboard"
+APIKEY_SOURCE = "apikey"
 
 
 def _adk_version() -> str:
@@ -79,14 +79,14 @@ class _Reporter:
         """Capture a telemetry event tagged with the current distinct id."""
         from poly.handlers.posthog import capture_event
 
-        capture_event(ONBOARD_REGION, event, {**self.base_properties, **extra}, self.distinct_id)
+        capture_event(APIKEY_REGION, event, {**self.base_properties, **extra}, self.distinct_id)
 
     def fail(self, exc: Exception, step: str, exit_code: int, *, verbose: bool) -> None:
         """Report a failure - telemetry, then a clean message or a full traceback - and exit."""
         from poly.handlers.posthog import flush
 
-        self.emit("onboard_failed", step=step, error_class=type(exc).__name__)
-        flush(ONBOARD_REGION)
+        self.emit("apikey_failed", step=step, error_class=type(exc).__name__)
+        flush(APIKEY_REGION)
         if verbose:
             raise exc
         message = str(exc)
@@ -120,7 +120,7 @@ def _resolve_account_id(api: AgentStudioInterface, jwt_token: str, account_id: s
         return account_id
     for _ in range(ACCOUNT_POLL_ATTEMPTS):
         accounts = api.get_accounts_internal(
-            region=ONBOARD_REGION, jwt_token=jwt_token, source=POSTHOG_SOURCE
+            region=APIKEY_REGION, jwt_token=jwt_token, source=APIKEY_SOURCE
         )
         if accounts:
             return accounts[0]["id"]
@@ -142,18 +142,18 @@ def _get_or_create_key(
         ValueError: The create call succeeded but returned no key.
     """
     keys = api.list_account_api_keys_internal(
-        region=ONBOARD_REGION, jwt_token=jwt_token, account_id=account_id, source=POSTHOG_SOURCE
+        region=APIKEY_REGION, jwt_token=jwt_token, account_id=account_id, source=APIKEY_SOURCE
     )
     existing_key = select_reusable_api_key(keys, key_name, datetime.now(timezone.utc))
     if existing_key is not None:
         return existing_key, True
 
     response = api.create_account_api_key_internal(
-        region=ONBOARD_REGION,
+        region=APIKEY_REGION,
         jwt_token=jwt_token,
         account_id=account_id,
         name=key_name,
-        source=POSTHOG_SOURCE,
+        source=APIKEY_SOURCE,
     )
     api_key = response.get("key")
     if not api_key:
@@ -168,10 +168,10 @@ def _save_credentials(api_key: str) -> tuple[bool, str]:
         tuple[bool, str]: Whether a new credential was saved, and a summary
             of what happened, for the completion output.
     """
-    if load_api_key_from_credential_file(ONBOARD_REGION) is not None:
+    if load_api_key_from_credential_file(APIKEY_REGION) is not None:
         return False, "existing credential kept"
-    save_api_key_credential_file(api_key, region=ONBOARD_REGION)
-    return True, f"{CREDENTIALS_FILE_PATH} ({ONBOARD_REGION})"
+    save_api_key_credential_file(api_key, region=APIKEY_REGION)
+    return True, f"{CREDENTIALS_FILE_PATH} ({APIKEY_REGION})"
 
 
 def _print_summary(
@@ -228,18 +228,18 @@ def _print_json(
     )
 
 
-class OnboardCommand(BaseCommand):
+class ApiKeyCommand(BaseCommand):
     """One-shot GitHub sign-in, account API key, and POLY_API_KEY setup."""
 
-    command = "onboard"
+    command = "apikey"
 
     group = GETTING_STARTED_GROUP
 
     @classmethod
     def add_arguments(cls, subparsers: _SubParsersAction[ArgumentParser], parents: Parents) -> None:
-        """Register the ``onboard`` subcommand."""
-        onboard_parser = subparsers.add_parser(
-            "onboard",
+        """Register the ``apikey`` subcommand."""
+        apikey_parser = subparsers.add_parser(
+            "apikey",
             parents=[parents.verbose, parents.debug, parents.json],
             help="One-shot setup for AI coding assistants.",
             description=(
@@ -249,23 +249,23 @@ class OnboardCommand(BaseCommand):
                 " yourself.\n\n"
                 "To sign in interactively instead, use `poly login`.\n\n"
                 "Examples:\n"
-                "  poly onboard\n"
-                "  poly onboard --account-id acc-123\n"
+                "  poly apikey\n"
+                "  poly apikey --account-id acc-123\n"
             ),
         )
-        onboard_parser.add_argument(
+        apikey_parser.add_argument(
             "--key-name",
             type=str,
             default=DEFAULT_KEY_NAME,
             help=f"Name for the account-scoped API key. Defaults to '{DEFAULT_KEY_NAME}'.",
         )
-        onboard_parser.add_argument(
+        apikey_parser.add_argument(
             "--account-id",
             type=str,
             default=None,
             help="Account ID to scope the key to. Skips polling for a newly created account.",
         )
-        onboard_parser.add_argument(
+        apikey_parser.add_argument(
             "--force",
             "-f",
             action="store_true",
@@ -274,8 +274,8 @@ class OnboardCommand(BaseCommand):
 
     @classmethod
     def run(cls, args: Namespace) -> None:
-        """Dispatch to the onboard handler."""
-        cls.onboard(
+        """Dispatch to the apikey handler."""
+        cls.apikey(
             key_name=args.key_name,
             account_id=args.account_id,
             force=args.force,
@@ -284,7 +284,7 @@ class OnboardCommand(BaseCommand):
         )
 
     @classmethod
-    def onboard(
+    def apikey(
         cls,
         key_name: str = DEFAULT_KEY_NAME,
         account_id: str | None = None,
@@ -301,7 +301,7 @@ class OnboardCommand(BaseCommand):
         reporter = _Reporter(
             output_json,
             {
-                "source": POSTHOG_SOURCE,
+                "source": APIKEY_SOURCE,
                 "adk_version": _adk_version(),
                 "os": platform.system(),
                 "shell": detect_profile().shell,
@@ -310,7 +310,7 @@ class OnboardCommand(BaseCommand):
 
         step = "start"
         try:
-            reporter.emit("onboard_started")
+            reporter.emit("apikey_started")
             reporter.say(info, "Setting up your PolyAI account and API key...")
 
             step = "signin"
@@ -330,22 +330,22 @@ class OnboardCommand(BaseCommand):
                     err_console.print(f"[info]{message}[/info]")
                 else:
                     reporter.say(info, message)
-                reporter.emit("onboard_device_code_issued")
+                reporter.emit("apikey_device_code_issued")
 
             jwt_token = signin_with_device_flow(
-                ONBOARD_AUTH_DETAILS, on_verification_url=on_verification_url
+                APIKEY_AUTH_DETAILS, on_verification_url=on_verification_url
             )
-            reporter.emit("onboard_authenticated")
+            reporter.emit("apikey_authenticated")
             reporter.say(success, "Authenticated successfully!")
 
             step = "authorise"
             api = AgentStudioInterface()
             reporter.say(info, "Setting up your account...")
-            api.authorise(region=ONBOARD_REGION, jwt_token=jwt_token)
+            api.authorise(region=APIKEY_REGION, jwt_token=jwt_token)
 
             step = "account"
             resolved_account_id = _resolve_account_id(api, jwt_token, account_id)
-            reporter.emit("onboard_account_resolved", account_id=resolved_account_id)
+            reporter.emit("apikey_account_resolved", account_id=resolved_account_id)
             _alias_to_account(reporter.distinct_id, resolved_account_id)
             reporter.distinct_id = resolved_account_id
 
@@ -354,12 +354,12 @@ class OnboardCommand(BaseCommand):
             if key_reused:
                 reporter.say(success, f"Reusing existing '{key_name}' key: {mask_api_key(api_key)}")
                 reporter.emit(
-                    "onboard_key_reused", account_id=resolved_account_id, key_name=key_name
+                    "apikey_key_reused", account_id=resolved_account_id, key_name=key_name
                 )
             else:
                 reporter.say(success, f"Created API key '{key_name}': {mask_api_key(api_key)}")
                 reporter.emit(
-                    "onboard_key_created", account_id=resolved_account_id, key_name=key_name
+                    "apikey_key_created", account_id=resolved_account_id, key_name=key_name
                 )
 
             step = "credentials"
@@ -367,20 +367,18 @@ class OnboardCommand(BaseCommand):
             if saved:
                 reporter.say(info, f"Saved to {credentials_summary}.")
             else:
-                reporter.say(info, f"Existing ADK credential for {ONBOARD_REGION} kept.")
+                reporter.say(info, f"Existing ADK credential for {APIKEY_REGION} kept.")
 
             step = "env"
             target, masked_line = write_env_var("POLY_API_KEY", api_key, force=force)
             reporter.say(info, f"Wrote to {target.path}:")
             reporter.say(plain, f"  {masked_line}")
             reporter.emit(
-                "onboard_env_written", account_id=resolved_account_id, profile_shell=target.shell
+                "apikey_env_written", account_id=resolved_account_id, profile_shell=target.shell
             )
 
-            reporter.emit(
-                "onboard_completed", account_id=resolved_account_id, key_reused=key_reused
-            )
-            flush(ONBOARD_REGION)
+            reporter.emit("apikey_completed", account_id=resolved_account_id, key_reused=key_reused)
+            flush(APIKEY_REGION)
 
             if output_json:
                 _print_json(
@@ -406,13 +404,13 @@ class OnboardCommand(BaseCommand):
 def _alias_to_account(anonymous_id: str, account_id: str) -> None:
     """Link the anonymous telemetry id to the resolved account, once.
 
-    Never raises: a failure here must not interrupt onboarding.
+    Never raises: a failure here must not interrupt the flow.
     """
     from poly.handlers.posthog import get_posthog_client, telemetry_disabled
 
     if telemetry_disabled():
         return
     try:
-        get_posthog_client(ONBOARD_REGION).alias(previous_id=anonymous_id, distinct_id=account_id)
+        get_posthog_client(APIKEY_REGION).alias(previous_id=anonymous_id, distinct_id=account_id)
     except Exception:
         logger.warning("PostHog alias failed", exc_info=True)

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -11,6 +11,7 @@ step-by-step behaviour.
 Copyright PolyAI Limited
 """
 
+import contextlib
 import logging
 import platform
 import sys
@@ -18,7 +19,6 @@ import time
 import traceback
 from argparse import ArgumentParser, Namespace, _SubParsersAction
 from datetime import datetime, timezone
-from importlib.metadata import version as get_package_version
 from typing import Callable
 
 from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
@@ -45,14 +45,6 @@ APIKEY_SOURCE = "apikey"
 def _default_key_name(region: str) -> str:
     """The default API key name - disambiguated by region so keys never collide."""
     return DEFAULT_KEY_NAME if region == "studio" else f"{DEFAULT_KEY_NAME}-{region}"
-
-
-def _adk_version() -> str:
-    """The installed ADK version, or "unknown" if it cannot be determined."""
-    try:
-        return get_package_version("polyai-adk")
-    except Exception:
-        return "unknown"
 
 
 class _Reporter:
@@ -164,6 +156,25 @@ def _get_or_create_key(
     if not api_key:
         raise ValueError("API key not found in response. Please contact support.")
     return api_key, False
+
+
+def _wait_for_key_active(api: AgentStudioInterface, region: str) -> bool:
+    """Poll until the saved key is usable, mirroring `poly login`'s activation wait.
+
+    A newly created key can take a few seconds to activate; polling here means a
+    command run immediately after `poly apikey` does not fail against a key the
+    platform has not finished activating yet.
+
+    Returns:
+        bool: Whether the key became active within the poll window.
+    """
+    for _ in range(ACCOUNT_POLL_ATTEMPTS):
+        try:
+            api.get_accounts(region=region)
+            return True
+        except Exception:
+            time.sleep(ACCOUNT_POLL_INTERVAL_SECONDS)
+    return False
 
 
 def _save_credentials(region: str, api_key: str) -> tuple[bool, str]:
@@ -317,6 +328,7 @@ class ApiKeyCommand(BaseCommand):
         """Sign in and provision an account API key for `region`, then export it."""
         import requests
 
+        from poly.cli_commands.shared import get_package_version
         from poly.handlers.posthog import flush
         from poly.output.console import err_console, info, mask_api_key, plain, success
 
@@ -327,7 +339,7 @@ class ApiKeyCommand(BaseCommand):
             output_json,
             {
                 "source": APIKEY_SOURCE,
-                "adk_version": _adk_version(),
+                "adk_version": get_package_version(),
                 "os": platform.system(),
                 "shell": detect_profile().shell,
             },
@@ -399,6 +411,23 @@ class ApiKeyCommand(BaseCommand):
                 reporter.say(info, f"Saved to {credentials_summary}.")
             else:
                 reporter.say(info, f"Existing ADK credential for {region} kept.")
+
+            step = "activation"
+            from poly.output.console import console, warning
+
+            status_ctx = (
+                contextlib.nullcontext()
+                if reporter.output_json
+                else console.status("[info]Verifying API key is active...[/info]")
+            )
+            with status_ctx:
+                key_active = _wait_for_key_active(api, region)
+            if not key_active:
+                reporter.say(
+                    warning,
+                    "API key was saved but is not active yet."
+                    " If your next command fails, wait a moment and retry.",
+                )
 
             step = "env"
             target, masked_line = write_env_var("POLY_API_KEY", api_key, force=force)

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -108,10 +108,15 @@ class _Reporter:
 def _resolve_account_id(
     api: AgentStudioInterface, region: str, jwt_token: str, account_id: str | None
 ) -> str:
-    """Return `account_id` unchanged, or poll for the first account to appear.
+    """Return `account_id` unchanged, or poll for the account to appear.
+
+    On `studio`, a user has exactly one account, so the first one found is used. On
+    enterprise regions, a user commonly has several - silently picking one would be a
+    guess, so more than one account without an explicit `--account-id` is an error.
 
     Raises:
-        ValueError: No account appeared within `ACCOUNT_POLL_TIMEOUT_SECONDS`.
+        ValueError: No account appeared within `ACCOUNT_POLL_TIMEOUT_SECONDS`, or (non-studio
+            only) more than one account was found and `account_id` was not given.
     """
     if account_id is not None:
         return account_id
@@ -120,6 +125,12 @@ def _resolve_account_id(
             region=region, jwt_token=jwt_token, source=APIKEY_SOURCE
         )
         if accounts:
+            if region != "studio" and len(accounts) > 1:
+                listing = ", ".join(f"{a['id']} ({a.get('name', 'unnamed')})" for a in accounts)
+                raise ValueError(
+                    f"Multiple accounts found for {region}: {listing}. "
+                    "Re-run with --account-id <id> to pick one."
+                )
             return accounts[0]["id"]
         time.sleep(ACCOUNT_POLL_INTERVAL_SECONDS)
     raise ValueError(
@@ -225,6 +236,7 @@ def _print_json(
     key_reused: bool,
     credentials_summary: str,
     target: ProfileTarget,
+    key_active: bool,
 ) -> None:
     """Print the --json completion object."""
     from poly.output.console import mask_secret
@@ -240,6 +252,7 @@ def _print_json(
             "credentials_file": credentials_summary,
             "profile_path": str(target.path),
             "profile_shell": target.shell,
+            "key_active": key_active,
         }
     )
 
@@ -294,7 +307,11 @@ class ApiKeyCommand(BaseCommand):
             "--account-id",
             type=str,
             default=None,
-            help="Account ID to scope the key to. Skips polling for a newly created account.",
+            help=(
+                "Account ID to scope the key to. Skips polling for a newly created account."
+                " Required for enterprise regions when your account has more than one -"
+                " the command refuses to guess which one you mean."
+            ),
         )
         apikey_parser.add_argument(
             "--force",
@@ -354,11 +371,15 @@ class ApiKeyCommand(BaseCommand):
             auth_details = (
                 APIKEY_AUTH_DETAILS if region == "studio" else REGION_TO_AUTH_DETAILS[region]
             )
-            sign_in_via = "GitHub" if region == "studio" else "your browser"
+            sign_in_line = (
+                "To sign in with GitHub, open the following link in your browser"
+                if region == "studio"
+                else "To sign in, open the following link in your browser"
+            )
 
             def on_verification_url(verification_uri: str, user_code: str) -> None:
                 message = (
-                    f"To sign in with {sign_in_via}, open the following link in your browser\n"
+                    f"{sign_in_line}\n"
                     "and enter the code when prompted.\n\n"
                     f"  URL:  {verification_uri}\n"
                     f"  Code: [bold]{user_code}[/bold]"
@@ -382,7 +403,16 @@ class ApiKeyCommand(BaseCommand):
             step = "authorise"
             api = AgentStudioInterface()
             reporter.say(info, "Setting up your account...")
-            api.authorise(region=region, jwt_token=jwt_token)
+            try:
+                api.authorise(region=region, jwt_token=jwt_token)
+            except requests.HTTPError as e:
+                if region != "studio" and e.response is not None and e.response.status_code == 403:
+                    raise ValueError(
+                        f"No account is provisioned for you on {region}. Enterprise accounts"
+                        " are set up by PolyAI - contact your PolyAI representative, or run"
+                        " `poly apikey` without --region to create a self-serve studio account."
+                    ) from e
+                raise
 
             step = "account"
             resolved_account_id = _resolve_account_id(api, region, jwt_token, account_id)
@@ -442,7 +472,13 @@ class ApiKeyCommand(BaseCommand):
 
             if output_json:
                 _print_json(
-                    resolved_account_id, api_key, key_name, key_reused, credentials_summary, target
+                    resolved_account_id,
+                    api_key,
+                    key_name,
+                    key_reused,
+                    credentials_summary,
+                    target,
+                    key_active,
                 )
             else:
                 _print_summary(

--- a/src/poly/cli_commands/apikey.py
+++ b/src/poly/cli_commands/apikey.py
@@ -1,12 +1,13 @@
-"""API key command: one-shot sign-in and account API key setup.
+"""API key command: sign in and provision an account-scoped API key.
 
-`poly apikey` signs a user in - via the GitHub-only Auth0 device flow for the
-default `studio` region, or the standard sign-in page for any other region -
-creates their PolyAI account if needed, provisions (or reuses) an
-account-scoped API key, and writes ``POLY_API_KEY`` into their shell profile -
-or, on Windows, their user environment. It never prompts. See
-``poly apikey --help`` or ``docs/docs/reference/cli/apikey.md`` for the full
-step-by-step behaviour.
+`poly apikey` is the narrower cousin of `poly login`: it exists to get an API key for
+the PolyAI APIs and Dialog RSN into your environment, not to set up the ADK itself. It
+signs a user in - via the GitHub-only Auth0 device flow for the default `studio` region, or
+the standard sign-in page for any other region - creates their PolyAI account if needed,
+provisions (or reuses) an account-scoped API key, and writes ``POLY_API_KEY`` into their
+shell profile - or, on Windows, their user environment. It never prompts. To set up the
+ADK itself, use ``poly setup`` or ``poly login`` instead. See ``poly apikey --help`` or
+``docs/docs/reference/cli/apikey.md`` for the full step-by-step behaviour.
 
 Copyright PolyAI Limited
 """
@@ -79,13 +80,12 @@ def _resolve_account_id(
 ) -> str:
     """Return `account_id` unchanged, or poll for the account to appear.
 
-    On `studio`, a user has exactly one account, so the first one found is used. On
-    enterprise regions, a user commonly has several - silently picking one would be a
-    guess, so more than one account without an explicit `--account-id` is an error.
+    More than one account without an explicit `--account-id` is an error - silently
+    picking one would be a guess.
 
     Raises:
-        ValueError: No account appeared within `ACCOUNT_POLL_TIMEOUT_SECONDS`, or (non-studio
-            only) more than one account was found and `account_id` was not given.
+        ValueError: No account appeared within `ACCOUNT_POLL_TIMEOUT_SECONDS`, or more
+            than one account was found and `account_id` was not given.
     """
     if account_id is not None:
         return account_id
@@ -94,7 +94,7 @@ def _resolve_account_id(
             region=region, jwt_token=jwt_token, source=APIKEY_SOURCE
         )
         if accounts:
-            if region != "studio" and len(accounts) > 1:
+            if len(accounts) > 1:
                 listing = ", ".join(f"{a['id']} ({a.get('name', 'unnamed')})" for a in accounts)
                 raise ValueError(
                     f"Multiple accounts found for {region}: {listing}. "
@@ -227,7 +227,7 @@ def _print_json(
 
 
 class ApiKeyCommand(BaseCommand):
-    """One-shot sign-in, account API key, and POLY_API_KEY setup."""
+    """Sign in, provision an account API key, and export POLY_API_KEY."""
 
     command = "apikey"
 
@@ -239,28 +239,30 @@ class ApiKeyCommand(BaseCommand):
         apikey_parser = subparsers.add_parser(
             "apikey",
             parents=[parents.verbose, parents.debug, parents.json],
-            help="One-shot setup for AI coding assistants.",
+            help="Create an account API key and export POLY_API_KEY for the PolyAI APIs.",
             description=(
-                "One-shot setup: sign-in, account API key, POLY_API_KEY in your"
-                " environment.\n\n"
-                "Never prompts. Designed to be run by an AI coding assistant; fine to run"
-                " yourself.\n\n"
-                "To sign in interactively instead, use `poly login`.\n\n"
+                "Sign in, create (or reuse) an account-scoped API key, and export it as"
+                " POLY_API_KEY for use with the PolyAI APIs and Dialog RSN. Non-interactive,"
+                " so an AI coding assistant can run it for you.\n\n"
+                "To set up the ADK itself, use `poly setup` or `poly login` instead - the ADK"
+                " reads its credentials from ~/.poly/credentials.json and does not need"
+                " POLY_API_KEY.\n\n"
                 "Examples:\n"
-                "  poly apikey\n"
-                "  poly apikey --account-id acc-123\n"
+                "  poly apikey --region studio\n"
+                "  poly apikey --region studio --account-id acc-123\n"
                 "  poly apikey --region us-1\n"
+                "  poly apikey --region studio --json\n"
             ),
         )
         apikey_parser.add_argument(
             "--region",
             type=str,
             choices=REGIONS,
-            default="studio",
+            required=True,
             help=(
-                "Region/cluster to create the key for. Defaults to 'studio' (PLG), which"
-                " signs in via GitHub only. Any other region uses the standard sign-in page"
-                " (email/SSO), the same one `poly login` uses."
+                "Region/cluster to create the key for. 'studio' is the self-serve cluster"
+                " individual developers sign up on via GitHub; any other region uses the"
+                " standard sign-in page (email/SSO), the same one `poly login` uses."
             ),
         )
         apikey_parser.add_argument(
@@ -278,8 +280,8 @@ class ApiKeyCommand(BaseCommand):
             default=None,
             help=(
                 "Account ID to scope the key to. Skips polling for a newly created account."
-                " Required for enterprise regions when your account has more than one -"
-                " the command refuses to guess which one you mean."
+                " Required when your account has more than one - the command refuses to"
+                " guess which one you mean."
             ),
         )
         apikey_parser.add_argument(
@@ -304,7 +306,7 @@ class ApiKeyCommand(BaseCommand):
     @classmethod
     def apikey(
         cls,
-        region: str = "studio",
+        region: str,
         key_name: str | None = None,
         account_id: str | None = None,
         force: bool = False,
@@ -363,7 +365,7 @@ class ApiKeyCommand(BaseCommand):
                     raise ValueError(
                         f"No account is provisioned for you on {region}. Enterprise accounts"
                         " are set up by PolyAI - contact your PolyAI representative, or run"
-                        " `poly apikey` without --region to create a self-serve studio account."
+                        " `poly apikey --region studio` to create a self-serve studio account."
                     ) from e
                 raise
 

--- a/src/poly/cli_commands/auth.py
+++ b/src/poly/cli_commands/auth.py
@@ -7,8 +7,9 @@ import os
 import sys
 from argparse import ArgumentParser, Namespace, _SubParsersAction
 
+from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
 from poly.cli_commands.base import GETTING_STARTED_GROUP, BaseCommand, Parents
-from poly.handlers.auth0_handler import Auth0Handler
+from poly.handlers.auth0_handler import REGION_TO_AUTH_DETAILS
 from poly.handlers.interface import REGIONS, AgentStudioInterface
 from poly.utils import (
     CREDENTIALS_FILE_PATH,
@@ -89,59 +90,21 @@ def _authenticate_and_save_key(jwt_access_token: str, region: str) -> None:
 
 def _signin(region: str) -> str:
     """Sign in via the Auth0 device authorization flow and return a JWT access token."""
-    import time
-    import webbrowser
+    from poly.output.console import error, success
 
-    import requests
-
-    from poly.output.console import console, error, info, success
-
-    auth0_handler = Auth0Handler()
-
-    try:
-        device_response = auth0_handler.request_device_code(region)
-    except Exception as e:
-        error(f"Failed to start authorization: {e}")
+    auth_details = REGION_TO_AUTH_DETAILS.get(region)
+    if auth_details is None:
+        error(
+            f"Failed to start authorization: Unknown region '{region}'. "
+            f"Valid regions: {', '.join(REGION_TO_AUTH_DETAILS)}"
+        )
         sys.exit(1)
 
-    user_code = device_response["user_code"]
-    verification_uri = device_response["verification_uri_complete"]
-    device_code = device_response["device_code"]
-    interval = device_response.get("interval", 5)
-
-    info(
-        "To sign in or create an account, open the following link in your browser\n"
-        "and enter the code when prompted.\n\n"
-        f"  URL:  {verification_uri}\n"
-        f"  Code: [bold]{user_code}[/bold]"
-    )
-    webbrowser.open(verification_uri)
-
-    access_token = None
-    with console.status("[info]Waiting for authorization...[/info]"):
-        while not access_token:
-            time.sleep(interval)
-            try:
-                token_response = auth0_handler.poll_device_token(region, device_code)
-                access_token = token_response.get("access_token")
-            except requests.HTTPError as e:
-                try:
-                    body = e.response.json()
-                except (ValueError, AttributeError):
-                    error(f"Authorization failed: {e}")
-                    sys.exit(1)
-                err_code = body.get("error")
-                if err_code == "authorization_pending":
-                    continue
-                elif err_code == "slow_down":
-                    interval += 5
-                    continue
-                elif err_code == "expired_token":
-                    error("Authorization timed out. Please try again.")
-                    sys.exit(1)
-                else:
-                    error(f"Authorization failed: {body.get('error_description', e)}")
-                    sys.exit(1)
+    try:
+        access_token = signin_with_device_flow(auth_details)
+    except DeviceFlowError as e:
+        error(str(e))
+        sys.exit(1)
 
     success("Authenticated successfully!")
     return access_token

--- a/src/poly/cli_commands/onboard.py
+++ b/src/poly/cli_commands/onboard.py
@@ -1,0 +1,414 @@
+"""Onboard command: one-shot GitHub sign-in and account API key setup.
+
+`poly onboard` signs a user in via the GitHub-only Auth0 device flow, creates
+their PolyAI account if needed, provisions (or reuses) an account-scoped API
+key, and writes ``POLY_API_KEY`` into their shell profile - or, on Windows,
+their user environment. It never prompts. See ``poly onboard --help`` or
+``docs/docs/reference/cli/onboard.md`` for the full step-by-step behaviour.
+
+Copyright PolyAI Limited
+"""
+
+import logging
+import platform
+import sys
+import time
+import traceback
+from argparse import ArgumentParser, Namespace, _SubParsersAction
+from datetime import datetime, timezone
+from importlib.metadata import version as get_package_version
+from typing import Callable
+
+import requests
+
+from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
+from poly.cli_commands.base import GETTING_STARTED_GROUP, BaseCommand, Parents
+from poly.handlers.auth0_handler import ONBOARD_AUTH_DETAILS
+from poly.handlers.interface import AgentStudioInterface
+from poly.handlers.posthog import (
+    capture_event,
+    flush,
+    get_anonymous_id,
+    get_posthog_client,
+    telemetry_disabled,
+)
+from poly.utils.api_keys import select_reusable_api_key
+from poly.utils.credentials import (
+    CREDENTIALS_FILE_PATH,
+    load_api_key_from_credential_file,
+    save_api_key_credential_file,
+)
+from poly.utils.env_profile import EnvVarConflict, ProfileTarget, detect_profile, write_env_var
+
+logger = logging.getLogger(__name__)
+
+# `poly onboard` always targets the PLG/studio cluster - it is the only
+# cluster the onboarding Auth0 client (GitHub-only login) is registered
+# against, so unlike `login`/`start` there is no --region choice here.
+ONBOARD_REGION = "studio"
+
+DEFAULT_KEY_NAME = "onboard-key"
+ACCOUNT_POLL_ATTEMPTS = 20
+ACCOUNT_POLL_INTERVAL_SECONDS = 1
+ACCOUNT_POLL_TIMEOUT_SECONDS = ACCOUNT_POLL_ATTEMPTS * ACCOUNT_POLL_INTERVAL_SECONDS
+POSTHOG_SOURCE = "onboard"
+
+CREDENTIALS_KEPT_SUMMARY = "existing credential kept"
+
+
+def _adk_version() -> str:
+    """The installed ADK version, or "unknown" if it cannot be determined."""
+    try:
+        return get_package_version("polyai-adk")
+    except Exception:
+        return "unknown"
+
+
+class _Reporter:
+    """Quiet-when-json printing and telemetry, tied to the flow's distinct id.
+
+    A small stateful object rather than closures, since the distinct id
+    changes partway through the flow (from an anonymous id to the resolved
+    account id) and every step after that needs to see the new value.
+    """
+
+    def __init__(self, output_json: bool, base_properties: dict[str, str]):
+        self.output_json = output_json
+        self.base_properties = base_properties
+        # Skip creating ~/.poly/telemetry_id entirely when telemetry is off,
+        # rather than writing it and then never using it.
+        self.distinct_id = "disabled" if telemetry_disabled() else get_anonymous_id()
+
+    def say(self, fn: Callable[[str], None], message: str) -> None:
+        """Print via `fn`, unless --json is active - its output must be the only thing on stdout."""
+        if not self.output_json:
+            fn(message)
+
+    def emit(self, event: str, **extra: object) -> None:
+        """Capture a telemetry event tagged with the current distinct id."""
+        capture_event(ONBOARD_REGION, event, {**self.base_properties, **extra}, self.distinct_id)
+
+    def fail(self, exc: Exception, step: str, exit_code: int, *, verbose: bool) -> None:
+        """Report a failure - telemetry, then a clean message or a full traceback - and exit."""
+        self.emit("onboard_failed", step=step, error_class=type(exc).__name__)
+        flush(ONBOARD_REGION)
+        if verbose:
+            raise exc
+        message = str(exc)
+        if isinstance(exc, EnvVarConflict):
+            message = f"{exc} Re-run with --force to replace it."
+        if self.output_json:
+            from poly.output.json_output import json_print
+
+            json_print(
+                {
+                    "success": False,
+                    "error": message,
+                    "traceback": traceback.format_exc(),
+                    "step": step,
+                }
+            )
+        else:
+            from poly.output.console import error
+
+            error(message)
+        sys.exit(exit_code)
+
+
+def _resolve_account_id(api: AgentStudioInterface, jwt_token: str, account_id: str | None) -> str:
+    """Return `account_id` unchanged, or poll for the first account to appear.
+
+    Raises:
+        ValueError: No account appeared within `ACCOUNT_POLL_TIMEOUT_SECONDS`.
+    """
+    if account_id is not None:
+        return account_id
+    for _ in range(ACCOUNT_POLL_ATTEMPTS):
+        accounts = api.get_accounts_internal(
+            region=ONBOARD_REGION, jwt_token=jwt_token, source=POSTHOG_SOURCE
+        )
+        if accounts:
+            return accounts[0]["id"]
+        time.sleep(ACCOUNT_POLL_INTERVAL_SECONDS)
+    raise ValueError(
+        f"No account appeared after {ACCOUNT_POLL_TIMEOUT_SECONDS}s. Re-run with --account-id <id>."
+    )
+
+
+def _get_or_create_key(
+    api: AgentStudioInterface, jwt_token: str, account_id: str, key_name: str
+) -> tuple[str, bool]:
+    """Reuse an active, unexpired key named `key_name`, or create one.
+
+    Returns:
+        tuple[str, bool]: The key, and whether it was reused rather than created.
+
+    Raises:
+        ValueError: The create call succeeded but returned no key.
+    """
+    keys = api.list_account_api_keys_internal(
+        region=ONBOARD_REGION, jwt_token=jwt_token, account_id=account_id, source=POSTHOG_SOURCE
+    )
+    existing_key = select_reusable_api_key(keys, key_name, datetime.now(timezone.utc))
+    if existing_key is not None:
+        return existing_key, True
+
+    response = api.create_account_api_key_internal(
+        region=ONBOARD_REGION,
+        jwt_token=jwt_token,
+        account_id=account_id,
+        name=key_name,
+        source=POSTHOG_SOURCE,
+    )
+    api_key = response.get("key")
+    if not api_key:
+        raise ValueError("API key not found in response. Please contact support.")
+    return api_key, False
+
+
+def _save_credentials(api_key: str) -> str:
+    """Save `api_key` to the credential file, unless studio already has one.
+
+    Returns:
+        str: A summary of what happened, for the completion output.
+    """
+    if load_api_key_from_credential_file(ONBOARD_REGION) is not None:
+        return CREDENTIALS_KEPT_SUMMARY
+    save_api_key_credential_file(api_key, region=ONBOARD_REGION)
+    return f"{CREDENTIALS_FILE_PATH} ({ONBOARD_REGION})"
+
+
+def _persist_env(api_key: str, force: bool) -> tuple[ProfileTarget, str]:
+    """Write POLY_API_KEY into the detected profile (or Windows user environment)."""
+    return write_env_var("POLY_API_KEY", api_key, force=force)
+
+
+def _print_summary(
+    account_id: str,
+    api_key: str,
+    key_name: str,
+    key_reused: bool,
+    credentials_summary: str,
+    target: ProfileTarget,
+    masked_line: str,
+) -> None:
+    """Print the human-readable completion summary."""
+    from poly.output.console import mask_api_key, plain
+
+    plain("")
+    plain("Done.")
+    plain(f"  Account:   {account_id}")
+    plain(
+        f"  API key:   {mask_api_key(api_key)}   "
+        f"({key_name}, {'reused' if key_reused else 'created'})"
+    )
+    plain(f"  Saved to:  {credentials_summary}")
+    plain(f"  Profile:   {target.path}  ({masked_line})")
+    plain("")
+    if target.shell == "powershell":
+        plain("Open a new terminal to pick up POLY_API_KEY.")
+    else:
+        plain(f"Open a new terminal, or run `source {target.path}`, to pick up POLY_API_KEY.")
+
+
+def _print_json(
+    account_id: str,
+    api_key: str,
+    key_name: str,
+    key_reused: bool,
+    credentials_summary: str,
+    target: ProfileTarget,
+) -> None:
+    """Print the --json completion object."""
+    from poly.output.console import mask_secret
+    from poly.output.json_output import json_print
+
+    json_print(
+        {
+            "success": True,
+            "account_id": account_id,
+            "key_name": key_name,
+            "key_reused": key_reused,
+            "api_key_masked": mask_secret(api_key),
+            "credentials_file": credentials_summary,
+            "profile_path": str(target.path),
+            "profile_shell": target.shell,
+        }
+    )
+
+
+class OnboardCommand(BaseCommand):
+    """One-shot GitHub sign-in, account API key, and POLY_API_KEY setup."""
+
+    command = "onboard"
+
+    group = GETTING_STARTED_GROUP
+
+    @classmethod
+    def add_arguments(cls, subparsers: _SubParsersAction[ArgumentParser], parents: Parents) -> None:
+        """Register the ``onboard`` subcommand."""
+        onboard_parser = subparsers.add_parser(
+            "onboard",
+            parents=[parents.verbose, parents.debug, parents.json],
+            help="One-shot setup for AI coding assistants.",
+            description=(
+                "One-shot setup: GitHub sign-in, account API key, POLY_API_KEY in your"
+                " environment.\n\n"
+                "Never prompts. Designed to be run by an AI coding assistant; fine to run"
+                " yourself.\n\n"
+                "To sign in interactively instead, use `poly login`.\n\n"
+                "Examples:\n"
+                "  poly onboard\n"
+                "  poly onboard --account-id acc-123\n"
+            ),
+        )
+        onboard_parser.add_argument(
+            "--key-name",
+            type=str,
+            default=DEFAULT_KEY_NAME,
+            help=f"Name for the account-scoped API key. Defaults to '{DEFAULT_KEY_NAME}'.",
+        )
+        onboard_parser.add_argument(
+            "--account-id",
+            type=str,
+            default=None,
+            help="Account ID to scope the key to. Skips polling for a newly created account.",
+        )
+        onboard_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Overwrite an existing POLY_API_KEY in your profile if it holds a different value.",
+        )
+
+    @classmethod
+    def run(cls, args: Namespace) -> None:
+        """Dispatch to the onboard handler."""
+        cls.onboard(
+            key_name=args.key_name,
+            account_id=args.account_id,
+            force=args.force,
+            output_json=args.json,
+            verbose=args.verbose,
+        )
+
+    @classmethod
+    def onboard(
+        cls,
+        key_name: str = DEFAULT_KEY_NAME,
+        account_id: str | None = None,
+        force: bool = False,
+        output_json: bool = False,
+        verbose: bool = False,
+    ) -> None:
+        """Sign in via GitHub, provision an account API key, and export it."""
+        from poly.output.console import info, mask_api_key, plain, success
+
+        reporter = _Reporter(
+            output_json,
+            {
+                "source": POSTHOG_SOURCE,
+                "adk_version": _adk_version(),
+                "os": platform.system(),
+                "shell": detect_profile().shell,
+            },
+        )
+
+        step = "start"
+        try:
+            reporter.emit("onboard_started")
+            reporter.say(info, "Setting up your PolyAI account and API key...")
+
+            step = "signin"
+
+            def on_verification_url(verification_uri: str, user_code: str) -> None:
+                reporter.say(
+                    info,
+                    "To sign in with GitHub, open the following link in your browser\n"
+                    "and enter the code when prompted.\n\n"
+                    f"  URL:  {verification_uri}\n"
+                    f"  Code: [bold]{user_code}[/bold]",
+                )
+                reporter.emit("onboard_device_code_issued")
+
+            jwt_token = signin_with_device_flow(
+                ONBOARD_AUTH_DETAILS, on_verification_url=on_verification_url
+            )
+            reporter.emit("onboard_authenticated")
+            reporter.say(success, "Authenticated successfully!")
+
+            step = "authorise"
+            api = AgentStudioInterface()
+            reporter.say(info, "Setting up your account...")
+            api.authorise(region=ONBOARD_REGION, jwt_token=jwt_token)
+
+            step = "account"
+            resolved_account_id = _resolve_account_id(api, jwt_token, account_id)
+            reporter.emit("onboard_account_resolved", account_id=resolved_account_id)
+            _alias_to_account(reporter.distinct_id, resolved_account_id)
+            reporter.distinct_id = resolved_account_id
+
+            step = "key"
+            api_key, key_reused = _get_or_create_key(api, jwt_token, resolved_account_id, key_name)
+            if key_reused:
+                reporter.say(success, f"Reusing existing '{key_name}' key: {mask_api_key(api_key)}")
+                reporter.emit(
+                    "onboard_key_reused", account_id=resolved_account_id, key_name=key_name
+                )
+            else:
+                reporter.say(success, f"Created API key '{key_name}': {mask_api_key(api_key)}")
+                reporter.emit(
+                    "onboard_key_created", account_id=resolved_account_id, key_name=key_name
+                )
+
+            step = "credentials"
+            credentials_summary = _save_credentials(api_key)
+            if credentials_summary == CREDENTIALS_KEPT_SUMMARY:
+                reporter.say(info, f"Existing ADK credential for {ONBOARD_REGION} kept.")
+            else:
+                reporter.say(info, f"Saved to {credentials_summary}.")
+
+            step = "env"
+            target, masked_line = _persist_env(api_key, force)
+            reporter.say(info, f"Wrote to {target.path}:")
+            reporter.say(plain, f"  {masked_line}")
+            reporter.emit(
+                "onboard_env_written", account_id=resolved_account_id, profile_shell=target.shell
+            )
+
+            reporter.emit(
+                "onboard_completed", account_id=resolved_account_id, key_reused=key_reused
+            )
+            flush(ONBOARD_REGION)
+
+            if output_json:
+                _print_json(
+                    resolved_account_id, api_key, key_name, key_reused, credentials_summary, target
+                )
+            else:
+                _print_summary(
+                    resolved_account_id,
+                    api_key,
+                    key_name,
+                    key_reused,
+                    credentials_summary,
+                    target,
+                    masked_line,
+                )
+
+        except EnvVarConflict as e:
+            reporter.fail(e, step, exit_code=2, verbose=verbose)
+        except (DeviceFlowError, requests.HTTPError, ValueError) as e:
+            reporter.fail(e, step, exit_code=1, verbose=verbose)
+
+
+def _alias_to_account(anonymous_id: str, account_id: str) -> None:
+    """Link the anonymous telemetry id to the resolved account, once.
+
+    Never raises: a failure here must not interrupt onboarding.
+    """
+    if telemetry_disabled():
+        return
+    try:
+        get_posthog_client(ONBOARD_REGION).alias(previous_id=anonymous_id, distinct_id=account_id)
+    except Exception:
+        logger.warning("PostHog alias failed", exc_info=True)

--- a/src/poly/cli_commands/onboard.py
+++ b/src/poly/cli_commands/onboard.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 # `poly onboard` always targets the PLG/studio cluster - it is the only
 # cluster the onboarding Auth0 client (GitHub-only login) is registered
-# against, so unlike `login`/`start` there is no --region choice here.
+# against, so unlike `login` there is no --region choice here.
 ONBOARD_REGION = "studio"
 
 DEFAULT_KEY_NAME = "onboard-key"
@@ -52,8 +52,6 @@ ACCOUNT_POLL_ATTEMPTS = 20
 ACCOUNT_POLL_INTERVAL_SECONDS = 1
 ACCOUNT_POLL_TIMEOUT_SECONDS = ACCOUNT_POLL_ATTEMPTS * ACCOUNT_POLL_INTERVAL_SECONDS
 POSTHOG_SOURCE = "onboard"
-
-CREDENTIALS_KEPT_SUMMARY = "existing credential kept"
 
 
 def _adk_version() -> str:
@@ -166,21 +164,17 @@ def _get_or_create_key(
     return api_key, False
 
 
-def _save_credentials(api_key: str) -> str:
+def _save_credentials(api_key: str) -> tuple[bool, str]:
     """Save `api_key` to the credential file, unless studio already has one.
 
     Returns:
-        str: A summary of what happened, for the completion output.
+        tuple[bool, str]: Whether a new credential was saved, and a summary
+            of what happened, for the completion output.
     """
     if load_api_key_from_credential_file(ONBOARD_REGION) is not None:
-        return CREDENTIALS_KEPT_SUMMARY
+        return False, "existing credential kept"
     save_api_key_credential_file(api_key, region=ONBOARD_REGION)
-    return f"{CREDENTIALS_FILE_PATH} ({ONBOARD_REGION})"
-
-
-def _persist_env(api_key: str, force: bool) -> tuple[ProfileTarget, str]:
-    """Write POLY_API_KEY into the detected profile (or Windows user environment)."""
-    return write_env_var("POLY_API_KEY", api_key, force=force)
+    return True, f"{CREDENTIALS_FILE_PATH} ({ONBOARD_REGION})"
 
 
 def _print_summary(
@@ -301,7 +295,7 @@ class OnboardCommand(BaseCommand):
         verbose: bool = False,
     ) -> None:
         """Sign in via GitHub, provision an account API key, and export it."""
-        from poly.output.console import info, mask_api_key, plain, success
+        from poly.output.console import err_console, info, mask_api_key, plain, success
 
         reporter = _Reporter(
             output_json,
@@ -321,13 +315,20 @@ class OnboardCommand(BaseCommand):
             step = "signin"
 
             def on_verification_url(verification_uri: str, user_code: str) -> None:
-                reporter.say(
-                    info,
+                message = (
                     "To sign in with GitHub, open the following link in your browser\n"
                     "and enter the code when prompted.\n\n"
                     f"  URL:  {verification_uri}\n"
-                    f"  Code: [bold]{user_code}[/bold]",
+                    f"  Code: [bold]{user_code}[/bold]"
                 )
+                if reporter.output_json:
+                    # --json only constrains stdout - an agent that can't open a
+                    # browser itself still needs this to complete sign-in, so it
+                    # goes to stderr rather than being dropped like every other
+                    # human-readable message in this mode.
+                    err_console.print(f"[info]{message}[/info]")
+                else:
+                    reporter.say(info, message)
                 reporter.emit("onboard_device_code_issued")
 
             jwt_token = signin_with_device_flow(
@@ -361,14 +362,14 @@ class OnboardCommand(BaseCommand):
                 )
 
             step = "credentials"
-            credentials_summary = _save_credentials(api_key)
-            if credentials_summary == CREDENTIALS_KEPT_SUMMARY:
-                reporter.say(info, f"Existing ADK credential for {ONBOARD_REGION} kept.")
-            else:
+            saved, credentials_summary = _save_credentials(api_key)
+            if saved:
                 reporter.say(info, f"Saved to {credentials_summary}.")
+            else:
+                reporter.say(info, f"Existing ADK credential for {ONBOARD_REGION} kept.")
 
             step = "env"
-            target, masked_line = _persist_env(api_key, force)
+            target, masked_line = write_env_var("POLY_API_KEY", api_key, force=force)
             reporter.say(info, f"Wrote to {target.path}:")
             reporter.say(plain, f"  {masked_line}")
             reporter.emit(

--- a/src/poly/cli_commands/onboard.py
+++ b/src/poly/cli_commands/onboard.py
@@ -19,19 +19,10 @@ from datetime import datetime, timezone
 from importlib.metadata import version as get_package_version
 from typing import Callable
 
-import requests
-
 from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
 from poly.cli_commands.base import GETTING_STARTED_GROUP, BaseCommand, Parents
 from poly.handlers.auth0_handler import ONBOARD_AUTH_DETAILS
 from poly.handlers.interface import AgentStudioInterface
-from poly.handlers.posthog import (
-    capture_event,
-    flush,
-    get_anonymous_id,
-    get_posthog_client,
-    telemetry_disabled,
-)
 from poly.utils.api_keys import select_reusable_api_key
 from poly.utils.credentials import (
     CREDENTIALS_FILE_PATH,
@@ -71,6 +62,8 @@ class _Reporter:
     """
 
     def __init__(self, output_json: bool, base_properties: dict[str, str]):
+        from poly.handlers.posthog import get_anonymous_id, telemetry_disabled
+
         self.output_json = output_json
         self.base_properties = base_properties
         # Skip creating ~/.poly/telemetry_id entirely when telemetry is off,
@@ -84,10 +77,14 @@ class _Reporter:
 
     def emit(self, event: str, **extra: object) -> None:
         """Capture a telemetry event tagged with the current distinct id."""
+        from poly.handlers.posthog import capture_event
+
         capture_event(ONBOARD_REGION, event, {**self.base_properties, **extra}, self.distinct_id)
 
     def fail(self, exc: Exception, step: str, exit_code: int, *, verbose: bool) -> None:
         """Report a failure - telemetry, then a clean message or a full traceback - and exit."""
+        from poly.handlers.posthog import flush
+
         self.emit("onboard_failed", step=step, error_class=type(exc).__name__)
         flush(ONBOARD_REGION)
         if verbose:
@@ -270,6 +267,7 @@ class OnboardCommand(BaseCommand):
         )
         onboard_parser.add_argument(
             "--force",
+            "-f",
             action="store_true",
             help="Overwrite an existing POLY_API_KEY in your profile if it holds a different value.",
         )
@@ -295,6 +293,9 @@ class OnboardCommand(BaseCommand):
         verbose: bool = False,
     ) -> None:
         """Sign in via GitHub, provision an account API key, and export it."""
+        import requests
+
+        from poly.handlers.posthog import flush
         from poly.output.console import err_console, info, mask_api_key, plain, success
 
         reporter = _Reporter(
@@ -407,6 +408,8 @@ def _alias_to_account(anonymous_id: str, account_id: str) -> None:
 
     Never raises: a failure here must not interrupt onboarding.
     """
+    from poly.handlers.posthog import get_posthog_client, telemetry_disabled
+
     if telemetry_disabled():
         return
     try:

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -48,7 +48,7 @@ REGION_TO_AUTH_DETAILS = {
 
 # Auth0 application whose login page exposes only the GitHub connection.
 # Not region-keyed and never added to REGION_TO_AUTH_DETAILS.
-ONBOARD_AUTH_DETAILS = AuthDetails(
+APIKEY_AUTH_DETAILS = AuthDetails(
     base_url="https://login.studio.poly.ai",
     device_client_id="fp7CIVelwOwMPBNNpHpQCLiRMj7nG0fs",
 )

--- a/src/poly/handlers/auth0_handler.py
+++ b/src/poly/handlers/auth0_handler.py
@@ -46,6 +46,13 @@ REGION_TO_AUTH_DETAILS = {
     ),
 }
 
+# Auth0 application whose login page exposes only the GitHub connection.
+# Not region-keyed and never added to REGION_TO_AUTH_DETAILS.
+ONBOARD_AUTH_DETAILS = AuthDetails(
+    base_url="https://login.studio.poly.ai",
+    device_client_id="fp7CIVelwOwMPBNNpHpQCLiRMj7nG0fs",
+)
+
 
 class Auth0Handler:
     """Handler for authentication with the PolyAI Auth0 tenant."""
@@ -99,6 +106,26 @@ class Auth0Handler:
         return api_response
 
     @classmethod
+    def request_device_code_for(cls, auth_details: AuthDetails) -> dict:
+        """Start the device authorization flow against a specific Auth0 application.
+
+        Args:
+            auth_details: The Auth0 application (base URL + client id) to authenticate against.
+
+        Returns:
+            Dict containing device_code, user_code, verification_uri,
+            verification_uri_complete, expires_in, and interval.
+        """
+        data = {
+            "client_id": auth_details.device_client_id,
+            "scope": "openid profile email",
+            "audience": "https://platform.polyai.app/api",
+        }
+        return cls.make_request(
+            auth_details.base_url, "/oauth/device/code", method="POST", data=data
+        )
+
+    @classmethod
     def request_device_code(cls, region: str) -> dict:
         """Start the device authorization flow.
 
@@ -111,14 +138,29 @@ class Auth0Handler:
             raise ValueError(
                 f"Unknown region '{region}'. Valid regions: {', '.join(REGION_TO_AUTH_DETAILS)}"
             )
+        return cls.request_device_code_for(auth_details)
+
+    @classmethod
+    def poll_device_token_for(cls, auth_details: AuthDetails, device_code: str) -> dict:
+        """Poll for a token after the user has authorized the device.
+
+        Args:
+            auth_details: The Auth0 application (base URL + client id) to poll.
+            device_code: The device_code from request_device_code_for.
+
+        Returns:
+            Dict containing access_token, id_token, etc. on success.
+
+        Raises:
+            requests.HTTPError: 403 with 'authorization_pending' or 'slow_down'
+                while the user hasn't authorized yet.
+        """
         data = {
             "client_id": auth_details.device_client_id,
-            "scope": "openid profile email",
-            "audience": "https://platform.polyai.app/api",
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            "device_code": device_code,
         }
-        return cls.make_request(
-            auth_details.base_url, "/oauth/device/code", method="POST", data=data
-        )
+        return cls.make_request(auth_details.base_url, "/oauth/token", method="POST", data=data)
 
     @classmethod
     def poll_device_token(cls, region: str, device_code: str) -> dict:
@@ -140,9 +182,4 @@ class Auth0Handler:
             raise ValueError(
                 f"Unknown region '{region}'. Valid regions: {', '.join(REGION_TO_AUTH_DETAILS)}"
             )
-        data = {
-            "client_id": auth_details.device_client_id,
-            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-            "device_code": device_code,
-        }
-        return cls.make_request(auth_details.base_url, "/oauth/token", method="POST", data=data)
+        return cls.poll_device_token_for(auth_details, device_code)

--- a/src/poly/handlers/interface.py
+++ b/src/poly/handlers/interface.py
@@ -1039,6 +1039,59 @@ class AgentStudioInterface:
         return PlatformAPIHandler.create_pat_internal(region, jwt_token, name)
 
     @staticmethod
+    def get_accounts_internal(region: str, jwt_token: str, source: str = "adk") -> list[dict]:
+        """Get the accounts visible to the authenticated user, via JWT auth.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            list[dict]: The raw list of account records.
+        """
+        return PlatformAPIHandler.get_accounts_internal(region, jwt_token, source=source)
+
+    @staticmethod
+    def list_account_api_keys_internal(
+        region: str, jwt_token: str, account_id: str, source: str = "adk"
+    ) -> list[dict]:
+        """List the account-scoped API keys for an account, via JWT auth.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            account_id: The account ID.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            list[dict]: The raw list of API key records.
+        """
+        return PlatformAPIHandler.list_account_api_keys_internal(
+            region, jwt_token, account_id, source=source
+        )
+
+    @staticmethod
+    def create_account_api_key_internal(
+        region: str, jwt_token: str, account_id: str, name: str, source: str = "adk"
+    ) -> dict:
+        """Create an account-scoped API key, via JWT auth.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            account_id: The account ID to scope the key to.
+            name: A label for the API key.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            dict: The full API key record, including the secret under ``key``.
+        """
+        return PlatformAPIHandler.create_account_api_key_internal(
+            region, jwt_token, account_id, name, source=source
+        )
+
+    @staticmethod
     def list_conversations(
         region: str,
         project_id: str,

--- a/src/poly/handlers/platform_api.py
+++ b/src/poly/handlers/platform_api.py
@@ -817,6 +817,25 @@ class PlatformAPIHandler:
         return PlatformAPIHandler.make_request(region, endpoint, "PATCH", data=data)
 
     @staticmethod
+    def _jwt_headers(jwt_token: str, source: str = "adk") -> dict[str, str]:
+        """Build the header set for a JWT-authenticated Jupiter API call.
+
+        Args:
+            jwt_token: A valid JWT access token.
+            source: Value for the ``X-Poly-Source`` header, used to distinguish
+                which command/flow a call originated from.
+
+        Returns:
+            dict[str, str]: Headers for a Bearer-authenticated request.
+        """
+        return {
+            "Authorization": f"Bearer {jwt_token}",
+            "Content-Type": "application/json",
+            "X-PolyAI-Correlation-Id": f"adk-{uuid.uuid4()}",
+            "X-Poly-Source": source,
+        }
+
+    @staticmethod
     def authorise(region: str, jwt_token: str) -> dict:
         """Authorise the user via JWT, creating their account if needed.
 
@@ -827,16 +846,12 @@ class PlatformAPIHandler:
         Returns:
             dict: The user record.
         """
-        correlation_id = f"adk-{uuid.uuid4()}"
-        headers = {
-            "Authorization": f"Bearer {jwt_token}",
-            "Content-Type": "application/json",
-            "X-PolyAI-Correlation-Id": correlation_id,
-            "X-Poly-Source": "adk",
-        }
-
         return PlatformAPIHandler.make_request(
-            region, "/jupiter/v1/authorise", "GET", headers=headers, use_jupiter_api=True
+            region,
+            "/jupiter/v1/authorise",
+            "GET",
+            headers=PlatformAPIHandler._jwt_headers(jwt_token),
+            use_jupiter_api=True,
         )
 
     @staticmethod
@@ -850,16 +865,12 @@ class PlatformAPIHandler:
         Returns:
             list[dict]: List of PAT records.
         """
-        correlation_id = f"adk-{uuid.uuid4()}"
-        headers = {
-            "Authorization": f"Bearer {jwt_token}",
-            "Content-Type": "application/json",
-            "X-PolyAI-Correlation-Id": correlation_id,
-            "X-Poly-Source": "adk",
-        }
-
         return PlatformAPIHandler.make_request(
-            region, "/jupiter/v2/pats", "GET", headers=headers, use_jupiter_api=True
+            region,
+            "/jupiter/v2/pats",
+            "GET",
+            headers=PlatformAPIHandler._jwt_headers(jwt_token),
+            use_jupiter_api=True,
         )
 
     @staticmethod
@@ -874,23 +885,86 @@ class PlatformAPIHandler:
         Returns:
             str: The PAT token.
         """
-        correlation_id = f"adk-{uuid.uuid4()}"
-        headers = {
-            "Authorization": f"Bearer {jwt_token}",
-            "Content-Type": "application/json",
-            "X-PolyAI-Correlation-Id": correlation_id,
-            "X-Poly-Source": "adk",
-        }
-
         response = PlatformAPIHandler.make_request(
             region,
             "/jupiter/v2/pats",
             "POST",
             data={"name": name},
-            headers=headers,
+            headers=PlatformAPIHandler._jwt_headers(jwt_token),
             use_jupiter_api=True,
         )
         return response.get("key")
+
+    @staticmethod
+    def get_accounts_internal(region: str, jwt_token: str, source: str = "adk") -> list[dict]:
+        """Get the accounts visible to the authenticated user, via JWT auth.
+
+        Unlike ``get_accounts`` (API-key auth, filtered to a name mapping),
+        this returns the raw account records for a JWT-authenticated caller.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            list[dict]: The raw list of account records.
+        """
+        return PlatformAPIHandler.make_request(
+            region,
+            "/jupiter/v2/accounts",
+            "GET",
+            headers=PlatformAPIHandler._jwt_headers(jwt_token, source=source),
+            use_jupiter_api=True,
+        )
+
+    @staticmethod
+    def list_account_api_keys_internal(
+        region: str, jwt_token: str, account_id: str, source: str = "adk"
+    ) -> list[dict]:
+        """List the account-scoped API keys for an account, via JWT auth.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            account_id: The account ID.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            list[dict]: The raw list of API key records.
+        """
+        return PlatformAPIHandler.make_request(
+            region,
+            f"/jupiter/v2/accounts/{account_id}/api-keys",
+            "GET",
+            headers=PlatformAPIHandler._jwt_headers(jwt_token, source=source),
+            use_jupiter_api=True,
+        )
+
+    @staticmethod
+    def create_account_api_key_internal(
+        region: str, jwt_token: str, account_id: str, name: str, source: str = "adk"
+    ) -> dict:
+        """Create an account-scoped API key, via JWT auth.
+
+        Args:
+            region: The region name.
+            jwt_token: A valid JWT access token.
+            account_id: The account ID to scope the key to.
+            name: A label for the API key.
+            source: Value for the ``X-Poly-Source`` header.
+
+        Returns:
+            dict: The full API key record, including the secret under ``key``.
+        """
+        return PlatformAPIHandler.make_request(
+            region,
+            f"/jupiter/v2/accounts/{account_id}/api-keys",
+            "POST",
+            data={"name": name},
+            headers=PlatformAPIHandler._jwt_headers(jwt_token, source=source),
+            use_jupiter_api=True,
+        )
 
     @staticmethod
     def list_conversations(

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -4,6 +4,8 @@ Copyright PolyAI Limited
 """
 
 import logging
+import os
+import uuid
 from typing import TYPE_CHECKING
 
 POSTHOG_HOST = "https://eu.i.posthog.com"
@@ -15,7 +17,19 @@ POSTHOG_KEY_NON_PROD = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
 NON_PROD_REGIONS = frozenset({"dev", "staging"})
 
 FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
+DEFAULT_FLUSH_TIMEOUT_SECONDS = 5.0
+
+TELEMETRY_ID_PATH = os.path.expanduser("~/.poly/telemetry_id")
+
 logger = logging.getLogger(__name__)
+
+# The posthog SDK logs its own warnings (e.g. a flush running out of budget)
+# at WARNING level, which would otherwise leak into a user's terminal. Our
+# own logger.warning calls for capture/flush failures are unaffected - only
+# the third-party SDK logger is raised, and once, at import time, so it
+# behaves the same regardless of which entry point (feature flags or
+# capture) is used first.
+logging.getLogger("posthog").setLevel(logging.ERROR)
 
 
 if TYPE_CHECKING:
@@ -72,6 +86,87 @@ def get_user_identity() -> str:
     import getpass
 
     return getpass.getuser()
+
+
+def _is_truthy_flag(value: str | None) -> bool:
+    """Whether an env var value means "on" (`"1"` or `"true"`, case-insensitive)."""
+    return (value or "").strip().lower() in {"1", "true"}
+
+
+def telemetry_disabled() -> bool:
+    """Whether telemetry capture is opted out of via environment variable.
+
+    Returns:
+        bool: True if `DO_NOT_TRACK` or `POLY_NO_TELEMETRY` is set to `1`/`true`.
+    """
+    return _is_truthy_flag(os.environ.get("DO_NOT_TRACK")) or _is_truthy_flag(
+        os.environ.get("POLY_NO_TELEMETRY")
+    )
+
+
+def get_anonymous_id() -> str:
+    """Get (or create) a stable anonymous id for this machine's telemetry events.
+
+    Returns:
+        str: A UUID4, persisted at `~/.poly/telemetry_id` (mode 600) so it is
+            stable across CLI invocations.
+    """
+    if os.path.isfile(TELEMETRY_ID_PATH):
+        try:
+            with open(TELEMETRY_ID_PATH, "r", encoding="utf-8") as f:
+                existing = f.read().strip()
+            if existing:
+                return existing
+        except OSError:
+            logger.warning(f"Could not read telemetry id at {TELEMETRY_ID_PATH!r}.")
+
+    new_id = str(uuid.uuid4())
+    os.makedirs(os.path.dirname(TELEMETRY_ID_PATH), exist_ok=True)
+    with open(TELEMETRY_ID_PATH, "w", encoding="utf-8") as f:
+        f.write(new_id)
+    os.chmod(TELEMETRY_ID_PATH, 0o600)
+    return new_id
+
+
+def capture_event(region: str, event: str, properties: dict, distinct_id: str) -> None:
+    """Capture a telemetry event, never raising and never blocking on a slow network.
+
+    A no-op when telemetry is disabled. Any failure to reach PostHog is
+    logged at warning level and swallowed - telemetry must never break or
+    slow down the command it is instrumenting.
+
+    Args:
+        region: The region the event relates to, used to pick the PostHog project.
+        event: The event name.
+        properties: Event properties. Must never include secrets (API keys, JWTs).
+        distinct_id: The PostHog distinct id to attribute the event to.
+    """
+    if telemetry_disabled():
+        return
+    try:
+        client = get_posthog_client(region)
+        client.capture(distinct_id=distinct_id, event=event, properties=properties)
+    except Exception as exc:
+        logger.warning(f"PostHog capture failed event={event!r}", exc_info=exc)
+
+
+def flush(region: str, timeout_seconds: float = DEFAULT_FLUSH_TIMEOUT_SECONDS) -> None:
+    """Flush any buffered telemetry events before the process exits.
+
+    Bounded by `timeout_seconds` so a slow or unreachable PostHog can't hang
+    process exit. Any failure is logged at warning level and swallowed.
+
+    Args:
+        region: The region whose PostHog client should be flushed.
+        timeout_seconds: Maximum time to wait for the flush to complete.
+    """
+    if telemetry_disabled():
+        return
+    try:
+        client = get_posthog_client(region)
+        client.flush(timeout_seconds=timeout_seconds)
+    except Exception as exc:
+        logger.warning("PostHog flush failed", exc_info=exc)
 
 
 class PosthogHandler:

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -8,6 +8,8 @@ import os
 import uuid
 from typing import TYPE_CHECKING
 
+from poly.constants import POLY_HOME_DIR
+
 POSTHOG_HOST = "https://eu.i.posthog.com"
 
 # Public client-side project keys, safe to commit. One PostHog project per
@@ -19,7 +21,7 @@ NON_PROD_REGIONS = frozenset({"dev", "staging"})
 FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
 DEFAULT_FLUSH_TIMEOUT_SECONDS = 5.0
 
-TELEMETRY_ID_PATH = os.path.expanduser("~/.poly/telemetry_id")
+TELEMETRY_ID_PATH = os.path.join(POLY_HOME_DIR, "telemetry_id")
 
 logger = logging.getLogger(__name__)
 
@@ -108,7 +110,7 @@ def get_anonymous_id() -> str:
     """Get (or create) a stable anonymous id for this machine's telemetry events.
 
     Returns:
-        str: A UUID4, persisted at `~/.poly/telemetry_id` (mode 600) so it is
+        str: A UUID4, persisted at `TELEMETRY_ID_PATH` (mode 600) so it is
             stable across CLI invocations.
     """
     if os.path.isfile(TELEMETRY_ID_PATH):

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -4,11 +4,7 @@ Copyright PolyAI Limited
 """
 
 import logging
-import os
-import uuid
 from typing import TYPE_CHECKING
-
-from poly.constants import POLY_HOME_DIR
 
 POSTHOG_HOST = "https://eu.i.posthog.com"
 
@@ -19,19 +15,7 @@ POSTHOG_KEY_NON_PROD = "phc_kS54QZyZRqi9T77rWEUfJ49vVYY4ADKEPnRUrJ7RNnZ6"
 NON_PROD_REGIONS = frozenset({"dev", "staging"})
 
 FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS = 1
-DEFAULT_FLUSH_TIMEOUT_SECONDS = 5.0
-
-TELEMETRY_ID_PATH = os.path.join(POLY_HOME_DIR, "telemetry_id")
-
 logger = logging.getLogger(__name__)
-
-# The posthog SDK logs its own warnings (e.g. a flush running out of budget)
-# at WARNING level, which would otherwise leak into a user's terminal. Our
-# own logger.warning calls for capture/flush failures are unaffected - only
-# the third-party SDK logger is raised, and once, at import time, so it
-# behaves the same regardless of which entry point (feature flags or
-# capture) is used first.
-logging.getLogger("posthog").setLevel(logging.ERROR)
 
 
 if TYPE_CHECKING:
@@ -88,87 +72,6 @@ def get_user_identity() -> str:
     import getpass
 
     return getpass.getuser()
-
-
-def _is_truthy_flag(value: str | None) -> bool:
-    """Whether an env var value means "on" (`"1"` or `"true"`, case-insensitive)."""
-    return (value or "").strip().lower() in {"1", "true"}
-
-
-def telemetry_disabled() -> bool:
-    """Whether telemetry capture is opted out of via environment variable.
-
-    Returns:
-        bool: True if `DO_NOT_TRACK` or `POLY_NO_TELEMETRY` is set to `1`/`true`.
-    """
-    return _is_truthy_flag(os.environ.get("DO_NOT_TRACK")) or _is_truthy_flag(
-        os.environ.get("POLY_NO_TELEMETRY")
-    )
-
-
-def get_anonymous_id() -> str:
-    """Get (or create) a stable anonymous id for this machine's telemetry events.
-
-    Returns:
-        str: A UUID4, persisted at `TELEMETRY_ID_PATH` (mode 600) so it is
-            stable across CLI invocations.
-    """
-    if os.path.isfile(TELEMETRY_ID_PATH):
-        try:
-            with open(TELEMETRY_ID_PATH, "r", encoding="utf-8") as f:
-                existing = f.read().strip()
-            if existing:
-                return existing
-        except OSError:
-            logger.warning(f"Could not read telemetry id at {TELEMETRY_ID_PATH!r}.")
-
-    new_id = str(uuid.uuid4())
-    os.makedirs(os.path.dirname(TELEMETRY_ID_PATH), exist_ok=True)
-    with open(TELEMETRY_ID_PATH, "w", encoding="utf-8") as f:
-        f.write(new_id)
-    os.chmod(TELEMETRY_ID_PATH, 0o600)
-    return new_id
-
-
-def capture_event(region: str, event: str, properties: dict, distinct_id: str) -> None:
-    """Capture a telemetry event, never raising and never blocking on a slow network.
-
-    A no-op when telemetry is disabled. Any failure to reach PostHog is
-    logged at warning level and swallowed - telemetry must never break or
-    slow down the command it is instrumenting.
-
-    Args:
-        region: The region the event relates to, used to pick the PostHog project.
-        event: The event name.
-        properties: Event properties. Must never include secrets (API keys, JWTs).
-        distinct_id: The PostHog distinct id to attribute the event to.
-    """
-    if telemetry_disabled():
-        return
-    try:
-        client = get_posthog_client(region)
-        client.capture(distinct_id=distinct_id, event=event, properties=properties)
-    except Exception as exc:
-        logger.warning(f"PostHog capture failed event={event!r}", exc_info=exc)
-
-
-def flush(region: str, timeout_seconds: float = DEFAULT_FLUSH_TIMEOUT_SECONDS) -> None:
-    """Flush any buffered telemetry events before the process exits.
-
-    Bounded by `timeout_seconds` so a slow or unreachable PostHog can't hang
-    process exit. Any failure is logged at warning level and swallowed.
-
-    Args:
-        region: The region whose PostHog client should be flushed.
-        timeout_seconds: Maximum time to wait for the flush to complete.
-    """
-    if telemetry_disabled():
-        return
-    try:
-        client = get_posthog_client(region)
-        client.flush(timeout_seconds=timeout_seconds)
-    except Exception as exc:
-        logger.warning("PostHog flush failed", exc_info=exc)
 
 
 class PosthogHandler:

--- a/src/poly/output/console.py
+++ b/src/poly/output/console.py
@@ -1220,10 +1220,14 @@ def print_welcome_message() -> None:
     console.print()
 
 
+def mask_secret(key: str) -> str:
+    """Mask a secret for safe display, with no markup - e.g. for JSON output or an exception message."""
+    return key[:4] + "****" + key[-4:] if len(key) > 8 else "****"
+
+
 def mask_api_key(key: str) -> str:
-    """Display masked API key"""
-    masked = key[:4] + "****" + key[-4:] if len(key) > 8 else "****"
-    return f"[yellow]{masked}[/yellow]"
+    """Display masked API key, coloured for the console."""
+    return f"[yellow]{mask_secret(key)}[/yellow]"
 
 
 def handle_exception(exc: Exception) -> None:

--- a/src/poly/tests/api/auth0_test.py
+++ b/src/poly/tests/api/auth0_test.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 import requests
 
 from poly.handlers.auth0_handler import (
-    ONBOARD_AUTH_DETAILS,
+    APIKEY_AUTH_DETAILS,
     REGION_TO_AUTH_DETAILS,
     Auth0Handler,
 )
@@ -90,17 +90,17 @@ class PollDeviceToken(unittest.TestCase):
             Auth0Handler.poll_device_token("mars-1", "dc-1")
 
 
-class OnboardAuthDetails(unittest.TestCase):
-    """Tests for the onboarding client's AuthDetails and the `_for` variants."""
+class ApiKeyAuthDetails(unittest.TestCase):
+    """Tests for the dedicated Auth0 client's AuthDetails and the `_for` variants."""
 
-    def test_onboard_auth_details_values(self):
-        """The onboarding client id and host match the dedicated Auth0 application."""
-        self.assertEqual(ONBOARD_AUTH_DETAILS.device_client_id, "fp7CIVelwOwMPBNNpHpQCLiRMj7nG0fs")
-        self.assertEqual(ONBOARD_AUTH_DETAILS.base_url, "https://login.studio.poly.ai")
+    def test_apikey_auth_details_values(self):
+        """The client id and host match the dedicated, GitHub-only Auth0 application."""
+        self.assertEqual(APIKEY_AUTH_DETAILS.device_client_id, "fp7CIVelwOwMPBNNpHpQCLiRMj7nG0fs")
+        self.assertEqual(APIKEY_AUTH_DETAILS.base_url, "https://login.studio.poly.ai")
 
-    def test_onboard_auth_details_not_a_region(self):
-        """The onboarding client is not selectable via any --region value."""
-        self.assertNotIn(ONBOARD_AUTH_DETAILS, REGION_TO_AUTH_DETAILS.values())
+    def test_apikey_auth_details_not_a_region(self):
+        """The dedicated Auth0 client is not selectable via any --region value."""
+        self.assertNotIn(APIKEY_AUTH_DETAILS, REGION_TO_AUTH_DETAILS.values())
 
     @patch("poly.handlers.auth0_handler.requests.request")
     def test_request_device_code_for_sends_given_client_id(self, mock_request):
@@ -109,13 +109,13 @@ class OnboardAuthDetails(unittest.TestCase):
             200, json_body={"device_code": "dc-1", "user_code": "ABCD"}
         )
 
-        result = Auth0Handler.request_device_code_for(ONBOARD_AUTH_DETAILS)
+        result = Auth0Handler.request_device_code_for(APIKEY_AUTH_DETAILS)
 
         sent = json.loads(mock_request.call_args.kwargs["data"])
-        self.assertEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertEqual(sent["client_id"], APIKEY_AUTH_DETAILS.device_client_id)
         self.assertEqual(
             mock_request.call_args.kwargs["url"],
-            ONBOARD_AUTH_DETAILS.base_url + "/oauth/device/code",
+            APIKEY_AUTH_DETAILS.base_url + "/oauth/device/code",
         )
         self.assertEqual(result, {"device_code": "dc-1", "user_code": "ABCD"})
 
@@ -124,13 +124,13 @@ class OnboardAuthDetails(unittest.TestCase):
         """poll_device_token_for sends the passed-in AuthDetails' client id, not a region's."""
         mock_request.return_value = make_mock_response(200, json_body={"access_token": "tok-1"})
 
-        result = Auth0Handler.poll_device_token_for(ONBOARD_AUTH_DETAILS, "dc-1")
+        result = Auth0Handler.poll_device_token_for(APIKEY_AUTH_DETAILS, "dc-1")
 
         sent = json.loads(mock_request.call_args.kwargs["data"])
-        self.assertEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertEqual(sent["client_id"], APIKEY_AUTH_DETAILS.device_client_id)
         self.assertEqual(sent["device_code"], "dc-1")
         self.assertEqual(
-            mock_request.call_args.kwargs["url"], ONBOARD_AUTH_DETAILS.base_url + "/oauth/token"
+            mock_request.call_args.kwargs["url"], APIKEY_AUTH_DETAILS.base_url + "/oauth/token"
         )
         self.assertEqual(result, {"access_token": "tok-1"})
 
@@ -145,7 +145,7 @@ class OnboardAuthDetails(unittest.TestCase):
 
         sent = json.loads(mock_request.call_args.kwargs["data"])
         self.assertEqual(sent["client_id"], REGION_TO_AUTH_DETAILS["studio"].device_client_id)
-        self.assertNotEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertNotEqual(sent["client_id"], APIKEY_AUTH_DETAILS.device_client_id)
 
     @patch("poly.handlers.auth0_handler.requests.request")
     def test_region_keyed_poll_device_token_still_uses_region_client_id(self, mock_request):
@@ -156,7 +156,7 @@ class OnboardAuthDetails(unittest.TestCase):
 
         sent = json.loads(mock_request.call_args.kwargs["data"])
         self.assertEqual(sent["client_id"], REGION_TO_AUTH_DETAILS["studio"].device_client_id)
-        self.assertNotEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertNotEqual(sent["client_id"], APIKEY_AUTH_DETAILS.device_client_id)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/api/auth0_test.py
+++ b/src/poly/tests/api/auth0_test.py
@@ -9,7 +9,11 @@ from unittest.mock import patch
 
 import requests
 
-from poly.handlers.auth0_handler import REGION_TO_AUTH_DETAILS, Auth0Handler
+from poly.handlers.auth0_handler import (
+    ONBOARD_AUTH_DETAILS,
+    REGION_TO_AUTH_DETAILS,
+    Auth0Handler,
+)
 from poly.tests.testing_utils import make_mock_response
 
 
@@ -84,6 +88,75 @@ class PollDeviceToken(unittest.TestCase):
         """An unknown region raises ValueError before any request is made."""
         with self.assertRaises(ValueError):
             Auth0Handler.poll_device_token("mars-1", "dc-1")
+
+
+class OnboardAuthDetails(unittest.TestCase):
+    """Tests for the onboarding client's AuthDetails and the `_for` variants."""
+
+    def test_onboard_auth_details_values(self):
+        """The onboarding client id and host match the dedicated Auth0 application."""
+        self.assertEqual(ONBOARD_AUTH_DETAILS.device_client_id, "fp7CIVelwOwMPBNNpHpQCLiRMj7nG0fs")
+        self.assertEqual(ONBOARD_AUTH_DETAILS.base_url, "https://login.studio.poly.ai")
+
+    def test_onboard_auth_details_not_a_region(self):
+        """The onboarding client is not selectable via any --region value."""
+        self.assertNotIn(ONBOARD_AUTH_DETAILS, REGION_TO_AUTH_DETAILS.values())
+
+    @patch("poly.handlers.auth0_handler.requests.request")
+    def test_request_device_code_for_sends_given_client_id(self, mock_request):
+        """request_device_code_for sends the passed-in AuthDetails' client id, not a region's."""
+        mock_request.return_value = make_mock_response(
+            200, json_body={"device_code": "dc-1", "user_code": "ABCD"}
+        )
+
+        result = Auth0Handler.request_device_code_for(ONBOARD_AUTH_DETAILS)
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertEqual(
+            mock_request.call_args.kwargs["url"],
+            ONBOARD_AUTH_DETAILS.base_url + "/oauth/device/code",
+        )
+        self.assertEqual(result, {"device_code": "dc-1", "user_code": "ABCD"})
+
+    @patch("poly.handlers.auth0_handler.requests.request")
+    def test_poll_device_token_for_sends_given_client_id(self, mock_request):
+        """poll_device_token_for sends the passed-in AuthDetails' client id, not a region's."""
+        mock_request.return_value = make_mock_response(200, json_body={"access_token": "tok-1"})
+
+        result = Auth0Handler.poll_device_token_for(ONBOARD_AUTH_DETAILS, "dc-1")
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+        self.assertEqual(sent["device_code"], "dc-1")
+        self.assertEqual(
+            mock_request.call_args.kwargs["url"], ONBOARD_AUTH_DETAILS.base_url + "/oauth/token"
+        )
+        self.assertEqual(result, {"access_token": "tok-1"})
+
+    @patch("poly.handlers.auth0_handler.requests.request")
+    def test_region_keyed_request_device_code_still_uses_region_client_id(self, mock_request):
+        """Delegating to the `_for` variant must not change the region-keyed client id sent."""
+        mock_request.return_value = make_mock_response(
+            200, json_body={"device_code": "dc-1", "user_code": "ABCD"}
+        )
+
+        Auth0Handler.request_device_code("studio")
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent["client_id"], REGION_TO_AUTH_DETAILS["studio"].device_client_id)
+        self.assertNotEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
+
+    @patch("poly.handlers.auth0_handler.requests.request")
+    def test_region_keyed_poll_device_token_still_uses_region_client_id(self, mock_request):
+        """Delegating to the `_for` variant must not change the region-keyed client id sent."""
+        mock_request.return_value = make_mock_response(200, json_body={"access_token": "tok-1"})
+
+        Auth0Handler.poll_device_token("studio", "dc-1")
+
+        sent = json.loads(mock_request.call_args.kwargs["data"])
+        self.assertEqual(sent["client_id"], REGION_TO_AUTH_DETAILS["studio"].device_client_id)
+        self.assertNotEqual(sent["client_id"], ONBOARD_AUTH_DETAILS.device_client_id)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -17,6 +17,102 @@ from poly.handlers.platform_api import (
 from poly.tests.testing_utils import make_mock_response
 
 
+class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
+    """Tests for the JWT-authenticated account/key methods used by `poly onboard`."""
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_authorise_sends_bearer_and_default_source(self, mock_make_request):
+        """authorise() keeps sending the Bearer header and the default 'adk' source."""
+        PlatformAPIHandler.authorise("studio", "jwt-token")
+
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(args[0], "studio")
+        self.assertEqual(args[1], "/jupiter/v1/authorise")
+        self.assertEqual(args[2], "GET")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer jwt-token")
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "adk")
+        self.assertTrue(kwargs["use_jupiter_api"])
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_get_accounts_internal_hits_expected_url(self, mock_make_request):
+        """get_accounts_internal() GETs /jupiter/v2/accounts with Bearer auth."""
+        mock_make_request.return_value = [{"id": "acc-1"}]
+
+        result = PlatformAPIHandler.get_accounts_internal("studio", "jwt-token")
+
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(args[0], "studio")
+        self.assertEqual(args[1], "/jupiter/v2/accounts")
+        self.assertEqual(args[2], "GET")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer jwt-token")
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "adk")
+        self.assertTrue(kwargs["use_jupiter_api"])
+        self.assertEqual(result, [{"id": "acc-1"}])
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_get_accounts_internal_sends_given_source(self, mock_make_request):
+        """get_accounts_internal() sends the caller-supplied X-Poly-Source."""
+        PlatformAPIHandler.get_accounts_internal("studio", "jwt-token", source="onboard")
+
+        kwargs = mock_make_request.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_list_account_api_keys_internal_hits_expected_url(self, mock_make_request):
+        """list_account_api_keys_internal() GETs the account's api-keys endpoint."""
+        mock_make_request.return_value = [{"key": "sk-1"}]
+
+        result = PlatformAPIHandler.list_account_api_keys_internal(
+            "studio", "jwt-token", "acc-1"
+        )
+
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(args[0], "studio")
+        self.assertEqual(args[1], "/jupiter/v2/accounts/acc-1/api-keys")
+        self.assertEqual(args[2], "GET")
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer jwt-token")
+        self.assertTrue(kwargs["use_jupiter_api"])
+        self.assertEqual(result, [{"key": "sk-1"}])
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_list_account_api_keys_internal_sends_given_source(self, mock_make_request):
+        """list_account_api_keys_internal() sends the caller-supplied X-Poly-Source."""
+        PlatformAPIHandler.list_account_api_keys_internal(
+            "studio", "jwt-token", "acc-1", source="onboard"
+        )
+
+        kwargs = mock_make_request.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_create_account_api_key_internal_posts_name(self, mock_make_request):
+        """create_account_api_key_internal() POSTs {"name": ...} to the api-keys endpoint."""
+        mock_make_request.return_value = {"key": "sk-new", "name": ""}
+
+        result = PlatformAPIHandler.create_account_api_key_internal(
+            "studio", "jwt-token", "acc-1", "onboard-key"
+        )
+
+        args, kwargs = mock_make_request.call_args
+        self.assertEqual(args[0], "studio")
+        self.assertEqual(args[1], "/jupiter/v2/accounts/acc-1/api-keys")
+        self.assertEqual(args[2], "POST")
+        self.assertEqual(kwargs["data"], {"name": "onboard-key"})
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer jwt-token")
+        self.assertTrue(kwargs["use_jupiter_api"])
+        self.assertEqual(result, {"key": "sk-new", "name": ""})
+
+    @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
+    def test_create_account_api_key_internal_sends_given_source(self, mock_make_request):
+        """create_account_api_key_internal() sends the caller-supplied X-Poly-Source."""
+        PlatformAPIHandler.create_account_api_key_internal(
+            "studio", "jwt-token", "acc-1", "onboard-key", source="onboard"
+        )
+
+        kwargs = mock_make_request.call_args.kwargs
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+
+
 class GetBaseUrl(unittest.TestCase):
     """Tests for PlatformAPIHandler.get_base_url region mapping."""
 

--- a/src/poly/tests/api/platform_api_test.py
+++ b/src/poly/tests/api/platform_api_test.py
@@ -18,7 +18,7 @@ from poly.tests.testing_utils import make_mock_response
 
 
 class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
-    """Tests for the JWT-authenticated account/key methods used by `poly onboard`."""
+    """Tests for the JWT-authenticated account/key methods used by `poly apikey`."""
 
     @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
     def test_authorise_sends_bearer_and_default_source(self, mock_make_request):
@@ -52,10 +52,10 @@ class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
     @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
     def test_get_accounts_internal_sends_given_source(self, mock_make_request):
         """get_accounts_internal() sends the caller-supplied X-Poly-Source."""
-        PlatformAPIHandler.get_accounts_internal("studio", "jwt-token", source="onboard")
+        PlatformAPIHandler.get_accounts_internal("studio", "jwt-token", source="apikey")
 
         kwargs = mock_make_request.call_args.kwargs
-        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "apikey")
 
     @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
     def test_list_account_api_keys_internal_hits_expected_url(self, mock_make_request):
@@ -78,11 +78,11 @@ class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
     def test_list_account_api_keys_internal_sends_given_source(self, mock_make_request):
         """list_account_api_keys_internal() sends the caller-supplied X-Poly-Source."""
         PlatformAPIHandler.list_account_api_keys_internal(
-            "studio", "jwt-token", "acc-1", source="onboard"
+            "studio", "jwt-token", "acc-1", source="apikey"
         )
 
         kwargs = mock_make_request.call_args.kwargs
-        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "apikey")
 
     @patch("poly.handlers.platform_api.PlatformAPIHandler.make_request")
     def test_create_account_api_key_internal_posts_name(self, mock_make_request):
@@ -90,14 +90,14 @@ class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
         mock_make_request.return_value = {"key": "sk-new", "name": ""}
 
         result = PlatformAPIHandler.create_account_api_key_internal(
-            "studio", "jwt-token", "acc-1", "onboard-key"
+            "studio", "jwt-token", "acc-1", "cli-generated-key"
         )
 
         args, kwargs = mock_make_request.call_args
         self.assertEqual(args[0], "studio")
         self.assertEqual(args[1], "/jupiter/v2/accounts/acc-1/api-keys")
         self.assertEqual(args[2], "POST")
-        self.assertEqual(kwargs["data"], {"name": "onboard-key"})
+        self.assertEqual(kwargs["data"], {"name": "cli-generated-key"})
         self.assertEqual(kwargs["headers"]["Authorization"], "Bearer jwt-token")
         self.assertTrue(kwargs["use_jupiter_api"])
         self.assertEqual(result, {"key": "sk-new", "name": ""})
@@ -106,11 +106,11 @@ class JwtAuthedAccountAndKeyCalls(unittest.TestCase):
     def test_create_account_api_key_internal_sends_given_source(self, mock_make_request):
         """create_account_api_key_internal() sends the caller-supplied X-Poly-Source."""
         PlatformAPIHandler.create_account_api_key_internal(
-            "studio", "jwt-token", "acc-1", "onboard-key", source="onboard"
+            "studio", "jwt-token", "acc-1", "cli-generated-key", source="apikey"
         )
 
         kwargs = mock_make_request.call_args.kwargs
-        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "onboard")
+        self.assertEqual(kwargs["headers"]["X-Poly-Source"], "apikey")
 
 
 class GetBaseUrl(unittest.TestCase):

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -3,11 +3,24 @@
 Copyright PolyAI Limited
 """
 
+import importlib
+import logging
+import os
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from poly.handlers import posthog as posthog_module
-from poly.handlers.posthog import PosthogHandler, get_posthog_client, get_user_identity
+from poly.handlers.posthog import (
+    PosthogHandler,
+    capture_event,
+    flush,
+    get_anonymous_id,
+    get_posthog_client,
+    get_user_identity,
+    telemetry_disabled,
+)
 
 
 class IsFeatureEnabledTest(unittest.TestCase):
@@ -243,6 +256,24 @@ class GetPosthogClientTest(unittest.TestCase):
         timeout = mock_posthog_cls.call_args.kwargs["feature_flags_request_timeout_seconds"]
         self.assertEqual(timeout, posthog_module.FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS)
 
+    def test_posthog_sdk_logger_is_raised_to_error_at_import(self):
+        """Importing the module silences the third-party posthog logger.
+
+        It must happen at import time (not inside get_posthog_client), so the
+        feature-flag path and the capture path behave the same regardless of
+        which runs first. Reloading the module re-triggers that import-time
+        side effect, which is what this test actually exercises.
+        """
+        posthog_logger = logging.getLogger("posthog")
+        original_level = posthog_logger.level
+        posthog_logger.setLevel(logging.WARNING)
+        try:
+            importlib.reload(posthog_module)
+            self.assertEqual(posthog_logger.level, logging.ERROR)
+        finally:
+            posthog_logger.setLevel(original_level)
+            importlib.reload(posthog_module)
+
 
 class GetUserIdentityTest(unittest.TestCase):
     """Tests for get_user_identity, the PostHog distinct_id source."""
@@ -251,6 +282,174 @@ class GetUserIdentityTest(unittest.TestCase):
         """The distinct_id is the OS username, so rollouts bucket per developer."""
         with patch("getpass.getuser", return_value="ada"):
             self.assertEqual(get_user_identity(), "ada")
+
+
+class TelemetryDisabledTest(unittest.TestCase):
+    """Tests for telemetry_disabled's env var handling."""
+
+    def setUp(self):
+        self._env_patch = patch.dict(os.environ, {}, clear=False)
+        self._env_patch.start()
+        os.environ.pop("DO_NOT_TRACK", None)
+        os.environ.pop("POLY_NO_TELEMETRY", None)
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_disabled_by_default(self):
+        """With neither env var set, telemetry is enabled."""
+        self.assertFalse(telemetry_disabled())
+
+    def test_do_not_track_disables_telemetry(self):
+        """DO_NOT_TRACK=1 or =true disables telemetry, case-insensitively."""
+        for value in ("1", "true", "True", "TRUE"):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {"DO_NOT_TRACK": value}):
+                    self.assertTrue(telemetry_disabled())
+
+    def test_poly_telemetry_disables_telemetry(self):
+        """POLY_NO_TELEMETRY=1 or =true disables telemetry, case-insensitively."""
+        for value in ("1", "true", "True"):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {"POLY_NO_TELEMETRY": value}):
+                    self.assertTrue(telemetry_disabled())
+
+    def test_other_values_do_not_disable_telemetry(self):
+        """A falsy or unrelated value leaves telemetry enabled."""
+        for value in ("0", "false", "no", ""):
+            with self.subTest(value=value):
+                with patch.dict(os.environ, {"DO_NOT_TRACK": value}):
+                    self.assertFalse(telemetry_disabled())
+
+
+class GetAnonymousIdTest(unittest.TestCase):
+    """Tests for get_anonymous_id's persisted UUID."""
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self._path_patch = patch.object(
+            posthog_module, "TELEMETRY_ID_PATH", str(Path(self._tmp_dir.name) / "telemetry_id")
+        )
+        self._path_patch.start()
+
+    def tearDown(self):
+        self._path_patch.stop()
+        self._tmp_dir.cleanup()
+
+    def test_creates_and_persists_a_uuid(self):
+        """A missing telemetry id file is created with a UUID, mode 600."""
+        first = get_anonymous_id()
+
+        path = Path(posthog_module.TELEMETRY_ID_PATH)
+        self.assertTrue(path.is_file())
+        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+        self.assertEqual(path.read_text(encoding="utf-8"), first)
+
+    def test_reuses_existing_id(self):
+        """A second call returns the same id as the first, rather than a new one."""
+        first = get_anonymous_id()
+        second = get_anonymous_id()
+
+        self.assertEqual(first, second)
+
+
+class CaptureEventTest(unittest.TestCase):
+    """Tests for capture_event's telemetry-opt-out and failure handling."""
+
+    def setUp(self):
+        self._env_patch = patch.dict(os.environ, {}, clear=False)
+        self._env_patch.start()
+        os.environ.pop("DO_NOT_TRACK", None)
+        os.environ.pop("POLY_NO_TELEMETRY", None)
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_disabled_env_var_means_no_client_call(self):
+        """When telemetry is disabled, get_posthog_client is never even reached."""
+        with (
+            patch.dict(os.environ, {"DO_NOT_TRACK": "1"}),
+            patch("poly.handlers.posthog.get_posthog_client") as mock_get_client,
+        ):
+            capture_event("studio", "onboard_started", {}, "anon-1")
+
+        mock_get_client.assert_not_called()
+
+    def test_forwards_event_and_properties_unchanged(self):
+        """capture_event passes distinct_id/event/properties straight through."""
+        mock_client = MagicMock()
+        properties = {"source": "onboard", "account_id": "acc-1"}
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
+            capture_event("studio", "onboard_account_resolved", properties, "anon-1")
+
+        mock_client.capture.assert_called_once_with(
+            distinct_id="anon-1", event="onboard_account_resolved", properties=properties
+        )
+        # No accidental secret leakage: only what the caller passed is sent.
+        sent_properties = mock_client.capture.call_args.kwargs["properties"]
+        self.assertNotIn("key", sent_properties)
+        self.assertNotIn("token", sent_properties)
+
+    def test_client_exception_is_swallowed(self):
+        """A PostHog failure never propagates out of capture_event."""
+        mock_client = MagicMock()
+        mock_client.capture.side_effect = RuntimeError("connection reset")
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
+            capture_event("studio", "onboard_started", {}, "anon-1")  # must not raise
+
+    def test_client_lookup_exception_is_swallowed(self):
+        """A failure building the client never propagates out of capture_event."""
+        with patch(
+            "poly.handlers.posthog.get_posthog_client", side_effect=RuntimeError("boom")
+        ):
+            capture_event("studio", "onboard_started", {}, "anon-1")  # must not raise
+
+
+class FlushTest(unittest.TestCase):
+    """Tests for flush's telemetry-opt-out and failure handling."""
+
+    def setUp(self):
+        self._env_patch = patch.dict(os.environ, {}, clear=False)
+        self._env_patch.start()
+        os.environ.pop("DO_NOT_TRACK", None)
+        os.environ.pop("POLY_NO_TELEMETRY", None)
+
+    def tearDown(self):
+        self._env_patch.stop()
+
+    def test_disabled_env_var_means_no_client_call(self):
+        """When telemetry is disabled, flush never reaches the client."""
+        with (
+            patch.dict(os.environ, {"DO_NOT_TRACK": "1"}),
+            patch("poly.handlers.posthog.get_posthog_client") as mock_get_client,
+        ):
+            flush("studio")
+
+        mock_get_client.assert_not_called()
+
+    def test_flushes_with_the_given_timeout(self):
+        """flush forwards the timeout to the underlying client."""
+        mock_client = MagicMock()
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
+            flush("studio", timeout_seconds=5.0)
+
+        mock_client.flush.assert_called_once_with(timeout_seconds=5.0)
+
+    def test_default_timeout_is_five_seconds(self):
+        """The default flush budget is 5s, not the SDK's own default."""
+        mock_client = MagicMock()
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
+            flush("studio")
+
+        mock_client.flush.assert_called_once_with(timeout_seconds=5.0)
+        self.assertEqual(posthog_module.DEFAULT_FLUSH_TIMEOUT_SECONDS, 5.0)
+
+    def test_client_exception_is_swallowed(self):
+        """A PostHog failure never propagates out of flush."""
+        mock_client = MagicMock()
+        mock_client.flush.side_effect = RuntimeError("connection reset")
+        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
+            flush("studio")  # must not raise
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -342,7 +342,9 @@ class GetAnonymousIdTest(unittest.TestCase):
 
         path = Path(posthog_module.TELEMETRY_ID_PATH)
         self.assertTrue(path.is_file())
-        self.assertEqual(path.stat().st_mode & 0o777, 0o600)
+        if os.name != "nt":
+            # Windows doesn't enforce POSIX mode bits - chmod only toggles read-only.
+            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
         self.assertEqual(path.read_text(encoding="utf-8"), first)
 
     def test_reuses_existing_id(self):

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -3,24 +3,11 @@
 Copyright PolyAI Limited
 """
 
-import importlib
-import logging
-import os
-import tempfile
 import unittest
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from poly.handlers import posthog as posthog_module
-from poly.handlers.posthog import (
-    PosthogHandler,
-    capture_event,
-    flush,
-    get_anonymous_id,
-    get_posthog_client,
-    get_user_identity,
-    telemetry_disabled,
-)
+from poly.handlers.posthog import PosthogHandler, get_posthog_client, get_user_identity
 
 
 class IsFeatureEnabledTest(unittest.TestCase):
@@ -256,24 +243,6 @@ class GetPosthogClientTest(unittest.TestCase):
         timeout = mock_posthog_cls.call_args.kwargs["feature_flags_request_timeout_seconds"]
         self.assertEqual(timeout, posthog_module.FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS)
 
-    def test_posthog_sdk_logger_is_raised_to_error_at_import(self):
-        """Importing the module silences the third-party posthog logger.
-
-        It must happen at import time (not inside get_posthog_client), so the
-        feature-flag path and the capture path behave the same regardless of
-        which runs first. Reloading the module re-triggers that import-time
-        side effect, which is what this test actually exercises.
-        """
-        posthog_logger = logging.getLogger("posthog")
-        original_level = posthog_logger.level
-        posthog_logger.setLevel(logging.WARNING)
-        try:
-            importlib.reload(posthog_module)
-            self.assertEqual(posthog_logger.level, logging.ERROR)
-        finally:
-            posthog_logger.setLevel(original_level)
-            importlib.reload(posthog_module)
-
 
 class GetUserIdentityTest(unittest.TestCase):
     """Tests for get_user_identity, the PostHog distinct_id source."""
@@ -282,176 +251,6 @@ class GetUserIdentityTest(unittest.TestCase):
         """The distinct_id is the OS username, so rollouts bucket per developer."""
         with patch("getpass.getuser", return_value="ada"):
             self.assertEqual(get_user_identity(), "ada")
-
-
-class TelemetryDisabledTest(unittest.TestCase):
-    """Tests for telemetry_disabled's env var handling."""
-
-    def setUp(self):
-        self._env_patch = patch.dict(os.environ, {}, clear=False)
-        self._env_patch.start()
-        os.environ.pop("DO_NOT_TRACK", None)
-        os.environ.pop("POLY_NO_TELEMETRY", None)
-
-    def tearDown(self):
-        self._env_patch.stop()
-
-    def test_disabled_by_default(self):
-        """With neither env var set, telemetry is enabled."""
-        self.assertFalse(telemetry_disabled())
-
-    def test_do_not_track_disables_telemetry(self):
-        """DO_NOT_TRACK=1 or =true disables telemetry, case-insensitively."""
-        for value in ("1", "true", "True", "TRUE"):
-            with self.subTest(value=value):
-                with patch.dict(os.environ, {"DO_NOT_TRACK": value}):
-                    self.assertTrue(telemetry_disabled())
-
-    def test_poly_telemetry_disables_telemetry(self):
-        """POLY_NO_TELEMETRY=1 or =true disables telemetry, case-insensitively."""
-        for value in ("1", "true", "True"):
-            with self.subTest(value=value):
-                with patch.dict(os.environ, {"POLY_NO_TELEMETRY": value}):
-                    self.assertTrue(telemetry_disabled())
-
-    def test_other_values_do_not_disable_telemetry(self):
-        """A falsy or unrelated value leaves telemetry enabled."""
-        for value in ("0", "false", "no", ""):
-            with self.subTest(value=value):
-                with patch.dict(os.environ, {"DO_NOT_TRACK": value}):
-                    self.assertFalse(telemetry_disabled())
-
-
-class GetAnonymousIdTest(unittest.TestCase):
-    """Tests for get_anonymous_id's persisted UUID."""
-
-    def setUp(self):
-        self._tmp_dir = tempfile.TemporaryDirectory()
-        self._path_patch = patch.object(
-            posthog_module, "TELEMETRY_ID_PATH", str(Path(self._tmp_dir.name) / "telemetry_id")
-        )
-        self._path_patch.start()
-
-    def tearDown(self):
-        self._path_patch.stop()
-        self._tmp_dir.cleanup()
-
-    def test_creates_and_persists_a_uuid(self):
-        """A missing telemetry id file is created with a UUID, mode 600."""
-        first = get_anonymous_id()
-
-        path = Path(posthog_module.TELEMETRY_ID_PATH)
-        self.assertTrue(path.is_file())
-        if os.name != "nt":
-            # Windows doesn't enforce POSIX mode bits - chmod only toggles read-only.
-            self.assertEqual(path.stat().st_mode & 0o777, 0o600)
-        self.assertEqual(path.read_text(encoding="utf-8"), first)
-
-    def test_reuses_existing_id(self):
-        """A second call returns the same id as the first, rather than a new one."""
-        first = get_anonymous_id()
-        second = get_anonymous_id()
-
-        self.assertEqual(first, second)
-
-
-class CaptureEventTest(unittest.TestCase):
-    """Tests for capture_event's telemetry-opt-out and failure handling."""
-
-    def setUp(self):
-        self._env_patch = patch.dict(os.environ, {}, clear=False)
-        self._env_patch.start()
-        os.environ.pop("DO_NOT_TRACK", None)
-        os.environ.pop("POLY_NO_TELEMETRY", None)
-
-    def tearDown(self):
-        self._env_patch.stop()
-
-    def test_disabled_env_var_means_no_client_call(self):
-        """When telemetry is disabled, get_posthog_client is never even reached."""
-        with (
-            patch.dict(os.environ, {"DO_NOT_TRACK": "1"}),
-            patch("poly.handlers.posthog.get_posthog_client") as mock_get_client,
-        ):
-            capture_event("studio", "apikey_started", {}, "anon-1")
-
-        mock_get_client.assert_not_called()
-
-    def test_forwards_event_and_properties_unchanged(self):
-        """capture_event passes distinct_id/event/properties straight through."""
-        mock_client = MagicMock()
-        properties = {"source": "apikey", "account_id": "acc-1"}
-        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            capture_event("studio", "apikey_account_resolved", properties, "anon-1")
-
-        mock_client.capture.assert_called_once_with(
-            distinct_id="anon-1", event="apikey_account_resolved", properties=properties
-        )
-        # No accidental secret leakage: only what the caller passed is sent.
-        sent_properties = mock_client.capture.call_args.kwargs["properties"]
-        self.assertNotIn("key", sent_properties)
-        self.assertNotIn("token", sent_properties)
-
-    def test_client_exception_is_swallowed(self):
-        """A PostHog failure never propagates out of capture_event."""
-        mock_client = MagicMock()
-        mock_client.capture.side_effect = RuntimeError("connection reset")
-        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            capture_event("studio", "apikey_started", {}, "anon-1")  # must not raise
-
-    def test_client_lookup_exception_is_swallowed(self):
-        """A failure building the client never propagates out of capture_event."""
-        with patch(
-            "poly.handlers.posthog.get_posthog_client", side_effect=RuntimeError("boom")
-        ):
-            capture_event("studio", "apikey_started", {}, "anon-1")  # must not raise
-
-
-class FlushTest(unittest.TestCase):
-    """Tests for flush's telemetry-opt-out and failure handling."""
-
-    def setUp(self):
-        self._env_patch = patch.dict(os.environ, {}, clear=False)
-        self._env_patch.start()
-        os.environ.pop("DO_NOT_TRACK", None)
-        os.environ.pop("POLY_NO_TELEMETRY", None)
-
-    def tearDown(self):
-        self._env_patch.stop()
-
-    def test_disabled_env_var_means_no_client_call(self):
-        """When telemetry is disabled, flush never reaches the client."""
-        with (
-            patch.dict(os.environ, {"DO_NOT_TRACK": "1"}),
-            patch("poly.handlers.posthog.get_posthog_client") as mock_get_client,
-        ):
-            flush("studio")
-
-        mock_get_client.assert_not_called()
-
-    def test_flushes_with_the_given_timeout(self):
-        """flush forwards the timeout to the underlying client."""
-        mock_client = MagicMock()
-        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            flush("studio", timeout_seconds=5.0)
-
-        mock_client.flush.assert_called_once_with(timeout_seconds=5.0)
-
-    def test_default_timeout_is_five_seconds(self):
-        """The default flush budget is 5s, not the SDK's own default."""
-        mock_client = MagicMock()
-        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            flush("studio")
-
-        mock_client.flush.assert_called_once_with(timeout_seconds=5.0)
-        self.assertEqual(posthog_module.DEFAULT_FLUSH_TIMEOUT_SECONDS, 5.0)
-
-    def test_client_exception_is_swallowed(self):
-        """A PostHog failure never propagates out of flush."""
-        mock_client = MagicMock()
-        mock_client.flush.side_effect = RuntimeError("connection reset")
-        with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            flush("studio")  # must not raise
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/api/posthog_test.py
+++ b/src/poly/tests/api/posthog_test.py
@@ -373,19 +373,19 @@ class CaptureEventTest(unittest.TestCase):
             patch.dict(os.environ, {"DO_NOT_TRACK": "1"}),
             patch("poly.handlers.posthog.get_posthog_client") as mock_get_client,
         ):
-            capture_event("studio", "onboard_started", {}, "anon-1")
+            capture_event("studio", "apikey_started", {}, "anon-1")
 
         mock_get_client.assert_not_called()
 
     def test_forwards_event_and_properties_unchanged(self):
         """capture_event passes distinct_id/event/properties straight through."""
         mock_client = MagicMock()
-        properties = {"source": "onboard", "account_id": "acc-1"}
+        properties = {"source": "apikey", "account_id": "acc-1"}
         with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            capture_event("studio", "onboard_account_resolved", properties, "anon-1")
+            capture_event("studio", "apikey_account_resolved", properties, "anon-1")
 
         mock_client.capture.assert_called_once_with(
-            distinct_id="anon-1", event="onboard_account_resolved", properties=properties
+            distinct_id="anon-1", event="apikey_account_resolved", properties=properties
         )
         # No accidental secret leakage: only what the caller passed is sent.
         sent_properties = mock_client.capture.call_args.kwargs["properties"]
@@ -397,14 +397,14 @@ class CaptureEventTest(unittest.TestCase):
         mock_client = MagicMock()
         mock_client.capture.side_effect = RuntimeError("connection reset")
         with patch("poly.handlers.posthog.get_posthog_client", return_value=mock_client):
-            capture_event("studio", "onboard_started", {}, "anon-1")  # must not raise
+            capture_event("studio", "apikey_started", {}, "anon-1")  # must not raise
 
     def test_client_lookup_exception_is_swallowed(self):
         """A failure building the client never propagates out of capture_event."""
         with patch(
             "poly.handlers.posthog.get_posthog_client", side_effect=RuntimeError("boom")
         ):
-            capture_event("studio", "onboard_started", {}, "anon-1")  # must not raise
+            capture_event("studio", "apikey_started", {}, "anon-1")  # must not raise
 
 
 class FlushTest(unittest.TestCase):

--- a/src/poly/tests/api_keys_test.py
+++ b/src/poly/tests/api_keys_test.py
@@ -15,7 +15,7 @@ def _key(
     key: str = "sk-1",
     active: bool = True,
     expires_at: str | None = None,
-    name: str = "onboard-key",
+    name: str = "cli-generated-key",
     created_at: str = "2026-01-01T00:00:00Z",
 ) -> dict:
     """Build a key record shaped like the accounts API response."""
@@ -33,10 +33,10 @@ class SelectReusableApiKey(unittest.TestCase):
 
     def test_matches_on_policy_name_not_top_level_name(self):
         """The key name lives under policies[0].name, not the key's own `name` field."""
-        key = _key(name="onboard-key")
+        key = _key(name="cli-generated-key")
         key["name"] = ""  # top-level `name` comes back empty, per the real API.
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertEqual(result, "sk-1")
 
@@ -44,7 +44,7 @@ class SelectReusableApiKey(unittest.TestCase):
         """An inactive key is never reused."""
         key = _key(active=False)
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertIsNone(result)
 
@@ -53,7 +53,7 @@ class SelectReusableApiKey(unittest.TestCase):
         expired = (NOW - timedelta(days=1)).isoformat()
         key = _key(expires_at=expired)
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertIsNone(result)
 
@@ -62,7 +62,7 @@ class SelectReusableApiKey(unittest.TestCase):
         future = (NOW + timedelta(days=1)).isoformat()
         key = _key(expires_at=future)
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertEqual(result, "sk-1")
 
@@ -70,7 +70,7 @@ class SelectReusableApiKey(unittest.TestCase):
         """A key with no expires_at (or None) never expires."""
         key = _key(expires_at=None)
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertEqual(result, "sk-1")
 
@@ -78,7 +78,7 @@ class SelectReusableApiKey(unittest.TestCase):
         """A key created under a different name is not reused."""
         key = _key(name="some-other-key")
 
-        result = select_reusable_api_key([key], "onboard-key", NOW)
+        result = select_reusable_api_key([key], "cli-generated-key", NOW)
 
         self.assertIsNone(result)
 
@@ -87,13 +87,13 @@ class SelectReusableApiKey(unittest.TestCase):
         older = _key(key="sk-old", created_at="2025-01-01T00:00:00Z")
         newer = _key(key="sk-new", created_at="2026-01-01T00:00:00Z")
 
-        result = select_reusable_api_key([older, newer], "onboard-key", NOW)
+        result = select_reusable_api_key([older, newer], "cli-generated-key", NOW)
 
         self.assertEqual(result, "sk-new")
 
     def test_empty_list_returns_none(self):
         """An empty key list has nothing to reuse."""
-        result = select_reusable_api_key([], "onboard-key", NOW)
+        result = select_reusable_api_key([], "cli-generated-key", NOW)
 
         self.assertIsNone(result)
 

--- a/src/poly/tests/api_keys_test.py
+++ b/src/poly/tests/api_keys_test.py
@@ -1,0 +1,102 @@
+"""Tests for select_reusable_api_key.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from datetime import datetime, timedelta, timezone
+
+from poly.utils.api_keys import select_reusable_api_key
+
+NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _key(
+    key: str = "sk-1",
+    active: bool = True,
+    expires_at: str | None = None,
+    name: str = "onboard-key",
+    created_at: str = "2026-01-01T00:00:00Z",
+) -> dict:
+    """Build a key record shaped like the accounts API response."""
+    return {
+        "key": key,
+        "active": active,
+        "expires_at": expires_at,
+        "policies": [{"name": name}],
+        "created_at": created_at,
+    }
+
+
+class SelectReusableApiKey(unittest.TestCase):
+    """Tests for select_reusable_api_key's matching rules."""
+
+    def test_matches_on_policy_name_not_top_level_name(self):
+        """The key name lives under policies[0].name, not the key's own `name` field."""
+        key = _key(name="onboard-key")
+        key["name"] = ""  # top-level `name` comes back empty, per the real API.
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertEqual(result, "sk-1")
+
+    def test_skips_inactive_keys(self):
+        """An inactive key is never reused."""
+        key = _key(active=False)
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertIsNone(result)
+
+    def test_skips_expired_keys(self):
+        """A key whose expires_at is in the past is never reused."""
+        expired = (NOW - timedelta(days=1)).isoformat()
+        key = _key(expires_at=expired)
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertIsNone(result)
+
+    def test_keeps_key_expiring_in_the_future(self):
+        """A key whose expires_at is still ahead of `now` is eligible."""
+        future = (NOW + timedelta(days=1)).isoformat()
+        key = _key(expires_at=future)
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertEqual(result, "sk-1")
+
+    def test_missing_expires_at_is_treated_as_valid(self):
+        """A key with no expires_at (or None) never expires."""
+        key = _key(expires_at=None)
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertEqual(result, "sk-1")
+
+    def test_skips_keys_with_a_different_policy_name(self):
+        """A key created under a different name is not reused."""
+        key = _key(name="some-other-key")
+
+        result = select_reusable_api_key([key], "onboard-key", NOW)
+
+        self.assertIsNone(result)
+
+    def test_picks_the_newest_matching_key(self):
+        """Among several matching keys, the one with the latest created_at wins."""
+        older = _key(key="sk-old", created_at="2025-01-01T00:00:00Z")
+        newer = _key(key="sk-new", created_at="2026-01-01T00:00:00Z")
+
+        result = select_reusable_api_key([older, newer], "onboard-key", NOW)
+
+        self.assertEqual(result, "sk-new")
+
+    def test_empty_list_returns_none(self):
+        """An empty key list has nothing to reuse."""
+        result = select_reusable_api_key([], "onboard-key", NOW)
+
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -1,4 +1,4 @@
-"""Tests for the `poly onboard` command.
+"""Tests for the `poly apikey` command.
 
 Copyright PolyAI Limited
 """
@@ -11,8 +11,8 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+from poly.cli_commands.apikey import ApiKeyCommand
 from poly.cli_commands.base import GETTING_STARTED_GROUP
-from poly.cli_commands.onboard import OnboardCommand
 from poly.utils.env_profile import EnvVarConflict, ProfileTarget
 
 FAKE_JWT = "jwt-1"
@@ -21,8 +21,8 @@ FAKE_ACCOUNT = "acc-1"
 FAKE_ANON_ID = "anon-fixed"
 
 
-class OnboardTestCase(unittest.TestCase):
-    """Base class wiring up the standard set of onboard collaborator mocks."""
+class ApiKeyTestCase(unittest.TestCase):
+    """Base class wiring up the standard set of apikey collaborator mocks."""
 
     def setUp(self):
         # Never touch the real ~/.poly or depend on the host's $SHELL.
@@ -30,30 +30,30 @@ class OnboardTestCase(unittest.TestCase):
         os.environ.pop("POLY_NO_TELEMETRY", None)
         patchers = {
             "signin": patch(
-                "poly.cli_commands.onboard.signin_with_device_flow", return_value=FAKE_JWT
+                "poly.cli_commands.apikey.signin_with_device_flow", return_value=FAKE_JWT
             ),
             "authorise": patch(
-                "poly.cli_commands.onboard.AgentStudioInterface.authorise"
+                "poly.cli_commands.apikey.AgentStudioInterface.authorise"
             ),
             "get_accounts": patch(
-                "poly.cli_commands.onboard.AgentStudioInterface.get_accounts_internal",
+                "poly.cli_commands.apikey.AgentStudioInterface.get_accounts_internal",
                 return_value=[{"id": FAKE_ACCOUNT}],
             ),
             "list_keys": patch(
-                "poly.cli_commands.onboard.AgentStudioInterface.list_account_api_keys_internal",
+                "poly.cli_commands.apikey.AgentStudioInterface.list_account_api_keys_internal",
                 return_value=[],
             ),
             "create_key": patch(
-                "poly.cli_commands.onboard.AgentStudioInterface.create_account_api_key_internal",
+                "poly.cli_commands.apikey.AgentStudioInterface.create_account_api_key_internal",
                 return_value={"key": FAKE_KEY},
             ),
             "load_cred": patch(
-                "poly.cli_commands.onboard.load_api_key_from_credential_file",
+                "poly.cli_commands.apikey.load_api_key_from_credential_file",
                 return_value=None,
             ),
-            "save_cred": patch("poly.cli_commands.onboard.save_api_key_credential_file"),
+            "save_cred": patch("poly.cli_commands.apikey.save_api_key_credential_file"),
             "write_env": patch(
-                "poly.cli_commands.onboard.write_env_var",
+                "poly.cli_commands.apikey.write_env_var",
                 return_value=(
                     ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
                     'export POLY_API_KEY="sk-n****7890"',
@@ -63,69 +63,69 @@ class OnboardTestCase(unittest.TestCase):
                 "poly.handlers.posthog.get_anonymous_id", return_value=FAKE_ANON_ID
             ),
             "detect_profile": patch(
-                "poly.cli_commands.onboard.detect_profile",
+                "poly.cli_commands.apikey.detect_profile",
                 return_value=ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
             ),
             "capture_event": patch("poly.handlers.posthog.capture_event"),
             "flush": patch("poly.handlers.posthog.flush"),
-            "alias": patch("poly.cli_commands.onboard._alias_to_account"),
-            "sleep": patch("poly.cli_commands.onboard.time.sleep"),
+            "alias": patch("poly.cli_commands.apikey._alias_to_account"),
+            "sleep": patch("poly.cli_commands.apikey.time.sleep"),
         }
         self.mocks = {name: p.start() for name, p in patchers.items()}
         for p in patchers.values():
             self.addCleanup(p.stop)
 
     def _failed_events(self):
-        """The properties dict of every onboard_failed capture_event call."""
+        """The properties dict of every apikey_failed capture_event call."""
         return [
             call.args[2]
             for call in self.mocks["capture_event"].call_args_list
-            if call.args[1] == "onboard_failed"
+            if call.args[1] == "apikey_failed"
         ]
 
     def _event_names(self):
         return [call.args[1] for call in self.mocks["capture_event"].call_args_list]
 
 
-class HappyPath(OnboardTestCase):
-    """Tests for the successful onboard flow."""
+class HappyPath(ApiKeyTestCase):
+    """Tests for the successful apikey flow."""
 
     def test_creates_key_and_writes_env(self):
         """No existing key: a new one is created and POLY_API_KEY is written."""
-        OnboardCommand.onboard()
+        ApiKeyCommand.apikey()
 
         self.mocks["create_key"].assert_called_once()
         self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=False)
-        self.assertIn("onboard_key_created", self._event_names())
-        self.assertIn("onboard_completed", self._event_names())
+        self.assertIn("apikey_key_created", self._event_names())
+        self.assertIn("apikey_completed", self._event_names())
 
     def test_existing_studio_credential_is_not_overwritten(self):
         """An existing credential-file entry for studio is left untouched."""
         self.mocks["load_cred"].return_value = "already-there"
 
-        OnboardCommand.onboard()
+        ApiKeyCommand.apikey()
 
         self.mocks["save_cred"].assert_not_called()
 
     def test_reuse_path_emits_key_reused(self):
         """A matching existing key is reused instead of creating a new one."""
         with patch(
-            "poly.cli_commands.onboard.select_reusable_api_key", return_value="sk-existing"
+            "poly.cli_commands.apikey.select_reusable_api_key", return_value="sk-existing"
         ):
-            OnboardCommand.onboard()
+            ApiKeyCommand.apikey()
 
         self.mocks["create_key"].assert_not_called()
-        self.assertIn("onboard_key_reused", self._event_names())
+        self.assertIn("apikey_key_reused", self._event_names())
 
     def test_account_id_flag_skips_the_poll(self):
         """--account-id bypasses polling GET /jupiter/v2/accounts entirely."""
-        OnboardCommand.onboard(account_id="acc-given")
+        ApiKeyCommand.apikey(account_id="acc-given")
 
         self.mocks["get_accounts"].assert_not_called()
         account_resolved = next(
             call.args[2]
             for call in self.mocks["capture_event"].call_args_list
-            if call.args[1] == "onboard_account_resolved"
+            if call.args[1] == "apikey_account_resolved"
         )
         self.assertEqual(account_resolved["account_id"], "acc-given")
 
@@ -133,14 +133,14 @@ class HappyPath(OnboardTestCase):
         """The real API key is never printed, masked or otherwise, in plain output."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            OnboardCommand.onboard()
+            ApiKeyCommand.apikey()
 
         self.assertNotIn(FAKE_KEY, buffer.getvalue())
 
     def test_anonymous_id_not_created_when_telemetry_disabled(self):
         """DO_NOT_TRACK=1 skips get_anonymous_id entirely - no ~/.poly/telemetry_id touched."""
         with patch.dict(os.environ, {"DO_NOT_TRACK": "1"}):
-            OnboardCommand.onboard()
+            ApiKeyCommand.apikey()
 
         self.mocks["get_anonymous_id"].assert_not_called()
 
@@ -148,7 +148,7 @@ class HappyPath(OnboardTestCase):
         """--json prints one object with the documented fields and a masked key only."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            OnboardCommand.onboard(output_json=True)
+            ApiKeyCommand.apikey(output_json=True)
 
         payload = json.loads(buffer.getvalue())
         self.assertTrue(payload["success"])
@@ -168,7 +168,7 @@ class HappyPath(OnboardTestCase):
         """The masked key in --json output is plain text, not `[yellow]...[/yellow]` markup."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            OnboardCommand.onboard(output_json=True)
+            ApiKeyCommand.apikey(output_json=True)
 
         self.assertNotIn("[", buffer.getvalue())
 
@@ -185,22 +185,22 @@ class HappyPath(OnboardTestCase):
         stdout = io.StringIO()
         stderr = io.StringIO()
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-            OnboardCommand.onboard(output_json=True)
+            ApiKeyCommand.apikey(output_json=True)
 
         self.assertIn(verification_uri, stderr.getvalue())
         payload = json.loads(stdout.getvalue())
         self.assertTrue(payload["success"])
 
 
-class AccountPollFailure(OnboardTestCase):
+class AccountPollFailure(ApiKeyTestCase):
     """Tests for the no-account-appeared failure path."""
 
     def test_empty_accounts_after_20_tries_fails_with_exit_1(self):
-        """20 empty polls without --account-id exits 1 with an onboard_failed(step=account)."""
+        """20 empty polls without --account-id exits 1 with an apikey_failed(step=account)."""
         self.mocks["get_accounts"].return_value = []
 
         with self.assertRaises(SystemExit) as ctx:
-            OnboardCommand.onboard()
+            ApiKeyCommand.apikey()
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertEqual(self.mocks["get_accounts"].call_count, 20)
@@ -209,7 +209,7 @@ class AccountPollFailure(OnboardTestCase):
         self.assertEqual(failed[0]["step"], "account")
 
 
-class EnvConflict(OnboardTestCase):
+class EnvConflict(ApiKeyTestCase):
     """Tests for the POLY_API_KEY conflict path."""
 
     def test_conflict_exits_2_without_force(self):
@@ -219,7 +219,7 @@ class EnvConflict(OnboardTestCase):
         )
 
         with self.assertRaises(SystemExit) as ctx:
-            OnboardCommand.onboard()
+            ApiKeyCommand.apikey()
 
         self.assertEqual(ctx.exception.code, 2)
         failed = self._failed_events()
@@ -235,7 +235,7 @@ class EnvConflict(OnboardTestCase):
 
         with contextlib.redirect_stdout(buffer):
             with self.assertRaises(SystemExit):
-                OnboardCommand.onboard(output_json=True)
+                ApiKeyCommand.apikey(output_json=True)
 
         payload = json.loads(buffer.getvalue())
         self.assertFalse(payload["success"])
@@ -246,12 +246,12 @@ class EnvConflict(OnboardTestCase):
 
     def test_force_is_forwarded_to_write_env_var(self):
         """--force is passed straight through to write_env_var."""
-        OnboardCommand.onboard(force=True)
+        ApiKeyCommand.apikey(force=True)
 
         self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=True)
 
 
-class Verbose(OnboardTestCase):
+class Verbose(ApiKeyTestCase):
     """Tests for --verbose re-raising instead of exiting cleanly."""
 
     def test_verbose_reraises_instead_of_exiting(self):
@@ -259,11 +259,11 @@ class Verbose(OnboardTestCase):
         self.mocks["get_accounts"].return_value = []
 
         with self.assertRaises(ValueError):
-            OnboardCommand.onboard(verbose=True)
+            ApiKeyCommand.apikey(verbose=True)
 
 
 class ArgParsing(unittest.TestCase):
-    """Tests for onboard's own argparse wiring."""
+    """Tests for apikey's own argparse wiring."""
 
     def test_force_short_alias(self):
         """-f is accepted as a short alias for --force, matching other commands."""
@@ -271,7 +271,7 @@ class ArgParsing(unittest.TestCase):
 
         cli = AgentStudioCLI()
         cli.register_commands()
-        args = cli._create_parser().parse_args(["onboard", "-f"])
+        args = cli._create_parser().parse_args(["apikey", "-f"])
 
         self.assertTrue(args.force)
 
@@ -280,13 +280,13 @@ class CommandRegistration(unittest.TestCase):
     """Tests that the command is wired into the CLI's Getting started group."""
 
     def test_command_name_and_group(self):
-        self.assertEqual(OnboardCommand.command, "onboard")
-        self.assertEqual(OnboardCommand.group, GETTING_STARTED_GROUP)
+        self.assertEqual(ApiKeyCommand.command, "apikey")
+        self.assertEqual(ApiKeyCommand.group, GETTING_STARTED_GROUP)
 
     def test_registered_in_cli_commands(self):
         from poly.cli import COMMANDS
 
-        self.assertIn(OnboardCommand, COMMANDS)
+        self.assertIn(ApiKeyCommand, COMMANDS)
 
 
 if __name__ == "__main__":

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -6,7 +6,6 @@ Copyright PolyAI Limited
 import contextlib
 import io
 import json
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -21,7 +20,6 @@ from poly.utils.env_profile import EnvVarConflict, ProfileTarget
 FAKE_JWT = "jwt-1"
 FAKE_KEY = "sk-newkey1234567890"
 FAKE_ACCOUNT = "acc-1"
-FAKE_ANON_ID = "anon-fixed"
 
 
 class ApiKeyTestCase(unittest.TestCase):
@@ -29,15 +27,11 @@ class ApiKeyTestCase(unittest.TestCase):
 
     def setUp(self):
         # Never touch the real ~/.poly or depend on the host's $SHELL.
-        os.environ.pop("DO_NOT_TRACK", None)
-        os.environ.pop("POLY_NO_TELEMETRY", None)
         patchers = {
             "signin": patch(
                 "poly.cli_commands.apikey.signin_with_device_flow", return_value=FAKE_JWT
             ),
-            "authorise": patch(
-                "poly.cli_commands.apikey.AgentStudioInterface.authorise"
-            ),
+            "authorise": patch("poly.cli_commands.apikey.AgentStudioInterface.authorise"),
             "get_accounts": patch(
                 "poly.cli_commands.apikey.AgentStudioInterface.get_accounts_internal",
                 return_value=[{"id": FAKE_ACCOUNT}],
@@ -66,32 +60,11 @@ class ApiKeyTestCase(unittest.TestCase):
                     'export POLY_API_KEY="sk-n****7890"',
                 ),
             ),
-            "get_anonymous_id": patch(
-                "poly.handlers.posthog.get_anonymous_id", return_value=FAKE_ANON_ID
-            ),
-            "detect_profile": patch(
-                "poly.cli_commands.apikey.detect_profile",
-                return_value=ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
-            ),
-            "capture_event": patch("poly.handlers.posthog.capture_event"),
-            "flush": patch("poly.handlers.posthog.flush"),
-            "alias": patch("poly.cli_commands.apikey._alias_to_account"),
             "sleep": patch("poly.cli_commands.apikey.time.sleep"),
         }
         self.mocks = {name: p.start() for name, p in patchers.items()}
         for p in patchers.values():
             self.addCleanup(p.stop)
-
-    def _failed_events(self):
-        """The properties dict of every apikey_failed capture_event call."""
-        return [
-            call.args[2]
-            for call in self.mocks["capture_event"].call_args_list
-            if call.args[1] == "apikey_failed"
-        ]
-
-    def _event_names(self):
-        return [call.args[1] for call in self.mocks["capture_event"].call_args_list]
 
 
 class HappyPath(ApiKeyTestCase):
@@ -103,8 +76,6 @@ class HappyPath(ApiKeyTestCase):
 
         self.mocks["create_key"].assert_called_once()
         self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=False)
-        self.assertIn("apikey_key_created", self._event_names())
-        self.assertIn("apikey_completed", self._event_names())
 
     def test_existing_studio_credential_is_not_overwritten(self):
         """An existing credential-file entry for studio is left untouched."""
@@ -114,27 +85,25 @@ class HappyPath(ApiKeyTestCase):
 
         self.mocks["save_cred"].assert_not_called()
 
-    def test_reuse_path_emits_key_reused(self):
+    def test_reuse_path_does_not_create_new_key(self):
         """A matching existing key is reused instead of creating a new one."""
-        with patch(
-            "poly.cli_commands.apikey.select_reusable_api_key", return_value="sk-existing"
-        ):
+        with patch("poly.cli_commands.apikey.select_reusable_api_key", return_value="sk-existing"):
             ApiKeyCommand.apikey()
 
         self.mocks["create_key"].assert_not_called()
-        self.assertIn("apikey_key_reused", self._event_names())
 
     def test_account_id_flag_skips_the_poll(self):
         """--account-id bypasses polling GET /jupiter/v2/accounts entirely."""
         ApiKeyCommand.apikey(account_id="acc-given")
 
         self.mocks["get_accounts"].assert_not_called()
-        account_resolved = next(
-            call.args[2]
-            for call in self.mocks["capture_event"].call_args_list
-            if call.args[1] == "apikey_account_resolved"
+        self.mocks["create_key"].assert_called_once_with(
+            region="studio",
+            jwt_token=FAKE_JWT,
+            account_id="acc-given",
+            name="cli-generated-key",
+            source="apikey",
         )
-        self.assertEqual(account_resolved["account_id"], "acc-given")
 
     def test_key_value_never_appears_in_stdout(self):
         """The real API key is never printed, masked or otherwise, in plain output."""
@@ -143,13 +112,6 @@ class HappyPath(ApiKeyTestCase):
             ApiKeyCommand.apikey()
 
         self.assertNotIn(FAKE_KEY, buffer.getvalue())
-
-    def test_anonymous_id_not_created_when_telemetry_disabled(self):
-        """DO_NOT_TRACK=1 skips get_anonymous_id entirely - no ~/.poly/telemetry_id touched."""
-        with patch.dict(os.environ, {"DO_NOT_TRACK": "1"}):
-            ApiKeyCommand.apikey()
-
-        self.mocks["get_anonymous_id"].assert_not_called()
 
     def test_json_output_has_expected_keys_and_masked_value(self):
         """--json prints one object with the documented fields and a masked key only."""
@@ -263,13 +225,6 @@ class RegionSelection(ApiKeyTestCase):
         )
         self.mocks["save_cred"].assert_called_once_with(FAKE_KEY, region="us-1")
 
-    def test_region_is_threaded_into_telemetry(self):
-        """capture_event receives the chosen region, not a hardcoded 'studio'."""
-        ApiKeyCommand.apikey(region="us-1")
-
-        regions = {call.args[0] for call in self.mocks["capture_event"].call_args_list}
-        self.assertEqual(regions, {"us-1"})
-
     def _sign_in_message(self, **kwargs) -> str:
         """Run apikey and return the verification message printed to stdout."""
 
@@ -301,17 +256,18 @@ class AccountPollFailure(ApiKeyTestCase):
     """Tests for the no-account-appeared failure path."""
 
     def test_empty_accounts_after_20_tries_fails_with_exit_1(self):
-        """20 empty polls without --account-id exits 1 with an apikey_failed(step=account)."""
+        """20 empty polls without --account-id exits 1 reporting the account step."""
         self.mocks["get_accounts"].return_value = []
 
-        with self.assertRaises(SystemExit) as ctx:
-            ApiKeyCommand.apikey()
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey(output_json=True)
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertEqual(self.mocks["get_accounts"].call_count, 20)
-        failed = self._failed_events()
-        self.assertEqual(len(failed), 1)
-        self.assertEqual(failed[0]["step"], "account")
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["step"], "account")
 
 
 class MultipleAccounts(ApiKeyTestCase):
@@ -428,7 +384,7 @@ class KeyActivationWait(ApiKeyTestCase):
         self.mocks["write_env"].assert_called_once()
 
     def test_never_activates_still_completes_and_warns(self):
-        """20 failed polls print a warning but do not fail the command or emit telemetry."""
+        """20 failed polls print a warning but do not fail the command."""
         self.mocks["get_accounts_static"].side_effect = Exception("not active")
 
         stdout = io.StringIO()
@@ -438,25 +394,24 @@ class KeyActivationWait(ApiKeyTestCase):
         self.assertEqual(self.mocks["get_accounts_static"].call_count, 20)
         self.mocks["write_env"].assert_called_once()
         self.assertIn("not active yet", stdout.getvalue())
-        self.assertNotIn("apikey_failed", self._event_names())
 
 
 class EnvConflict(ApiKeyTestCase):
     """Tests for the POLY_API_KEY conflict path."""
 
     def test_conflict_exits_2_without_force(self):
-        """A conflicting existing value exits 2 and reports the env step."""
+        """A conflicting existing value exits 2 with a --force hint."""
         self.mocks["write_env"].side_effect = EnvVarConflict(
             "old****", "new****", Path("/home/user/.zshrc")
         )
 
-        with self.assertRaises(SystemExit) as ctx:
-            ApiKeyCommand.apikey()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey()
 
         self.assertEqual(ctx.exception.code, 2)
-        failed = self._failed_events()
-        self.assertEqual(failed[0]["step"], "env")
-        self.assertEqual(failed[0]["error_class"], "EnvVarConflict")
+        self.assertIn("Re-run with --force", stderr.getvalue())
 
     def test_json_error_matches_the_documented_contract(self):
         """--json failures include success/error/traceback/step, with no Rich markup."""

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -40,6 +40,10 @@ class ApiKeyTestCase(unittest.TestCase):
                 "poly.cli_commands.apikey.AgentStudioInterface.get_accounts_internal",
                 return_value=[{"id": FAKE_ACCOUNT}],
             ),
+            "get_accounts_static": patch(
+                "poly.cli_commands.apikey.AgentStudioInterface.get_accounts",
+                return_value={FAKE_ACCOUNT: "Account One"},
+            ),
             "list_keys": patch(
                 "poly.cli_commands.apikey.AgentStudioInterface.list_account_api_keys_internal",
                 return_value=[],
@@ -278,6 +282,37 @@ class AccountPollFailure(ApiKeyTestCase):
         failed = self._failed_events()
         self.assertEqual(len(failed), 1)
         self.assertEqual(failed[0]["step"], "account")
+
+
+class KeyActivationWait(ApiKeyTestCase):
+    """Tests for the post-credentials key-activation poll."""
+
+    def test_activates_on_third_poll(self):
+        """The command completes normally once the key activates partway through the poll."""
+        self.mocks["get_accounts_static"].side_effect = [
+            Exception("not active"),
+            Exception("not active"),
+            {FAKE_ACCOUNT: "Account One"},
+        ]
+
+        with contextlib.redirect_stdout(io.StringIO()):
+            ApiKeyCommand.apikey()
+
+        self.assertEqual(self.mocks["get_accounts_static"].call_count, 3)
+        self.mocks["write_env"].assert_called_once()
+
+    def test_never_activates_still_completes_and_warns(self):
+        """20 failed polls print a warning but do not fail the command or emit telemetry."""
+        self.mocks["get_accounts_static"].side_effect = Exception("not active")
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            ApiKeyCommand.apikey()
+
+        self.assertEqual(self.mocks["get_accounts_static"].call_count, 20)
+        self.mocks["write_env"].assert_called_once()
+        self.assertIn("not active yet", stdout.getvalue())
+        self.assertNotIn("apikey_failed", self._event_names())
 
 
 class EnvConflict(ApiKeyTestCase):

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 from poly.cli_commands.apikey import ApiKeyCommand
 from poly.cli_commands.base import GETTING_STARTED_GROUP
+from poly.handlers.auth0_handler import APIKEY_AUTH_DETAILS, REGION_TO_AUTH_DETAILS
 from poly.utils.env_profile import EnvVarConflict, ProfileTarget
 
 FAKE_JWT = "jwt-1"
@@ -192,6 +193,76 @@ class HappyPath(ApiKeyTestCase):
         self.assertTrue(payload["success"])
 
 
+class RegionSelection(ApiKeyTestCase):
+    """Tests for --region's effect on sign-in, key naming, and region threading."""
+
+    def test_default_region_signs_in_via_github_only_client(self):
+        """With no --region, sign-in uses the studio GitHub-only client."""
+        ApiKeyCommand.apikey()
+
+        auth_details = self.mocks["signin"].call_args.args[0]
+        self.assertIs(auth_details, APIKEY_AUTH_DETAILS)
+
+    def test_non_studio_region_signs_in_via_standard_client(self):
+        """--region us-1 uses the same Auth0 app `poly login --region us-1` uses."""
+        ApiKeyCommand.apikey(region="us-1")
+
+        auth_details = self.mocks["signin"].call_args.args[0]
+        self.assertIs(auth_details, REGION_TO_AUTH_DETAILS["us-1"])
+
+    def test_default_key_name_for_studio(self):
+        """The default key name for studio is unchanged."""
+        ApiKeyCommand.apikey()
+
+        self.mocks["create_key"].assert_called_once_with(
+            region="studio",
+            jwt_token=FAKE_JWT,
+            account_id=FAKE_ACCOUNT,
+            name="cli-generated-key",
+            source="apikey",
+        )
+
+    def test_default_key_name_for_other_region_is_suffixed(self):
+        """The default key name for a non-studio region is disambiguated by region."""
+        ApiKeyCommand.apikey(region="us-1")
+
+        self.mocks["create_key"].assert_called_once_with(
+            region="us-1",
+            jwt_token=FAKE_JWT,
+            account_id=FAKE_ACCOUNT,
+            name="cli-generated-key-us-1",
+            source="apikey",
+        )
+
+    def test_explicit_key_name_overrides_the_region_default(self):
+        """--key-name wins over the region-based default regardless of region."""
+        ApiKeyCommand.apikey(region="us-1", key_name="my-key")
+
+        self.mocks["create_key"].assert_called_once_with(
+            region="us-1",
+            jwt_token=FAKE_JWT,
+            account_id=FAKE_ACCOUNT,
+            name="my-key",
+            source="apikey",
+        )
+
+    def test_region_is_threaded_into_account_and_credentials_calls(self):
+        """The chosen region reaches get_accounts_internal and the credentials file."""
+        ApiKeyCommand.apikey(region="us-1")
+
+        self.mocks["get_accounts"].assert_called_once_with(
+            region="us-1", jwt_token=FAKE_JWT, source="apikey"
+        )
+        self.mocks["save_cred"].assert_called_once_with(FAKE_KEY, region="us-1")
+
+    def test_region_is_threaded_into_telemetry(self):
+        """capture_event receives the chosen region, not a hardcoded 'studio'."""
+        ApiKeyCommand.apikey(region="us-1")
+
+        regions = {call.args[0] for call in self.mocks["capture_event"].call_args_list}
+        self.assertEqual(regions, {"us-1"})
+
+
 class AccountPollFailure(ApiKeyTestCase):
     """Tests for the no-account-appeared failure path."""
 
@@ -274,6 +345,26 @@ class ArgParsing(unittest.TestCase):
         args = cli._create_parser().parse_args(["apikey", "-f"])
 
         self.assertTrue(args.force)
+
+    def test_region_defaults_to_studio(self):
+        """With no --region flag, args.region is 'studio' - the individual-dev path."""
+        from poly.cli import AgentStudioCLI
+
+        cli = AgentStudioCLI()
+        cli.register_commands()
+        args = cli._create_parser().parse_args(["apikey"])
+
+        self.assertEqual(args.region, "studio")
+
+    def test_region_accepts_a_production_region(self):
+        """--region us-1 is accepted, matching poly login's region choices."""
+        from poly.cli import AgentStudioCLI
+
+        cli = AgentStudioCLI()
+        cli.register_commands()
+        args = cli._create_parser().parse_args(["apikey", "--region", "us-1"])
+
+        self.assertEqual(args.region, "us-1")
 
 
 class CommandRegistration(unittest.TestCase):

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -72,7 +72,7 @@ class HappyPath(ApiKeyTestCase):
 
     def test_creates_key_and_writes_env(self):
         """No existing key: a new one is created and POLY_API_KEY is written."""
-        ApiKeyCommand.apikey()
+        ApiKeyCommand.apikey(region="studio")
 
         self.mocks["create_key"].assert_called_once()
         self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=False)
@@ -81,20 +81,20 @@ class HappyPath(ApiKeyTestCase):
         """An existing credential-file entry for studio is left untouched."""
         self.mocks["load_cred"].return_value = "already-there"
 
-        ApiKeyCommand.apikey()
+        ApiKeyCommand.apikey(region="studio")
 
         self.mocks["save_cred"].assert_not_called()
 
     def test_reuse_path_does_not_create_new_key(self):
         """A matching existing key is reused instead of creating a new one."""
         with patch("poly.cli_commands.apikey.select_reusable_api_key", return_value="sk-existing"):
-            ApiKeyCommand.apikey()
+            ApiKeyCommand.apikey(region="studio")
 
         self.mocks["create_key"].assert_not_called()
 
     def test_account_id_flag_skips_the_poll(self):
         """--account-id bypasses polling GET /jupiter/v2/accounts entirely."""
-        ApiKeyCommand.apikey(account_id="acc-given")
+        ApiKeyCommand.apikey(region="studio", account_id="acc-given")
 
         self.mocks["get_accounts"].assert_not_called()
         self.mocks["create_key"].assert_called_once_with(
@@ -109,7 +109,7 @@ class HappyPath(ApiKeyTestCase):
         """The real API key is never printed, masked or otherwise, in plain output."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            ApiKeyCommand.apikey()
+            ApiKeyCommand.apikey(region="studio")
 
         self.assertNotIn(FAKE_KEY, buffer.getvalue())
 
@@ -117,7 +117,7 @@ class HappyPath(ApiKeyTestCase):
         """--json prints one object with the documented fields and a masked key only."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            ApiKeyCommand.apikey(output_json=True)
+            ApiKeyCommand.apikey(region="studio", output_json=True)
 
         payload = json.loads(buffer.getvalue())
         self.assertTrue(payload["success"])
@@ -139,7 +139,7 @@ class HappyPath(ApiKeyTestCase):
         """The masked key in --json output is plain text, not `[yellow]...[/yellow]` markup."""
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
-            ApiKeyCommand.apikey(output_json=True)
+            ApiKeyCommand.apikey(region="studio", output_json=True)
 
         self.assertNotIn("[", buffer.getvalue())
 
@@ -156,7 +156,7 @@ class HappyPath(ApiKeyTestCase):
         stdout = io.StringIO()
         stderr = io.StringIO()
         with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
-            ApiKeyCommand.apikey(output_json=True)
+            ApiKeyCommand.apikey(region="studio", output_json=True)
 
         self.assertIn(verification_uri, stderr.getvalue())
         payload = json.loads(stdout.getvalue())
@@ -166,9 +166,9 @@ class HappyPath(ApiKeyTestCase):
 class RegionSelection(ApiKeyTestCase):
     """Tests for --region's effect on sign-in, key naming, and region threading."""
 
-    def test_default_region_signs_in_via_github_only_client(self):
-        """With no --region, sign-in uses the studio GitHub-only client."""
-        ApiKeyCommand.apikey()
+    def test_studio_region_signs_in_via_github_only_client(self):
+        """With --region studio, sign-in uses the studio GitHub-only client."""
+        ApiKeyCommand.apikey(region="studio")
 
         auth_details = self.mocks["signin"].call_args.args[0]
         self.assertIs(auth_details, APIKEY_AUTH_DETAILS)
@@ -182,7 +182,7 @@ class RegionSelection(ApiKeyTestCase):
 
     def test_default_key_name_for_studio(self):
         """The default key name for studio is unchanged."""
-        ApiKeyCommand.apikey()
+        ApiKeyCommand.apikey(region="studio")
 
         self.mocks["create_key"].assert_called_once_with(
             region="studio",
@@ -240,7 +240,7 @@ class RegionSelection(ApiKeyTestCase):
 
     def test_studio_sign_in_message_names_github(self):
         """Studio's sign-in line still names GitHub explicitly."""
-        message = self._sign_in_message()
+        message = self._sign_in_message(region="studio")
 
         self.assertIn("To sign in with GitHub, open the following link", message)
 
@@ -262,7 +262,7 @@ class AccountPollFailure(ApiKeyTestCase):
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
             with self.assertRaises(SystemExit) as ctx:
-                ApiKeyCommand.apikey(output_json=True)
+                ApiKeyCommand.apikey(region="studio", output_json=True)
 
         self.assertEqual(ctx.exception.code, 1)
         self.assertEqual(self.mocks["get_accounts"].call_count, 20)
@@ -271,7 +271,7 @@ class AccountPollFailure(ApiKeyTestCase):
 
 
 class MultipleAccounts(ApiKeyTestCase):
-    """Tests for refusing to guess an account among several on enterprise regions."""
+    """Tests for refusing to guess an account among several, on any region."""
 
     TWO_ACCOUNTS = [
         {"id": "acc-1", "name": "Account One"},
@@ -279,7 +279,7 @@ class MultipleAccounts(ApiKeyTestCase):
     ]
 
     def test_non_studio_with_two_accounts_and_no_account_id_fails_with_list(self):
-        """Two accounts on an enterprise region without --account-id is a clean, listed error."""
+        """Two accounts without --account-id is a clean, listed error."""
         self.mocks["get_accounts"].return_value = self.TWO_ACCOUNTS
 
         buffer = io.StringIO()
@@ -310,19 +310,21 @@ class MultipleAccounts(ApiKeyTestCase):
             source="apikey",
         )
 
-    def test_studio_with_two_accounts_still_takes_the_first(self):
-        """Studio keeps picking the first account even with more than one - unchanged."""
+    def test_studio_with_two_accounts_errors_like_any_region(self):
+        """Studio has no special case - more than one account is an error there too."""
         self.mocks["get_accounts"].return_value = self.TWO_ACCOUNTS
 
-        ApiKeyCommand.apikey()
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey(region="studio", output_json=True)
 
-        self.mocks["create_key"].assert_called_once_with(
-            region="studio",
-            jwt_token=FAKE_JWT,
-            account_id="acc-1",
-            name="cli-generated-key",
-            source="apikey",
-        )
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["step"], "account")
+        self.assertIn("acc-1", payload["error"])
+        self.assertIn("acc-2", payload["error"])
+        self.assertIn("--account-id", payload["error"])
 
 
 class UnprovisionedEnterpriseUser(ApiKeyTestCase):
@@ -357,7 +359,7 @@ class UnprovisionedEnterpriseUser(ApiKeyTestCase):
         buffer = io.StringIO()
         with contextlib.redirect_stdout(buffer):
             with self.assertRaises(SystemExit) as ctx:
-                ApiKeyCommand.apikey(output_json=True)
+                ApiKeyCommand.apikey(region="studio", output_json=True)
 
         self.assertEqual(ctx.exception.code, 1)
         payload = json.loads(buffer.getvalue())
@@ -378,7 +380,7 @@ class KeyActivationWait(ApiKeyTestCase):
         ]
 
         with contextlib.redirect_stdout(io.StringIO()):
-            ApiKeyCommand.apikey()
+            ApiKeyCommand.apikey(region="studio")
 
         self.assertEqual(self.mocks["get_accounts_static"].call_count, 3)
         self.mocks["write_env"].assert_called_once()
@@ -389,7 +391,7 @@ class KeyActivationWait(ApiKeyTestCase):
 
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
-            ApiKeyCommand.apikey()
+            ApiKeyCommand.apikey(region="studio")
 
         self.assertEqual(self.mocks["get_accounts_static"].call_count, 20)
         self.mocks["write_env"].assert_called_once()
@@ -408,7 +410,7 @@ class EnvConflict(ApiKeyTestCase):
         stderr = io.StringIO()
         with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(stderr):
             with self.assertRaises(SystemExit) as ctx:
-                ApiKeyCommand.apikey()
+                ApiKeyCommand.apikey(region="studio")
 
         self.assertEqual(ctx.exception.code, 2)
         self.assertIn("Re-run with --force", stderr.getvalue())
@@ -422,7 +424,7 @@ class EnvConflict(ApiKeyTestCase):
 
         with contextlib.redirect_stdout(buffer):
             with self.assertRaises(SystemExit):
-                ApiKeyCommand.apikey(output_json=True)
+                ApiKeyCommand.apikey(region="studio", output_json=True)
 
         payload = json.loads(buffer.getvalue())
         self.assertFalse(payload["success"])
@@ -433,7 +435,7 @@ class EnvConflict(ApiKeyTestCase):
 
     def test_force_is_forwarded_to_write_env_var(self):
         """--force is passed straight through to write_env_var."""
-        ApiKeyCommand.apikey(force=True)
+        ApiKeyCommand.apikey(region="studio", force=True)
 
         self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=True)
 
@@ -446,7 +448,7 @@ class Verbose(ApiKeyTestCase):
         self.mocks["get_accounts"].return_value = []
 
         with self.assertRaises(ValueError):
-            ApiKeyCommand.apikey(verbose=True)
+            ApiKeyCommand.apikey(region="studio", verbose=True)
 
 
 class ArgParsing(unittest.TestCase):
@@ -458,19 +460,23 @@ class ArgParsing(unittest.TestCase):
 
         cli = AgentStudioCLI()
         cli.register_commands()
-        args = cli._create_parser().parse_args(["apikey", "-f"])
+        args = cli._create_parser().parse_args(["apikey", "-f", "--region", "studio"])
 
         self.assertTrue(args.force)
 
-    def test_region_defaults_to_studio(self):
-        """With no --region flag, args.region is 'studio' - the individual-dev path."""
+    def test_region_is_required(self):
+        """Omitting --region is an argparse error (exit code 2)."""
         from poly.cli import AgentStudioCLI
 
         cli = AgentStudioCLI()
         cli.register_commands()
-        args = cli._create_parser().parse_args(["apikey"])
+        parser = cli._create_parser()
 
-        self.assertEqual(args.region, "studio")
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit) as ctx:
+                parser.parse_args(["apikey"])
+
+        self.assertEqual(ctx.exception.code, 2)
 
     def test_region_accepts_a_production_region(self):
         """--region us-1 is accepted, matching poly login's region choices."""

--- a/src/poly/tests/apikey_test.py
+++ b/src/poly/tests/apikey_test.py
@@ -9,7 +9,9 @@ import json
 import os
 import unittest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
+
+import requests
 
 from poly.cli_commands.apikey import ApiKeyCommand
 from poly.cli_commands.base import GETTING_STARTED_GROUP
@@ -165,8 +167,10 @@ class HappyPath(ApiKeyTestCase):
             "credentials_file",
             "profile_path",
             "profile_shell",
+            "key_active",
         ):
             self.assertIn(key, payload)
+        self.assertIs(payload["key_active"], True)
         self.assertNotIn(FAKE_KEY, buffer.getvalue())
 
     def test_json_output_has_no_rich_markup(self):
@@ -266,6 +270,32 @@ class RegionSelection(ApiKeyTestCase):
         regions = {call.args[0] for call in self.mocks["capture_event"].call_args_list}
         self.assertEqual(regions, {"us-1"})
 
+    def _sign_in_message(self, **kwargs) -> str:
+        """Run apikey and return the verification message printed to stdout."""
+
+        def fake_signin(auth_details, *, on_verification_url=None, **_kwargs):
+            on_verification_url("https://example.test/activate", "ABCD-EFGH")
+            return FAKE_JWT
+
+        self.mocks["signin"].side_effect = fake_signin
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            ApiKeyCommand.apikey(**kwargs)
+        return buffer.getvalue()
+
+    def test_studio_sign_in_message_names_github(self):
+        """Studio's sign-in line still names GitHub explicitly."""
+        message = self._sign_in_message()
+
+        self.assertIn("To sign in with GitHub, open the following link", message)
+
+    def test_non_studio_sign_in_message_has_no_redundant_browser_mention(self):
+        """A non-studio region's sign-in line doesn't say 'with your browser open ... in your browser'."""
+        message = self._sign_in_message(region="us-1")
+
+        self.assertIn("To sign in, open the following link", message)
+        self.assertNotIn("with your browser", message)
+
 
 class AccountPollFailure(ApiKeyTestCase):
     """Tests for the no-account-appeared failure path."""
@@ -282,6 +312,102 @@ class AccountPollFailure(ApiKeyTestCase):
         failed = self._failed_events()
         self.assertEqual(len(failed), 1)
         self.assertEqual(failed[0]["step"], "account")
+
+
+class MultipleAccounts(ApiKeyTestCase):
+    """Tests for refusing to guess an account among several on enterprise regions."""
+
+    TWO_ACCOUNTS = [
+        {"id": "acc-1", "name": "Account One"},
+        {"id": "acc-2", "name": "Account Two"},
+    ]
+
+    def test_non_studio_with_two_accounts_and_no_account_id_fails_with_list(self):
+        """Two accounts on an enterprise region without --account-id is a clean, listed error."""
+        self.mocks["get_accounts"].return_value = self.TWO_ACCOUNTS
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey(region="us-1", output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["step"], "account")
+        self.assertIn("acc-1", payload["error"])
+        self.assertIn("Account One", payload["error"])
+        self.assertIn("acc-2", payload["error"])
+        self.assertIn("Account Two", payload["error"])
+        self.assertIn("--account-id", payload["error"])
+
+    def test_non_studio_with_one_account_proceeds(self):
+        """A single account on an enterprise region resolves without --account-id."""
+        self.mocks["get_accounts"].return_value = [{"id": "acc-solo", "name": "Solo"}]
+
+        ApiKeyCommand.apikey(region="us-1")
+
+        self.mocks["create_key"].assert_called_once_with(
+            region="us-1",
+            jwt_token=FAKE_JWT,
+            account_id="acc-solo",
+            name="cli-generated-key-us-1",
+            source="apikey",
+        )
+
+    def test_studio_with_two_accounts_still_takes_the_first(self):
+        """Studio keeps picking the first account even with more than one - unchanged."""
+        self.mocks["get_accounts"].return_value = self.TWO_ACCOUNTS
+
+        ApiKeyCommand.apikey()
+
+        self.mocks["create_key"].assert_called_once_with(
+            region="studio",
+            jwt_token=FAKE_JWT,
+            account_id="acc-1",
+            name="cli-generated-key",
+            source="apikey",
+        )
+
+
+class UnprovisionedEnterpriseUser(ApiKeyTestCase):
+    """Tests for the friendly-403 rewrite when authorise fails on an enterprise region."""
+
+    @staticmethod
+    def _forbidden_error() -> requests.HTTPError:
+        """Build the HTTPError authorise raises for an unprovisioned enterprise user."""
+        response = MagicMock()
+        response.status_code = 403
+        return requests.HTTPError("403 Client Error: Forbidden", response=response)
+
+    def test_403_on_enterprise_region_is_rewritten(self):
+        """A 403 from authorise on us-1 becomes the friendly provisioning message."""
+        self.mocks["authorise"].side_effect = self._forbidden_error()
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey(region="us-1", output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["step"], "authorise")
+        self.assertIn("No account is provisioned for you on us-1", payload["error"])
+        self.assertIn("poly apikey", payload["error"])
+
+    def test_403_on_studio_is_not_rewritten(self):
+        """A 403 from authorise on studio is a genuine auth error and surfaces as-is."""
+        self.mocks["authorise"].side_effect = self._forbidden_error()
+
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit) as ctx:
+                ApiKeyCommand.apikey(output_json=True)
+
+        self.assertEqual(ctx.exception.code, 1)
+        payload = json.loads(buffer.getvalue())
+        self.assertEqual(payload["step"], "authorise")
+        self.assertNotIn("No account is provisioned", payload["error"])
+        self.assertIn("403", payload["error"])
 
 
 class KeyActivationWait(ApiKeyTestCase):

--- a/src/poly/tests/auth_test.py
+++ b/src/poly/tests/auth_test.py
@@ -1,0 +1,45 @@
+"""Tests for the `_signin` wrapper in cli_commands.auth.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import patch
+
+from poly.cli_commands.auth import _signin
+from poly.handlers.auth0_handler import REGION_TO_AUTH_DETAILS
+
+
+class Signin(unittest.TestCase):
+    """Tests for _signin's delegation to the shared device flow."""
+
+    @patch("poly.cli_commands.auth.signin_with_device_flow")
+    def test_delegates_to_shared_flow_with_region_auth_details(self, mock_signin):
+        """_signin resolves the region's AuthDetails and returns the shared flow's token."""
+        mock_signin.return_value = "tok-1"
+
+        token = _signin("studio")
+
+        self.assertEqual(token, "tok-1")
+        mock_signin.assert_called_once_with(REGION_TO_AUTH_DETAILS["studio"])
+
+    def test_unknown_region_exits_with_error(self):
+        """An unknown region exits(1) without calling the device flow."""
+        with self.assertRaises(SystemExit) as ctx:
+            _signin("mars-1")
+        self.assertEqual(ctx.exception.code, 1)
+
+    @patch("poly.cli_commands.auth.signin_with_device_flow")
+    def test_device_flow_error_exits_with_error(self, mock_signin):
+        """A DeviceFlowError from the shared flow exits(1) instead of propagating."""
+        from poly.auth.device_flow import DeviceFlowError
+
+        mock_signin.side_effect = DeviceFlowError("Authorization timed out. Please try again.")
+
+        with self.assertRaises(SystemExit) as ctx:
+            _signin("studio")
+        self.assertEqual(ctx.exception.code, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/console_test.py
+++ b/src/poly/tests/console_test.py
@@ -12,12 +12,30 @@ from poly.output.console import (
     _OverflowPager,
     console,
     flatten_branch_tree,
+    mask_api_key,
+    mask_secret,
     paged_output,
     print_archived_branches,
     print_branch_history,
     print_releases_branches,
     resolve_parent_branch_label,
 )
+
+
+class MaskSecretTest(unittest.TestCase):
+    """Tests for mask_secret and mask_api_key's markup-free/coloured split."""
+
+    def test_mask_secret_has_no_markup(self):
+        """mask_secret is plain text, safe for JSON output or an exception message."""
+        self.assertEqual(mask_secret("sk-abcdefgh1234"), "sk-a****1234")
+
+    def test_short_secret_is_fully_masked(self):
+        """A secret too short to safely reveal 4+4 characters of is masked entirely."""
+        self.assertEqual(mask_secret("short"), "****")
+
+    def test_mask_api_key_wraps_mask_secret_in_colour_markup(self):
+        """mask_api_key adds console colour markup around the same masked value."""
+        self.assertEqual(mask_api_key("sk-abcdefgh1234"), "[yellow]sk-a****1234[/yellow]")
 
 
 def _branch(

--- a/src/poly/tests/device_flow_test.py
+++ b/src/poly/tests/device_flow_test.py
@@ -1,0 +1,177 @@
+"""Tests for the shared device authorization flow.
+
+Copyright PolyAI Limited
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from poly.auth.device_flow import DeviceFlowError, signin_with_device_flow
+from poly.handlers.auth0_handler import AuthDetails
+
+AUTH_DETAILS = AuthDetails(base_url="https://login.test", device_client_id="test-client-id")
+
+DEVICE_CODE_RESPONSE = {
+    "device_code": "dc-1",
+    "user_code": "ABCD-EFGH",
+    "verification_uri_complete": "https://login.test/activate?user_code=ABCD-EFGH",
+    "interval": 0,
+}
+
+
+def _http_error(error_code: str, description: str | None = None) -> requests.HTTPError:
+    """Build an HTTPError shaped like Auth0's device-flow poll error responses."""
+    body = {"error": error_code}
+    if description is not None:
+        body["error_description"] = description
+    response = MagicMock()
+    response.json.return_value = body
+    err = requests.HTTPError(response=response)
+    return err
+
+
+class SigninWithDeviceFlow(unittest.TestCase):
+    """Tests for signin_with_device_flow."""
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_success_on_first_poll(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """Returns the access token as soon as the first poll succeeds."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.return_value = {"access_token": "tok-1"}
+
+        token = signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(token, "tok-1")
+        mock_open.assert_called_once_with(DEVICE_CODE_RESPONSE["verification_uri_complete"])
+        mock_poll.assert_called_once_with(AUTH_DETAILS, "dc-1")
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_pending_then_success(self, mock_open, mock_request_code, mock_poll, mock_sleep):
+        """authorization_pending is retried until the token comes back."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.side_effect = [
+            _http_error("authorization_pending"),
+            _http_error("authorization_pending"),
+            {"access_token": "tok-1"},
+        ]
+
+        token = signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(token, "tok-1")
+        self.assertEqual(mock_poll.call_count, 3)
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_slow_down_increases_interval_up_to_cap(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """slow_down increases the poll interval by 5s each time, capped at 30s."""
+        mock_request_code.return_value = {**DEVICE_CODE_RESPONSE, "interval": 28}
+        mock_poll.side_effect = [
+            _http_error("slow_down"),
+            _http_error("slow_down"),
+            {"access_token": "tok-1"},
+        ]
+
+        token = signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(token, "tok-1")
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        # Starts at 28s, then capped at 30s after the first slow_down (28+5=33 -> 30).
+        self.assertEqual(sleep_calls, [28, 30, 30])
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_expired_token_raises_device_flow_error(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """expired_token raises DeviceFlowError with a user-facing retry message."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.side_effect = _http_error("expired_token")
+
+        with self.assertRaises(DeviceFlowError) as ctx:
+            signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(str(ctx.exception), "Authorization timed out. Please try again.")
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_unknown_error_raises_with_description(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """An unrecognized error code raises DeviceFlowError with its description."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.side_effect = _http_error("invalid_grant", description="Something went wrong")
+
+        with self.assertRaises(DeviceFlowError) as ctx:
+            signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(str(ctx.exception), "Authorization failed: Something went wrong")
+
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_request_device_code_failure_raises_device_flow_error(
+        self, mock_open, mock_request_code
+    ):
+        """A failure starting the flow raises DeviceFlowError rather than propagating."""
+        mock_request_code.side_effect = ValueError("boom")
+
+        with self.assertRaises(DeviceFlowError) as ctx:
+            signin_with_device_flow(AUTH_DETAILS)
+
+        self.assertEqual(str(ctx.exception), "Failed to start authorization: boom")
+        mock_open.assert_not_called()
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_open_browser_false_does_not_open_browser(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """open_browser=False never launches a browser, even on success."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.return_value = {"access_token": "tok-1"}
+
+        signin_with_device_flow(AUTH_DETAILS, open_browser=False)
+
+        mock_open.assert_not_called()
+
+    @patch("poly.auth.device_flow.time.sleep")
+    @patch("poly.auth.device_flow.Auth0Handler.poll_device_token_for")
+    @patch("poly.auth.device_flow.Auth0Handler.request_device_code_for")
+    @patch("poly.auth.device_flow.webbrowser.open")
+    def test_on_verification_url_callback_used_instead_of_default_message(
+        self, mock_open, mock_request_code, mock_poll, mock_sleep
+    ):
+        """When given, on_verification_url is called instead of printing the default message."""
+        mock_request_code.return_value = DEVICE_CODE_RESPONSE
+        mock_poll.return_value = {"access_token": "tok-1"}
+        callback = MagicMock()
+
+        signin_with_device_flow(AUTH_DETAILS, on_verification_url=callback)
+
+        callback.assert_called_once_with(
+            DEVICE_CODE_RESPONSE["verification_uri_complete"],
+            DEVICE_CODE_RESPONSE["user_code"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/env_profile_test.py
+++ b/src/poly/tests/env_profile_test.py
@@ -1,0 +1,272 @@
+"""Tests for shell/registry environment variable persistence.
+
+Copyright PolyAI Limited
+"""
+
+import os
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from poly.utils.env_profile import (
+    MARKER_COMMENT,
+    EnvVarConflict,
+    _get_windows_registry_backend,
+    detect_profile,
+    write_env_var,
+)
+
+
+@contextmanager
+def _home_env():
+    """Patch HOME to a fresh temp dir so detect_profile()'s "~" resolves there."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        home = Path(tmp_dir)
+        with patch.dict(os.environ, {"HOME": str(home)}):
+            yield home
+
+
+class DetectProfile(unittest.TestCase):
+    """Tests for detect_profile's shell -> file mapping."""
+
+    def test_zsh(self):
+        """zsh resolves to ~/.zshrc."""
+        with _home_env() as home, patch.dict(os.environ, {"SHELL": "/bin/zsh"}):
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".zshrc")
+        self.assertEqual(target.shell, "zsh")
+
+    def test_bash_on_macos(self):
+        """bash on macOS resolves to ~/.bash_profile."""
+        with (
+            _home_env() as home,
+            patch.dict(os.environ, {"SHELL": "/bin/bash"}),
+            patch("poly.utils.env_profile.sys.platform", "darwin"),
+        ):
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".bash_profile")
+        self.assertEqual(target.shell, "bash")
+
+    def test_bash_on_linux(self):
+        """bash on Linux resolves to ~/.bashrc."""
+        with (
+            _home_env() as home,
+            patch.dict(os.environ, {"SHELL": "/bin/bash"}),
+            patch("poly.utils.env_profile.sys.platform", "linux"),
+        ):
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".bashrc")
+        self.assertEqual(target.shell, "bash")
+
+    def test_fish(self):
+        """fish resolves to ~/.config/fish/config.fish."""
+        with _home_env() as home, patch.dict(os.environ, {"SHELL": "/usr/bin/fish"}):
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".config" / "fish" / "config.fish")
+        self.assertEqual(target.shell, "fish")
+
+    def test_unknown_shell_falls_back_to_profile(self):
+        """An unrecognized $SHELL falls back to ~/.profile."""
+        with _home_env() as home, patch.dict(os.environ, {"SHELL": "/bin/tcsh"}):
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".profile")
+        self.assertEqual(target.shell, "sh")
+
+    def test_unset_shell_falls_back_to_profile(self):
+        """A missing $SHELL falls back to ~/.profile."""
+        with _home_env() as home:
+            os.environ.pop("SHELL", None)
+            target = detect_profile()
+        self.assertEqual(target.path, home / ".profile")
+        self.assertEqual(target.shell, "sh")
+
+    def test_windows_returns_registry_target_regardless_of_shell(self):
+        """On Windows, the target is always the registry, $SHELL is not consulted."""
+        with patch("poly.utils.env_profile.os.name", "nt"):
+            target = detect_profile()
+        self.assertEqual(str(target.path), "HKCU\\Environment")
+        self.assertEqual(target.shell, "powershell")
+
+
+class WriteEnvVarUnix(unittest.TestCase):
+    """Tests for write_env_var against a real temp file on Unix-style profiles."""
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp_dir.name)
+        self._env_patch = patch.dict(os.environ, {"HOME": str(self.home), "SHELL": "/bin/zsh"})
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+        self._tmp_dir.cleanup()
+
+    def test_creates_file_with_marker_and_export_line(self):
+        """A missing profile file is created with the marker and export line."""
+        target, masked_line = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertIn(MARKER_COMMENT, content)
+        self.assertIn('export POLY_API_KEY="sk-abcdefgh1234"', content)
+        self.assertNotIn("sk-abcdefgh1234", masked_line)
+
+    def test_appends_to_existing_file_preserving_content(self):
+        """Existing profile content is preserved; the new line is appended."""
+        target_path = self.home / ".zshrc"
+        target_path.write_text("alias ll='ls -la'\n", encoding="utf-8")
+
+        target, _ = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertIn("alias ll='ls -la'", content)
+        self.assertIn(MARKER_COMMENT, content)
+        self.assertIn('export POLY_API_KEY="sk-abcdefgh1234"', content)
+
+    def test_identical_value_is_a_no_op(self):
+        """Writing the same value twice does not duplicate the line."""
+        write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+        target, message = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertEqual(content.count("POLY_API_KEY"), 1)
+        self.assertIn("already set", message)
+
+    def test_conflicting_value_raises_without_force(self):
+        """A differing existing value raises EnvVarConflict when force is False."""
+        write_env_var("POLY_API_KEY", "sk-old-value-1")
+
+        with self.assertRaises(EnvVarConflict) as ctx:
+            write_env_var("POLY_API_KEY", "sk-new-value-2")
+
+        self.assertNotIn("sk-old-value-1", str(ctx.exception))
+        self.assertNotIn("sk-new-value-2", str(ctx.exception))
+
+    def test_force_replaces_in_place_with_single_marker(self):
+        """force=True replaces the value in place without duplicating the marker."""
+        write_env_var("POLY_API_KEY", "sk-old-value-1")
+
+        target, _ = write_env_var("POLY_API_KEY", "sk-new-value-2", force=True)
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertEqual(content.count(MARKER_COMMENT), 1)
+        self.assertIn('export POLY_API_KEY="sk-new-value-2"', content)
+        self.assertNotIn("sk-old-value-1", content)
+
+    def test_force_on_foreign_line_inserts_marker(self):
+        """force=True replacing a user-authored line inserts the marker above it."""
+        target_path = self.home / ".zshrc"
+        target_path.write_text('export POLY_API_KEY="user-set-value"\n', encoding="utf-8")
+
+        target, _ = write_env_var("POLY_API_KEY", "sk-new-value-2", force=True)
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertEqual(content.count(MARKER_COMMENT), 1)
+        self.assertIn('export POLY_API_KEY="sk-new-value-2"', content)
+
+
+class WriteEnvVarFish(unittest.TestCase):
+    """Tests for the fish shell's `set -gx` syntax."""
+
+    def setUp(self):
+        self._tmp_dir = tempfile.TemporaryDirectory()
+        self.home = Path(self._tmp_dir.name)
+        self._env_patch = patch.dict(
+            os.environ, {"HOME": str(self.home), "SHELL": "/usr/bin/fish"}
+        )
+        self._env_patch.start()
+
+    def tearDown(self):
+        self._env_patch.stop()
+        self._tmp_dir.cleanup()
+
+    def test_uses_set_gx_syntax_and_creates_parent_dir(self):
+        """fish's config.fish is created (with parent dir) using `set -gx` syntax."""
+        target, _ = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        self.assertEqual(target.path, self.home / ".config" / "fish" / "config.fish")
+        content = target.path.read_text(encoding="utf-8")
+        self.assertIn('set -gx POLY_API_KEY "sk-abcdefgh1234"', content)
+
+    def test_identical_value_is_a_no_op(self):
+        """Re-running with the same value in fish syntax is a no-op."""
+        write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+        target, message = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        content = target.path.read_text(encoding="utf-8")
+        self.assertEqual(content.count("POLY_API_KEY"), 1)
+        self.assertIn("already set", message)
+
+
+class WriteEnvVarWindows(unittest.TestCase):
+    """Tests for the Windows registry path, using an injected fake backend."""
+
+    def tearDown(self):
+        # write_env_var sets this on the current process so tests don't leak it.
+        os.environ.pop("POLY_API_KEY", None)
+
+    def _fake_backend(self, existing=None):
+        backend = MagicMock()
+        backend.read.return_value = existing
+        return backend
+
+    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._get_windows_registry_backend")
+    def test_writes_new_value_and_broadcasts(self, mock_get_backend):
+        """A fresh value is written to the registry and the change is broadcast."""
+        backend = self._fake_backend(existing=None)
+        mock_get_backend.return_value = backend
+
+        target, masked_line = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        self.assertEqual(str(target.path), "HKCU\\Environment")
+        backend.write.assert_called_once_with("POLY_API_KEY", "sk-abcdefgh1234")
+        backend.broadcast.assert_called_once()
+        self.assertNotIn("sk-abcdefgh1234", masked_line)
+        self.assertEqual(os.environ["POLY_API_KEY"], "sk-abcdefgh1234")
+
+    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._get_windows_registry_backend")
+    def test_identical_value_is_a_no_op(self, mock_get_backend):
+        """An identical existing registry value is left untouched."""
+        backend = self._fake_backend(existing="sk-abcdefgh1234")
+        mock_get_backend.return_value = backend
+
+        _, message = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
+
+        backend.write.assert_not_called()
+        self.assertIn("already set", message)
+
+    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._get_windows_registry_backend")
+    def test_conflicting_value_raises_without_force(self, mock_get_backend):
+        """A differing existing registry value raises EnvVarConflict without --force."""
+        backend = self._fake_backend(existing="old-value")
+        mock_get_backend.return_value = backend
+
+        with self.assertRaises(EnvVarConflict):
+            write_env_var("POLY_API_KEY", "new-value")
+        backend.write.assert_not_called()
+
+    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._get_windows_registry_backend")
+    def test_force_overwrites_conflicting_value(self, mock_get_backend):
+        """force=True overwrites a differing existing registry value."""
+        backend = self._fake_backend(existing="old-value")
+        mock_get_backend.return_value = backend
+
+        write_env_var("POLY_API_KEY", "new-value", force=True)
+
+        backend.write.assert_called_once_with("POLY_API_KEY", "new-value")
+        backend.broadcast.assert_called_once()
+
+    def test_default_backend_factory_returns_real_backend_type(self):
+        """The default factory returns the real backend (used only on actual Windows)."""
+        from poly.utils.env_profile import _WindowsRegistryBackend
+
+        self.assertIsInstance(_get_windows_registry_backend(), _WindowsRegistryBackend)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/env_profile_test.py
+++ b/src/poly/tests/env_profile_test.py
@@ -21,10 +21,19 @@ from poly.utils.env_profile import (
 
 @contextmanager
 def _home_env():
-    """Patch HOME to a fresh temp dir so detect_profile()'s "~" resolves there."""
+    """Patch HOME/USERPROFILE to a fresh temp dir and force the posix code path.
+
+    Needed so the Unix/fish tests behave identically on the Windows CI
+    runner: `os.path.expanduser("~")` reads `USERPROFILE` on Windows and
+    ignores `HOME` (Python 3.8+), and `detect_profile()`/`write_env_var()`
+    both branch on `os.name`, which is `"nt"` there.
+    """
     with tempfile.TemporaryDirectory() as tmp_dir:
         home = Path(tmp_dir)
-        with patch.dict(os.environ, {"HOME": str(home)}):
+        with (
+            patch.dict(os.environ, {"HOME": str(home), "USERPROFILE": str(home)}),
+            patch("poly.utils.env_profile.os.name", "posix"),
+        ):
             yield home
 
 
@@ -89,6 +98,24 @@ class DetectProfile(unittest.TestCase):
         self.assertEqual(str(target.path), "HKCU\\Environment")
         self.assertEqual(target.shell, "powershell")
 
+    def test_resolves_under_temp_dir_when_posix_is_forced(self):
+        """Regression for the Windows CI fix.
+
+        Forcing posix resolution while both HOME and USERPROFILE are set (as
+        they would be on the Windows runner) must still resolve under the
+        patched home, not the real Windows profile directory.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            home = Path(tmp_dir)
+            with (
+                patch.dict(
+                    os.environ, {"HOME": str(home), "USERPROFILE": str(home), "SHELL": "/bin/zsh"}
+                ),
+                patch("poly.utils.env_profile.os.name", "posix"),
+            ):
+                target = detect_profile()
+        self.assertEqual(target.path, home / ".zshrc")
+
 
 class WriteEnvVarUnix(unittest.TestCase):
     """Tests for write_env_var against a real temp file on Unix-style profiles."""
@@ -96,10 +123,16 @@ class WriteEnvVarUnix(unittest.TestCase):
     def setUp(self):
         self._tmp_dir = tempfile.TemporaryDirectory()
         self.home = Path(self._tmp_dir.name)
-        self._env_patch = patch.dict(os.environ, {"HOME": str(self.home), "SHELL": "/bin/zsh"})
+        self._env_patch = patch.dict(
+            os.environ,
+            {"HOME": str(self.home), "USERPROFILE": str(self.home), "SHELL": "/bin/zsh"},
+        )
         self._env_patch.start()
+        self._os_name_patch = patch("poly.utils.env_profile.os.name", "posix")
+        self._os_name_patch.start()
 
     def tearDown(self):
+        self._os_name_patch.stop()
         self._env_patch.stop()
         self._tmp_dir.cleanup()
 
@@ -173,11 +206,15 @@ class WriteEnvVarFish(unittest.TestCase):
         self._tmp_dir = tempfile.TemporaryDirectory()
         self.home = Path(self._tmp_dir.name)
         self._env_patch = patch.dict(
-            os.environ, {"HOME": str(self.home), "SHELL": "/usr/bin/fish"}
+            os.environ,
+            {"HOME": str(self.home), "USERPROFILE": str(self.home), "SHELL": "/usr/bin/fish"},
         )
         self._env_patch.start()
+        self._os_name_patch = patch("poly.utils.env_profile.os.name", "posix")
+        self._os_name_patch.start()
 
     def tearDown(self):
+        self._os_name_patch.stop()
         self._env_patch.stop()
         self._tmp_dir.cleanup()
 

--- a/src/poly/tests/env_profile_test.py
+++ b/src/poly/tests/env_profile_test.py
@@ -21,18 +21,20 @@ from poly.utils.env_profile import (
 
 @contextmanager
 def _home_env():
-    """Patch HOME/USERPROFILE to a fresh temp dir and force the posix code path.
+    """Patch HOME/USERPROFILE to a fresh temp dir and force the non-Windows code path.
 
     Needed so the Unix/fish tests behave identically on the Windows CI
     runner: `os.path.expanduser("~")` reads `USERPROFILE` on Windows and
     ignores `HOME` (Python 3.8+), and `detect_profile()`/`write_env_var()`
-    both branch on `os.name`, which is `"nt"` there.
+    both branch on `_is_windows()`, which is true there. Patching the seam
+    (rather than the real `os.name`) means `pathlib` still sees the actual
+    host platform and doesn't try to build the wrong path flavor.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         home = Path(tmp_dir)
         with (
             patch.dict(os.environ, {"HOME": str(home), "USERPROFILE": str(home)}),
-            patch("poly.utils.env_profile.os.name", "posix"),
+            patch("poly.utils.env_profile._is_windows", return_value=False),
         ):
             yield home
 
@@ -52,7 +54,7 @@ class DetectProfile(unittest.TestCase):
         with (
             _home_env() as home,
             patch.dict(os.environ, {"SHELL": "/bin/bash"}),
-            patch("poly.utils.env_profile.sys.platform", "darwin"),
+            patch("poly.utils.env_profile._is_macos", return_value=True),
         ):
             target = detect_profile()
         self.assertEqual(target.path, home / ".bash_profile")
@@ -63,7 +65,7 @@ class DetectProfile(unittest.TestCase):
         with (
             _home_env() as home,
             patch.dict(os.environ, {"SHELL": "/bin/bash"}),
-            patch("poly.utils.env_profile.sys.platform", "linux"),
+            patch("poly.utils.env_profile._is_macos", return_value=False),
         ):
             target = detect_profile()
         self.assertEqual(target.path, home / ".bashrc")
@@ -93,17 +95,17 @@ class DetectProfile(unittest.TestCase):
 
     def test_windows_returns_registry_target_regardless_of_shell(self):
         """On Windows, the target is always the registry, $SHELL is not consulted."""
-        with patch("poly.utils.env_profile.os.name", "nt"):
+        with patch("poly.utils.env_profile._is_windows", return_value=True):
             target = detect_profile()
-        self.assertEqual(str(target.path), "HKCU\\Environment")
+        self.assertEqual(target.path, Path(r"HKCU\Environment"))
         self.assertEqual(target.shell, "powershell")
 
-    def test_resolves_under_temp_dir_when_posix_is_forced(self):
+    def test_resolves_under_temp_dir_with_both_home_variables_set(self):
         """Regression for the Windows CI fix.
 
-        Forcing posix resolution while both HOME and USERPROFILE are set (as
-        they would be on the Windows runner) must still resolve under the
-        patched home, not the real Windows profile directory.
+        With `_is_windows` forced False and both HOME and USERPROFILE set (as
+        they would be on the Windows runner), detect_profile() must still
+        resolve under the patched home, not the real Windows profile directory.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
             home = Path(tmp_dir)
@@ -111,7 +113,7 @@ class DetectProfile(unittest.TestCase):
                 patch.dict(
                     os.environ, {"HOME": str(home), "USERPROFILE": str(home), "SHELL": "/bin/zsh"}
                 ),
-                patch("poly.utils.env_profile.os.name", "posix"),
+                patch("poly.utils.env_profile._is_windows", return_value=False),
             ):
                 target = detect_profile()
         self.assertEqual(target.path, home / ".zshrc")
@@ -128,11 +130,11 @@ class WriteEnvVarUnix(unittest.TestCase):
             {"HOME": str(self.home), "USERPROFILE": str(self.home), "SHELL": "/bin/zsh"},
         )
         self._env_patch.start()
-        self._os_name_patch = patch("poly.utils.env_profile.os.name", "posix")
-        self._os_name_patch.start()
+        self._is_windows_patch = patch("poly.utils.env_profile._is_windows", return_value=False)
+        self._is_windows_patch.start()
 
     def tearDown(self):
-        self._os_name_patch.stop()
+        self._is_windows_patch.stop()
         self._env_patch.stop()
         self._tmp_dir.cleanup()
 
@@ -210,11 +212,11 @@ class WriteEnvVarFish(unittest.TestCase):
             {"HOME": str(self.home), "USERPROFILE": str(self.home), "SHELL": "/usr/bin/fish"},
         )
         self._env_patch.start()
-        self._os_name_patch = patch("poly.utils.env_profile.os.name", "posix")
-        self._os_name_patch.start()
+        self._is_windows_patch = patch("poly.utils.env_profile._is_windows", return_value=False)
+        self._is_windows_patch.start()
 
     def tearDown(self):
-        self._os_name_patch.stop()
+        self._is_windows_patch.stop()
         self._env_patch.stop()
         self._tmp_dir.cleanup()
 
@@ -248,7 +250,7 @@ class WriteEnvVarWindows(unittest.TestCase):
         backend.read.return_value = existing
         return backend
 
-    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._is_windows", new=lambda: True)
     @patch("poly.utils.env_profile._get_windows_registry_backend")
     def test_writes_new_value_and_broadcasts(self, mock_get_backend):
         """A fresh value is written to the registry and the change is broadcast."""
@@ -257,13 +259,13 @@ class WriteEnvVarWindows(unittest.TestCase):
 
         target, masked_line = write_env_var("POLY_API_KEY", "sk-abcdefgh1234")
 
-        self.assertEqual(str(target.path), "HKCU\\Environment")
+        self.assertEqual(target.path, Path(r"HKCU\Environment"))
         backend.write.assert_called_once_with("POLY_API_KEY", "sk-abcdefgh1234")
         backend.broadcast.assert_called_once()
         self.assertNotIn("sk-abcdefgh1234", masked_line)
         self.assertEqual(os.environ["POLY_API_KEY"], "sk-abcdefgh1234")
 
-    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._is_windows", new=lambda: True)
     @patch("poly.utils.env_profile._get_windows_registry_backend")
     def test_identical_value_is_a_no_op(self, mock_get_backend):
         """An identical existing registry value is left untouched."""
@@ -275,7 +277,7 @@ class WriteEnvVarWindows(unittest.TestCase):
         backend.write.assert_not_called()
         self.assertIn("already set", message)
 
-    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._is_windows", new=lambda: True)
     @patch("poly.utils.env_profile._get_windows_registry_backend")
     def test_conflicting_value_raises_without_force(self, mock_get_backend):
         """A differing existing registry value raises EnvVarConflict without --force."""
@@ -286,7 +288,7 @@ class WriteEnvVarWindows(unittest.TestCase):
             write_env_var("POLY_API_KEY", "new-value")
         backend.write.assert_not_called()
 
-    @patch("poly.utils.env_profile.os.name", "nt")
+    @patch("poly.utils.env_profile._is_windows", new=lambda: True)
     @patch("poly.utils.env_profile._get_windows_registry_backend")
     def test_force_overwrites_conflicting_value(self, mock_get_backend):
         """force=True overwrites a differing existing registry value."""

--- a/src/poly/tests/onboard_test.py
+++ b/src/poly/tests/onboard_test.py
@@ -60,14 +60,14 @@ class OnboardTestCase(unittest.TestCase):
                 ),
             ),
             "get_anonymous_id": patch(
-                "poly.cli_commands.onboard.get_anonymous_id", return_value=FAKE_ANON_ID
+                "poly.handlers.posthog.get_anonymous_id", return_value=FAKE_ANON_ID
             ),
             "detect_profile": patch(
                 "poly.cli_commands.onboard.detect_profile",
                 return_value=ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
             ),
-            "capture_event": patch("poly.cli_commands.onboard.capture_event"),
-            "flush": patch("poly.cli_commands.onboard.flush"),
+            "capture_event": patch("poly.handlers.posthog.capture_event"),
+            "flush": patch("poly.handlers.posthog.flush"),
             "alias": patch("poly.cli_commands.onboard._alias_to_account"),
             "sleep": patch("poly.cli_commands.onboard.time.sleep"),
         }
@@ -260,6 +260,20 @@ class Verbose(OnboardTestCase):
 
         with self.assertRaises(ValueError):
             OnboardCommand.onboard(verbose=True)
+
+
+class ArgParsing(unittest.TestCase):
+    """Tests for onboard's own argparse wiring."""
+
+    def test_force_short_alias(self):
+        """-f is accepted as a short alias for --force, matching other commands."""
+        from poly.cli import AgentStudioCLI
+
+        cli = AgentStudioCLI()
+        cli.register_commands()
+        args = cli._create_parser().parse_args(["onboard", "-f"])
+
+        self.assertTrue(args.force)
 
 
 class CommandRegistration(unittest.TestCase):

--- a/src/poly/tests/onboard_test.py
+++ b/src/poly/tests/onboard_test.py
@@ -172,6 +172,25 @@ class HappyPath(OnboardTestCase):
 
         self.assertNotIn("[", buffer.getvalue())
 
+    def test_json_mode_prints_verification_url_to_stderr(self):
+        """--json still surfaces the sign-in URL/code - on stderr, since stdout is JSON-only."""
+        verification_uri = "https://login.studio.poly.ai/activate?user_code=ABCD-EFGH"
+
+        def fake_signin(auth_details, *, on_verification_url=None, **kwargs):
+            on_verification_url(verification_uri, "ABCD-EFGH")
+            return FAKE_JWT
+
+        self.mocks["signin"].side_effect = fake_signin
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+            OnboardCommand.onboard(output_json=True)
+
+        self.assertIn(verification_uri, stderr.getvalue())
+        payload = json.loads(stdout.getvalue())
+        self.assertTrue(payload["success"])
+
 
 class AccountPollFailure(OnboardTestCase):
     """Tests for the no-account-appeared failure path."""

--- a/src/poly/tests/onboard_test.py
+++ b/src/poly/tests/onboard_test.py
@@ -1,0 +1,260 @@
+"""Tests for the `poly onboard` command.
+
+Copyright PolyAI Limited
+"""
+
+import contextlib
+import io
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from poly.cli_commands.base import GETTING_STARTED_GROUP
+from poly.cli_commands.onboard import OnboardCommand
+from poly.utils.env_profile import EnvVarConflict, ProfileTarget
+
+FAKE_JWT = "jwt-1"
+FAKE_KEY = "sk-newkey1234567890"
+FAKE_ACCOUNT = "acc-1"
+FAKE_ANON_ID = "anon-fixed"
+
+
+class OnboardTestCase(unittest.TestCase):
+    """Base class wiring up the standard set of onboard collaborator mocks."""
+
+    def setUp(self):
+        # Never touch the real ~/.poly or depend on the host's $SHELL.
+        os.environ.pop("DO_NOT_TRACK", None)
+        os.environ.pop("POLY_NO_TELEMETRY", None)
+        patchers = {
+            "signin": patch(
+                "poly.cli_commands.onboard.signin_with_device_flow", return_value=FAKE_JWT
+            ),
+            "authorise": patch(
+                "poly.cli_commands.onboard.AgentStudioInterface.authorise"
+            ),
+            "get_accounts": patch(
+                "poly.cli_commands.onboard.AgentStudioInterface.get_accounts_internal",
+                return_value=[{"id": FAKE_ACCOUNT}],
+            ),
+            "list_keys": patch(
+                "poly.cli_commands.onboard.AgentStudioInterface.list_account_api_keys_internal",
+                return_value=[],
+            ),
+            "create_key": patch(
+                "poly.cli_commands.onboard.AgentStudioInterface.create_account_api_key_internal",
+                return_value={"key": FAKE_KEY},
+            ),
+            "load_cred": patch(
+                "poly.cli_commands.onboard.load_api_key_from_credential_file",
+                return_value=None,
+            ),
+            "save_cred": patch("poly.cli_commands.onboard.save_api_key_credential_file"),
+            "write_env": patch(
+                "poly.cli_commands.onboard.write_env_var",
+                return_value=(
+                    ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
+                    'export POLY_API_KEY="sk-n****7890"',
+                ),
+            ),
+            "get_anonymous_id": patch(
+                "poly.cli_commands.onboard.get_anonymous_id", return_value=FAKE_ANON_ID
+            ),
+            "detect_profile": patch(
+                "poly.cli_commands.onboard.detect_profile",
+                return_value=ProfileTarget(path=Path("/home/user/.zshrc"), shell="zsh"),
+            ),
+            "capture_event": patch("poly.cli_commands.onboard.capture_event"),
+            "flush": patch("poly.cli_commands.onboard.flush"),
+            "alias": patch("poly.cli_commands.onboard._alias_to_account"),
+            "sleep": patch("poly.cli_commands.onboard.time.sleep"),
+        }
+        self.mocks = {name: p.start() for name, p in patchers.items()}
+        for p in patchers.values():
+            self.addCleanup(p.stop)
+
+    def _failed_events(self):
+        """The properties dict of every onboard_failed capture_event call."""
+        return [
+            call.args[2]
+            for call in self.mocks["capture_event"].call_args_list
+            if call.args[1] == "onboard_failed"
+        ]
+
+    def _event_names(self):
+        return [call.args[1] for call in self.mocks["capture_event"].call_args_list]
+
+
+class HappyPath(OnboardTestCase):
+    """Tests for the successful onboard flow."""
+
+    def test_creates_key_and_writes_env(self):
+        """No existing key: a new one is created and POLY_API_KEY is written."""
+        OnboardCommand.onboard()
+
+        self.mocks["create_key"].assert_called_once()
+        self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=False)
+        self.assertIn("onboard_key_created", self._event_names())
+        self.assertIn("onboard_completed", self._event_names())
+
+    def test_existing_studio_credential_is_not_overwritten(self):
+        """An existing credential-file entry for studio is left untouched."""
+        self.mocks["load_cred"].return_value = "already-there"
+
+        OnboardCommand.onboard()
+
+        self.mocks["save_cred"].assert_not_called()
+
+    def test_reuse_path_emits_key_reused(self):
+        """A matching existing key is reused instead of creating a new one."""
+        with patch(
+            "poly.cli_commands.onboard.select_reusable_api_key", return_value="sk-existing"
+        ):
+            OnboardCommand.onboard()
+
+        self.mocks["create_key"].assert_not_called()
+        self.assertIn("onboard_key_reused", self._event_names())
+
+    def test_account_id_flag_skips_the_poll(self):
+        """--account-id bypasses polling GET /jupiter/v2/accounts entirely."""
+        OnboardCommand.onboard(account_id="acc-given")
+
+        self.mocks["get_accounts"].assert_not_called()
+        account_resolved = next(
+            call.args[2]
+            for call in self.mocks["capture_event"].call_args_list
+            if call.args[1] == "onboard_account_resolved"
+        )
+        self.assertEqual(account_resolved["account_id"], "acc-given")
+
+    def test_key_value_never_appears_in_stdout(self):
+        """The real API key is never printed, masked or otherwise, in plain output."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            OnboardCommand.onboard()
+
+        self.assertNotIn(FAKE_KEY, buffer.getvalue())
+
+    def test_anonymous_id_not_created_when_telemetry_disabled(self):
+        """DO_NOT_TRACK=1 skips get_anonymous_id entirely - no ~/.poly/telemetry_id touched."""
+        with patch.dict(os.environ, {"DO_NOT_TRACK": "1"}):
+            OnboardCommand.onboard()
+
+        self.mocks["get_anonymous_id"].assert_not_called()
+
+    def test_json_output_has_expected_keys_and_masked_value(self):
+        """--json prints one object with the documented fields and a masked key only."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            OnboardCommand.onboard(output_json=True)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertTrue(payload["success"])
+        for key in (
+            "account_id",
+            "key_name",
+            "key_reused",
+            "api_key_masked",
+            "credentials_file",
+            "profile_path",
+            "profile_shell",
+        ):
+            self.assertIn(key, payload)
+        self.assertNotIn(FAKE_KEY, buffer.getvalue())
+
+    def test_json_output_has_no_rich_markup(self):
+        """The masked key in --json output is plain text, not `[yellow]...[/yellow]` markup."""
+        buffer = io.StringIO()
+        with contextlib.redirect_stdout(buffer):
+            OnboardCommand.onboard(output_json=True)
+
+        self.assertNotIn("[", buffer.getvalue())
+
+
+class AccountPollFailure(OnboardTestCase):
+    """Tests for the no-account-appeared failure path."""
+
+    def test_empty_accounts_after_20_tries_fails_with_exit_1(self):
+        """20 empty polls without --account-id exits 1 with an onboard_failed(step=account)."""
+        self.mocks["get_accounts"].return_value = []
+
+        with self.assertRaises(SystemExit) as ctx:
+            OnboardCommand.onboard()
+
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(self.mocks["get_accounts"].call_count, 20)
+        failed = self._failed_events()
+        self.assertEqual(len(failed), 1)
+        self.assertEqual(failed[0]["step"], "account")
+
+
+class EnvConflict(OnboardTestCase):
+    """Tests for the POLY_API_KEY conflict path."""
+
+    def test_conflict_exits_2_without_force(self):
+        """A conflicting existing value exits 2 and reports the env step."""
+        self.mocks["write_env"].side_effect = EnvVarConflict(
+            "old****", "new****", Path("/home/user/.zshrc")
+        )
+
+        with self.assertRaises(SystemExit) as ctx:
+            OnboardCommand.onboard()
+
+        self.assertEqual(ctx.exception.code, 2)
+        failed = self._failed_events()
+        self.assertEqual(failed[0]["step"], "env")
+        self.assertEqual(failed[0]["error_class"], "EnvVarConflict")
+
+    def test_json_error_matches_the_documented_contract(self):
+        """--json failures include success/error/traceback/step, with no Rich markup."""
+        self.mocks["write_env"].side_effect = EnvVarConflict(
+            "old****", "new****", Path("/home/user/.zshrc")
+        )
+        buffer = io.StringIO()
+
+        with contextlib.redirect_stdout(buffer):
+            with self.assertRaises(SystemExit):
+                OnboardCommand.onboard(output_json=True)
+
+        payload = json.loads(buffer.getvalue())
+        self.assertFalse(payload["success"])
+        self.assertEqual(payload["step"], "env")
+        self.assertIn("traceback", payload)
+        self.assertTrue(payload["traceback"])
+        self.assertNotIn("[", buffer.getvalue())
+
+    def test_force_is_forwarded_to_write_env_var(self):
+        """--force is passed straight through to write_env_var."""
+        OnboardCommand.onboard(force=True)
+
+        self.mocks["write_env"].assert_called_once_with("POLY_API_KEY", FAKE_KEY, force=True)
+
+
+class Verbose(OnboardTestCase):
+    """Tests for --verbose re-raising instead of exiting cleanly."""
+
+    def test_verbose_reraises_instead_of_exiting(self):
+        """With verbose=True, the original exception propagates (for a full traceback)."""
+        self.mocks["get_accounts"].return_value = []
+
+        with self.assertRaises(ValueError):
+            OnboardCommand.onboard(verbose=True)
+
+
+class CommandRegistration(unittest.TestCase):
+    """Tests that the command is wired into the CLI's Getting started group."""
+
+    def test_command_name_and_group(self):
+        self.assertEqual(OnboardCommand.command, "onboard")
+        self.assertEqual(OnboardCommand.group, GETTING_STARTED_GROUP)
+
+    def test_registered_in_cli_commands(self):
+        from poly.cli import COMMANDS
+
+        self.assertIn(OnboardCommand, COMMANDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/poly/tests/setup_test.py
+++ b/src/poly/tests/setup_test.py
@@ -14,14 +14,11 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import requests
-
 from poly.cli import AgentStudioCLI
 from poly.cli_commands.auth import (
     LoginCommand,
     _authenticate_and_save_key,
     _select_region,
-    _signin,
 )
 from poly.cli_commands.setup import COMPLETION_MARKER, SetupCommand
 from poly.cli_commands.skills import (
@@ -644,100 +641,6 @@ class AuthenticateAndSaveKeyTest(unittest.TestCase):
 
         self.mock_save.assert_called_once_with("existing-pat", region="us-1")
         self.assertIn("not active yet", mock_warning.call_args[0][0])
-
-
-class SigninDeviceFlowTest(unittest.TestCase):
-    """Tests for auth._signin, the browser device flow shared by setup/login."""
-
-    DEVICE_RESPONSE = {
-        "user_code": "ABCD-EFGH",
-        "verification_uri_complete": "https://example.test/activate?code=ABCD-EFGH",
-        "device_code": "device-code",
-        "interval": 5,
-    }
-
-    def setUp(self):
-        self.auth0 = patch("poly.cli_commands.auth.Auth0Handler").start().return_value
-        self.auth0.request_device_code.return_value = dict(self.DEVICE_RESPONSE)
-        self.auth0.poll_device_token.return_value = {"access_token": "jwt-token"}
-        self.mock_browser = patch("webbrowser.open").start()
-        patch("time.sleep").start()
-        self.addCleanup(patch.stopall)
-
-    @staticmethod
-    def _device_flow_error(error_code: str) -> requests.HTTPError:
-        """Build the HTTPError Auth0 returns while a device code is outstanding."""
-        response = MagicMock()
-        response.json.return_value = {"error": error_code}
-        return requests.HTTPError(error_code, response=response)
-
-    def test_successful_authorization_returns_the_access_token(self):
-        """A completed browser sign-in returns the JWT and opens the verification page."""
-        token = _signin("us-1")
-
-        self.assertEqual(token, "jwt-token")
-        self.mock_browser.assert_called_once_with(self.DEVICE_RESPONSE["verification_uri_complete"])
-
-    def test_pending_authorization_is_polled_until_the_user_finishes(self):
-        """'authorization_pending' keeps polling rather than failing the sign-in."""
-        self.auth0.poll_device_token.side_effect = [
-            self._device_flow_error("authorization_pending"),
-            {"access_token": "jwt-token"},
-        ]
-
-        self.assertEqual(_signin("us-1"), "jwt-token")
-        self.assertEqual(self.auth0.poll_device_token.call_count, 2)
-
-    def test_slow_down_response_keeps_polling(self):
-        """'slow_down' backs the polling off instead of failing the sign-in."""
-        self.auth0.poll_device_token.side_effect = [
-            self._device_flow_error("slow_down"),
-            {"access_token": "jwt-token"},
-        ]
-
-        self.assertEqual(_signin("us-1"), "jwt-token")
-        self.assertEqual(self.auth0.poll_device_token.call_count, 2)
-
-    def test_unknown_authorization_error_exits(self):
-        """An unrecognised Auth0 error ends the sign-in."""
-        self.auth0.poll_device_token.side_effect = self._device_flow_error("access_denied")
-
-        with self.assertRaises(SystemExit) as ctx:
-            _signin("us-1")
-
-        self.assertEqual(ctx.exception.code, 1)
-
-    def test_non_json_error_response_exits(self):
-        """An HTTP error with an unparseable body ends the sign-in rather than crashing."""
-        response = MagicMock()
-        response.json.side_effect = ValueError("not json")
-        self.auth0.poll_device_token.side_effect = requests.HTTPError(
-            "502 Bad Gateway", response=response
-        )
-
-        with self.assertRaises(SystemExit) as ctx:
-            _signin("us-1")
-
-        self.assertEqual(ctx.exception.code, 1)
-
-    def test_expired_device_code_exits(self):
-        """An expired device code ends the command rather than polling forever."""
-        self.auth0.poll_device_token.side_effect = self._device_flow_error("expired_token")
-
-        with self.assertRaises(SystemExit) as ctx:
-            _signin("us-1")
-
-        self.assertEqual(ctx.exception.code, 1)
-
-    def test_failure_to_start_authorization_exits(self):
-        """If the device code request fails, sign-in exits instead of opening a browser."""
-        self.auth0.request_device_code.side_effect = Exception("network down")
-
-        with self.assertRaises(SystemExit) as ctx:
-            _signin("us-1")
-
-        self.assertEqual(ctx.exception.code, 1)
-        self.mock_browser.assert_not_called()
 
 
 class LoginCommandRegionTest(unittest.TestCase):

--- a/src/poly/utils/__init__.py
+++ b/src/poly/utils/__init__.py
@@ -4,6 +4,8 @@ Utilities live in focused submodules — ``poly.utils.credentials``,
 ``poly.utils.merge``, ``poly.utils.stub_gen``, ``poly.utils.decorators``,
 ``poly.utils.variable_references`` and ``poly.utils.commands`` — with the
 public names re-exported here for convenience and backwards compatibility.
+Newer submodules (``poly.utils.api_keys``, ``poly.utils.env_profile``) are
+imported directly by their callers instead.
 
 Copyright PolyAI Limited
 """

--- a/src/poly/utils/api_keys.py
+++ b/src/poly/utils/api_keys.py
@@ -1,0 +1,54 @@
+"""Selection logic for reusing an existing account-scoped API key.
+
+Copyright PolyAI Limited
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from dateutil import parser as date_parser
+
+
+def _is_active_and_unexpired(key: dict, now: datetime) -> bool:
+    """Whether a key record is active and either has no expiry or expires after `now`."""
+    if key.get("active") is not True:
+        return False
+
+    expires_at = key.get("expires_at")
+    if not expires_at:
+        return True
+
+    return date_parser.isoparse(expires_at) > now
+
+
+def _policy_name(key: dict) -> str:
+    """The name a key was created with.
+
+    The name passed at creation does not land on the key's own `name` field
+    (which comes back empty) - it lands on `policies[0].name`.
+    """
+    policies = key.get("policies") or [{}]
+    return policies[0].get("name") or ""
+
+
+def select_reusable_api_key(keys: list[dict], name: str, now: datetime) -> Optional[str]:
+    """Pick the newest active, unexpired API key named `name`, if one exists.
+
+    Args:
+        keys: Raw API key records, as returned by the accounts API.
+        name: The key name to match (compared against `policies[0].name`).
+        now: The current time, used to evaluate `expires_at`. Must be
+            timezone-aware (e.g. `datetime.now(timezone.utc)`), since
+            `expires_at` values are timezone-aware ISO 8601 timestamps.
+
+    Returns:
+        The matching key's secret, or `None` if no key qualifies.
+    """
+    matching = [
+        key for key in keys if _is_active_and_unexpired(key, now) and _policy_name(key) == name
+    ]
+    if not matching:
+        return None
+
+    newest = max(matching, key=lambda key: key.get("created_at") or "")
+    return newest.get("key")

--- a/src/poly/utils/credentials.py
+++ b/src/poly/utils/credentials.py
@@ -49,8 +49,21 @@ def save_api_key_credential_file(api_key: str, region: str) -> None:
     os.chmod(CREDENTIALS_FILE_PATH, 0o600)
 
 
-def _load_api_key_from_credential_file(region: str) -> Optional[str]:
-    """Load the API key for the given region from the credential file, if it exists."""
+def load_api_key_from_credential_file(region: str) -> Optional[str]:
+    """Look up the API key stored for `region` in the credential file, if any.
+
+    Unlike `retrieve_api_key`, this never falls back to an environment
+    variable and never raises - it answers "is there already a stored
+    credential for this region", which is all a caller deciding whether to
+    overwrite one needs.
+
+    Args:
+        region: The region to look up.
+
+    Returns:
+        The stored API key, or None if the credential file has no entry for
+        `region`.
+    """
     if os.path.isfile(CREDENTIALS_FILE_PATH):
         with open(CREDENTIALS_FILE_PATH, "r", encoding="utf-8") as f:
             try:
@@ -73,7 +86,7 @@ def retrieve_api_key(region: str) -> str:
 
     Raises ``ValueError`` with a helpful message when no key is found.
     """
-    api_key = _load_api_key_from_credential_file(region)
+    api_key = load_api_key_from_credential_file(region)
     if api_key:
         return api_key
 

--- a/src/poly/utils/env_profile.py
+++ b/src/poly/utils/env_profile.py
@@ -1,0 +1,255 @@
+"""Detects the user's shell profile and persists an environment variable into it.
+
+On Windows, "the profile" is the user's registry environment block
+(``HKCU\\Environment``) rather than a file, since that is what actually makes
+a variable visible to new processes system-wide.
+
+Copyright PolyAI Limited
+"""
+
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Marker written immediately above a line this module added, so a later run
+# can tell "we wrote this" apart from a line the user added by hand, and so
+# replacing a value in place never leaves a duplicate marker behind.
+MARKER_COMMENT = "# Added by poly onboard"
+
+# HWND_BROADCAST / WM_SETTINGCHANGE / SMTO_ABORTIFHUNG, used to notify running
+# processes (Explorer, the Start menu, already-open terminals) that the user
+# environment block changed, without requiring a reboot or logoff.
+_HWND_BROADCAST = 0xFFFF
+_WM_SETTINGCHANGE = 0x1A
+_SMTO_ABORTIFHUNG = 0x0002
+
+_WINDOWS_ENVIRONMENT_DISPLAY_PATH = "HKCU\\Environment"
+
+
+@dataclass
+class ProfileTarget:
+    """Where an environment variable gets persisted, and in what dialect."""
+
+    path: Path
+    shell: str  # "zsh" | "bash" | "fish" | "sh" | "powershell"
+
+
+class EnvVarConflict(Exception):
+    """Raised when an environment variable is already set to a different value.
+
+    Attributes:
+        existing_masked: The current value, masked for safe display.
+        new_masked: The value that was about to be written, masked for safe display.
+        path: Where the conflicting value lives.
+    """
+
+    def __init__(self, existing_masked: str, new_masked: str, path: Path):
+        self.existing_masked = existing_masked
+        self.new_masked = new_masked
+        self.path = path
+        super().__init__(
+            f"{path} already sets this variable to a different value "
+            f"({existing_masked} vs {new_masked})."
+        )
+
+
+def detect_profile() -> ProfileTarget:
+    """Detect where an environment variable should be persisted for this user.
+
+    Returns:
+        ProfileTarget: The file (or, on Windows, the registry location) and
+            dialect to write to.
+    """
+    if os.name == "nt":
+        return ProfileTarget(path=Path(_WINDOWS_ENVIRONMENT_DISPLAY_PATH), shell="powershell")
+
+    home = Path(os.path.expanduser("~"))
+    shell = os.path.basename(os.environ.get("SHELL", ""))
+
+    if shell == "zsh":
+        return ProfileTarget(path=home / ".zshrc", shell="zsh")
+    if shell == "bash":
+        if sys.platform == "darwin":
+            return ProfileTarget(path=home / ".bash_profile", shell="bash")
+        return ProfileTarget(path=home / ".bashrc", shell="bash")
+    if shell == "fish":
+        return ProfileTarget(path=home / ".config" / "fish" / "config.fish", shell="fish")
+    return ProfileTarget(path=home / ".profile", shell="sh")
+
+
+def write_env_var(name: str, value: str, *, force: bool = False) -> tuple[ProfileTarget, str]:
+    """Persist an environment variable so it is visible in new shells/processes.
+
+    Args:
+        name: The environment variable name.
+        value: The value to persist. Never logged.
+        force: Replace a differing existing value instead of raising.
+
+    Returns:
+        tuple[ProfileTarget, str]: The target written to, and a masked line
+            describing what was written (safe to print).
+
+    Raises:
+        EnvVarConflict: `name` is already set to a different value and `force`
+            is false.
+    """
+    if os.name == "nt":
+        return _write_env_var_windows(name, value, force=force)
+    return _write_env_var_unix(name, value, force=force)
+
+
+def _format_line(shell: str, name: str, value: str) -> str:
+    """Render the export line for the given shell dialect."""
+    if shell == "fish":
+        return f'set -gx {name} "{value}"'
+    return f'export {name}="{value}"'
+
+
+def _existing_line_pattern(shell: str, name: str) -> re.Pattern:
+    """A regex matching a line that already sets `name`, capturing its raw value."""
+    escaped_name = re.escape(name)
+    if shell == "fish":
+        return re.compile(rf"^\s*set\s+(?:-gx|-x)\s+{escaped_name}\s+(.*)$")
+    return re.compile(rf"^\s*(?:export\s+)?{escaped_name}=(.*)$")
+
+
+def _strip_quotes(raw: str) -> str:
+    """Strip a single layer of matching quotes from a captured shell value."""
+    raw = raw.strip()
+    if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in "\"'":
+        return raw[1:-1]
+    return raw
+
+
+def _write_env_var_unix(name: str, value: str, *, force: bool) -> tuple[ProfileTarget, str]:
+    """Persist an environment variable into the detected shell profile file."""
+    from poly.output.console import mask_secret
+
+    target = detect_profile()
+    target.path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = target.path.read_text(encoding="utf-8") if target.path.exists() else ""
+    lines = content.splitlines()
+
+    pattern = _existing_line_pattern(target.shell, name)
+    existing_index: Optional[int] = None
+    existing_value: Optional[str] = None
+    for i, line in enumerate(lines):
+        match = pattern.match(line)
+        if match:
+            existing_index = i
+            existing_value = _strip_quotes(match.group(1))
+
+    masked_line = _format_line(target.shell, name, mask_secret(value))
+
+    if existing_index is not None:
+        if existing_value == value:
+            return target, f"{name} already set in {target.path} (unchanged)."
+
+        if not force:
+            raise EnvVarConflict(mask_secret(existing_value), mask_secret(value), target.path)
+
+        new_line = _format_line(target.shell, name, value)
+        has_marker_above = existing_index > 0 and lines[existing_index - 1].strip() == (
+            MARKER_COMMENT
+        )
+        lines[existing_index] = new_line
+        if not has_marker_above:
+            lines.insert(existing_index, MARKER_COMMENT)
+
+        target.path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return target, masked_line
+
+    new_line = _format_line(target.shell, name, value)
+    separator = "\n" if content and not content.endswith("\n") else ""
+    addition = f"{MARKER_COMMENT}\n{new_line}\n"
+    target.path.write_text(f"{content}{separator}{addition}", encoding="utf-8")
+    return target, masked_line
+
+
+def _write_env_var_windows(name: str, value: str, *, force: bool) -> tuple[ProfileTarget, str]:
+    """Persist an environment variable into the user's registry environment block."""
+    from poly.output.console import mask_secret
+
+    target = ProfileTarget(path=Path(_WINDOWS_ENVIRONMENT_DISPLAY_PATH), shell="powershell")
+    backend = _get_windows_registry_backend()
+
+    existing = backend.read(name)
+    if existing is not None:
+        if existing == value:
+            os.environ[name] = value
+            return target, f"{name} already set in {target.path} (unchanged)."
+        if not force:
+            raise EnvVarConflict(mask_secret(existing), mask_secret(value), target.path)
+
+    backend.write(name, value)
+    backend.broadcast()
+    os.environ[name] = value
+
+    masked_line = f"{name}={mask_secret(value)}"
+    return target, masked_line
+
+
+class _WindowsRegistryBackend:
+    """Real HKCU\\Environment access. Only ever instantiated on Windows.
+
+    Split out from `_write_env_var_windows` so tests can substitute a fake via
+    `_get_windows_registry_backend`, without importing `winreg`/`ctypes` (both
+    Windows-only) at module import time - this module must still import
+    cleanly on macOS/Linux CI.
+    """
+
+    def read(self, name: str) -> Optional[str]:
+        """Read `name` from HKCU\\Environment, or None if it is not set."""
+        import winreg
+
+        try:
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER, "Environment", access=winreg.KEY_READ
+            ) as key:
+                value, _ = winreg.QueryValueEx(key, name)
+                return value
+        except FileNotFoundError:
+            return None
+
+    def write(self, name: str, value: str) -> None:
+        """Write `name` into HKCU\\Environment."""
+        import winreg
+
+        with winreg.OpenKey(
+            winreg.HKEY_CURRENT_USER, "Environment", access=winreg.KEY_READ | winreg.KEY_WRITE
+        ) as key:
+            winreg.SetValueEx(key, name, 0, winreg.REG_SZ, value)
+
+    def broadcast(self) -> None:
+        """Notify running processes that the environment block changed.
+
+        A failure here is a warning, not an error: the registry write above
+        already persisted, so a new terminal will pick up the value regardless.
+        """
+        try:
+            import ctypes
+
+            result = ctypes.c_ulong()
+            ctypes.windll.user32.SendMessageTimeoutW(
+                _HWND_BROADCAST,
+                _WM_SETTINGCHANGE,
+                0,
+                "Environment",
+                _SMTO_ABORTIFHUNG,
+                5000,
+                ctypes.byref(result),
+            )
+        except Exception:
+            logger.warning("Failed to broadcast environment variable change", exc_info=True)
+
+
+def _get_windows_registry_backend() -> _WindowsRegistryBackend:
+    """Factory for the registry backend, patched by tests on non-Windows CI."""
+    return _WindowsRegistryBackend()

--- a/src/poly/utils/env_profile.py
+++ b/src/poly/utils/env_profile.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Marker written immediately above a line this module added, so a later run
 # can tell "we wrote this" apart from a line the user added by hand, and so
 # replacing a value in place never leaves a duplicate marker behind.
-MARKER_COMMENT = "# Added by poly onboard"
+MARKER_COMMENT = "# Added by poly apikey"
 
 # HWND_BROADCAST / WM_SETTINGCHANGE / SMTO_ABORTIFHUNG, used to notify running
 # processes (Explorer, the Start menu, already-open terminals) that the user

--- a/src/poly/utils/env_profile.py
+++ b/src/poly/utils/env_profile.py
@@ -32,6 +32,16 @@ _SMTO_ABORTIFHUNG = 0x0002
 _WINDOWS_ENVIRONMENT_DISPLAY_PATH = "HKCU\\Environment"
 
 
+def _is_windows() -> bool:
+    """Whether to use the Windows registry environment instead of a profile file."""
+    return os.name == "nt"
+
+
+def _is_macos() -> bool:
+    """Whether bash should be pointed at ~/.bash_profile (macOS) rather than ~/.bashrc."""
+    return sys.platform == "darwin"
+
+
 @dataclass
 class ProfileTarget:
     """Where an environment variable gets persisted, and in what dialect."""
@@ -66,7 +76,7 @@ def detect_profile() -> ProfileTarget:
         ProfileTarget: The file (or, on Windows, the registry location) and
             dialect to write to.
     """
-    if os.name == "nt":
+    if _is_windows():
         return ProfileTarget(path=Path(_WINDOWS_ENVIRONMENT_DISPLAY_PATH), shell="powershell")
 
     home = Path(os.path.expanduser("~"))
@@ -75,7 +85,7 @@ def detect_profile() -> ProfileTarget:
     if shell == "zsh":
         return ProfileTarget(path=home / ".zshrc", shell="zsh")
     if shell == "bash":
-        if sys.platform == "darwin":
+        if _is_macos():
             return ProfileTarget(path=home / ".bash_profile", shell="bash")
         return ProfileTarget(path=home / ".bashrc", shell="bash")
     if shell == "fish":
@@ -99,7 +109,7 @@ def write_env_var(name: str, value: str, *, force: bool = False) -> tuple[Profil
         EnvVarConflict: `name` is already set to a different value and `force`
             is false.
     """
-    if os.name == "nt":
+    if _is_windows():
         return _write_env_var_windows(name, value, force=force)
     return _write_env_var_unix(name, value, force=force)
 
@@ -251,5 +261,11 @@ class _WindowsRegistryBackend:
 
 
 def _get_windows_registry_backend() -> _WindowsRegistryBackend:
-    """Factory for the registry backend, patched by tests on non-Windows CI."""
+    """Factory for the registry backend, patched by tests on non-Windows CI.
+
+    Alongside `_is_windows()` and `_is_macos()`, this is one of three test
+    seams in this module - patching them lets a test force a code path
+    without mutating the real `os.name`/`sys.platform`, which would break
+    `pathlib` and other stdlib code on the actual host platform.
+    """
     return _WindowsRegistryBackend()


### PR DESCRIPTION
## Summary

Adds `poly apikey`, a non-interactive command whose job is to get an API key for the PolyAI
APIs and Dialog RSN into a user's environment - not to set up the ADK itself, which stays with
`poly setup`/`poly login`. It signs a user in through the device flow, creates their Agent
Studio account if needed, mints (or reuses) an account-scoped API key, saves it to the
credentials file, and exports `POLY_API_KEY` into the user's shell profile (or user environment
on Windows). `--region studio` targets the PLG cluster via a GitHub-only sign-in page, for
individual developers; `--region <region>` targets any other cluster (us-1/uk-1/euw-1) via the
same email/SSO page `poly login` uses, for enterprise users who need a key for a region other
than where their identity lives. It's runnable by an AI coding assistant on the user's behalf,
since it never prompts and handles no secrets outside the process.

## Motivation

The studio sign-in page is getting a "Set up with your AI coding assistant" panel: a prompt the
user copies into Claude Code, Cursor or Codex. The first version of that prompt had the agent
drive the Auth0 device flow and edit dotfiles directly. Agents frequently refused it as a
prompt-injection pattern, and when they did run it the token and key passed through the agent's
transcript. Moving the flow into the CLI makes the pasted prompt "install the package and run one
command", which agents accept, and keeps every secret inside the process. `poly apikey` is
scoped narrowly to the API-key/Dialog RSN use case; ADK onboarding for an assistant still goes
through `poly setup`/`poly login`, unchanged by this PR.

Sign-up tracking is done on the Auth0 side (post-login Action -> PostHog), so the ADK sends no
telemetry.

Why this is a separate command rather than a flag on `poly login`, or part of `poly setup` (#305):

- It authenticates against a different Auth0 application, whose login page shows only
  "Continue with GitHub". `login` and `setup` keep the email/Google/GitHub page.
- It creates an **account-scoped** API key on the accounts API, not a user PAT.
- It exports `POLY_API_KEY` for use by the PolyAI SDKs and other tools, which `login`
  deliberately does not. The ADK itself keeps reading `~/.poly/credentials.json`, so the variable
  is for everything downstream of onboarding rather than for `poly` commands.
- It never prompts, and its `--json` shape is a stable contract for the agent driving it.
  `setup` is the interactive, human-facing path and stays that way.

## Changes

- Add `poly apikey` (Getting started group) with `--region`, `--key-name`, `--account-id`,
  `-f/--force`, and the shared `--json` / `--verbose` / `--debug` parents. Exit `0` on success,
  `1` on sign-in, account or API failure, `2` when `POLY_API_KEY` is already set to a different
  value and `--force` was not given. After saving credentials it polls (up to 20×, 1 s apart,
  mirroring `poly login`/`poly setup`) for the key to become active before writing
  `POLY_API_KEY`, so a command run immediately afterwards doesn't fail against a key the
  platform hasn't finished activating; if it never activates, it warns and continues rather
  than failing.
- `--region` (required, no default) picks which cluster's Auth0 app to sign in against and which
  cluster's account/key APIs to call - reusing `REGION_TO_AUTH_DETAILS` and the region-keyed
  interface methods `poly login` already uses, so no new Auth0 infrastructure was needed. The
  default key name becomes `cli-generated-key-<region>` for any non-`studio` region, so a key
  created for one region never collides with or overwrites a key from another - each region's
  credential also gets its own independent entry in `~/.poly/credentials.json`.
- Extract the RFC 8628 device-flow loop from `auth.py` into `poly.auth.device_flow`, taking an
  `AuthDetails` rather than a region so a caller can target a specific Auth0 application. `login`
  and `setup` keep their exact output; they now call the shared helper. The poll interval is
  capped at 30 s under repeated `slow_down`.
- Add JWT-authenticated platform calls for listing accounts and listing/creating account API
  keys, and factor the repeated Bearer header block into `_jwt_headers(jwt, source)`. The
  `X-Poly-Source` header is parameterised so apikey traffic is distinguishable from the rest
  of the ADK; existing callers still send `adk`.
- Add `poly.utils.api_keys.select_reusable_api_key`: newest active, unexpired key whose
  `policies[0].name` matches (the creation name lands there, not on the key's own `name`).
- Add `poly.utils.env_profile`: detects the profile file from `$SHELL` (`~/.zshrc`,
  `~/.bash_profile` on macOS / `~/.bashrc` on Linux, fish config, `~/.profile` fallback) and
  writes the export line with a marker comment, replacing an existing line in place only with
  `--force`. On Windows it writes the user-scope registry environment and broadcasts
  `WM_SETTINGCHANGE`, via a small backend seam so the logic is testable on Linux CI.
- Never overwrite an existing `studio` entry in `~/.poly/credentials.json`; report that it was
  kept.
- On enterprise regions (`us-1`/`uk-1`/`euw-1`), `/jupiter/v1/authorise` only auto-creates a
  workspace for `@poly-ai.com` users (verified in `poly_core`,
  `src/agent_v3/jupiter_api/interactors/auth_interactor.py`) - anyone else who isn't already
  provisioned in Aegis gets a raw `403`. `apikey` now catches that and raises a friendly
  message pointing at `--account-id`/PolyAI provisioning instead of surfacing the HTTP error;
  studio's 403 behaviour (a genuine auth error) is untouched. Also: account resolution now
  refuses to silently pick among multiple accounts on any region - including studio - erroring
  and listing them unless `--account-id` is given; the sign-in message no longer reads "with
  your browser ... in your browser" for non-studio regions, and `--json` output includes
  `key_active` so an agent can tell whether the activation wait actually succeeded.
- Docs: reference page for `apikey`, entries in the CLI overview and nav, a short subsection in
  Getting started, and a README line.

## Test strategy

- [x] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

Unit tests (run on both the Ubuntu and Windows CI runners) cover the device flow (first-poll success, pending, slow-down cap, expiry, unknown
error, no-browser, custom callback), key selection (policy-name match, inactive, expired, missing
expiry, newest wins), profile detection and writing for zsh/bash/fish/fallback and the Windows
registry path (fake backend), and the command itself (create and reuse paths, `--account-id`,
empty-account timeout, conflict exit 2, `--force` forwarding, `--json` shape, key never printed,
region selection - `--region studio` vs. `--region us-1` sign-in target, per-region default key
name, `--key-name` overriding it, region threaded into account/credentials calls, `--region`
required). Tests make no network calls and do not touch the real `~/.poly`.

Manual runs against studio with a fresh GitHub account, all passing end to end:

| Platform | Shell / store | Paths exercised |
|---|---|---|
| macOS 15 | zsh, `~/.zshrc` | new account, key created, conflict exit 2, `--force` replace in place |
| Debian 12 (Docker) | bash, `~/.bashrc` | key reused, append with marker, fresh login shell sees the variable |
| Windows Server 2022 (GCP) | user registry | key reused, `HKCU\Environment` written, value visible from a new process |

In each case `poly project list --region studio` authenticated with the saved credential
afterwards.

`--region` for a non-`studio` cluster has not been exercised against a live enterprise tenant in
this environment (no credentials for one here) - it reuses the exact `AuthDetails`/device-flow/
interface calls `poly login --region <region>` already uses in production, so risk is limited to
this file's own plumbing, covered by the unit tests above.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

`--region` went from optional (defaulting to `studio`) to required in a later push of this same
PR. `poly apikey` has never shipped in a release, so this is not a break in released behaviour -
just tightening the interface before it goes out.

Overlaps with #305 (`poly setup`) in `auth.py` imports, `cli.py`'s command list and the docs
index pages; whichever lands second rebases. This branch no longer references `poly start`, so
merge order does not change its docs.

## Screenshots / Logs

```
$ poly apikey --region studio
Setting up your PolyAI account and API key...
To sign in with GitHub, open the following link in your browser
and enter the code when prompted.

  URL:  https://login.studio.poly.ai/activate?user_code=XXXX-XXXX
  Code: XXXX-XXXX
Authenticated successfully!
Setting up your account...
Created API key 'cli-generated-key': abcd****wxyz
Saved to ~/.poly/credentials.json (studio).
Wrote to ~/.zshrc:
  export POLY_API_KEY="abcd****wxyz"

Done.
  Account:   ws-xxxxxxxx
  API key:   abcd****wxyz   (cli-generated-key, created)
  Saved to:  ~/.poly/credentials.json (studio)
  Profile:   ~/.zshrc  (export POLY_API_KEY="abcd****wxyz")

Open a new terminal, or run `source ~/.zshrc`, to pick up POLY_API_KEY.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)




