### PR TITLE
fix: stop disabled settings residuals and prompt whitespace breaking flow step equality

### DIFF
--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -368,9 +368,7 @@ class FlowStep(BaseFlowStep, YamlResource):
             Condition(**condition) if not isinstance(condition, Condition) else condition
             for condition in (conditions or [])
         ]
-        # The YAML read has always stripped the prompt, so stripped is the canonical
-        # form — normalise here so a projection read (where Studio edits often leave
-        # trailing whitespace) compares equal to a disk read of the same content.
+        # Stripped is the canonical form — YAML reads have always stripped.
         self.prompt = (prompt or "").strip()
         self.position = position or {}
 
@@ -1341,11 +1339,8 @@ class FlowSettings(SubResource):
 
         # asr_biasing and dtmf can't be cleared on the backend, so an absent section
         # means disabled — normalise here so every construction path (YAML, projection,
-        # bare defaults) compares equal. The same goes for a disabled section's
-        # residual sub-values: to_yaml_dict drops disabled sections entirely, so
-        # residuals the platform still stores (e.g. a stale interDigitTimeout on a
-        # step whose DTMF was later disabled) can never round-trip through disk and
-        # must not make identical content compare unequal.
+        # bare defaults) compares equal. Disabled sections normalise to bare defaults:
+        # YAML drops them entirely, so their residual values can't round-trip.
         self.asr_biasing = asr_biasing if asr_biasing is not None else ASRBiasing()
         self.dtmf = dtmf if dtmf is not None else DTMFConfig()
         if not self.asr_biasing.is_enabled:

--- a/src/poly/resources/flows.py
+++ b/src/poly/resources/flows.py
@@ -368,7 +368,10 @@ class FlowStep(BaseFlowStep, YamlResource):
             Condition(**condition) if not isinstance(condition, Condition) else condition
             for condition in (conditions or [])
         ]
-        self.prompt = prompt
+        # The YAML read has always stripped the prompt, so stripped is the canonical
+        # form — normalise here so a projection read (where Studio edits often leave
+        # trailing whitespace) compares equal to a disk read of the same content.
+        self.prompt = (prompt or "").strip()
         self.position = position or {}
 
     @classmethod
@@ -552,7 +555,7 @@ class FlowStep(BaseFlowStep, YamlResource):
             flow_name=flow_name,
             step_type=step_type,
             settings=settings,
-            prompt=yaml_dict.get("prompt", "").strip(),
+            prompt=yaml_dict.get("prompt", ""),
             conditions=conditions,
             position=known_position,
             extracted_entities=extracted_entities,
@@ -1338,9 +1341,17 @@ class FlowSettings(SubResource):
 
         # asr_biasing and dtmf can't be cleared on the backend, so an absent section
         # means disabled — normalise here so every construction path (YAML, projection,
-        # bare defaults) compares equal.
+        # bare defaults) compares equal. The same goes for a disabled section's
+        # residual sub-values: to_yaml_dict drops disabled sections entirely, so
+        # residuals the platform still stores (e.g. a stale interDigitTimeout on a
+        # step whose DTMF was later disabled) can never round-trip through disk and
+        # must not make identical content compare unequal.
         self.asr_biasing = asr_biasing if asr_biasing is not None else ASRBiasing()
         self.dtmf = dtmf if dtmf is not None else DTMFConfig()
+        if not self.asr_biasing.is_enabled:
+            self.asr_biasing = ASRBiasing()
+        if not self.dtmf.is_enabled:
+            self.dtmf = DTMFConfig()
         self.asr = asr
         self.vad = vad
         self.barge_in = barge_in

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -11510,6 +11510,38 @@ class FlowStepFromProjection(unittest.TestCase):
         self.assertEqual(step.flow_name, "Booking")
         self.assertEqual(step.prompt, "Hello!")
 
+    def test_prompt_whitespace_is_stripped_on_every_path(self):
+        """Surrounding prompt whitespace must not affect equality.
+
+        The YAML read has always stripped the prompt, but the projection read did
+        not, so a step whose prompt was saved in Studio with a trailing newline
+        compared unequal to the identical disk read forever — the same failure mode
+        variable_references had for functions.
+        """
+        projection = {
+            "flows": {
+                "flows": {
+                    "entities": {
+                        "FLOW-1": {
+                            "name": "Booking",
+                            "steps": {
+                                "entities": {
+                                    "STEP-A": {
+                                        "name": "greet",
+                                        "type": "default_step",
+                                        "prompt": "  Hello!\n",
+                                        "conditions": [],
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        step = FlowStep.from_projection(projection)["FLOW-1_STEP-A"]
+        self.assertEqual(step.prompt, "Hello!")
+
     def test_skips_function_steps(self):
         """function_step type entries should be excluded from FlowStep parsing."""
         projection = {
@@ -11653,6 +11685,68 @@ class FlowSettingsFromProjectionTest(unittest.TestCase):
         self.assertEqual(settings.to_yaml_dict(), {})
         self.assertEqual(settings.step_id, self.STEP_ID)
         self.assertEqual(settings.flow_id, self.FLOW_ID)
+
+
+class FlowSettingsEqualityTest(unittest.TestCase):
+    """Disabled asr_biasing/dtmf residuals must not affect equality.
+
+    to_yaml_dict drops disabled sections entirely, so residual sub-values the
+    platform still stores (e.g. a stale interDigitTimeout on a step whose DTMF was
+    later disabled) can never round-trip through disk. Including them in the
+    generated __eq__ made every projection-read step with such residuals compare
+    unequal to a disk read of identical content — and sync_ids_with_sandbox compares
+    whole resources, so one duplicate-name merge fallback rewrote every step in the
+    project.
+    """
+
+    STEP_ID = "step-1"
+    FLOW_ID = "FLOW-abc"
+
+    def _settings(self, **kwargs) -> FlowSettings:
+        return FlowSettings(step_id=self.STEP_ID, flow_id=self.FLOW_ID, **kwargs)
+
+    def test_disabled_dtmf_residuals_are_normalised(self):
+        with_residuals = self._settings(
+            dtmf=DTMFConfig(
+                is_enabled=False,
+                inter_digit_timeout=3,
+                end_key="",
+                collect_while_agent_speaking=True,
+                is_pii=True,
+                max_digits=1,
+            )
+        )
+        self.assertEqual(with_residuals, self._settings())
+        self.assertEqual(with_residuals.dtmf, DTMFConfig())
+
+    def test_disabled_asr_biasing_residuals_are_normalised(self):
+        with_residuals = self._settings(
+            asr_biasing=ASRBiasing(
+                is_enabled=False, precise_date=True, custom_keywords=["acme"]
+            )
+        )
+        self.assertEqual(with_residuals, self._settings())
+        self.assertEqual(with_residuals.asr_biasing, ASRBiasing())
+
+    def test_enabled_sections_still_compare_by_value(self):
+        enabled = self._settings(dtmf=DTMFConfig(is_enabled=True, inter_digit_timeout=3))
+        self.assertNotEqual(enabled, self._settings())
+        self.assertNotEqual(
+            enabled, self._settings(dtmf=DTMFConfig(is_enabled=True, inter_digit_timeout=5))
+        )
+        self.assertEqual(
+            enabled, self._settings(dtmf=DTMFConfig(is_enabled=True, inter_digit_timeout=3))
+        )
+
+    def test_enabling_or_disabling_is_still_a_change(self):
+        self.assertNotEqual(
+            self._settings(dtmf=DTMFConfig(is_enabled=True)),
+            self._settings(dtmf=DTMFConfig(is_enabled=False)),
+        )
+        self.assertNotEqual(
+            self._settings(asr_biasing=ASRBiasing(is_enabled=True)),
+            self._settings(),
+        )
 
 
 class FlowSettingsSerializationTest(unittest.TestCase):
@@ -11874,6 +11968,8 @@ class FlowSettingsValidationTest(unittest.TestCase):
         ]
 
     def test_negative_dtmf_values_are_rejected(self):
+        # Enabled, because a disabled section is normalised to bare defaults at
+        # construction — residual values are discarded before validation.
         for kwargs, expected in [
             ({"max_digits": -1}, "max_digits"),
             ({"inter_digit_timeout": -1}, "inter_digit_timeout"),
@@ -11882,7 +11978,7 @@ class FlowSettingsValidationTest(unittest.TestCase):
                 settings = FlowSettings(
                     step_id="step-1",
                     flow_id="flow-123",
-                    dtmf=DTMFConfig(**kwargs),
+                    dtmf=DTMFConfig(is_enabled=True, **kwargs),
                 )
                 with self.assertRaises(ValueError) as ctx:
                     settings.validate()
@@ -11914,8 +12010,13 @@ class FlowSettingsValidationTest(unittest.TestCase):
         self.assertIsNone(settings.validate())
 
     def test_flow_step_validate_checks_its_settings(self):
-        """Settings are a sub-resource, so nothing else validates them."""
-        step = self._step(dtmf=DTMFConfig(max_digits=-1))
+        """Settings are a sub-resource, so nothing else validates them.
+
+        The invalid config must be enabled: a disabled section is normalised to
+        bare defaults at construction, discarding residual values before
+        validation can see them.
+        """
+        step = self._step(dtmf=DTMFConfig(is_enabled=True, max_digits=-1))
 
         with self.assertRaises(ValueError) as ctx:
             step.validate(resource_mappings=self._mappings())

--- a/src/poly/tests/resources_test.py
+++ b/src/poly/tests/resources_test.py
@@ -11511,13 +11511,8 @@ class FlowStepFromProjection(unittest.TestCase):
         self.assertEqual(step.prompt, "Hello!")
 
     def test_prompt_whitespace_is_stripped_on_every_path(self):
-        """Surrounding prompt whitespace must not affect equality.
-
-        The YAML read has always stripped the prompt, but the projection read did
-        not, so a step whose prompt was saved in Studio with a trailing newline
-        compared unequal to the identical disk read forever — the same failure mode
-        variable_references had for functions.
-        """
+        """Surrounding prompt whitespace must not affect equality — YAML reads
+        strip, so projection reads must too."""
         projection = {
             "flows": {
                 "flows": {
@@ -11690,13 +11685,9 @@ class FlowSettingsFromProjectionTest(unittest.TestCase):
 class FlowSettingsEqualityTest(unittest.TestCase):
     """Disabled asr_biasing/dtmf residuals must not affect equality.
 
-    to_yaml_dict drops disabled sections entirely, so residual sub-values the
-    platform still stores (e.g. a stale interDigitTimeout on a step whose DTMF was
-    later disabled) can never round-trip through disk. Including them in the
-    generated __eq__ made every projection-read step with such residuals compare
-    unequal to a disk read of identical content — and sync_ids_with_sandbox compares
-    whole resources, so one duplicate-name merge fallback rewrote every step in the
-    project.
+    YAML drops disabled sections entirely, so their residual values can never
+    round-trip through disk — a projection read carrying residuals must still
+    compare equal to a disk read of identical content.
     """
 
     STEP_ID = "step-1"
@@ -11968,8 +11959,7 @@ class FlowSettingsValidationTest(unittest.TestCase):
         ]
 
     def test_negative_dtmf_values_are_rejected(self):
-        # Enabled, because a disabled section is normalised to bare defaults at
-        # construction — residual values are discarded before validation.
+        # Enabled: a disabled section is normalised away before validation.
         for kwargs, expected in [
             ({"max_digits": -1}, "max_digits"),
             ({"inter_digit_timeout": -1}, "inter_digit_timeout"),
@@ -12010,12 +12000,8 @@ class FlowSettingsValidationTest(unittest.TestCase):
         self.assertIsNone(settings.validate())
 
     def test_flow_step_validate_checks_its_settings(self):
-        """Settings are a sub-resource, so nothing else validates them.
-
-        The invalid config must be enabled: a disabled section is normalised to
-        bare defaults at construction, discarding residual values before
-        validation can see them.
-        """
+        """Settings are a sub-resource, so nothing else validates them."""
+        # Enabled: a disabled section is normalised away before validation.
         step = self._step(dtmf=DTMFConfig(is_enabled=True, max_digits=-1))
 
         with self.assertRaises(ValueError) as ctx:


### PR DESCRIPTION
## Summary

Flow step equality treated platform-stored residuals of *disabled* `asr_biasing`/`dtmf` sections — values YAML cannot represent — as real differences, and the projection read kept prompt whitespace that the YAML read strips. Both made identical content compare unequal forever; `sync_ids_with_sandbox` compares whole resources, so a single duplicate-name merge fallback rewrote **every step in the project** (86× `update_flow_step` + 86× `update_step_settings` on the affected project).

## Motivation

Investigating the one remaining "Found duplicate name errors, attempting sync and merge" hit after the 0.55 parent-id-adoption fix, the sync's 177-command batch turned out to be a mass no-op rewrite. Reproduced against a second production project whose steps had never been through a sync: **40/79 steps compared unequal — 38 of them purely on disabled-DTMF residuals** (`interDigitTimeout: 3` vs default `0`, `endKey: ''` vs `'#'`, `collectWhileAgentSpeaking: true` vs `false`), the rest on prompt whitespace. This is the same failure mode `variable_references` had for functions (see `test_equality_ignores_variable_references`).

## Changes

- `FlowSettings.__init__` normalises a disabled `asr_biasing`/`dtmf` section to bare defaults, extending the existing absent-means-disabled normalisation — `to_yaml_dict` drops disabled sections, so their residuals can never round-trip through disk and must not affect equality.
- `FlowStep.__init__` strips surrounding prompt whitespace so every construction path agrees (the YAML read already stripped; the projection read did not). The now-redundant strip in `from_yaml_dict` is removed.
- Tests: `FlowSettingsEqualityTest` (disabled residuals normalised; enabled sections still compare by value; enable/disable still a change), prompt-strip coverage in `FlowStepFromProjection`, and the two validation tests that relied on disabled-but-invalid residuals now use enabled configs.

## Test strategy

- [x] Added/updated unit tests
- [ ] Manual CLI testing (`poly <command>`)
- [x] Tested against a live Agent Studio project

Re-ran the sync-style whole-resource comparison against the live unmigrated project: **40/79 unequal → 2/79**, and both survivors are genuine prompt content drift between the repo and Studio (verified by character diff), not false positives.

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes (1794 passed, 211 subtests)
- [x] No breaking changes to the `poly` CLI interface (or migration path documented) — note: a push of a step whose disabled DTMF carried residuals now sends canonical disabled values, which is what disk-read pushes already sent
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)