### PR TITLE
fix: stop PostHog background threads hanging CLI exit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ dependencies = [
     "ty",
     "argcomplete>=3.0.0",
     "langcodes==3.5.1",
-    "posthog==7.35.4",
+    "posthog==7.51.2",
     "packaging>=24.0"
 ]
 

--- a/src/poly/handlers/posthog.py
+++ b/src/poly/handlers/posthog.py
@@ -58,6 +58,7 @@ def get_posthog_client(region: str) -> Posthog:
             project_api_key=project_api_key,
             host=POSTHOG_HOST,
             feature_flags_request_timeout_seconds=FEATURE_FLAGS_REQUEST_TIMEOUT_SECONDS,
+            sync_mode=True,
         )
         _clients[project_api_key] = client
     return client

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ wheels = [
 
 [[package]]
 name = "polyai-adk"
-version = "0.53.0"
+version = "0.55.0"
 source = { editable = "." }
 dependencies = [
     { name = "argcomplete" },
@@ -397,7 +397,7 @@ requires-dist = [
     { name = "licensecheck", marker = "extra == 'dev'", specifier = ">=2024.3" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.5.1" },
-    { name = "posthog", specifier = "==7.35.4" },
+    { name = "posthog", specifier = "==7.51.2" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "protobuf", specifier = ">=4.21.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
@@ -415,7 +415,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "posthog"
-version = "7.35.4"
+version = "7.51.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -423,9 +423,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/b9/9471861b836eed9be1da207792d8ad69b385e99a174029f13d52467493fa/posthog-7.35.4.tar.gz", hash = "sha256:b0342314599c25bd9d32877a9525f9632ed49037d3b25a920b01be641dd1b368", size = 395178, upload-time = "2026-07-31T11:15:39.463Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/27/6d1369d67579d1087a0db271f521de974bfb0c0e240d3dd445ee5b9ffc13/posthog-7.51.2.tar.gz", hash = "sha256:db63f41ca9d965b206acd1cb539618c1105e03ed3a29159d3909ade042135037", size = 543138, upload-time = "2026-09-11T09:15:02.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/94/4e63655fa86054459be1bb50497198efd27bb76db50da977643739fa1c25/posthog-7.35.4-py3-none-any.whl", hash = "sha256:79e3979e7a68b98d2ff2064916eed60b2ee3b2c687e73c41b77e4de00514ec74", size = 468387, upload-time = "2026-07-31T11:15:37.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/c6/c6417a93d2281818ee0f1c33f02178bc22c3b019fb70dd901c4549441010/posthog-7.51.2-py3-none-any.whl", hash = "sha256:813506742ab5e3c0a7cab79d254071f50c8465bb76f881944039a7546ce57121", size = 637430, upload-time = "2026-09-11T09:15:00.307Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Constructs the flags-only PostHog client with `sync_mode=True` so it starts no consumer threads and registers no atexit flush hook, and bumps `posthog` 7.35.4 → 7.51.2.

## Motivation

The CLI only ever evaluates feature flags (`feature_enabled` with `send_feature_flag_events=False`) and never captures events, but the default client still eagerly spawns capture consumer threads and registers an atexit flush hook. That machinery is pure liability here: the SDK's lock choreography around the capture queue has caused hangs (stuck threads, delayed process exit) in other services, and a CLI must always exit promptly. With `sync_mode=True` none of it is constructed, so there is nothing left to hang, while flag evaluation is unchanged (a plain HTTP call bounded by the existing 1s timeout).

## Changes

- Pass `sync_mode=True` when constructing the PostHog client in `src/poly/handlers/posthog.py`
- Bump `posthog` 7.35.4 → 7.51.2 in `pyproject.toml` and `uv.lock`

## Test strategy

- [ ] Added/updated unit tests
- [x] Manual CLI testing (`poly <command>`)
- [ ] Tested against a live Agent Studio project
- [ ] N/A (docs, config, or trivial change)

## Checklist

- [x] `ruff check .` and `ruff format --check .` pass
- [x] `pytest` passes
- [x] No breaking changes to the `poly` CLI interface (or migration path documented)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)

## Screenshots / Logs

Verified no background threads after client construction:

```
>>> get_posthog_client('dev')
threads after client init: ['MainThread']   # previously spawned a consumer thread
sync_mode: True
```

Full suite: 1789 passed, 211 subtests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)